### PR TITLE
Cache expires control from collection

### DIFF
--- a/config/kinto.ini
+++ b/config/kinto.ini
@@ -46,6 +46,7 @@ multiauth.policies = basicauth
 #
 # cliquet.bucket_cache_expires_seconds = 3600
 # cliquet.collection_cache_expires_seconds = 3600
+# cliquet.group_cache_expires_seconds = 3600
 # cliquet.record_cache_expires_seconds = 3600
 
 [server:main]

--- a/config/kinto.ini
+++ b/config/kinto.ini
@@ -44,10 +44,23 @@ multiauth.policies = basicauth
 #
 # Client cache headers
 #
+# Every bucket objects objects and list
 # cliquet.bucket_cache_expires_seconds = 3600
+#
+# Every collection objects and list of every buckets
 # cliquet.collection_cache_expires_seconds = 3600
+#
+# Every group objects and list of every buckets
 # cliquet.group_cache_expires_seconds = 3600
+#
+# Every records objects and list of every collections
 # cliquet.record_cache_expires_seconds = 3600
+#
+# Records in a specific bucket
+# cliquet.blog_record_cache_expires_seconds = 3600
+#
+# Records in a specific collection in a specific bucket
+# cliquet.blog_article_record_cache_expires_seconds = 3600
 
 [server:main]
 use = egg:waitress#main

--- a/config/kinto.ini
+++ b/config/kinto.ini
@@ -41,6 +41,13 @@ multiauth.policies = basicauth
 # fxa-oauth.scope = profile
 # fxa-oauth.relier.enabled = true
 
+#
+# Client cache headers
+#
+# cliquet.bucket_cache_expires_seconds = 3600
+# cliquet.collection_cache_expires_seconds = 3600
+# cliquet.record_cache_expires_seconds = 3600
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -221,3 +221,31 @@ Here's an example:
 
 To use a different ini file, the ``KINTO_INI`` environment variable
 should be present with a path to it.
+
+.. _production-cache-server:
+
+Nginx as cache server
+---------------------
+
+If *Nginx* is used as a reverse proxy, it can also `act as a cache server <https://serversforhackers.com/nginx-caching>`_
+by taking advantage of *Kinto* optional cache control response headers
+(forced :ref:`in settings <configuration-client-caching>`
+or set :ref:`on collections <collection-caching>`).
+
+A sample *Nginx* configuration could look like so:
+
+::
+
+    proxy_cache_path /tmp/nginx levels=1:2 keys_zone=my_zone:100m inactive=200m;
+    proxy_cache_key "$scheme$request_method$host$request_uri$";
+
+    server {
+        ...
+
+        location / {
+            proxy_cache my_zone;
+
+            include proxy_params;
+            proxy_pass http://127.0.0.1:8888;
+        }
+    }

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -519,7 +519,7 @@ The client (or cache server or proxy) will use them to cache the collection
 records for a certain amount of time, in seconds.
 
 The setting can be set for any kind of object (``bucket``, ``group``, ``collection``, ``record``),
