### PR TITLE
Fix usage of prefixed_userid (cliquet master)

### DIFF
--- a/kinto/plugins/default_bucket/__init__.py
+++ b/kinto/plugins/default_bucket/__init__.py
@@ -3,7 +3,7 @@ import uuid
 import six
 from pyramid import httpexceptions
 from pyramid.settings import asbool
-from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
 from cliquet.errors import raise_invalid
 from cliquet.utils import build_request, reapply_cors, hmac_digest
@@ -90,7 +90,7 @@ def default_bucket(request):
         })
         return request.invoke_subrequest(subrequest)
 
-    if getattr(request, 'prefixed_userid', None) is None:
+    if Authenticated not in request.effective_principals:
         # Pass through the forbidden_view_config
         raise httpexceptions.HTTPForbidden()
 

--- a/kinto/plugins/default_bucket/test_plugin.py
+++ b/kinto/plugins/default_bucket/test_plugin.py
@@ -9,7 +9,6 @@ from cliquet.storage import exceptions as storage_exceptions
 from cliquet.tests.support import FormattedErrorMixin
 from cliquet.utils import hmac_digest
 
-from kinto.plugins.default_bucket import default_bucket
 from kinto.tests.support import (BaseWebTest, unittest, get_user_headers,
                                  MINIMALIST_RECORD)
 

--- a/kinto/plugins/default_bucket/test_plugin.py
+++ b/kinto/plugins/default_bucket/test_plugin.py
@@ -192,25 +192,20 @@ class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
             "Method not allowed on this endpoint.")
 
     def test_formatted_error_are_passed_through(self):
-        request = mock.MagicMock()
-        request.method = 'PUT'
-        request.url = 'http://localhost/v1/buckets/default/collections/tasks'
-        request.path = 'http://localhost/v1/buckets/default/collections/tasks'
-        request.prefixed_userid = 'fxa:abcd'
-        request.registry.settings = {
-            'readonly': False,
-            'userid_hmac_secret': 'This is no secret'
-        }
-
         response = http_error(HTTPBadRequest(),
                               errno=ERRORS.INVALID_PARAMETERS,
                               message='Yop')
 
-        with mock.patch('kinto.plugins.default_bucket.create_bucket'):
-            with mock.patch('kinto.plugins.default_bucket.create_collection'):
-                request.invoke_subrequest.side_effect = response
-                resp = default_bucket(request)
-                self.assertEqual(resp.body, response.body)
+        with mock.patch.object(self.storage, 'create') as mocked:
+            mocked.side_effect = [
+                {"id": "abc", "last_modified": 43},
+                {"id": "abc", "last_modified": 44},
+                response
+            ]
+            resp = self.app.post(self.collection_url + '/records',
+                                 headers=self.headers,
+                                 status=400)
+            self.assertEqual(resp.body, response.body)
 
 
 class ReadonlyDefaultBucket(BaseWebTest, unittest.TestCase):

--- a/kinto/tests/test_views_collections_schema.py
+++ b/kinto/tests/test_views_collections_schema.py
@@ -1,8 +1,9 @@
 from .support import BaseWebTest, unittest
 
 
-COLLECTION_URL = '/buckets/default/collections/articles'
-RECORDS_URL = '/buckets/default/collections/articles/records'
+BUCKET_URL = '/buckets/blog'
+COLLECTION_URL = '/buckets/blog/collections/articles'
+RECORDS_URL = '/buckets/blog/collections/articles/records'
 
 
 SCHEMA = {
@@ -22,6 +23,8 @@ class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
     def test_schema_should_be_json_schema(self):
         newschema = SCHEMA.copy()
         newschema['type'] = 'Washmachine'
+        self.app.put_json(BUCKET_URL, headers=self.headers)
+        self.app.put(COLLECTION_URL, headers=self.headers)
         resp = self.app.put_json(COLLECTION_URL,
                                  {'data': {'schema': newschema}},
                                  headers=self.headers,
@@ -30,6 +33,8 @@ class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
         self.assertIn(error_msg, resp.json['message'])
 
     def test_records_are_not_invalid_if_do_not_match_schema(self):
+        self.app.put_json(BUCKET_URL, headers=self.headers)
+        self.app.put(COLLECTION_URL, headers=self.headers)
         resp = self.app.put_json(COLLECTION_URL,
                                  {'data': {'schema': SCHEMA}},
                                  headers=self.headers)
@@ -47,6 +52,11 @@ class BaseWebTestWithSchema(BaseWebTest):
             additional_settings)
         settings['experimental_collection_schema_validation'] = 'True'
         return settings
+
+    def setUp(self):
+        super(BaseWebTestWithSchema, self).setUp()
+        self.app.put_json(BUCKET_URL, headers=self.headers)
+        self.app.put_json(COLLECTION_URL, headers=self.headers)
 
 
 class MissingSchemaTest(BaseWebTestWithSchema, unittest.TestCase):

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -2,6 +2,7 @@ import jsonschema
 from cliquet import resource, schema
 from cliquet.errors import raise_invalid
 from jsonschema import exceptions as jsonschema_exceptions
+from pyramid.security import Authenticated
 from pyramid.settings import asbool
 
 from kinto.views import object_exists_or_404
@@ -90,7 +91,7 @@ class Record(resource.ProtectedResource):
             Those headers are also sent if the
             ``kinto.record_cache_expires_seconds`` setting is defined.
         """
-        is_anonymous = self.request.prefixed_userid is None
+        is_anonymous = Authenticated not in self.request.effective_principals
         if not is_anonymous:
             return
 


### PR DESCRIPTION
* [x] Remove default bucket from schema tests (to isolate tests by feature) 
* [x] Rely on `effective_principals` which calls `authenticated_userid()`

@Natim r?