### PR TITLE
Possibility to exclude default bucket plugin (fixes #466)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ This document describes changes between each past release.
 - Allow buckets to store arbitrary properties. (#462)
 - Speed-up startup (ref #490)
 
+**Breaking changes**
+- kinto.plugins.default_bucket plugin is no longer assumed. We invite users to check that the kinto.plugins.default_bucket is present in the includes setting if they expect it. (ref #495)
+
 
 1.11.2 (2016-02-03)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ This document describes changes between each past release.
 - Speed-up startup (ref #490)
 
 **Breaking changes**
-- kinto.plugins.default_bucket plugin is no longer assumed. We invite users to check that the kinto.plugins.default_bucket is present in the includes setting if they expect it. (ref #495)
+- ``kinto.plugins.default_bucket`` plugin is no longer assumed. We invite users to check that the ``kinto.plugins.default_bucket`` is present in the ``includes`` setting if they expect it. (ref #495)
 
 
 1.11.2 (2016-02-03)

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -438,12 +438,6 @@ to create your own plugin.
 
 .. _configuring-notifications:
 
-It is also possible to exclude the default bucket plugin:
-
-.. code-block:: ini
-
-    kinto.excludes = kinto.plugins.default_bucket
-
 Notifications
 =============
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -438,6 +438,12 @@ to create your own plugin.
 
 .. _configuring-notifications:
 
+It is also possible to exclude the default bucket plugin:
+
+.. code-block:: ini
+
+    kinto.excludes = kinto.plugins.default_bucket
+
 Notifications
 =============
 

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -46,10 +46,13 @@ def main(global_config, config=None, **settings):
     settings = config.get_settings()
 
     # In Kinto API 1.x, a default bucket is available.
-    # Force its inclusion if not specified in settings.
-    if 'kinto.plugins.default_bucket' not in settings['includes'] \
-	 and 'kinto.plugins.default_bucket' not in settings['excludes']:
-        config.include('kinto.plugins.default_bucket')
+    default_bucket_plugin='kinto.plugins.default_bucket'
+    if 'excludes' in settings and default_bucket_plugin in settings['excludes']:
+        # do not include the default bucket plugin
+        pass
+    # Force its inclusion if not specified in settings and not explictly excluded
+    elif default_bucket_plugin not in settings['includes']:
+        config.include(default_bucket_plugin)
 
     # Retro-compatibility with first Kinto clients.
     config.registry.public_settings.add('cliquet.batch_max_requests')

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -47,7 +47,8 @@ def main(global_config, config=None, **settings):
 
     # In Kinto API 1.x, a default bucket is available.
     # Force its inclusion if not specified in settings.
-    if 'kinto.plugins.default_bucket' not in settings['includes']:
+    if 'kinto.plugins.default_bucket' not in settings['includes'] \
+	 and 'kinto.plugins.default_bucket' not in settings['excludes']:
         config.include('kinto.plugins.default_bucket')
 
     # Retro-compatibility with first Kinto clients.

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -45,15 +45,6 @@ def main(global_config, config=None, **settings):
 
     settings = config.get_settings()
 
-    # In Kinto API 1.x, a default bucket is available.
-    default_bucket_plugin='kinto.plugins.default_bucket'
-    if 'excludes' in settings and default_bucket_plugin in settings['excludes']:
-        # do not include the default bucket plugin
-        pass
-    # Force its inclusion if not specified in settings and not explictly excluded
-    elif default_bucket_plugin not in settings['includes']:
-        config.include(default_bucket_plugin)
-
     # Retro-compatibility with first Kinto clients.
     config.registry.public_settings.add('cliquet.batch_max_requests')
 

--- a/kinto/tests/test_views_disable_default.py
+++ b/kinto/tests/test_views_disable_default.py
@@ -1,0 +1,47 @@
+import webtest
+from pyramid.config import Configurator
+
+from cliquet.tests import support as cliquet_support
+from kinto import main
+
+from .support import (BaseWebTest, unittest, get_user_headers,
+                      MINIMALIST_BUCKET, MINIMALIST_COLLECTION,
+                      MINIMALIST_RECORD)
+
+
+class DisableDefaultBucketViewTest(BaseWebTest, unittest.TestCase):
+
+    test_url = '/buckets/default'
+
+    def setUp(self):
+        super(DisableDefaultBucketViewTest, self).setUp()
+        self.events = []
+
+
+    def tearDown(self):
+        self.events = []
+        super(DisableDefaultBucketViewTest, self).tearDown()
+
+    def _get_test_app(self, settings=None):
+        app_settings = self.get_app_settings(settings)
+        self.config = Configurator(settings=app_settings)
+        app = webtest.TestApp(main({}, config=self.config, **app_settings))
+        app.RequestClass = cliquet_support.get_request_class(prefix="v1")
+
+        return app
+
+    def get_app_settings(self, extra=None):
+        if extra is None:
+            extra = {}
+        settings = super(DisableDefaultBucketViewTest, self).get_app_settings(extra)
+        return settings
+
+    def test_returns_503_if_excluded_in_configuration(self):
+        extra = {'kinto.excludes': 'kinto.plugins.default_bucket'}
+        app = self._get_test_app(settings=extra)
+        app.get(self.test_url, headers=self.headers, status=403)
+
+    def test_returns_200_if_not_excluded_in_configuration(self):
+        extra = {'kinto.excludes': ''}
+        app = self._get_test_app(settings=extra)
+        app.get(self.test_url, headers=self.headers, status=200)

--- a/kinto/tests/test_views_disable_default.py
+++ b/kinto/tests/test_views_disable_default.py
@@ -36,12 +36,12 @@ class DisableDefaultBucketViewTest(BaseWebTest, unittest.TestCase):
         settings = super(DisableDefaultBucketViewTest, self).get_app_settings(extra)
         return settings
 
-    def test_returns_503_if_excluded_in_configuration(self):
-        extra = {'kinto.excludes': 'kinto.plugins.default_bucket'}
+    def test_returns_403_if_excluded_in_configuration(self):
+        extra = {'includes': ''}
         app = self._get_test_app(settings=extra)
         app.get(self.test_url, headers=self.headers, status=403)
 
-    def test_returns_200_if_not_excluded_in_configuration(self):
-        extra = {'kinto.excludes': ''}
+    def test_returns_200_if_included_in_configuration(self):
+        extra = {'includes': 'kinto.plugins.default_bucket'}
         app = self._get_test_app(settings=extra)
         app.get(self.test_url, headers=self.headers, status=200)

--- a/kinto/tests/test_views_disable_default.py
+++ b/kinto/tests/test_views_disable_default.py
@@ -13,29 +13,6 @@ class DisableDefaultBucketViewTest(BaseWebTest, unittest.TestCase):
 
     test_url = '/buckets/default'
 
-    def setUp(self):
-        super(DisableDefaultBucketViewTest, self).setUp()
-        self.events = []
-
-
-    def tearDown(self):
-        self.events = []
-        super(DisableDefaultBucketViewTest, self).tearDown()
-
-    def _get_test_app(self, settings=None):
-        app_settings = self.get_app_settings(settings)
-        self.config = Configurator(settings=app_settings)
-        app = webtest.TestApp(main({}, config=self.config, **app_settings))
-        app.RequestClass = cliquet_support.get_request_class(prefix="v1")
-
-        return app
-
-    def get_app_settings(self, extra=None):
-        if extra is None:
-            extra = {}
-        settings = super(DisableDefaultBucketViewTest, self).get_app_settings(extra)
-        return settings
-
     def test_returns_403_if_excluded_in_configuration(self):
         extra = {'includes': ''}
         app = self._get_test_app(settings=extra)


### PR DESCRIPTION
To solve issue https://github.com/Kinto/kinto/issues/466, in the configuration the 'default-bucket' plugin (personal buckets) can be excluded.