### PR TITLE
Remove mentions of cloud storage.

### DIFF
--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -18,7 +18,7 @@ DEFAULT_SETTINGS = {
     'cliquet.cache_backend': 'cliquet.cache.memory',
     'cliquet.permission_backend': 'cliquet.permission.memory',
     'cliquet.storage_backend': 'cliquet.storage.memory',
-    'cliquet.project_name': 'Cloud Storage',
+    'cliquet.project_name': 'Kinto',
     'cliquet.project_docs': 'https://kinto.readthedocs.org/',
     'cliquet.bucket_create_principals': Authenticated,
     'multiauth.authorization_policy': (

--- a/kinto/tests/test_views_hello.py
+++ b/kinto/tests/test_views_hello.py
@@ -9,6 +9,6 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         self.assertEqual(response.json['version'], VERSION)
         self.assertEqual(response.json['url'], 'http://localhost/v1/')
-        self.assertEqual(response.json['hello'], 'Cloud Storage')
+        self.assertEqual(response.json['hello'], 'Kinto')
         self.assertEqual(response.json['documentation'],
                          'https://kinto.readthedocs.org/')


### PR DESCRIPTION
The project is now referenced as "Kinto".