### PR TITLE
[WIP] Default bucket: redirect instead of running subrequest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,15 @@ This document describes changes between each past release.
 1.8.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Protocol**
+
+- Replaced ``userid`` field in root URL hello view by a ``user`` mapping
+  containing ``id`` and ``bucket``, her default bucket id.
+- Changed the ``/buckets/default`` behaviour. Implicit creation of collections
+  is preserved, but an explicit ``307`` redirects the client to the actual
+  underlying bucket.
+  For clients that follow redirections (like *kinto.js* or Python *requests*),
+  the new behaviour is retrocompatible.
 
 
 1.7.0 (2015-10-28)

--- a/docs/api/buckets.rst
+++ b/docs/api/buckets.rst
@@ -300,3 +300,104 @@ Retrieving all buckets
                 }
             ]
         }
+
+
+.. buckets-default-id:
+
+Personal bucket «default»
+=========================
+
+.. note::
+
+    In the examples below, the ``--follow`` command-line parameter of *HTTPie*
+    is used to follow the client redirections dictated by the server.
+
+.. http:get:: /buckets/default
+
+    :synopsis: Returns the current user personnal bucket.
+
+    **Requires authentication**
+
+    **Example Request**
+
+    .. sourcecode:: bash
+
+        $ http get http://localhost:8888/v1/buckets/default -v --follow --auth='bob:'
+
+    .. sourcecode:: http
+
+        GET /v1/buckets/b8f3fa97-3e0a-00ae-7f07-ce8ce05ce0e5 HTTP/1.1
+        Accept: */*
+        Accept-Encoding: gzip, deflate
+        Authorization: Basic Ym9iOg==
+        Connection: keep-alive
+        Host: localhost:8888
+        User-Agent: HTTPie/0.8.0
+
+    **Example Response**
+
+    .. sourcecode:: http
+        :emphasize-lines: 12
+
+        HTTP/1.1 200 OK
+        Access-Control-Expose-Headers: Content-Length, Expires, Alert, Retry-After, Last-Modified, ETag, Pragma, Cache-Control, Backoff
+        Content-Length: 187
+        Content-Type: application/json; charset=UTF-8
+        Date: Wed, 28 Oct 2015 16:29:00 GMT
+        Etag: "1446049740955"
+        Last-Modified: Wed, 28 Oct 2015 16:29:00 GMT
+        Server: waitress
+
+        {
+            "data": {
+                "id": "b8f3fa97-3e0a-00ae-7f07-ce8ce05ce0e5",
+                "last_modified": 1446049740955
+            },
+            "permissions": {
+                "write": [
+                    "basicauth:62e79bedacd2508c7da3dfb16e9724501fb4bdf9a830de7f8abcc8f7f1496c35"
+                ]
+            }
+        }
+
+
+For convenience, the default bucket id is provided in the root URL of *Kinto*:
+
+.. http:get:: /
+
+    :synopsis: Obtain current user personnal bucket in root URL.
+
+    **Requires authentication**
+
+    **Example Request**
+
+    .. sourcecode:: bash
+
+        $ http get http://localhost:8888/v1/ -v --follow --auth='bob:'
+
+    **Example Response**
+
+    .. sourcecode:: http
+        :emphasize-lines: 19
+
+        HTTP/1.1 200 OK
+        Access-Control-Expose-Headers: Retry-After, Content-Length, Alert, Backoff
+        Content-Length: 400
+        Content-Type: application/json; charset=UTF-8
+        Date: Wed, 28 Oct 2015 16:52:49 GMT
+        Server: waitress
+
+        {
+            "hello": "kinto",
+            "version": "1.7.0.dev0"
+            "url": "http://localhost:8888/v1/",
+            "documentation": "https://kinto.readthedocs.org/",
+            "settings": {
+                "batch_max_requests": 25,
+                "cliquet.batch_max_requests": 25
+            },
+            "user": {
+                "id": "basicauth:62e79bedacd2508c7da3dfb16e9724501fb4bdf9a830de7f8abcc8f7f1496c35",
+                "bucket": "b8f3fa97-3e0a-00ae-7f07-ce8ce05ce0e5",
+            }
+        }

--- a/docs/api/collections.rst
+++ b/docs/api/collections.rst
@@ -21,12 +21,13 @@ A collection is a mapping with the following attribute:
     shortcut: ie ``/buckets/default/collections/contacts`` will be
     the current user contacts.
 
-    Internally the user default bucket is assigned to an ID that can
-    later be used to share data from a user personnal bucket.
+    Internally the user default bucket is assigned to an ID, and the client
+    is redirected when accessing it.
 
-    Collections on the "default" bucket are created silently upon first
-    access and therefore don't need to be set beforehand.
+    When going through the default bucket, the collections are created silently
+    upon first access before redirecting the client.
 
+    Users can share data from their personnal bucket, by sharing :ref:`its URL using the full ID <buckets-default-id>`.
 
 
 .. _collection-put:
@@ -295,11 +296,11 @@ Just modify the ``schema`` attribute of the collection object:
           "required": ["title"]
         }
       }
-    }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" --auth admin: --verbose
+    }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" -v --follow --auth 'admin:'
 
 .. code-block:: http
 
-    PATCH /v1/buckets/default/collections/articles HTTP/1.1
+    PATCH /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/articles HTTP/1.1
     Accept: application/json
     Accept-Encoding: gzip, deflate
     Authorization: Basic YWRtaW46
@@ -380,7 +381,7 @@ Once a schema has been defined, the posted records must match it:
 
     $ echo '{"data": {
         "body": "Fails if no title"
-    }}' | http POST http://localhost:8888/v1/buckets/blog/collections/articles/records --auth "admin:"
+    }}' | http POST http://localhost:8888/v1/buckets/blog/collections/articles/records -v --follow --auth 'admin:'
 
 .. code-block:: http
 
@@ -434,11 +435,11 @@ to an empty mapping.
 
 .. code-block:: bash
 
-    echo '{"data": {"schema": {}} }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" --auth admin: --verbose
+    echo '{"data": {"schema": {}} }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" -v --follow --auth 'admin:'
 
 .. code-block:: http
 
-    PATCH /v1/buckets/default/collections/articles HTTP/1.1
+    PATCH /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/articles HTTP/1.1
     Accept: application/json
     Accept-Encoding: gzip, deflate
     Authorization: Basic YWRtaW46
@@ -495,13 +496,13 @@ For example, set it to ``3600`` (1 hour):
 
 .. code-block:: bash
 
-    echo '{"data": {"cache_expires": 3600} }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" --auth admin:
+    echo '{"data": {"cache_expires": 3600} }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" -v --follow --auth 'admin:'
 
 From now on, the cache control headers are set for the `GET` requests:
 
 .. code-block:: bash
 
-    http  "http://localhost:8888/v1/buckets/default/collections/articles/records" --auth admin:
+    http  "http://localhost:8888/v1/buckets/default/collections/articles/records" -v --follow --auth 'admin:'
 
 .. code-block:: http
     :emphasize-lines: 3,8
@@ -527,7 +528,7 @@ If set to ``0``, the collection records become explicitly uncacheable (``no-cach
 
 .. code-block:: bash
 
-    echo '{"data": {"cache_expires": 0} }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" --auth admin:
+    echo '{"data": {"cache_expires": 0} }' | http PATCH "http://localhost:8888/v1/buckets/default/collections/articles" -v --follow --auth 'admin:'
 
 .. code-block:: http
     :emphasize-lines: 3,8,10

--- a/docs/api/synchronisation.rst
+++ b/docs/api/synchronisation.rst
@@ -33,7 +33,7 @@ When fetching the collection records with ``?_since=<timestamp>``, *Kinto* retur
 every records that was created/updated/deleted **after** this timestamp.
 
 #. Cold sync → no ``?_since``.
-#. ``GET /buckets/default/collections/articles?_since=<timestamp>`` (with header ``If-Unmodified-Since = <timestamp>``)
+#. ``GET /buckets/blog/collections/articles?_since=<timestamp>`` (with header ``If-Unmodified-Since = <timestamp>``)
 #. If response is ``304 Not modified``, done → up to date, nothing to do.
 #. If response is ``200 OK`` store ``ETag`` response header value for next
    synchronisation and handle the obtained list of changes.
@@ -58,7 +58,7 @@ Since changes can occur between the first and the last page, the synchronisation
 process is a bit more complex.
 
 #. Cold sync → no ``?_since``.
-#. ``GET /buckets/default/collections/articles?_since=<timestamp>`` (with header ``If-Unmodified-Since = <timestamp>``)
+#. ``GET /buckets/blog/collections/articles?_since=<timestamp>`` (with header ``If-Unmodified-Since = <timestamp>``)
 #. If response is ``304 Not modified``, done → up to date, nothing to do.
 #. If no ``Next-Page`` response header, done → store ``ETag`` response header valuè for next
    synchronisation.

--- a/docs/tutorials/first-steps.rst
+++ b/docs/tutorials/first-steps.rst
@@ -20,7 +20,8 @@ In order to separate data between each user, we will use the default
 *personal bucket*.
 
 Unlike other buckets, the :ref:`collections <collections>` in the ``default``
-:ref:`bucket <buckets>` are created implicitly.
+:ref:`bucket <buckets>` are created implicitly and the client is redirected
+to the URL with the full bucket id.
 
 We'll start with a relatively simple data model:
 
@@ -34,9 +35,9 @@ Using the `httpie <http://httpie.org>` tool we can post a sample record in the
 
     $ echo '{"data": {"description": "Write a tutorial explaining Kinto", "status": "todo"}}' | \
         http POST https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records \
-             -v --auth 'user:password'
+             -v --follow --auth 'user:password'
 
-    POST /v1/buckets/default/collections/tasks/records HTTP/1.1
+    POST /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records HTTP/1.1
     Accept: application/json
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -88,8 +89,8 @@ Let us fetch our new collection of tasks:
 .. code-block:: http
 
     $ http GET https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records \
-           -v --auth 'user:password'
-    GET /v1/buckets/default/collections/tasks/records HTTP/1.1
+           -v --follow --auth 'user:password'
+    GET /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records HTTP/1.1
     Accept: */*
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -131,9 +132,9 @@ We can also update one of our tasks using its ``id``:
 
     $ echo '{"data": {"status": "doing"}}' | \
          http PATCH https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 \
