### PR TITLE
Add custom (meta) data on buckets and collections 

### DIFF
--- a/kinto/tests/test_views_collections.py
+++ b/kinto/tests/test_views_collections.py
@@ -64,6 +64,18 @@ class CollectionViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
+    def test_collections_can_handle_arbitrary_attributes(self):
+        collection = MINIMALIST_COLLECTION.copy()
+        fingerprint = "5866f245a00bb3a39100d31b2f14d453"
+        collection['data'] = {'fingerprint': fingerprint}
+        resp = self.app.put_json('/buckets/beers/collections/barley',
+                                 collection,
+                                 headers=self.headers,
+                                 status=200)
+        data = resp.json['data']
+        self.assertIn('fingerprint', data)
+        self.assertEqual(data['fingerprint'], fingerprint)
+
 
 class CollectionDeletionTest(BaseWebTest, unittest.TestCase):
 

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -28,6 +28,9 @@ class JSONSchemaMapping(colander.SchemaNode):
 class CollectionSchema(resource.ResourceSchema):
     schema = JSONSchemaMapping(missing=colander.drop)
 
+    class Options:
+        preserve_unknown = True
+
 
 @resource.register(name='collection',
                    collection_methods=('GET',),

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -7,7 +7,7 @@ from kinto.views import object_exists_or_404
 
 
 class RecordSchema(schema.ResourceSchema):
-    class Options():
+    class Options:
         preserve_unknown = True
 
 


### PR DESCRIPTION
For some use-cases, it might become useful to be able to store some custom attributes in buckets or collections (e.g. metadata like application version, contact email or whatever).

Currently both Collection and Bucket resources do not define extra fields in their schema, and Cliquet drops unknown fields if not explicitly allowed.

We can either:
* Allow unknown fields in collection and buckets schemas
* Add a specific root level field (along ``data`` and ``permissions``)
* Add a specific field (called ``meta`` for example) in the schema that could receive anything.

The advantage of the latter is that custom fields do not interfere with anything in the protocol, and are trivial to implement. The inconvenient is having to put ``{data: {metadata: {email: "toto@yo.com"}}`` in the payload.

Thoughts ?