### PR TITLE
 Fix crash in JSON schema validation when additional properties are provided (fixes #548)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ This document describes changes between each past release.
 
 **Bug fixes**
 
+- Fix crash in JSON schema validation when additional properties are provided (fixes #548)
 - Strip internal fields before validating JSON schema (fixes #549)
 
 

--- a/kinto/tests/test_views_collections_schema.py
+++ b/kinto/tests/test_views_collections_schema.py
@@ -221,5 +221,4 @@ class ExtraPropertiesValidationTest(BaseWebTestWithSchema, unittest.TestCase):
                                  {'data': record},
                                  headers=self.headers,
                                  status=400)
-        assert resp.json['message'] == ("body: Additional properties are not "
-                                        "allowed ('extra' was unexpected)")
+        assert "'extra' was unexpected)" in resp.json['message']

--- a/kinto/tests/test_views_collections_schema.py
+++ b/kinto/tests/test_views_collections_schema.py
@@ -212,3 +212,12 @@ class ExtraPropertiesValidationTest(BaseWebTestWithSchema, unittest.TestCase):
         self.app.patch_json(record_url,
                             {'data': record},
                             headers=self.headers)
+
+    def test_additional_properties_are_rejected(self):
+        record_id = '5443d83f-852a-481a-8e9d-5aa804b05b08'
+        record = VALID_RECORD.copy()
+        record['extra'] = 'blah!'
+        self.app.put_json('%s/%s' % (RECORDS_URL, record_id),
+                          {'data': record},
+                          headers=self.headers,
+                          status=400)

--- a/kinto/tests/test_views_collections_schema.py
+++ b/kinto/tests/test_views_collections_schema.py
@@ -217,7 +217,9 @@ class ExtraPropertiesValidationTest(BaseWebTestWithSchema, unittest.TestCase):
         record_id = '5443d83f-852a-481a-8e9d-5aa804b05b08'
         record = VALID_RECORD.copy()
         record['extra'] = 'blah!'
-        self.app.put_json('%s/%s' % (RECORDS_URL, record_id),
-                          {'data': record},
-                          headers=self.headers,
-                          status=400)
+        resp = self.app.put_json('%s/%s' % (RECORDS_URL, record_id),
+                                 {'data': record},
+                                 headers=self.headers,
+                                 status=400)
+        assert resp.json['message'] == ("body: Additional properties are not "
+                                        "allowed ('extra' was unexpected)")

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -73,7 +73,10 @@ class Record(resource.ShareableResource):
             stripped.pop(self.schema_field, None)
             jsonschema.validate(stripped, schema)
         except jsonschema_exceptions.ValidationError as e:
-            field = e.path.pop() if e.path else e.validator_value.pop()
+            try:
+                field = e.path.pop() if e.path else e.validator_value.pop()
+            except AttributeError:
+                field = None
             raise_invalid(self.request, name=field, description=e.message)
 
         new[self.schema_field] = collection_timestamp


### PR DESCRIPTION
Fixes #548 
Based on #554 