### PR TITLE
kinto executable fails if no arg is passed to it

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,3 @@
 [run]
 omit = kinto/tests/*
        kinto/plugins/*/test_*
-       kinto/__main__.py
-

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -54,16 +54,16 @@ def main(args=None):
                               default=False)
     parser_start.set_defaults(which='start')
 
-    args = vars(parser.parse_args(args))
+    parsed_args = vars(parser.parse_args(args))
 
-    config_file = args['ini_file']
+    config_file = parsed_args['ini_file']
 
-    if args['which'] == 'init':
+    if parsed_args['which'] == 'init':
         if os.path.exists(config_file):
             print("%s already exists." % config_file, file=sys.stderr)
             return 1
 
-        backend = args['backend']
+        backend = parsed_args['backend']
         if not backend:
             while True:
                 prompt = ("Select the backend you would like to use: "
@@ -86,13 +86,13 @@ def main(args=None):
                 import pip
                 pip.main(['install', "cliquet[postgresql]"])
 
-    elif args['which'] == 'migrate':
+    elif parsed_args['which'] == 'migrate':
         env = bootstrap(config_file)
         cliquet.init_schema(env)
 
-    elif args['which'] == 'start':
+    elif parsed_args['which'] == 'start':
         pserve_argv = ['pserve', config_file]
-        if args['reload']:
+        if parsed_args['reload']:
             pserve_argv.append('--reload')
         pserve.main(pserve_argv)
 

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -52,13 +52,21 @@ def main(args=None):
                               default=False)
     parser_start.set_defaults(which='start')
 
-    args = vars(parser.parse_args())
+    try:
+        args = vars(parser.parse_args(args))
+    except SystemExit:  # pragma: no cover for python2
+        return 10
+
     config_file = args['ini_file']
+
+    if 'which' not in args:  # pragma: no cover
+        parser.print_help(sys.stderr)
+        return 10
 
     if args['which'] == 'init':
         if os.path.exists(config_file):
-            print("%s already exist." % config_file, file=sys.stderr)
-            sys.exit(1)
+            print("%s already exists." % config_file, file=sys.stderr)
+            return 1
 
         backend = args['backend']
         if not backend:
@@ -77,9 +85,9 @@ def main(args=None):
 
         # Install postgresql libraries if necessary
         if backend == "postgresql":
-            try:
+            try:  # pragma: no cover
                 import psycopg2  # NOQA
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 import pip
                 pip.main(['install', "cliquet[postgresql]"])
 
@@ -93,6 +101,4 @@ def main(args=None):
             pserve_argv.append('--reload')
         pserve.main(pserve_argv)
 
-
-if __name__ == "__main__":
-    main()
+    return 0

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -36,7 +36,9 @@ def main(args=None):
 
     subparsers = parser.add_subparsers(title='subcommands',
                                        description='valid subcommands',
+                                       dest='subcommand',
                                        help='init/start/migrate')
+    subparsers.required = True
 
     parser_init = subparsers.add_parser('init')
     parser_init.set_defaults(which='init')
@@ -58,10 +60,6 @@ def main(args=None):
         return 10
 
     config_file = args['ini_file']
-
-    if 'which' not in args:  # pragma: no cover
-        parser.print_help(sys.stderr)
-        return 10
 
     if args['which'] == 'init':
         if os.path.exists(config_file):

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -54,10 +54,7 @@ def main(args=None):
                               default=False)
     parser_start.set_defaults(which='start')
 
-    try:
-        args = vars(parser.parse_args(args))
-    except SystemExit:  # pragma: no cover for python2
-        return 10
+    args = vars(parser.parse_args(args))
 
     config_file = args['ini_file']
 

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -85,9 +85,9 @@ def main(args=None):
 
         # Install postgresql libraries if necessary
         if backend == "postgresql":
-            try:  # pragma: no cover
+            try:
                 import psycopg2  # NOQA
-            except ImportError:  # pragma: no cover
+            except ImportError:
                 import pip
                 pip.main(['install', "cliquet[postgresql]"])
 

