### PR TITLE
Cache user principals per request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ This document describes changes between each past release.
 - Fix 500 error response (instead of 503) when storage backend fails during
   implicit creation of objects on ``default`` bucket (fixes #236)
 
+**Internal changes**
+
+- Optimization for obtention of user principals (#263)
+
 
 1.8.0 (2015-10-30)
 ==================

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -138,11 +138,18 @@ def build_permissions_set(object_uri, unbound_permission,
     return granters
 
 
-# XXX: May need caching
 def groupfinder(userid, request):
     authn_type = request.authn_type
     prefixed_userid = '%s:%s' % (authn_type.lower(), userid)
-    return request.registry.permission.user_principals(prefixed_userid)
+
+    cache_key = prefixed_userid + '_principals'
+
+    if cache_key not in request.bound_data:
+        backend = request.registry.permission
+        principals = backend.user_principals(prefixed_userid)
+        request.bound_data[cache_key] = principals
+
+    return request.bound_data[cache_key]
 
 
 @implementer(IAuthorizationPolicy)

--- a/kinto/tests/test_views_permissions.py
+++ b/kinto/tests/test_views_permissions.py
@@ -1,3 +1,5 @@
+import mock
+
 from .support import (BaseWebTest, unittest, get_user_headers,
                       MINIMALIST_BUCKET, MINIMALIST_COLLECTION,
                       MINIMALIST_GROUP, MINIMALIST_RECORD)
@@ -178,3 +180,25 @@ class RecordPermissionsTest(PermissionsTest):
                                    {'permissions': {'read': ['fxa:user']}},
                                    headers=self.headers)
         self.assertIn('fxa:user', resp.json['permissions']['read'])
+
+    def test_user_principals_are_cached_per_user(self):
+        patch = mock.patch.object(self.permission, 'user_principals',
+                                  wraps=self.permission.user_principals)
+        self.addCleanup(patch.stop)
+        mocked = patch.start()
+        batch = {
+            "defaults": {
+                "method": "POST",
+                "headers": self.headers,
+                "path": "/buckets/default/collections/tests/records"
+            },
+            "requests": [
+                {"body": MINIMALIST_RECORD},
+                {"body": MINIMALIST_RECORD},
+                {"body": MINIMALIST_RECORD},
+                {"body": MINIMALIST_RECORD,
+                 "headers": {"Authorization": "Basic Ym9iOg=="}},
+            ]
+        }
+        self.app.post_json('/batch', batch)
+        self.assertEqual(mocked.call_count, 2)  # Instead of 20!


### PR DESCRIPTION
When working on transactions, I realized that the permissions database was queried many (many) times per request on the default bucket.

Here is a quick fix :)

@Natim r?