### PR TITLE
Relax content-type validation when no body is posted (fixes #507)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 2.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Relax content-type validation when no body is posted (fixes #507)
 
 
 2.0.0 (2016-03-08)

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -105,6 +105,11 @@ class BucketCreationTest(BaseWebTest, unittest.TestCase):
                                headers=self.headers)
         self.assertEqual(r.json['data']['id'], bucket)
 
+    def test_bucket_can_be_created_without_body_nor_contenttype(self):
+        headers = self.headers.copy()
+        headers.pop("Content-Type")
+        self.app.put('/buckets/catalog', headers=headers)
+
 
 class BucketReadPermissionTest(BaseWebTest, unittest.TestCase):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cliquet==3.1.0
 colander==1.2
 colorama==0.3.7
-cornice==1.2.0
+cornice==1.2.1
 enum34==1.1.2
 functools32==3.2.3.post2
 iso8601==0.1.11


### PR DESCRIPTION
@almet r?

(I confirm the test fails with cornice==1.2.0)