### PR TITLE
Preparing release 3.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@ This document describes changes between each past release.
 
 **Bug fixes**
 
-- Fix crash when a cache expires setting is set for a specific bucket or collection.
-- Mark old cliquet backend settings as deprecated (but continue to support them).
+- Fix crash when a cache expires setting is set for a specific bucket or collection. (#597)
+- Mark old cliquet backend settings as deprecated (but continue to support them). (#596)
 
 
 3.0.0 (2016-05-18)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-3.0.1 (unreleased)
+3.0.1 (2016-05-20)
 ==================
 
 **Bug fixes**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = u'2015-2016 — Mozilla Services'
 # The short X.Y version.
 version = '3.0'
 # The full version, including alpha/beta/rc tags.
-release = '3.0.0'
+release = '3.0.1'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ jsonschema==2.5.1
 newrelic==2.64.0.48
 PasteDeploy==1.5.2
 psycopg2==2.6.1
-pyramid==1.6.1
+pyramid==1.7
 pyramid-multiauth==0.8.0
 pyramid-tm==0.12.1
 python-dateutil==2.5.3
-raven==5.17.0
+raven==5.18.0
 redis==2.10.5
 repoze.lru==0.6
 requests==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='3.0.1.dev0',
+      version='3.0.1',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',


### PR DESCRIPTION
This is an incredibly minor release to ease transition to the 3.0 series of Kinto. It adds a little backwards compatibility with old Cliquet settings.

I'm following the protocol at https://github.com/Kinto/kinto/pull/572 (according to @Natim 's suggestion).

**Step 1**
```
$ git co -b prepare-X.X
$ prerelease
$ vim docs/conf.py
$ git ci -a --amend
$ git push origin prepare-X.X
```

* [x] Merge remaining pull requests
* [x] Update changelog
* [x] Update version in docs/conf.py
* [x] Version dependencies
* [x] if the  protocol was updated, upgrade API protocol in docs/

**Step 2**
```
$ git co master
$ git merge --no-ff prepare-X.X
$ release
$ postrelease
```
* [x] Tag vX.Y.Z
* [x] Publish on Pypi

**Step 3**
* [x] Close milestone in Github
* [ ] Add entry in Github release page
* [ ] Create next milestone in Github
* [ ] Configure the version in ReadTheDocs
* [ ] Update kinto version in kinto.js repo
* [ ] Upgrade demo server
* [ ] Upgrade kinto-dist
* [ ] Send mail to ML
* [ ] Tweet!

@Natim @leplatrem r?