### PR TITLE
Preparing 3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-3.0.0 (unreleased)
+3.0.0 (2016-05-18)
 ==================
 
 - Major version update. Merged cliquet into kinto.core. This is
@@ -29,6 +29,10 @@ This document describes changes between each past release.
 - Add an explicit message when the server is configured as read-only and the
   collection timestamp fails to be saved (ref Kinto/kinto#558)
 - Prevent the browser to cache server responses between two sessions. (#593)
+- Redirects version prefix to hello page when trailing_slash_redirect is enabled. (#700)
+- Fix crash when setting empty permission list with PostgreSQL permission backend (fixes Kinto/kinto#575)
+- Fix crash when type of values in querystring for exclude/include is wrong (fixes Kinto/kinto#587)
+- Fix crash when providing duplicated principals in permissions with PostgreSQL permission backend (fixes #702)
 
 
 2.1.1 (2016-04-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ This document describes changes between each past release.
 - Fix crash when setting empty permission list with PostgreSQL permission backend (fixes Kinto/kinto#575)
 - Fix crash when type of values in querystring for exclude/include is wrong (fixes Kinto/kinto#587)
 - Fix crash when providing duplicated principals in permissions with PostgreSQL permission backend (fixes #702)
+- Add ``app.wsgi`` to the manifest file. This helps address #543.
 
 
 2.1.1 (2016-04-29)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
-include *.rst LICENSE Makefile tox.ini .coveragerc
+include *.rst LICENSE Makefile tox.ini .coveragerc app.wsgi
 include kinto/config/kinto.tpl
-recursive-include kinto *.sql *.html
-recursive-include docs *.rst *.png *.svg
+include dev-requirements.txt
+recursive-include kinto *.sql *.html *.ini
+recursive-include docs *.rst *.png *.svg *.css *.html conf.py piwik.js
 prune docs/_build/*
+prune loadtests
+prune talks

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='3.0.0.dev0',
+      version='3.0.0',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',


### PR DESCRIPTION
This is the Kinto release that will contain the merged version of Cliquet. The docs are still a mess but we want to release first to simplify updating all the plugins.

I'm following the protocol at https://github.com/Kinto/kinto/pull/572 (according to @Natim 's suggestion).

**Step 1**
```
$ git co -b prepare-X.X
$ prerelease
$ vim docs/conf.py
$ git ci -a --amend
$ git push origin prepare-X.X
```

* [x] Merge remaining pull requests
* [x] Update changelog
* [ ] Update version in docs/conf.py
* [x] Version dependencies
* [ ] Update the link to ``kinto.core`` default settings in the docs
* [x] if the  protocol was updated, upgrade API protocol in docs/

**Step 2**
```
$ git co master
$ git merge --no-ff prepare-X.X
$ release
$ postrelease
```
* [x] Tag vX.Y.Z
* [x] Publish on Pypi

**Step 3**
* [ ] Close milestone in Github
* [x] Add entry in Github release page
* [ ] Create next milestone in Github
* [ ] Configure the version in ReadTheDocs
* [ ] Update kinto version in kinto.js repo
* [ ] Upgrade demo server
* [ ] Upgrade kinto-dist
* [ ] Send mail to ML
* [ ] Tweet!

@Natim r?