-              -v  --auth 'user:password'
+              -v --follow --auth 'user:password'
 
-    PATCH /v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
+    PATCH /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
     Accept: application/json
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -192,9 +193,9 @@ while we fetched the collection earlier - you kept a note, didn't you?):
     $ echo '{"data": {"status": "done"}}' | \
         http PATCH https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 \
             If-Match:'"1434641515332"' \
-            -v  --auth 'user:password'
+            -v --follow --auth 'user:password'
 
-    PATCH /v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
+    PATCH /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
     Accept: application/json
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -236,9 +237,9 @@ single record and merge attributes locally:
 .. code-block:: http
 
     $ http GET https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 \
-           -v  --auth 'user:password'
+           -v --follow --auth 'user:password'
 
-    GET /v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
+    GET /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
     Accept: */*
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -285,9 +286,9 @@ record ``ETag`` value:
     $ echo '{"data": {"status": "done"}}' | \
         http PATCH https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 \
             If-Match:'"1436172229372"' \
-            -v  --auth 'user:password'
+            -v --follow --auth 'user:password'
 
-    PATCH /v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
+    PATCH /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
     Accept: application/json
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -334,9 +335,9 @@ You can also delete the record and use the same mechanism to avoid conflicts:
 
     $ http DELETE https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 \
            If-Match:'"1436172442466"' \
-           -v  --auth 'user:password'
+           -v --follow --auth 'user:password'
 
-    DELETE /v1/buckets/default/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
+    DELETE /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records/a5f490b2-218e-4d71-ac5a-f046ae285c55 HTTP/1.1
     Accept: */*
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==
@@ -374,9 +375,9 @@ Just add the ``_since`` querystring filter, using the value of any ``ETag`` (or
 .. code-block:: http
 
     $ http GET https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks/records?_since=1434642603605 \
-           -v  --auth 'user:password'
+           -v --follow --auth 'user:password'
 
-    GET /v1/buckets/default/collections/tasks/records?_since=1434642603605 HTTP/1.1
+    GET /v1/buckets/3d45de3c-d116-7060-6797-c6b525f7ee51/collections/tasks/records?_since=1434642603605 HTTP/1.1
     Accept: */*
     Accept-Encoding: gzip, deflate
     Authorization: Basic dXNlcjpwYXNzd29yZA==

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -2,6 +2,8 @@ import pkg_resources
 import logging
 
 import cliquet
+import uuid
+import six
 from pyramid.config import Configurator
 from pyramid.settings import asbool
 from pyramid.security import Authenticated
@@ -29,6 +31,24 @@ DEFAULT_SETTINGS = {
 }
 
 
+def default_bucket_id(request):
+    if getattr(request, 'prefixed_userid', None) is None:
+        return None
+    settings = request.registry.settings
+    secret = settings['userid_hmac_secret']
+    # Build the user unguessable bucket_id UUID from its user_id
+    digest = cliquet.utils.hmac_digest(secret, request.prefixed_userid)
+    return six.text_type(uuid.UUID(digest[:32]))
+
+
+def get_user_info(request):
+    user_info = {
+        'id': request.prefixed_userid,
+        'bucket': request.default_bucket_id
+    }
+    return user_info
+
+
 def main(global_config, **settings):
     config = Configurator(settings=settings, root_factory=RouteFactory)
 
@@ -43,6 +63,11 @@ def main(global_config, **settings):
     config.add_route('default_bucket_collection',
                      '/buckets/default/{subpath:.*}')
     config.add_route('default_bucket', '/buckets/default')
+
+    # Provide helpers
+    config.add_request_method(default_bucket_id, reify=True)
+    # Override Cliquet default user info
+    config.add_request_method(get_user_info)
 
     # Retro-compatibility with first Kinto clients.
     config.registry.public_settings.add('cliquet.batch_max_requests')

--- a/kinto/tests/support.py
+++ b/kinto/tests/support.py
@@ -72,6 +72,20 @@ class BaseWebTest(object):
         self.app.put_json('/buckets/%s' % bucket_id, MINIMALIST_BUCKET,
                           headers=self.headers, status=201)
 
+    def create_record_in_collection(self, bucket_id, collection_id):
+        self.app.put_json('/buckets/%s' % bucket_id,
+                          MINIMALIST_BUCKET,
+                          headers=self.headers)
+        collection_url = '/buckets/%s/collections/%s' % (bucket_id,
+                                                         collection_id)
+        self.app.put_json(collection_url,
+                          MINIMALIST_COLLECTION,
+                          headers=self.headers)
+        r = self.app.post_json(collection_url + '/records',
+                               MINIMALIST_RECORD,
+                               headers=self.headers)
+        return r.json['data']
+
 
 def get_user_headers(user):
     credentials = "%s:secret" % user

--- a/kinto/tests/test_default_bucket.py
+++ b/kinto/tests/test_default_bucket.py
@@ -107,6 +107,12 @@ class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
                             headers=headers, status=304)
         self.assertIn('Access-Control-Allow-Origin', resp.headers)
 
+    def test_cors_headers_are_provided_on_redirection(self):
+        headers = self.headers.copy()
+        headers['Origin'] = 'http://localhost:8000'
+        resp = self.app.get(self.bucket_url, headers=headers, status=307)
+        self.assertIn('Access-Control-Allow-Origin', resp.headers)
+
     def test_bucket_id_starting_with_default_can_still_be_created(self):
         # We need to create the bucket first since it is not the default bucket
         classic_bucket = self.bucket_url.replace('default', 'default-1234')
@@ -135,7 +141,7 @@ class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
         with mock.patch.object(self.storage, 'create',
                                wraps=self.storage.create) as patched:
             self.app.post_json('/batch', batch, headers=self.headers)
-            self.assertEqual(patched.call_count, 2)
+            self.assertEqual(patched.call_count, nb_create + 2)
 
     def test_parent_collection_is_taken_from_the_one_created_in_batch(self):
         batch = {'requests': []}

--- a/kinto/tests/test_views_collections_schema.py
+++ b/kinto/tests/test_views_collections_schema.py
@@ -1,8 +1,9 @@
-from .support import BaseWebTest, unittest
+from .support import (BaseWebTest, unittest, MINIMALIST_BUCKET,
+                      MINIMALIST_COLLECTION)
 
 
-COLLECTION_URL = '/buckets/default/collections/articles'
-RECORDS_URL = '/buckets/default/collections/articles/records'
+COLLECTION_URL = '/buckets/blog/collections/articles'
+RECORDS_URL = '/buckets/blog/collections/articles/records'
 
 
 SCHEMA = {
@@ -19,6 +20,11 @@ VALID_RECORD = {'title': 'About us', 'body': '<h1>About</h1>'}
 
 
 class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
+    def setUp(self):
+        super(DeactivatedSchemaTest, self).setUp()
+        self.app.put_json('/buckets/blog', MINIMALIST_BUCKET,
+                          headers=self.headers)
+
     def test_schema_should_be_json_schema(self):
         newschema = SCHEMA.copy()
         newschema['type'] = 'Washmachine'
@@ -47,6 +53,14 @@ class BaseWebTestWithSchema(BaseWebTest):
             additional_settings)
         settings['experimental_collection_schema_validation'] = 'True'
         return settings
+
+    def setUp(self):
+        super(BaseWebTestWithSchema, self).setUp()
+        self.app.put_json('/buckets/blog', MINIMALIST_BUCKET,
+                          headers=self.headers)
+        self.app.put_json(COLLECTION_URL,
+                          MINIMALIST_COLLECTION,
+                          headers=self.headers)
 
 
 class MissingSchemaTest(BaseWebTestWithSchema, unittest.TestCase):

--- a/kinto/tests/test_views_hello.py
+++ b/kinto/tests/test_views_hello.py
@@ -12,3 +12,18 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(response.json['hello'], 'kinto')
         self.assertEqual(response.json['documentation'],
                          'https://kinto.readthedocs.org/')
+
+    def test_hides_user_info_if_anonymous(self):
+        response = self.app.get('/')
+        self.assertNotIn('user', response.json)
+
+    def test_returns_user_id_if_authenticated(self):
+        response = self.app.get('/', headers=self.headers)
+        self.assertEqual(response.json['user']['id'],
+                         ('basicauth:3a0c56d278def4113f38d0cfff6db1b06b'
+                          '84fcc4384ee890cf7bbaa772317e10'))
+
+    def test_returns_bucket_id_and_url_if_authenticated(self):
+        response = self.app.get('/', headers=self.headers)
+        self.assertEqual(response.json['user']['bucket'],
+                         '23bb0efc-e80d-829e-6757-79d41e16640f')


### PR DESCRIPTION
* [x] POC
* [x] 307 Redirect (same verb) after implicit creations of objects in `default` bucket
* [x] Put bucket id+url in hello view
* [ ] ~~Implicit creation of object when `bucket_id` == `request.default_bucket_id` everywhere ?~~ No, so far. Hard to keep it consistent with authorization policies for example
* [x] Design nice layout of hello view fields (`{'user': {'id':.., 'bucket':...)`?)
* [x] Test the whole thing properly
* [x] Update docs
* [x] Add breaking change in protocol section in changelog 
* [ ] Check that kinto.js 1.0 (i.e. fetch) follows the redirections

Basically:

Default bucket can still be manipulated via the default endpoint.

```
http --follow GET http://localhost:8888/v1/buckets/default --auth natim:
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Content-Length, Expires, Alert, Retry-After, Last-Modified, ETag, Pragma, Cache-Control, Backoff
Content-Length: 187
Content-Type: application/json; charset=UTF-8
Date: Wed, 28 Oct 2015 10:47:23 GMT
Etag: "1446029243668"
Last-Modified: Wed, 28 Oct 2015 10:47:23 GMT
Server: waitress

{
    "data": {
        "id": "b4f6b878-44c5-dbdc-25e0-66e36e1673d0", 
        "last_modified": 1446029243668
    }, 
    "permissions": {
        "write": [
            "basicauth:71c5e3dd315eaf28ec38dbba4e11e67ec34892c7f67c6264506957dc92ae6481"
        ]
    }
}
```

Hello view gives bucket id and url (please `#help` for naming and json layout)

```
http GET http://localhost:8888/v1/  --auth natim:
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Retry-After, Content-Length, Alert, Backoff
Content-Length: 400
Content-Type: application/json; charset=UTF-8
Date: Wed, 28 Oct 2015 10:55:23 GMT
Server: waitress

{
    "bucket": {
        "id": "b4f6b878-44c5-dbdc-25e0-66e36e1673d0", 
        "url": "/v1/buckets/b4f6b878-44c5-dbdc-25e0-66e36e1673d0"
    }, 
    "documentation": "https://kinto.readthedocs.org/", 
    "hello": "kinto", 
    "settings": {
        "batch_max_requests": 25, 
        "cliquet.batch_max_requests": 25
    }, 
    "url": "http://localhost:8888/v1/", 
    "userid": "basicauth:71c5e3dd315eaf28ec38dbba4e11e67ec34892c7f67c6264506957dc92ae6481", 
    "version": "1.7.0.dev0"
}

```
