### PR TITLE
Recreate objects after deletion fails

### DIFF
--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -211,3 +211,9 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get('%s/records?_since=0' % self.collection_url,
                             headers=self.headers)
         self.assertEqual(len(resp.json['data']), 0)
+
+    def test_can_be_created_after_deletion_with_if_none_match_star(self):
+        headers = self.headers.copy()
+        headers['If-None-Match'] = '*'
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
+                          headers=headers, status=201)

--- a/kinto/tests/test_views_collections.py
+++ b/kinto/tests/test_views_collections.py
@@ -129,6 +129,12 @@ class CollectionDeletionTest(BaseWebTest, unittest.TestCase):
                             headers=self.headers)
         self.assertEqual(len(resp.json['data']), 0)
 
+    def test_can_be_created_after_deletion_with_if_none_match_star(self):
+        headers = self.headers.copy()
+        headers['If-None-Match'] = '*'
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
+                          headers=headers, status=201)
+
 
 class CollectionCreationTest(BaseWebTest, unittest.TestCase):
 

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -158,6 +158,13 @@ class GroupManagementTest(BaseWebTest, unittest.TestCase):
         self.assertEquals(self.permission.user_principals('mat'),
                           {group_url})
 
+    def test_groups_can_be_created_after_deletion(self):
+        self.app.delete(self.group_url, headers=self.headers)
+        headers = self.headers.copy()
+        headers['If-None-Match'] = '*'
+        self.app.put_json(self.group_url, MINIMALIST_GROUP,
+                          headers=headers, status=201)
+
 
 class InvalidGroupTest(BaseWebTest, unittest.TestCase):
 

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -159,10 +159,12 @@ class GroupManagementTest(BaseWebTest, unittest.TestCase):
                           {group_url})
 
     def test_groups_can_be_created_after_deletion(self):
-        self.app.delete(self.group_url, headers=self.headers)
+        self.create_group('beers', 'moderators')
+        group_url = '/buckets/beers/groups/moderators'
+        self.app.delete(group_url, headers=self.headers)
         headers = self.headers.copy()
         headers['If-None-Match'] = '*'
-        self.app.put_json(self.group_url, MINIMALIST_GROUP,
+        self.app.put_json(group_url, MINIMALIST_GROUP,
                           headers=headers, status=201)
 
 

--- a/kinto/tests/test_views_records.py
+++ b/kinto/tests/test_views_records.py
@@ -227,3 +227,12 @@ class RecordsViewTest(BaseWebTest, unittest.TestCase):
                      MINIMALIST_RECORD,
                      headers=headers,
                      status=200)
+
+    def test_records_can_be_created_after_deletion(self):
+        self.app.delete(self.record_url,
+                        headers=self.headers,
+                        status=200)
+        headers = self.headers.copy()
+        headers['If-None-Match'] = '*'
+        self.app.put_json(self.record_url, MINIMALIST_RECORD,
+                          headers=headers, status=201)


### PR DESCRIPTION
kinto.py is struggeling recreating collection, buckets, groups and records with the ``safe=True`` flag if they have been deleted.

These are the test cases that are covering the matter.