### PR TITLE
405 error on default bucket doesn't return JSON

### DIFF
--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -2,13 +2,16 @@ import mock
 from six import text_type
 from uuid import UUID
 
+from cliquet.errors import ERRORS
+from cliquet.tests.support import FormattedErrorMixin
 from cliquet.utils import hmac_digest
 
 from .support import (BaseWebTest, unittest, get_user_headers,
                       MINIMALIST_RECORD)
 
 
-class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
+class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
+                            unittest.TestCase):
 
     bucket_url = '/buckets/default'
     collection_url = '/buckets/default/collections/tasks'
@@ -151,3 +154,10 @@ class DefaultBucketViewTest(BaseWebTest, unittest.TestCase):
                                wraps=self.storage.get) as patched:
             self.app.post_json('/batch', batch, headers=self.headers)
             self.assertEqual(patched.call_count, 0)
+
+    def test_405_is_a_valid_formatted_error(self):
+        response = self.app.post(self.collection_url,
+                                 headers=self.headers, status=405)
+        self.assertFormattedError(
+            response, 405, ERRORS.METHOD_NOT_ALLOWED, "Method Not Allowed",
+            "Method not allowed on this endpoint.")

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -6,7 +6,7 @@ from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
 
 from cliquet import resource
-from cliquet.utils import hmac_digest, build_request, reapply_cors
+from cliquet.utils import hmac_digest, build_request
 from cliquet.storage import exceptions as storage_exceptions
 
 from kinto.authorization import RouteFactory

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -137,7 +137,7 @@ def default_bucket(request):
         return request.invoke_subrequest(subrequest)
 
     if getattr(request, 'prefixed_userid', None) is None:
-        raise HTTPForbidden  # Pass through the forbidden_view_config
+        raise HTTPForbidden()  # Pass through the forbidden_view_config
 
     settings = request.registry.settings
     hmac_secret = settings['userid_hmac_secret']
@@ -164,5 +164,5 @@ def default_bucket(request):
     try:
         response = request.invoke_subrequest(subrequest)
     except HTTPException as error:
-        response = reapply_cors(subrequest, error)
+        raise error
     return response


### PR DESCRIPTION
```http
POST /v1/buckets/default/collections/bookmarks HTTP/1.1
Host: kinto.dev.mozaws.net

{
    "data": {
        "title": "Website", 
        "url": "http://coworking-pb.com/"
    }
}

HTTP/1.1 405 Method Not Allowed
Allow: GET, HEAD, PUT, PATCH, DELETE, OPTIONS
Connection: keep-alive
Content-Length: 77
Content-Type: text/plain; charset=UTF-8
Date: Sun, 18 Oct 2015 08:54:33 GMT
Server: nginx/1.4.6 (Ubuntu)

405 Method Not Allowed

The method POST is not allowed for this resource. 
```