### PR TITLE
python as a plugin required to run kinto in config/kinto.ini file

### DIFF
--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -333,6 +333,7 @@ Here's an example:
     single-interpreter = true
     buffer-size = 65535
     post-buffering = 65535
+    plugins = python
 
 To use a different ini file, the ``KINTO_INI`` environment variable
 should be present with a path to it.


### PR DESCRIPTION
Python as a plugin required to solve the following warning and issue:
```
*** Operational MODE: preforking ***
!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!
no request plugin is loaded, you will not be able to manage requests.
you may need to install the package for your language of choice, or simply load it with --plugin.
!!!!!!!!!!! END OF WARNING !!!!!!!!!!
spawned uWSGI master process (pid: 29841)
spawned uWSGI worker 1 (pid: 29842, cores: 1)
spawned uWSGI worker 2 (pid: 29843, cores: 1)
spawned uWSGI worker 3 (pid: 29844, cores: 1)
*** no app loaded. going in full dynamic mode ***
*** no app loaded. going in full dynamic mode ***
*** no app loaded. going in full dynamic mode ***
```