### PR TITLE
Kinto creates blank record on Content-Type:text/plain

### DIFF
--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -50,6 +50,14 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
+    def test_buckets_should_reject_unaccepted_request_content_type(self):
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'text/plain'
+        self.app.put('/buckets/beers',
+                     MINIMALIST_BUCKET,
+                     headers=headers,
+                     status=415)
+
     def test_create_permissions_can_be_added_on_buckets(self):
         bucket = MINIMALIST_BUCKET.copy()
         bucket['permissions'] = {'collection:create': ['fxa:user'],

--- a/kinto/tests/test_views_collections.py
+++ b/kinto/tests/test_views_collections.py
@@ -31,6 +31,14 @@ class CollectionViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
+    def test_collections_should_reject_unaccepted_request_content_type(self):
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'text/plain'
+        self.app.put('/buckets/beers/collections/barley',
+                     MINIMALIST_COLLECTION,
+                     headers=headers,
+                     status=415)
+
     def test_unknown_bucket_raises_403(self):
         other_bucket = self.collections_url.replace('beers', 'sodas')
         self.app.get(other_bucket, headers=self.headers, status=403)

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -39,6 +39,14 @@ class GroupViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
+    def test_groups_should_reject_unaccepted_request_content_type(self):
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'text/plain'
+        self.app.put('/buckets/beers/groups/moderator',
+                     MINIMALIST_GROUP,
+                     headers=headers,
+                     status=415)
+
     def test_unknown_bucket_raises_403(self):
         other_bucket = self.collection_url.replace('beers', 'sodas')
         self.app.get(other_bucket, headers=self.headers, status=403)

--- a/kinto/tests/test_views_records.py
+++ b/kinto/tests/test_views_records.py
@@ -212,3 +212,18 @@ class RecordsViewTest(BaseWebTest, unittest.TestCase):
                      headers=headers,
                      status=415)
 
+    def test_records_should_reject_unaccepted_client_accept(self):
+        headers = self.headers.copy()
+        headers['Accept'] = 'text/plain'
+        self.app.get(self.record_url,
+                     MINIMALIST_RECORD,
+                     headers=headers,
+                     status=406)
+
+    def test_records_should_accept_client_accept(self):
+        headers = self.headers.copy()
+        headers['Accept'] = '*/*'
+        self.app.get(self.record_url,
+                     MINIMALIST_RECORD,
+                     headers=headers,
+                     status=200)

--- a/kinto/tests/test_views_records.py
+++ b/kinto/tests/test_views_records.py
@@ -203,3 +203,12 @@ class RecordsViewTest(BaseWebTest, unittest.TestCase):
         self.app.get(self.record_url,
                      headers=self.aaron_headers,
                      status=200)
+
+    def test_records_should_reject_unaccepted_request_content_type(self):
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'text/plain'
+        self.app.put(self.record_url,
+                     MINIMALIST_RECORD,
+                     headers=headers,
+                     status=415)
+


### PR DESCRIPTION
As Kinto is JSON Datastore and whenever we POST text/plain instead of JSON it creates a blank record in DB instead of rejecting text/plain requests. 

Request: 
```
echo '{"data": {"description": "xyz"}}' | http POST http://localhost:8080/v1/buckets/default/collections/test-collection/records Content-Type:text/plain  -v --auth 'token:my-secret'
```

```
POST /v1/buckets/default/collections/test-collection/records HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Authorization: Basic dG9rZW46bXktc2VjcmV0
Connection: keep-alive
Content-Length: 33
Content-Type: text/plain
Host: localhost:8080
User-Agent: HTTPie/0.9.2

{"data": {"description": "xyz"}}

``` 

Response :

```
HTTP/1.1 201 Created
Access-Control-Expose-Headers: Retry-After, Content-Length, Alert, Backoff
Connection: keep-alive
Content-Length: 187
Content-Type: application/json; charset=UTF-8
Date: Thu, 25 Feb 2016 10:46:57 GMT
Server: nginx/1.8.0

{
    "data": {
        "id": "1227cf0c-66a5-4620-a178-255e7f479f28",
        "last_modified": 1456417017195
    },
    "permissions": {
        "write": [
            "basicauth:157beded4ea96ad4a21ed7fd91fff2a92a5daf47f054877d2e9768259e61600c"
        ]
    }
}
```