### PR TITLE
Authenticated user should be allowed to browse her buckets by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fix internal storage filtering when an empty list of values is provided.
+- Authenticated users are now allowed to obtain an empty list of buckets on
+  ``GET /buckets`` even if no bucket is readable (#454)
 
 
 3.0.1 (2016-05-20)

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -145,4 +145,7 @@ class AuthorizationPolicy(core_authorization.AuthorizationPolicy):
 
 
 class RouteFactory(core_authorization.RouteFactory):
-    pass
+    def __init__(self, request):
+        super(RouteFactory, self).__init__(request)
+        if self.on_collection and self.resource_name == 'bucket':
+            self.force_empty_list = True

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -86,6 +86,9 @@ class AuthorizationPolicy(object):
                 principals,
                 get_bound_permissions=self.get_bound_permissions)
             allowed = len(shared_records) > 0
+            if not allowed and context.force_empty_list:
+                allowed = True
+                context.forced_empty_list = True
 
         return allowed
 
@@ -101,6 +104,7 @@ class RouteFactory(object):
     permission_object_id = None
     current_record = None
     get_shared_ids = None
+    force_empty_list = False
 
     method_permissions = {
         "head": "read",

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -85,10 +85,7 @@ class AuthorizationPolicy(object):
                 permission,
                 principals,
                 get_bound_permissions=self.get_bound_permissions)
-            allowed = len(shared_records) > 0
-            if not allowed and context.force_empty_list:
-                allowed = True
-                context.forced_empty_list = True
+            allowed = shared_records is not None
 
         return allowed
 
@@ -104,7 +101,6 @@ class RouteFactory(object):
     permission_object_id = None
     current_record = None
     get_shared_ids = None
