### PR TITLE
Mention Next-Page in CDN headers to let pass

### DIFF
--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -161,6 +161,7 @@ In the configuration of the CDN service, you should also:
 
 - Allow ``OPTIONS`` requests (CORS)
 - Pass through cache and concurrency control headers: ``ETag``, ``Last-Modified``, ``Expire``
+- Pass through pagination header: ``Next-Page``
 - Cached responses should depend on querystring parameters (e.g. try with different ``?_limit=`` values)
 
 


### PR DESCRIPTION
When I reach a paginated list through the CDN, I shall obtain a `Next-Page` header containing the full URL.

This pull-request adds the `Next-Page` to the list of headers to let pass on the CDN.

@Natim r?

