### PR TITLE
skip missing interpreters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27,py34,pypy,flake8
+skip_missing_interpreters = True
 
 [testenv]
 commands =


### PR DESCRIPTION
We should not force contributors to have pypy installed to be able to run "make tests"