### PR TITLE
Fix link to Heroku deploy (fixes #412)

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -247,7 +247,7 @@ and we're a small team.
 
 Currently we make sure it's :ref:`easy to run with Docker or Python pip <get-started>`.
 
-We also have a `single-click deployment on Heroku <get-started>`.
+We also have a `single-click deployment on Heroku <get-started.html#deploy-an-instance-on-heroku>`.
 
 .. important::
 


### PR DESCRIPTION
In terms of rst format, I left it as a normal relative hyperlink here, not sure if it's better to use `:ref:` like in the link a few lines up, and what the target should be then?