### PR TITLE
permissions examples

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -8,5 +8,5 @@ Tutorials
 
    first-steps
    permissions
-   permissions
+   permission-setups
    app-examples

--- a/docs/tutorials/permission-setups.rst
+++ b/docs/tutorials/permission-setups.rst
@@ -1,5 +1,5 @@
-Permissions setups
-==================
+Permissions examples
+====================
 
 In order to better understand how the *Kinto* permission model works, it is
 possible to refer to this set of examples:


### PR DESCRIPTION
The new doc is really neat !

there's one thing I found misplaced: https://kinto.readthedocs.org/en/latest/tutorials/app-examples.html#permissions-setups

It seemed more logical to me to have the "permissions setups" section right after the permissions tutorial here https://kinto.readthedocs.org/en/latest/tutorials/permissions.html and renamed "permissions setups example"