### PR TITLE
Fix documentation warning and glitches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,6 @@ loadtest-check-simulation: install-postgres
 	  EXIT_CODE=$$?; kill $$PID; exit $$EXIT_CODE
 
 docs: install-dev
-	$(VENV)/bin/sphinx-build -a -b html -d $(SPHINX_BUILDDIR)/doctrees docs $(SPHINX_BUILDDIR)/html
+	$(VENV)/bin/sphinx-build -a -n -b html -d $(SPHINX_BUILDDIR)/doctrees docs $(SPHINX_BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(SPHINX_BUILDDIR)/html/index.html"

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,6 @@ loadtest-check-simulation: install-postgres
 	  EXIT_CODE=$$?; kill $$PID; exit $$EXIT_CODE
 
 docs: install-dev
-	$(VENV)/bin/sphinx-build -b html -d $(SPHINX_BUILDDIR)/doctrees docs $(SPHINX_BUILDDIR)/html
+	$(VENV)/bin/sphinx-build -a -b html -d $(SPHINX_BUILDDIR)/doctrees docs $(SPHINX_BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(SPHINX_BUILDDIR)/html/index.html"

--- a/docs/api/buckets.rst
+++ b/docs/api/buckets.rst
@@ -302,7 +302,7 @@ Retrieving all buckets
         }
 
 
-.. buckets-default-id:
+.. _buckets-default-id:
 
 Personal bucket «default»
 =========================

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,4 +1,4 @@
-.. _api-endpoints:
+.. _kinto-api-endpoints:
 
 API
 ###

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -79,6 +79,7 @@ Full detailed API documentation:
 .. toctree::
    :maxdepth: 2
 
+   cliquet/utilities
    cliquet/versioning
    cliquet/authentication
    cliquet/resource

--- a/docs/api/permissions.rst
+++ b/docs/api/permissions.rst
@@ -85,7 +85,7 @@ grant the `write` permission to their creator.
 Principals
 ==========
 
-During the authentication phase, a set of :term:`principal`s for the current
+During the authentication phase, a set of :term:`principals` for the current
 authenticated *user* will be bound to to the request.
 
 The main principal is considered the **user ID** and follows this formalism:

--- a/docs/api/records.rst
+++ b/docs/api/records.rst
@@ -133,7 +133,7 @@ Updating a record
 .. http:patch:: /buckets/(bucket_id)/collections/(collection_id)/records/(record_id)
 
     :synopsis: Update a record in the collection. Specify only the fields to be
-    modified (all the rest will remain intact).
+               modified (all the rest will remain intact).
 
     **Requires authentication**
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,3 +1,5 @@
+.. _kinto-concepts:
+
 Concepts
 ########
 
@@ -103,6 +105,7 @@ Regarding permissions, the following vocabulary is used in the documentation:
 .. glossary::
 
     Principal
+    Principals
         An entity that can be authenticated. Principals can be individual people,
         applications, services, or any group of such things
         (e.g. ``username``, ``group:authors``).
@@ -125,6 +128,14 @@ Regarding permissions, the following vocabulary is used in the documentation:
     ACL
     Access Control List
         A list of ACEs.
+
+    Firefox Accounts
+        Account account system run by Mozilla (https://accounts.firefox.com).
+
+    User id
+    User identifier
+    User identifiers
+        A string that identifies a user.
 
 .. note::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Copy the docs from Cliquet inside these ones.
 destination = os.path.join(__HERE__, 'api', 'cliquet')
 cliquet_docs.copy_docs('api', destination)
+os.remove(os.path.join(destination, 'index.rst'))
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -230,7 +230,7 @@ run the Kinto application:
 Using nginx
 -----------
 
-nginx can act as a *reverse proxy* in front of :rtd:`uWSGI <uwsgi-docs>`_
+nginx can act as a *reverse proxy* in front of :rtd:`uWSGI <uwsgi-docs>`
 (or any other wsgi server like `Gunicorn <http://gunicorn.org>`_ or :rtd:`Circus <circus>`).
 
 Download the ``uwsgi_params`` file:

--- a/docs/tutorials/first-steps.rst
+++ b/docs/tutorials/first-steps.rst
@@ -903,8 +903,8 @@ In this tutorial you have seen some of the concepts exposed by *Kinto*:
 - Creating groups, collections and records
 - Modifying objects permissions, for users and groups
 
-More details about :ref:`permissions <permissions>`, :ref:`HTTP API headers and
-status codes <api-endpoints>`.
+More details about :ref:`permissions <api-permissions>`, :ref:`HTTP API headers and
+status codes <kinto-api-endpoints>`.
 
 .. note::
 

--- a/docs/tutorials/permission-setups.rst
+++ b/docs/tutorials/permission-setups.rst
@@ -16,6 +16,8 @@ possible to refer to this set of examples:
 | Microblogging | A micro blogging platform like twitter                                  |
 +---------------+-------------------------------------------------------------------------+
 
+.. _permissions-setups-blog:
+
 A Blog
 ------
 

--- a/docs/tutorials/permissions.rst
+++ b/docs/tutorials/permissions.rst
@@ -3,12 +3,12 @@
 Step by step permissions tutorial
 #################################
 
-Let's use one of the :ref:`application examples <app-examples-blog>`: using *Kinto* as
+Let's use one of the :ref:`application examples <permissions-setups-blog>`: using *Kinto* as
 a storage API for a blog application.
 
 .. note::
 
-    Some general details are provided in the :ref:`concepts` and :ref:`api/permissions`
+    Some general details are provided in the :ref:`kinto-concepts` and :ref:`api-permissions`
     sections. Make sure you are familiar with main concepts before starting this.
 
 


### PR DESCRIPTION
I would have liked to enable the `-W` option in Sphinx to turn warnings into errors. But there is one warning I can't figure out how to fix: 
`kinto/docs/api/cliquet/index.rst:: WARNING: document isn't included in any toctree`