### PR TITLE
Require config/kinto.ini on make serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ build-requirements:
 $(SERVER_CONFIG):
 	$(VENV)/bin/kinto --ini $(SERVER_CONFIG) init
 
-serve: install-dev migrate
+serve: install-dev $(SERVER_CONFIG) migrate
 	$(VENV)/bin/kinto --ini $(SERVER_CONFIG) start
 
-migrate: install
+migrate: install $(SERVER_CONFIG)
 	$(VENV)/bin/kinto --ini $(SERVER_CONFIG) migrate
 
 tests-once: install-dev


### PR DESCRIPTION
Otherwise `make serve` fails:

```

$ make serve
/home/mathieu/Code/Mozilla/kinto/.venv/bin/kinto --ini config/kinto.ini migrate
Traceback (most recent call last):
  File "/home/mathieu/Code/Mozilla/kinto/.venv/bin/kinto", line 9, in <module>
    load_entry_point('kinto==1.10.0.dev0', 'console_scripts', 'kinto')()
  File "/home/mathieu/Code/Mozilla/kinto/kinto/__main__.py", line 50, in main
    env = bootstrap(config_file)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/local/lib/python2.7/site-packages/pyramid/paster.py", line 131, in bootstrap
    app = get_app(config_uri, options=options)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/local/lib/python2.7/site-packages/pyramid/paster.py", line 31, in get_app
    global_conf=options)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/lib/python2.7/site-packages/PasteDeploy-1.5.2-py2.7.egg/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/lib/python2.7/site-packages/PasteDeploy-1.5.2-py2.7.egg/paste/deploy/loadwsgi.py", line 271, in loadobj
    global_conf=global_conf)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/lib/python2.7/site-packages/PasteDeploy-1.5.2-py2.7.egg/paste/deploy/loadwsgi.py", line 296, in loadcontext
    global_conf=global_conf)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/lib/python2.7/site-packages/PasteDeploy-1.5.2-py2.7.egg/paste/deploy/loadwsgi.py", line 317, in _loadconfig
    loader = ConfigLoader(path)
  File "/home/mathieu/Code/Mozilla/kinto/.venv/lib/python2.7/site-packages/PasteDeploy-1.5.2-py2.7.egg/paste/deploy/loadwsgi.py", line 393, in __init__
    with open(filename) as f:
IOError: [Errno 2] No such file or directory: '/home/mathieu/Code/Mozilla/kinto/config/kinto.ini'
Makefile:50: recipe for target 'migrate' failed
make: *** [migrate] Error 1

```