### PR TITLE
When deleting a collections, records are deleted but tombstone aren't

### DIFF
--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -137,11 +137,19 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
         self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
                           headers=self.headers)
         self.app.get(self.collection_url, headers=self.headers, status=404)
+        # Verify tombstones
+        resp = self.app.get('%s/collections?_since=0' % self.bucket_url,
+                            headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)
 
     def test_every_groups_are_deleted_too(self):
         self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
                           headers=self.headers)
         self.app.get(self.group_url, headers=self.headers, status=404)
+        # Verify tombstones
+        resp = self.app.get('%s/groups?_since=0' % self.bucket_url,
+                            headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)
 
     def test_every_records_are_deleted_too(self):
         self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
@@ -149,3 +157,8 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
         self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
                           headers=self.headers)
         self.app.get(self.record_url, headers=self.headers, status=404)
+
+        # Verify tombstones
+        resp = self.app.get('%s/records?_since=0' % self.collection_url,
+                            headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)

--- a/kinto/tests/test_views_collections.py
+++ b/kinto/tests/test_views_collections.py
@@ -90,3 +90,8 @@ class CollectionDeletionTest(BaseWebTest, unittest.TestCase):
         self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
                           headers=self.headers)
         self.app.get(self.record_url, headers=self.headers, status=404)
+
+        # Verify tombstones
+        resp = self.app.get('%s/records?_since=0' % self.collection_url,
+                            headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -117,7 +117,9 @@ class Bucket(resource.ProtectedResource):
         # Delete groups.
         storage = self.collection.storage
         parent_id = '/buckets/%s' % self.record_id
-        storage.delete_all(collection_id='group', parent_id=parent_id)
+        storage.delete_all(collection_id='group',
+                           parent_id=parent_id,
+                           with_deleted=False)
         storage.purge_deleted(collection_id='group',
                               parent_id=parent_id)
 

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -118,16 +118,24 @@ class Bucket(resource.ProtectedResource):
         storage = self.collection.storage
         parent_id = '/buckets/%s' % self.record_id
         storage.delete_all(collection_id='group', parent_id=parent_id)
+        storage.purge_deleted(collection_id='group',
+                              parent_id=parent_id)
 
         # Delete collections.
         deleted = storage.delete_all(collection_id='collection',
-                                     parent_id=parent_id)
+                                     parent_id=parent_id,
+                                     with_deleted=False)
+        storage.purge_deleted(collection_id='collection',
+                              parent_id=parent_id)
 
         # Delete records.
         id_field = self.collection.id_field
         for collection in deleted:
             parent_id = '/buckets/%s/collections/%s' % (self.record_id,
                                                         collection[id_field])
-            storage.delete_all(collection_id='record', parent_id=parent_id)
+            storage.delete_all(collection_id='record',
+                               parent_id=parent_id,
+                               with_deleted=False)
+            storage.purge_deleted(collection_id='record', parent_id=parent_id)
 
         return result

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -32,7 +32,9 @@ class Collection(resource.ProtectedResource):
         storage = self.collection.storage
         parent_id = '%s/collections/%s' % (self.collection.parent_id,
                                            self.record_id)
-        storage.delete_all(collection_id='record', parent_id=parent_id)
+        storage.delete_all(collection_id='record',
+                           parent_id=parent_id,
+                           with_deleted=False)
         storage.purge_deleted(collection_id='record', parent_id=parent_id)
 
         return result

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -33,5 +33,6 @@ class Collection(resource.ProtectedResource):
         parent_id = '%s/collections/%s' % (self.collection.parent_id,
                                            self.record_id)
         storage.delete_all(collection_id='record', parent_id=parent_id)
+        storage.purge_deleted(collection_id='record', parent_id=parent_id)
 
         return result


### PR DESCRIPTION
https://github.com/mozilla-services/kinto/blob/master/kinto/views/collections.py#L31-L35

```
echo '{"data": {"title": "toto"}}' | http POST http://localhost:8888/v1/buckets/default/collections/tasks/records --auth user:pass

http DELETE http://localhost:8888/v1/buckets/default/collections/tasks/records/667c36ba-5a27-45bc-b9a4-94f3d4d46bf4 --auth user:pass

http GET http://localhost:8888/v1/buckets/default/collections/tasks/records?_since=1436786412344 --auth user:pass

http DELETE http://localhost:8888/v1/buckets/default/collections/tasks --auth user:pass

echo '{"data": {}}' | http PUT http://localhost:8888/v1/buckets/default/collections/tasks --auth user:pass

http GET http://localhost:8888/v1/buckets/default/collections/tasks/records?_since=1436786412344 --auth user:pass
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Backoff, Retry-After, Alert, Next-Page, Total-Records, Last-Modified, ETag
Content-Length: 101
Content-Type: application/json; charset=UTF-8
Date: Mon, 13 Jul 2015 11:20:52 GMT
Etag: "1436786412345"
Last-Modified: Mon, 13 Jul 2015 11:20:12 GMT
Server: waitress
Total-Records: 0

{
    "data": [
        {
            "deleted": true, 
            "id": "667c36ba-5a27-45bc-b9a4-94f3d4d46bf4", 
            "last_modified": 1436786412345
        }
    ]
}
```