### PR TITLE
bug fix for: kinto init fails when the config folder already exists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst LICENSE Makefile tox.ini .coveragerc
 include kinto/config/kinto.tpl
+

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -9,10 +9,7 @@ def render_template(template, destination, **kwargs):
     template = os.path.join(HERE, template)
 
     folder = os.path.dirname(destination)
-    if os.path.exists(folder):
-            print("%s already exists. kinto.ini will be created" % folder)
-         
-    else:
+    if os.path.exists(folder) == False:
             os.makedirs(folder)
 
     with codecs.open(template, 'r', encoding='utf-8') as f:

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -9,8 +9,8 @@ def render_template(template, destination, **kwargs):
     template = os.path.join(HERE, template)
 
     folder = os.path.dirname(destination)
-    if os.path.exists(folder) == False:
-            os.makedirs(folder)
+    if not os.path.exists(folder):
+        os.makedirs(folder)
 
     with codecs.open(template, 'r', encoding='utf-8') as f:
         raw_template = f.read()

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -9,7 +9,11 @@ def render_template(template, destination, **kwargs):
     template = os.path.join(HERE, template)
 
     folder = os.path.dirname(destination)
-    os.makedirs(folder)
+    if os.path.exists(folder):
+            print("%s already exists. kinto.ini will be created" % folder)
+         
+    else:
+            os.makedirs(folder)
 
     with codecs.open(template, 'r', encoding='utf-8') as f:
         raw_template = f.read()

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -4,7 +4,6 @@ import codecs
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-
 def render_template(template, destination, **kwargs):
     template = os.path.join(HERE, template)
 

--- a/kinto/tests/test_config.py
+++ b/kinto/tests/test_config.py
@@ -1,0 +1,24 @@
+from ..config import render_template as origin
+from .support import unittest
+
+class ConfigTest(unittest.TestCase):
+
+#to check if values dict is not empty
+    def test_values_is_not_empty():
+        assertNotEqual(origin.values, {})
+        
+        
+#To check if template location is correct
+    def test_template_location_is_not_null():
+        assertNotEqual(origin.template, '')
+
+
+#To check if destination location is correct
+    def test_destination_location_is_not_null():
+        assertNotEqual(origin.destination, '')
+
+
+
+#To check if file is created at correct location
+    def test_file_is_craeted():
+        assertNotEqual(origin.output, NULL)


### PR DESCRIPTION
@almet  @leplatrem  @Natim  this solved it for me. For issue: https://github.com/Kinto/kinto/issues/337