### PR TITLE
Fix Docker with PostgreSQL and Docker Compose

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,10 +19,12 @@ This document describes changes between each past release.
 
 - Fix 500 error response (instead of 503) when storage backend fails during
   implicit creation of objects on ``default`` bucket (fixes #236)
+- Fixed ``Dockerfile`` for PostgreSQL backends
 
 **Internal changes**
 
 - Optimization for obtention of user principals (#263)
+- Do not build the Docker container when using Docker Compose
 
 
 1.8.0 (2015-10-30)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:2.7
 WORKDIR /code
 ADD . /code
-RUN pip install -e .[postgresql,monitoring]
-CMD pserve config/kinto.ini --reload
+RUN pip install cliquet[postgresql,monitoring]
+RUN pip install -e .
+CMD kinto --ini config/kinto.ini start

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ build-requirements:
 	$(TEMPDIR)/bin/pip freeze > requirements.txt
 
 serve: install-dev migrate
-	$(VENV)/bin/pserve $(SERVER_CONFIG) --reload
+	$(VENV)/bin/kinto --ini $(SERVER_CONFIG) start
 
 migrate: install
-	$(VENV)/bin/cliquet --ini $(SERVER_CONFIG) migrate
+	$(VENV)/bin/kinto --ini $(SERVER_CONFIG) migrate
 
 tests-once: install-dev
 	$(VENV)/bin/py.test --cov-report term-missing --cov-fail-under 100 --cov kinto
@@ -64,7 +64,7 @@ maintainer-clean: distclean
 
 loadtest-check-tutorial: install-postgres
 	$(VENV)/bin/cliquet --ini loadtests/server.ini migrate > kinto.log &&\
-	$(VENV)/bin/pserve loadtests/server.ini > kinto.log & PID=$$! && \
+	$(VENV)/bin/kinto --ini loadtests/server.ini start > kinto.log & PID=$$! && \
 	  rm kinto.log || cat kinto.log; \
 	  sleep 1 && cd loadtests && \
 	  make tutorial SERVER_URL=http://127.0.0.1:8888; \
@@ -72,7 +72,7 @@ loadtest-check-tutorial: install-postgres
 
 loadtest-check-simulation: install-postgres
 	$(VENV)/bin/cliquet --ini loadtests/server.ini migrate > kinto.log &&\
-	$(VENV)/bin/pserve loadtests/server.ini > kinto.log & PID=$$! && \
+	$(VENV)/bin/kinto --ini loadtests/server.ini start > kinto.log & PID=$$! && \
 	  rm kinto.log || cat kinto.log; \
 	  sleep 1 && cd loadtests && \
 	  make simulation SERVER_URL=http://127.0.0.1:8888; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ db:
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
 web:
-  build: .
+  image: kinto/kinto-server
   links:
    - db
   ports:

--- a/docs/configuration/installation.rst
+++ b/docs/configuration/installation.rst
@@ -120,14 +120,6 @@ In the future, run the tagged version of the container ::
     sudo docker stop $kintodb
 
 
-In order to build the Kinto container locally and run it against a PostgreSQL
-container, Kinto supports `Docker Compose <http://docs.docker.com/compose/>`_:
-
-::
-
-    docker-compose up
-
-
 OS X
 ----
 

--- a/docs/tutorials/run-kinto.rst
+++ b/docs/tutorials/run-kinto.rst
@@ -28,13 +28,34 @@ The server should now be running on http://localhost:8888
 It is possible to specify every Kinto setting through environment variables.
 For example, using an environment file:
 
-::
+.. code-block:: shell
 
     # kinto.env
     KINTO_USERID_HMAC_SECRET = tr0ub4d@ur
     KINTO_BATCH_MAX_REQUESTS = 200
+    # KINTO_STORAGE_BACKEND = cliquet.storage.postgresql
+    # KINTO_STORAGE_URL = postgres://user:pass@localhost/kintodb
 
-And running the container with ``docker run --env-file ./kinto.env ...``
+And running the container with:
+
+::
+
+    docker run --env-file ./kinto.env -p 8888:8888 kinto/kinto-server
+
+The server should now be running on http://localhost:8888
+
+
+Using Docker Compose
+--------------------
+
+A sample configuration for `Docker Compose <http://docs.docker.com/compose/>`_
+is provided in the Kinto repository. It pulls the *Kinto* container and run it
+with a *PostgreSQL* container.
+
+::
+
+    wget https://raw.githubusercontent.com/Kinto/kinto/master/docker-compose.yml
+    sudo docker-compose up
 
 
 Using Python package
@@ -74,9 +95,10 @@ Then install the package using the default configuration:
 
     pip install kinto
     wget https://raw.githubusercontent.com/Kinto/kinto/master/config/kinto.ini
-    pserve kinto.ini
+    kinto --ini kinto.ini start
 
 The server should now be running on http://localhost:8888
+
 
 .. _run-kinto-from-source:
 


### PR DESCRIPTION
Using docker compose is now a lot lighter, it does not build the container locally, it just pulls it from Docker hub