### PR TITLE
If data is not provided, then don't raise a missing but default to empty.

### DIFF
--- a/kinto/tests/support.py
+++ b/kinto/tests/support.py
@@ -10,8 +10,8 @@ from kinto import main as testapp
 from kinto import DEFAULT_SETTINGS
 
 
-MINIMALIST_BUCKET = {'data': dict()}
-MINIMALIST_COLLECTION = {'data': dict()}
+MINIMALIST_BUCKET = {}
+MINIMALIST_COLLECTION = {}
 MINIMALIST_GROUP = {'data': dict(members=['fxa:user'])}
 MINIMALIST_RECORD = {'data': dict(name="Hulled Barley",
                                   type="Whole Grain")}

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -12,16 +12,14 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
 
     def setUp(self):
         super(BucketViewTest, self).setUp()
-        bucket = MINIMALIST_BUCKET.copy()
         resp = self.app.put_json(self.record_url,
-                                 bucket,
+                                 MINIMALIST_BUCKET,
                                  headers=self.headers)
         self.record = resp.json['data']
 
     def test_buckets_are_global_to_every_users(self):
         self.app.patch_json(self.record_url,
-                            {'data': {},
-                             'permissions': {'read': [Authenticated]}},
+                            {'permissions': {'read': [Authenticated]}},
                             headers=self.headers)
         self.app.get(self.record_url, headers=get_user_headers('alice'))
 

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -166,9 +166,9 @@ class InvalidGroupTest(BaseWebTest, unittest.TestCase):
                                  headers=self.headers,
                                  status=400)
         self.assertEqual(resp.json['message'],
-                         "data.members in body: Required")
-        self.assertDictEqual(resp.json['details'], {
-            "description": "Required",
+                         "data is missing")
+        self.assertDictEqual(resp.json['details'][0], {
+            "description": "data is missing",
             "location": "body",
-            "name": "data.members"
+            "name": "data"
         })

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -161,7 +161,14 @@ class InvalidGroupTest(BaseWebTest, unittest.TestCase):
 
     def test_groups_must_have_members_attribute(self):
         invalid = {}
-        self.app.put_json(self.group_url,
-                          invalid,
-                          headers=self.headers,
-                          status=400)
+        resp = self.app.put_json(self.group_url,
+                                 invalid,
+                                 headers=self.headers,
+                                 status=400)
+        self.assertEqual(resp.json['message'],
+                         "data.members in body: Required")
+        self.assertDictEqual(resp.json['details'], {
+            "description": "Required",
+            "location": "body",
+            "name": "data.members"
+        })

--- a/loadtests/loadtest/tutorial.py
+++ b/loadtests/loadtest/tutorial.py
@@ -139,8 +139,7 @@ class TutorialLoadTest(BaseLoadTest):
 
         # Create a new bucket and check for permissions
         resp = self.session.put(
-            self.bucket_url(bucket_id),
-            data=json.dumps({'data': {}}))
+            self.bucket_url(bucket_id))
         self.incr_counter("status-%s" % resp.status_code)
         # We should always have a 201 here. See mozilla-services/cliquet#367
         # if resp.status_code == 200:
@@ -153,7 +152,7 @@ class TutorialLoadTest(BaseLoadTest):
         permissions = {"record:create": ['system.Authenticated']}
         resp = self.session.put(
             re.sub('/records$', '', collection_url),
-            data=json.dumps({'data': {}, 'permissions': permissions}))
+            data=json.dumps({'permissions': permissions}))
         self.incr_counter("status-%s" % resp.status_code)
         # We should always have a 201 here. See mozilla-services/cliquet#367
         # if resp.status_code == 200:
@@ -223,7 +222,7 @@ class TutorialLoadTest(BaseLoadTest):
         permissions = {"group:create": ['system.Authenticated']}
         resp = self.session.put(
             self.bucket_url(bucket_id),
-            data=json.dumps({'data': {}, 'permissions': permissions}))
+            data=json.dumps({'permissions': permissions}))
         self.incr_counter("status-%s" % resp.status_code)
         self.assertEqual(resp.status_code, 200)
         record = resp.json()

--- a/loadtests/loadtest/tutorial.py
+++ b/loadtests/loadtest/tutorial.py
@@ -108,8 +108,7 @@ class TutorialLoadTest(BaseLoadTest):
         self.incr_counter("status-%s" % resp.status_code)
         self.assertEqual(resp.status_code, 200)
         record = resp.json()['data']
-        # XXX: Should be the ETag header see mozilla-services/cliquet#352
-        etag = '"%s"' % record['last_modified']
+        etag = resp.headers['ETag']
 
         # Delete the record with If-Match
         resp = self.session.delete(
@@ -187,7 +186,6 @@ class TutorialLoadTest(BaseLoadTest):
         self.assertEqual(resp.status_code, 201)
         record = resp.json()
         self.assertIn('write', record['permissions'])
-        # bob_task_id = record['data']['id']
         bob_user_id = record['permissions']['write'][0]
 
         # Share Alice's task with Bob


### PR DESCRIPTION
```http
$ http PUT http://localhost:8888/v1/buckets/toto --auth="admin:"
HTTP/1.1 400 Bad Request
Access-Control-Expose-Headers: Backoff, Retry-After, Alert
Content-Length: 159
Content-Type: application/json; charset=UTF-8
Date: Tue, 16 Jun 2015 09:47:26 GMT
Server: waitress

{
    "code": 400, 
    "details": [
        {
            "description": "data is missing", 
            "location": "body", 
            "name": "data"
        }
    ], 
    "errno": 107, 
    "error": "Invalid parameters", 
    "message": "data is missing"
}
```

It should be:

```http
$ http PUT http://localhost:8888/v1/buckets/toto --auth="admin:"
HTTP/1.1 201 Created
Access-Control-Expose-Headers: Backoff, Retry-After, Alert
Content-Length: 69
Content-Type: application/json; charset=UTF-8
Date: Tue, 16 Jun 2015 09:47:49 GMT
Server: waitress

{
    "data": {
        "id": "toto", 
        "last_modified": 1434455269317
    }, 
    "permissions": {}
}
```