### PR TITLE
a GET on "/v1" returns a 404, maybe it should return a 307 like on "/"?

### DIFF
--- a/kinto/tests/test_views_hello.py
+++ b/kinto/tests/test_views_hello.py
@@ -17,6 +17,10 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         self.assertNotIn('user', response.json)
 
+    def test_redirect_to_hello_page(self):
+        response = self.app.get('', status=307)
+        assert response.request.path == '/v1'
+
     def test_returns_user_id_if_authenticated(self):
         response = self.app.get('/', headers=self.headers)
         self.assertEqual(response.json['user']['id'],


### PR DESCRIPTION
If you try to GET the url `/`, it gives you a `307 temporary redirect`. However, if you GET the url `/v1`, it simply returns a `404 not found`.

Is that expected?