-    force_empty_list = False
 
     method_permissions = {
         "head": "read",
@@ -121,7 +117,7 @@ class RouteFactory(object):
         self._check_permission = request.registry.permission.check_permission
 
         # Partial collections of ShareableResource:
-        self.shared_ids = []
+        self.shared_ids = None
 
         # Store service, resource, record and required permission.
         service = utils.current_service(request)
@@ -173,12 +169,25 @@ class RouteFactory(object):
         return self._check_permission(self.permission_object_id, *args, **kw)
 
     def fetch_shared_records(self, perm, principals, get_bound_permissions):
-        ids = self.get_shared_ids(
-            permission=perm,
-            principals=principals,
-            get_bound_permissions=get_bound_permissions)
-        # Store for later use in ``ShareableResource``.
-        self.shared_ids = [self.extract_object_id(id_) for id_ in ids]
+        """Fetch records that are readable or writable for the current
+        principals.
+
+        If no record is shared, it returns None.
+
+        .. warning::
+            This sets the ``shared_ids`` attribute to the context with the
+            return value. The attribute is then read by
+            :class:`kinto.core.resource.ShareableResource`
+        """
+        ids = self.get_shared_ids(permission=perm,
+                                  principals=principals,
+                                  get_bound_permissions=get_bound_permissions)
+        if len(ids) > 0:
+            # Store for later use in ``ShareableResource``.
+            self.shared_ids = [self.extract_object_id(id_) for id_ in ids]
+        else:
+            self.shared_ids = None
+
         return self.shared_ids
 
     def get_permission_object_id(self, request, record_id=None):

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -1128,6 +1128,9 @@ class ShareableResource(UserResource):
         filters = super(ShareableResource, self)._extract_filters(queryparams)
 
         ids = self.context.shared_ids
+        if getattr(self.context, "forced_empty_list", False):
+            ids = ['UNKNOWN']
+
         if ids:
             filter_by_id = Filter(self.model.id_field, ids, COMPARISON.IN)
             filters.insert(0, filter_by_id)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -245,37 +245,42 @@ class UserResource(object):
         self._raise_412_if_modified()
 
         headers = self.request.response.headers
-        filters = self._extract_filters()
         limit = self._extract_limit()
-        sorting = self._extract_sorting(limit)
-        partial_fields = self._extract_partial_fields()
 
-        filter_fields = [f.field for f in filters]
-        include_deleted = self.model.modified_field in filter_fields
+        if getattr(self.context, "forced_empty_list", False):
+            records, total_records = [], 0
+        else:
+            filters = self._extract_filters()
+            sorting = self._extract_sorting(limit)
+            partial_fields = self._extract_partial_fields()
 
-        pagination_rules, offset = self._extract_pagination_rules_from_token(
-            limit, sorting)
+            filter_fields = [f.field for f in filters]
+            include_deleted = self.model.modified_field in filter_fields
 
-        records, total_records = self.model.get_records(
-            filters=filters,
-            sorting=sorting,
-            limit=limit,
-            pagination_rules=pagination_rules,
-            include_deleted=include_deleted)
+            rules, offset = self._extract_pagination_rules_from_token(
+                limit, sorting)
 
-        offset = offset + len(records)
-        next_page = None
+            records, total_records = self.model.get_records(
+                filters=filters,
+                sorting=sorting,
+                limit=limit,
+                pagination_rules=rules,
+                include_deleted=include_deleted)
 
-        if limit and len(records) == limit and offset < total_records:
-            lastrecord = records[-1]
-            next_page = self._next_page_url(sorting, limit, lastrecord, offset)
-            headers['Next-Page'] = encode_header(next_page)
+            offset = offset + len(records)
+            next_page = None
 
-        if partial_fields:
-            records = [
-                dict_subset(record, partial_fields)
-                for record in records
-            ]
+            if limit and len(records) == limit and offset < total_records:
+                lastrecord = records[-1]
+                next_page = self._next_page_url(sorting, limit, lastrecord,
+                                                offset)
+                headers['Next-Page'] = encode_header(next_page)
+
+            if partial_fields:
+                records = [
+                    dict_subset(record, partial_fields)
+                    for record in records
+                ]
 
         # Bind metric about response size.
         logger.bind(nb_records=len(records), limit=limit)
@@ -1128,9 +1133,6 @@ class ShareableResource(UserResource):
         filters = super(ShareableResource, self)._extract_filters(queryparams)
 
         ids = self.context.shared_ids
-        if getattr(self.context, "forced_empty_list", False):
-            ids = ['UNKNOWN']
-
         if ids:
             filter_by_id = Filter(self.model.id_field, ids, COMPARISON.IN)
             filters.insert(0, filter_by_id)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -246,11 +246,6 @@ class UserResource(object):
 
         headers = self.request.response.headers
 
-        if getattr(self.context, "forced_empty_list", False):
-            # Return an empty list.
-            headers['Total-Records'] = encode_header('0')
-            return self.postprocess([])
-
         filters = self._extract_filters()
         limit = self._extract_limit()
         sorting = self._extract_sorting(limit)
@@ -1134,7 +1129,7 @@ class ShareableResource(UserResource):
         filters = super(ShareableResource, self)._extract_filters(queryparams)
 
         ids = self.context.shared_ids
-        if ids:
+        if ids is not None:
             filter_by_id = Filter(self.model.id_field, ids, COMPARISON.IN)
             filters.insert(0, filter_by_id)
 

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -30,6 +30,8 @@ class ViewSet(object):
 
     readonly_methods = ('GET', 'OPTIONS', 'HEAD')
 
+    factory = authorization.RouteFactory
+
     service_arguments = {
         'description': 'Collection of {resource_name}',
     }
@@ -226,7 +228,7 @@ class ShareableViewSet(ViewSet):
 
     def get_service_arguments(self):
         args = super(ShareableViewSet, self).get_service_arguments()
-        args['factory'] = authorization.RouteFactory
+        args['factory'] = self.factory
         return args
 
 

--- a/kinto/tests/core/resource/test_object_permissions.py
+++ b/kinto/tests/core/resource/test_object_permissions.py
@@ -219,7 +219,7 @@ class GuestCollectionListTest(PermissionTest):
         self.assertEqual(len(result['data']), 0)
 
     def test_permission_backend_is_not_queried_if_not_guest(self):
-        self.resource.context.shared_ids = []
+        self.resource.context.shared_ids = None
         self.resource.request.registry.permission = None  # would fail!
         result = self.resource.collection_get()
         self.assertEqual(len(result['data']), 3)

--- a/kinto/tests/core/test_authorization.py
+++ b/kinto/tests/core/test_authorization.py
@@ -241,7 +241,7 @@ class GuestAuthorizationPolicyTest(unittest.TestCase):
         self.assertFalse(allowed)
 
     def test_permits_returns_false_if_collection_is_unknown(self):
-        self.context.fetch_shared_records = mock.MagicMock(return_value=[])
+        self.context.fetch_shared_records = mock.MagicMock(return_value=None)
         allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
         self.context.fetch_shared_records.assert_called_with(
             'read',

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -34,10 +34,11 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
                                  headers=self.headers)
         self.assertEqual(resp.json['data']['id'], 'alexis_beers')
 
-    def test_nobody_can_list_buckets_by_default(self):
-        self.app.get(self.collection_url,
-                     headers=get_user_headers('alice'),
-                     status=403)
+    def test_everybody_can_list_buckets_by_default(self):
+        resp = self.app.get(self.collection_url,
+                            headers=get_user_headers('alice'),
+                            status=200)
+        assert resp.json['data'] == []
 
     def test_nobody_can_read_bucket_information_by_default(self):
         self.app.get(self.record_url,

--- a/kinto/tests/test_views_buckets.py
+++ b/kinto/tests/test_views_buckets.py
@@ -40,10 +40,14 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
                             status=200)
         assert resp.json['data'] == []
 
-    def test_nobody_can_read_bucket_information_by_default(self):
-        self.app.get(self.record_url,
-                     headers=get_user_headers('alice'),
-                     status=403)
+    def test_no_anonymous_can_list_buckets_by_default(self):
+        self.app.get(self.collection_url, status=401)
+
+    def test_anybody_can_list_buckets_by_default(self):
+        resp = self.app.get(self.collection_url,
+                            headers=get_user_headers('alice'))
+        # But it contains no record if no read permission.
+        self.assertEqual(len(resp.json['data']), 0)
 
     def test_buckets_name_should_be_simple(self):
         self.app.put_json('/buckets/__beers__',

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -11,7 +11,6 @@ class BucketSchema(resource.ResourceSchema):
 
 
 @resource.register(name='bucket',
-                   collection_methods=('GET', 'POST', 'DELETE'),
                    collection_path='/buckets',
                    record_path='/buckets/{{id}}')
 class Bucket(resource.ShareableResource):

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -1,7 +1,7 @@
 from kinto.core import resource
 from kinto.core.events import ResourceChanged, ACTIONS
 from pyramid.events import subscriber
-
+from kinto.authorization import RouteFactory
 from kinto.views import NameGenerator
 
 
@@ -12,7 +12,8 @@ class BucketSchema(resource.ResourceSchema):
 
 @resource.register(name='bucket',
                    collection_path='/buckets',
-                   record_path='/buckets/{{id}}')
+                   record_path='/buckets/{{id}}',
+                   factory=RouteFactory)
 class Bucket(resource.ShareableResource):
     mapping = BucketSchema()
     permissions = ('read', 'write', 'collection:create', 'group:create')

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -1,7 +1,7 @@
 from kinto.core import resource
 from kinto.core.events import ResourceChanged, ACTIONS
 from pyramid.events import subscriber
-from kinto.authorization import RouteFactory
+from kinto.authorization import BucketRouteFactory
 from kinto.views import NameGenerator
 
 
@@ -13,7 +13,7 @@ class BucketSchema(resource.ResourceSchema):
 @resource.register(name='bucket',
                    collection_path='/buckets',
                    record_path='/buckets/{{id}}',
-                   factory=RouteFactory)
+                   factory=BucketRouteFactory)
 class Bucket(resource.ShareableResource):
     mapping = BucketSchema()
     permissions = ('read', 'write', 'collection:create', 'group:create')

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -36,7 +36,6 @@ class CollectionSchema(resource.ResourceSchema):
 
 
 @resource.register(name='collection',
-                   collection_methods=('GET', 'POST', 'DELETE'),
                    collection_path='/buckets/{{bucket_id}}/collections',
                    record_path='/buckets/{{bucket_id}}/collections/{{id}}')
 class Collection(resource.ShareableResource):


