### PR TITLE
fix the tox path so its in the venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tests-once: install-dev
 	$(VENV)/bin/py.test --cov-report term-missing --cov-fail-under 100 --cov kinto
 
 tests:
-	tox
+	$(VENV)/bin/tox
 
 clean:
 	find . -name '*.pyc' -delete


### PR DESCRIPTION
Unless you have tox globally installed, "make tests" fails. Since we do install tox in the venv, let's use that one.