--- a/kinto/tests/test_main.py
+++ b/kinto/tests/test_main.py
@@ -1,0 +1,114 @@
+try:
+    import builtins
+    builtins_name = 'builtins'
+except ImportError:
+    import __builtin__ as builtins
+    builtins_name = '__builtins__'
+
+import mock
+import os
+import sys
+import unittest
+
+from six import StringIO
+
+from kinto.__main__ import main
+
+
+class TestMain(unittest.TestCase):
+    def tearDown(self):
+        try:
+            os.remove('/tmp/kinto.ini')
+        except OSError:
+            pass
+
+    def test_cli_init_generate_configuration(self):
+        res = main(['--ini', '/tmp/kinto.ini', '--backend', 'memory', 'init'])
+        assert res == 0
+        assert os.path.exists('/tmp/kinto.ini')
+
+    def test_cli_init_returns_if_file_exists(self):
+        with open('/tmp/kinto.ini', 'w') as f:
+            f.write("exists")
+        with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+            res = main(['--ini', '/tmp/kinto.ini',
+                        '--backend', 'memory', 'init'])
+            assert res == 1
+            content = mock_stderr.getvalue()
+            assert '/tmp/kinto.ini already exists.' in content
+
+    def test_cli_init_ask_for_backend_if_not_specified(self):
+        with mock.patch("kinto.__main__.input", create=True, return_value="2"):
+            res = main(['--ini', '/tmp/kinto.ini', 'init'])
+            assert res == 0
+
+    def test_cli_init_ask_until_backend_is_valid(self):
+        with mock.patch("kinto.__main__.input", create=True,
+                        side_effect=["10", "2"]):
+            res = main(['--ini', '/tmp/kinto.ini', 'init'])
+            assert res == 0
+            with open('/tmp/kinto.ini') as f:
+                content = f.read()
+            assert 'redis' in content
+
+    def test_fails_if_not_enough_args(self):
+        with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+            res = main(['--ini', '/tmp/kinto.ini'])
+            assert res == 10
+            assert 'INI_FILE' in mock_stderr.getvalue()
+
+    def test_cli_init_install_postgresql_dependencies_if_needed(self):
+        realimport = builtins.__import__
+
+        def myimport(name, *args, **kwargs):
+            if name == 'psycopg2':
+                raise ImportError()
+            else:
+                return realimport(name, *args, **kwargs)
+
+            with mock.patch('{}.__import__'.format(builtins_name),
+                            side_effect=myimport):
+                with mock.patch('pip.main', return_value=None) as mocked_pip:
+                    with mock.patch("kinto.__main__.input", create=True,
+                                    return_value="1"):
+                        res = main(['--ini', '/tmp/kinto.ini', 'init'])
+                        assert res == 0
+                        assert mocked_pip.call_count == 1
+
+    def test_main_takes_sys_argv_by_default(self):
+        testargs = ["prog", "--ini", "/tmp/kinto.ini",
+                    '--backend', 'memory', 'init']
+        with mock.patch.object(sys, 'argv', testargs):
+            main()
+
+        with open('/tmp/kinto.ini') as f:
+            content = f.read()
+        assert 'memory' in content
+
+    def test_cli_migrate_command_runs_init_schema(self):
+        with mock.patch('kinto.__main__.cliquet.init_schema') as mocked_init:
+            res = main(['--ini', '/tmp/kinto.ini',
+                        '--backend', 'memory', 'init'])
+            assert res == 0
+            res = main(['--ini', '/tmp/kinto.ini', 'migrate'])
+            assert res == 0
+            assert mocked_init.call_count == 1
+
+    def test_cli_start_runs_pserve(self):
+        with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
+            res = main(['--ini', '/tmp/kinto.ini',
+                        '--backend', 'memory', 'init'])
+            assert res == 0
+            res = main(['--ini', '/tmp/kinto.ini', 'start'])
+            assert res == 0
+            assert mocked_pserve.call_count == 1
+
+    def test_cli_start_with_reload_runs_pserve_with_reload(self):
+        with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
+            res = main(['--ini', '/tmp/kinto.ini',
+                        '--backend', 'memory', 'init'])
+            assert res == 0
+            res = main(['--ini', '/tmp/kinto.ini', 'start', '--reload'])
+            assert res == 0
+            assert mocked_pserve.call_count == 1
+            assert '--reload' in mocked_pserve.call_args[0][0]

--- a/kinto/tests/test_main.py
+++ b/kinto/tests/test_main.py
@@ -3,7 +3,7 @@ try:
     builtins_name = 'builtins'
 except ImportError:
     import __builtin__ as builtins
-    builtins_name = '__builtins__'
+    builtins_name = '__builtin__'
 
 import mock
 import os
@@ -66,14 +66,14 @@ class TestMain(unittest.TestCase):
             else:
                 return realimport(name, *args, **kwargs)
 