### PR DESCRIPTION
Kinto config:

```
[app:main]
use = egg:kinto

# Required by integration tests
kinto.flush_endpoint_enabled = true

# Required by basic auth
kinto.userid_hmac_secret = a-secret-string

[server:main]
use = egg:waitress#main
host = 0.0.0.0
port = 8888
```

Starting server

```
./.venv/bin/pserve test/kinto.ini
Starting server in PID 3230.
serving on http://0.0.0.0:8888
```

Listing buckets:

```
$ http :8888/v1/buckets -a a:
HTTP/1.1 403 Forbidden
Access-Control-Expose-Headers: Content-Length, Expires, Alert, Retry-After, Last-Modified, Total-Records, ETag, Pragma, Cache-Control, Backoff, Next-Page
Content-Length: 95
Content-Type: application/json; charset=UTF-8
Date: Tue, 23 Feb 2016 08:58:07 GMT
Server: waitress

{
    "code": 403, 
    "errno": 121, 
    "error": "Forbidden", 
    "message": "This user cannot access this resource."
}
```

This is quite surprising, as one might expect being able to at least list his own default bucket in there.

If you create a custom bucket, then you're suddenly allowed to browser buckets:

```
$ http PUT :8888/v1/buckets/foo -a a:
HTTP/1.1 201 Created
Access-Control-Expose-Headers: Retry-After, Content-Length, Alert, Backoff
Content-Length: 154
Content-Type: application/json; charset=UTF-8
Date: Tue, 23 Feb 2016 09:03:09 GMT
Etag: "1456218189534"
Last-Modified: Tue, 23 Feb 2016 09:03:09 GMT
Server: waitress

{
    "data": {
        "id": "foo", 
        "last_modified": 1456218189534
    }, 
    "permissions": {
        "write": [
            "basicauth:a2125d3ab6f6b9509e1bc87932010af71cebfd50424e972934a0e4b5a1047f42"
        ]
    }
}

$ http :8888/v1/buckets -a a:        
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Content-Length, Expires, Alert, Retry-After, Last-Modified, Total-Records, ETag, Pragma, Cache-Control, Backoff, Next-Page
Cache-Control: no-cache
Content-Length: 53
Content-Type: application/json; charset=UTF-8
Date: Tue, 23 Feb 2016 09:03:17 GMT
Etag: "1456218189534"
Last-Modified: Tue, 23 Feb 2016 09:03:09 GMT
Server: waitress
Total-Records: 1

{
    "data": [
        {
            "id": "foo", 
            "last_modified": 1456218189534
        }
    ]
}
```

TL;DR: I think authenticated users should be able to list the buckets they have access to by default.