-and concerns read-only requests (``GET /buckets``, ``GET /buckets/{}/groups``, ``GET /buckets/{}/collections``,
+and concerns GET requests (``GET /buckets``, ``GET /buckets/{}/groups``, ``GET /buckets/{}/collections``,
 ``GET /buckets/{}/collections/{}/records``).
 
 .. code-block:: ini
@@ -529,6 +529,12 @@ and concerns read-only requests (``GET /buckets``, ``GET /buckets/{}/groups``, `
     # cliquet.collection_cache_expires_seconds = 3600
     cliquet.record_cache_expires_seconds = 3600
 
+It can also be specified per bucket or collections for records:
+
+.. code-block:: ini
+
+    cliquet.blog_record_cache_expires_seconds = 30
+    cliquet.blog_articles_record_cache_expires_seconds = 3600
 
 If set to ``0`` then the resource becomes uncacheable (``no-cache``).
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -514,7 +514,7 @@ Client caching
 ==============
 
 In addition to :ref:`per-collection caching <collection-caching>`, it is possible
-to add cache control headers for every :app:`Kinto` object.
+to add cache control headers for every *Kinto* object.
 The client (or cache server or proxy) will use them to cache the collection
 records for a certain amount of time, in seconds.
 
@@ -531,30 +531,10 @@ and concerns read-only requests (``GET /buckets``, ``GET /buckets/{}/collections
 
 If set to ``0`` then the resource becomes uncacheable (``no-cache``).
 
+.. note::
 
-Nginx
-:::::
-
-If *Nginx* is used as a reverse proxy, it can also `act as a cache server <https://serversforhackers.com/nginx-caching>`_
-using those :app:`Kinto` response headers.
-
-A sample *Nginx* configuration could look like so:
-
-::
-
-    proxy_cache_path /tmp/nginx levels=1:2 keys_zone=my_zone:100m inactive=200m;
-    proxy_cache_key "$scheme$request_method$host$request_uri$";
-
-    server {
-        ...
-
-        location / {
-            proxy_cache my_zone;
-
-            include proxy_params;
-            proxy_pass http://127.0.0.1:8888;
-        }
-    }
+    In production, :ref:`Nginx can act as a cache-server <production-cache-server>`
+    using those client cache control headers.
 
 
 Project information

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -518,13 +518,14 @@ to add cache control headers for every *Kinto* object.
 The client (or cache server or proxy) will use them to cache the collection
 records for a certain amount of time, in seconds.
 
-The setting can be set for any kind of object (``bucket``, ``collection``, ``record``),
-and concerns read-only requests (``GET /buckets``, ``GET /buckets/{}/collections``,
+The setting can be set for any kind of object (``bucket``, ``group``, ``collection``, ``record``),
+and concerns read-only requests (``GET /buckets``, ``GET /buckets/{}/groups``, ``GET /buckets/{}/collections``,
 ``GET /buckets/{}/collections/{}/records``).
 
 .. code-block:: ini
 
     # cliquet.bucket_cache_expires_seconds = 3600
+    # cliquet.group_cache_expires_seconds = 3600
     # cliquet.collection_cache_expires_seconds = 3600
     cliquet.record_cache_expires_seconds = 3600
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -507,6 +507,56 @@ dangerous to leave on by default, and must therefore be enabled explicitly.
 Then, issue a `POST` request to the `/__flush__` endpoint to flush all
 the data.
 
+
+.. _configuration-client-caching:
+
+Client caching
+==============
+
+In addition to :ref:`per-collection caching <collection-caching>`, it is possible
+to add cache control headers for every :app:`Kinto` object.
+The client (or cache server or proxy) will use them to cache the collection
+records for a certain amount of time, in seconds.
+
+The setting can be set for any kind of object (``bucket``, ``collection``, ``record``),
+and concerns read-only requests (``GET /buckets``, ``GET /buckets/{}/collections``,
+``GET /buckets/{}/collections/{}/records``).
+
+.. code-block:: ini
+
+    # cliquet.bucket_cache_expires_seconds = 3600
+    # cliquet.collection_cache_expires_seconds = 3600
+    cliquet.record_cache_expires_seconds = 3600
+
+
+If set to ``0`` then the resource becomes uncacheable (``no-cache``).
+
+
+Nginx
+:::::
+
+If *Nginx* is used as a reverse proxy, it can also `act as a cache server <https://serversforhackers.com/nginx-caching>`_
+using those :app:`Kinto` response headers.
+
+A sample *Nginx* configuration could look like so:
+
+::
+
+    proxy_cache_path /tmp/nginx levels=1:2 keys_zone=my_zone:100m inactive=200m;
+    proxy_cache_key "$scheme$request_method$host$request_uri$";
+
+    server {
+        ...
+
+        location / {
+            proxy_cache my_zone;
+
+            include proxy_params;
+            proxy_pass http://127.0.0.1:8888;
+        }
+    }
+
+
 Project information
 ===================
 

--- a/kinto/tests/test_views_collections_cache.py
+++ b/kinto/tests/test_views_collections_cache.py
@@ -1,0 +1,81 @@
+from .support import (BaseWebTest, unittest, MINIMALIST_RECORD)
+
+
+class ForcedCacheExpiresTest(BaseWebTest, unittest.TestCase):
+    def setUp(self):
+        super(ForcedCacheExpiresTest, self).setUp()
+        r = self.app.post_json('/buckets/default/collections/cached/records',
+                               MINIMALIST_RECORD,
+                               headers=self.headers)
+        self.record = r.json['data']
+
+    def get_app_settings(self, extra=None):
+        settings = super(ForcedCacheExpiresTest, self).get_app_settings(extra)
+        settings['cliquet.record_cache_expires_seconds'] = 3600
+        return settings
+
+    def test_expire_and_cache_control_are_set(self):
+        url = '/buckets/default/collections/cached/records'
+        r = self.app.get(url,
+                         headers=self.headers)
+        self.assertIn('Expires', r.headers)
+        self.assertIn('Cache-Control', r.headers)
+        r = self.app.get(url + '/%s' % self.record['id'],
+                         headers=self.headers)
+        self.assertIn('Expires', r.headers)
+        self.assertIn('Cache-Control', r.headers)
+
+
+class CollectionExpiresTest(BaseWebTest, unittest.TestCase):
+    def setUp(self):
+        super(CollectionExpiresTest, self).setUp()
+        self.collection_url = '/buckets/default/collections/cached'
+        self.app.put_json(self.collection_url,
+                          {'data': {'cache_expires': 3600}},
+                          headers=self.headers)
+
+        self.records_url = self.collection_url + '/records'
+
+        resp = self.app.post_json(self.records_url,
+                                  MINIMALIST_RECORD,
+                                  headers=self.headers)
+        self.record = resp.json['data']
+        self.record_url = self.records_url + '/' + self.record['id']
+
+    def test_cache_expires_must_be_an_integer(self):
+        self.app.put_json(self.collection_url,
+                          {'data': {'cache_expires': 'abc'}},
+                          headers=self.headers,
+                          status=400)
+
+    def test_expire_and_cache_control_are_set_on_records(self):
+        r = self.app.get(self.records_url,
+                         headers=self.headers)
+        self.assertIn('Expires', r.headers)
+        self.assertIn('Cache-Control', r.headers)
+
+    def test_expire_and_cache_control_are_set_on_record(self):
+        r = self.app.get(self.record_url,
+                         headers=self.headers)
+        self.assertIn('Expires', r.headers)
+        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')
+
+    def test_cache_control_is_set_no_cache_if_zero(self):
+        self.app.put_json(self.collection_url,
+                          {'data': {'cache_expires': 0}},
+                          headers=self.headers)
+        r = self.app.get(self.records_url,
+                         headers=self.headers)
+        self.assertIn('Expires', r.headers)
+        self.assertEqual(r.headers['Cache-Control'],
+                         'max-age=0, must-revalidate, no-cache, no-store')
+        self.assertEqual(r.headers['Pragma'], 'no-cache')
+
+    def test_cache_control_on_collection_overrides_setting(self):
+        app = self._get_test_app({'cliquet.record_cache_expires_seconds': 10})
+        app.put_json(self.collection_url,
+                     {'data': {'cache_expires': 3600}},
+                     headers=self.headers)
+        r = app.get(self.records_url, headers=self.headers)
+        self.assertIn('Expires', r.headers)
+        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -27,6 +27,7 @@ class JSONSchemaMapping(colander.SchemaNode):
 
 class CollectionSchema(resource.ResourceSchema):
     schema = JSONSchemaMapping(missing=colander.drop)
+    cache_expires = colander.SchemaNode(colander.Int(), missing=colander.drop)
 
     class Options:
         preserve_unknown = True

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -61,3 +61,26 @@ class Record(resource.ProtectedResource):
             raise_invalid(self.request, name=field, description=e.message)
 
         return new
+
+    def collection_get(self):
+        result = super(Record, self).collection_get()
+        self._handle_cache_expires(self.request.response)
+        return result
+
+    def get(self):
+        result = super(Record, self).get()
+        self._handle_cache_expires(self.request.response)
+        return result
+
+    def _handle_cache_expires(self, response):
+        """If the parent collection defines a ``cache_expires`` attribute,
+        then cache-control response headers are sent.
+
+        .. note::
+
+            Those headers are also sent if setting
+            ``cliquet.record_cache_expires_seconds`` is defined.
+        """
+        cache_expires = self._collection.get('cache_expires')
+        if cache_expires is not None:
+            response.cache_expires(seconds=cache_expires)

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -78,8 +78,8 @@ class Record(resource.ProtectedResource):
 
         .. note::
 
-            Those headers are also sent if setting
-            ``cliquet.record_cache_expires_seconds`` is defined.
+            Those headers are also sent if the
+            ``cliquet.record_cache_expires_seconds`` setting is defined.
         """
         cache_expires = self._collection.get('cache_expires')
         if cache_expires is not None:


### PR DESCRIPTION
**Requires cliquet dev version**

* [x] Example `ini` setting for records
* [x] Control cache expires value from collection *metadata*
* [x] Control cache expires value from bucket ~~metadata (thus all sub-collections)~~ using settings
* [x] Control cache expires value from a collection using settings
* [x] Documentation