### PR TITLE
Prepare 2.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-2.2.0 (unreleased)
+2.1.2 (2016-05-20)
 ==================
 
 **Bug fixes**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fix crash when a cache expires setting is set for a specific bucket or collection.
+- Redirects version prefix to hello page when trailing_slash_redirect is enabled. (mozilla-services/cliquet#700)
+- Fix crash when setting empty permission list with PostgreSQL permission backend (#575)
+- Fix crash when type of values in querystring for exclude/include is wrong (#587)
+- Fix crash when providing duplicated principals in permissions with PostgreSQL permission backend (#702)
+- Prevent the browser to cache server responses between two sessions. (#593)
 
 
 2.1.1 (2016-04-29)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ copyright = u'2015-2016 — Mozilla Services'
 # The short X.Y version.
 version = '2.1'
 # The full version, including alpha/beta/rc tags.
-release = '2.1.1'
+release = '2.1.2'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cliquet==3.1.3
+cliquet==3.1.5
 colander==1.2
 colorama==0.3.7
 cornice==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import codecs
 import os
-import sys
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ DEPENDENCY_LINKS = [
 ]
 
 setup(name='kinto',
-      version='2.2.0.dev0',
+      version='2.1.2',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',


### PR DESCRIPTION
Bug fix release.

Picked Cliquet changelog from last two bugfix releases 3.1.4 and 3.1.5

And I already pushed the merge commit from #597  to the `2.X` branch

Using `git cherry-pick -m 1  56653ad48dd73f73bf`

```
-m parent-number, --mainline parent-number
           Usually you cannot cherry-pick a merge because you do not know which side of the merge should be considered the mainline. This option specifies the parent number (starting
           from 1) of the mainline and allows cherry-pick to replay the change relative to the specified parent.
```

------------------------------


**Step 1**
```
$ git co -b prepare-X.X
$ prerelease
$ vim docs/conf.py
$ git ci -a --amend
$ git push origin prepare-X.X
```

* [ ] Merge remaining pull requests
* [x] Update changelog
* [x] Update version in docs/conf.py
* [ ] Version dependencies
* [ ] Update the link to ``kinto.core`` default settings in the docs
* [ ] if the  protocol was updated, upgrade API protocol in docs/

**Step 2**
```
$ git co 2.X
$ git merge --no-ff prepare-X.X
$ release
$ postrelease
```
* [ ] Tag vX.Y.Z
* [ ] Publish on Pypi

**Step 3**
* [ ] Close milestone in Github
* [ ] Add entry in Github release page
* [ ] Create next milestone in Github
* [ ] Configure the version in ReadTheDocs
* [ ] Update kinto version in kinto.js repo
* [ ] Upgrade demo server
* [ ] Upgrade kinto-dist
* [ ] Send mail to ML
* [ ] Tweet!

@Natim r?