-            with mock.patch('{}.__import__'.format(builtins_name),
-                            side_effect=myimport):
-                with mock.patch('pip.main', return_value=None) as mocked_pip:
-                    with mock.patch("kinto.__main__.input", create=True,
-                                    return_value="1"):
-                        res = main(['--ini', '/tmp/kinto.ini', 'init'])
-                        assert res == 0
-                        assert mocked_pip.call_count == 1
+        with mock.patch('{}.__import__'.format(builtins_name),
+                        side_effect=myimport):
+            with mock.patch('pip.main', return_value=None) as mocked_pip:
+                with mock.patch("kinto.__main__.input", create=True,
+                                return_value="1"):
+                    res = main(['--ini', '/tmp/kinto.ini', 'init'])
+                    assert res == 0
+                    assert mocked_pip.call_count == 1
 
     def test_main_takes_sys_argv_by_default(self):
         testargs = ["prog", "--ini", "/tmp/kinto.ini",

--- a/kinto/tests/test_main.py
+++ b/kinto/tests/test_main.py
@@ -9,108 +9,111 @@ import mock
 import os
 import pytest
 import sys
+import tempfile
 import unittest
 
 from six import StringIO
 
 from kinto.__main__ import main
 
+_, TEMP_KINTO_INI = tempfile.mkstemp(prefix='kinto_config')
+
 
 class TestMain(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         try:
-            os.remove('/tmp/kinto.ini')
+            os.remove(TEMP_KINTO_INI)
         except OSError:
             pass
 
-    def test_cli_init_generate_configuration(self):
-        res = main(['--ini', '/tmp/kinto.ini', '--backend', 'memory', 'init'])
+    def test_cli_init_generates_configuration(self):
+        res = main(['--ini', TEMP_KINTO_INI, '--backend', 'memory', 'init'])
         assert res == 0
-        assert os.path.exists('/tmp/kinto.ini')
+        assert os.path.exists(TEMP_KINTO_INI)
 
     def test_cli_init_returns_if_file_exists(self):
-        with open('/tmp/kinto.ini', 'w') as f:
+        with open(TEMP_KINTO_INI, 'w') as f:
             f.write("exists")
         with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
-            res = main(['--ini', '/tmp/kinto.ini',
+            res = main(['--ini', TEMP_KINTO_INI,
                         '--backend', 'memory', 'init'])
             assert res == 1
             content = mock_stderr.getvalue()
-            assert '/tmp/kinto.ini already exists.' in content
+            assert '{} already exists.'.format(TEMP_KINTO_INI) in content
 
-    def test_cli_init_ask_for_backend_if_not_specified(self):
+    def test_cli_init_asks_for_backend_if_not_specified(self):
         with mock.patch("kinto.__main__.input", create=True, return_value="2"):
-            res = main(['--ini', '/tmp/kinto.ini', 'init'])
+            res = main(['--ini', TEMP_KINTO_INI, 'init'])
             assert res == 0
 
-    def test_cli_init_ask_until_backend_is_valid(self):
+    def test_cli_init_asks_until_backend_is_valid(self):
         with mock.patch("kinto.__main__.input", create=True,
                         side_effect=["10", "2"]):
-            res = main(['--ini', '/tmp/kinto.ini', 'init'])
+            res = main(['--ini', TEMP_KINTO_INI, 'init'])
             assert res == 0
-            with open('/tmp/kinto.ini') as f:
+            with open(TEMP_KINTO_INI) as f:
                 content = f.read()
             assert 'redis' in content
 
     def test_fails_if_not_enough_args(self):
         with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
             with pytest.raises(SystemExit) as excinfo:
-                main(['--ini', '/tmp/kinto.ini'])
+                main(['--ini', TEMP_KINTO_INI])
             assert 'INI_FILE' in mock_stderr.getvalue()
             assert excinfo.value.code == 2
 
-    def test_cli_init_install_postgresql_dependencies_if_needed(self):
+    def test_cli_init_installs_postgresql_dependencies_if_needed(self):
         realimport = builtins.__import__
 
-        def myimport(name, *args, **kwargs):
+        def psycopg2_missing(name, *args, **kwargs):
             if name == 'psycopg2':
                 raise ImportError()
             else:
                 return realimport(name, *args, **kwargs)
 
         with mock.patch('{}.__import__'.format(builtins_name),
-                        side_effect=myimport):
+                        side_effect=psycopg2_missing):
             with mock.patch('pip.main', return_value=None) as mocked_pip:
                 with mock.patch("kinto.__main__.input", create=True,
                                 return_value="1"):
-                    res = main(['--ini', '/tmp/kinto.ini', 'init'])
+                    res = main(['--ini', TEMP_KINTO_INI, 'init'])
                     assert res == 0
                     assert mocked_pip.call_count == 1
 
     def test_main_takes_sys_argv_by_default(self):
-        testargs = ["prog", "--ini", "/tmp/kinto.ini",
+        testargs = ["prog", "--ini", TEMP_KINTO_INI,
                     '--backend', 'memory', 'init']
         with mock.patch.object(sys, 'argv', testargs):
             main()
 
-        with open('/tmp/kinto.ini') as f:
+        with open(TEMP_KINTO_INI) as f:
             content = f.read()
         assert 'memory' in content
 
     def test_cli_migrate_command_runs_init_schema(self):
         with mock.patch('kinto.__main__.cliquet.init_schema') as mocked_init:
-            res = main(['--ini', '/tmp/kinto.ini',
+            res = main(['--ini', TEMP_KINTO_INI,
                         '--backend', 'memory', 'init'])
             assert res == 0
-            res = main(['--ini', '/tmp/kinto.ini', 'migrate'])
+            res = main(['--ini', TEMP_KINTO_INI, 'migrate'])
             assert res == 0
             assert mocked_init.call_count == 1
 
     def test_cli_start_runs_pserve(self):
         with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
-            res = main(['--ini', '/tmp/kinto.ini',
+            res = main(['--ini', TEMP_KINTO_INI,
                         '--backend', 'memory', 'init'])
             assert res == 0
-            res = main(['--ini', '/tmp/kinto.ini', 'start'])
+            res = main(['--ini', TEMP_KINTO_INI, 'start'])
             assert res == 0
             assert mocked_pserve.call_count == 1
 
     def test_cli_start_with_reload_runs_pserve_with_reload(self):
         with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
-            res = main(['--ini', '/tmp/kinto.ini',
+            res = main(['--ini', TEMP_KINTO_INI,
                         '--backend', 'memory', 'init'])
             assert res == 0
-            res = main(['--ini', '/tmp/kinto.ini', 'start', '--reload'])
+            res = main(['--ini', TEMP_KINTO_INI, 'start', '--reload'])
             assert res == 0
             assert mocked_pserve.call_count == 1
             assert '--reload' in mocked_pserve.call_args[0][0]

--- a/kinto/tests/test_main.py
+++ b/kinto/tests/test_main.py
@@ -7,6 +7,7 @@ except ImportError:
 
 import mock
 import os
+import pytest
 import sys
 import unittest
 
@@ -53,9 +54,10 @@ class TestMain(unittest.TestCase):
 
     def test_fails_if_not_enough_args(self):
         with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
-            res = main(['--ini', '/tmp/kinto.ini'])
-            assert res == 10
+            with pytest.raises(SystemExit) as excinfo:
+                main(['--ini', '/tmp/kinto.ini'])
             assert 'INI_FILE' in mock_stderr.getvalue()
+            assert excinfo.value.code == 2
 
     def test_cli_init_install_postgresql_dependencies_if_needed(self):
         realimport = builtins.__import__

--- a/kinto/tests/test_main.py
+++ b/kinto/tests/test_main.py
@@ -45,6 +45,9 @@ class TestMain(unittest.TestCase):
         with mock.patch("kinto.__main__.input", create=True, return_value="2"):
             res = main(['--ini', TEMP_KINTO_INI, 'init'])
             assert res == 0
+        with open(TEMP_KINTO_INI) as f:
+            content = f.read()
+        assert 'redis' in content
 
     def test_cli_init_asks_until_backend_is_valid(self):
         with mock.patch("kinto.__main__.input", create=True,


### PR DESCRIPTION
```
$ .venv/bin/pip install kinto
$ .venv/bin/kinto --ini test/kinto.ini
Traceback (most recent call last):
  File ".venv/bin/kinto", line 11, in <module>
    sys.exit(main())
  File "/home/niko/work/kinto.js/.venv/lib/python3.5/site-packages/kinto/__main__.py", line 58, in main
    if args['which'] == 'init':
KeyError: 'which'
```

Versions:

```
$ .venv/bin/kinto --version
2.1.1
$ .venv/bin/python --version
Python 3.5.1+
```