### PR TITLE
Lighter Docker container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 # Mozilla Kinto server
 FROM python:3.5
-WORKDIR /code
-ADD . /code
+ADD kinto /code/kinto
+ADD README.rst /code/
+ADD CHANGELOG.rst /code/
+ADD CONTRIBUTORS.rst /code/
+ADD setup.py /code/
+ADD MANIFEST.in /code/
 RUN pip install cliquet[postgresql,monitoring]
-RUN pip install -e .
-RUN kinto --ini /etc/kinto/kinto.ini --backend=memory init
-CMD kinto --ini /etc/kinto/kinto.ini migrate && kinto --ini /etc/kinto/kinto.ini start
+RUN pip install -e /code
+ENV KINTO_INI /etc/kinto/kinto.ini
+RUN kinto --ini $KINTO_INI --backend=memory init
+CMD kinto --ini $KINTO_INI migrate && kinto --ini $KINTO_INI start


### PR DESCRIPTION
seems more or less ok, but fails to run :)

```
Installing collected packages: waitress, jsonschema, kinto
  Running setup.py install for waitress
  Running setup.py develop for kinto
Successfully installed jsonschema-2.5.1 kinto waitress-0.8.10
 ---> 6654db014ac8
Removing intermediate container 41053e79e4be
Step 7 : RUN kinto --ini /etc/kinto/kinto.ini --backend=memory init
 ---> Running in 6848afbbc35f
Traceback (most recent call last):
  File "/usr/local/bin/kinto", line 9, in <module>
    load_entry_point('kinto==1.11.0.dev0', 'console_scripts', 'kinto')()
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 558, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2682, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2355, in load
    return self.resolve()
  File "/usr/local/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2361, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ImportError: No module named 'kinto'
The command '/bin/sh -c kinto --ini /etc/kinto/kinto.ini --backend=memory init' returned a non-zero code: 1
```