### PR TITLE
Mention Scalingo one-click option

### DIFF
--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -34,6 +34,18 @@ You want to get started with a working online Kinto server right now?
 
 You have got a free plan for up to 10000 rows.
 
+.. _deploy-an-instance-on-heroku:
+
+Deploy an instance on Scalingo
+==============================
+
+You want to get started with a working online Kinto server right now?
+
+.. image:: https://cdn.scalingo.com/deploy/button.svg
+   :target: https://my.scalingo.com/deploy?source=https://github.com/Scalingo/kinto-scalingo>
+   :alt: Deploy on Scalingo
+
+You have got a free plan for a 512MB (512MB RAM, 512MB on disk) PostgreSQL database.
 
 .. _run-kinto-docker:
 

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -42,7 +42,7 @@ Deploy an instance on Scalingo
 You want to get started with a working online Kinto server right now?
 
 .. image:: https://cdn.scalingo.com/deploy/button.svg
-   :target: https://my.scalingo.com/deploy?source=https://github.com/Scalingo/kinto-scalingo>
+   :target: https://my.scalingo.com/deploy?source=https://github.com/Scalingo/kinto-scalingo
    :alt: Deploy on Scalingo
 
 You have got a free plan for a 512MB (512MB RAM, 512MB on disk) PostgreSQL database.

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -34,7 +34,7 @@ You want to get started with a working online Kinto server right now?
 
 You have got a free plan for up to 10000 rows.
 
-.. _deploy-an-instance-on-heroku:
+.. _deploy-an-instance-on-scalingo:
 
 Deploy an instance on Scalingo
 ==============================


### PR DESCRIPTION
Following the works to have Kinto one-click deployable on Scalingo (French PaaS, Heroku compatible) inhttps://github.com/Kinto/kinto-heroku/pull/1 and https://github.com/Scalingo/kinto-scalingo, here is the mention in the documentation.