### PR TITLE
Fix enabling flush enpoint with KINTO_FLUSH_ENDPOINT_ENABLED environment variable (fixes #588)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This document describes changes between each past release.
 - Fix internal storage filtering when an empty list of values is provided.
 - Authenticated users are now allowed to obtain an empty list of buckets on
   ``GET /buckets`` even if no bucket is readable (#454)
+- Fix enabling flush enpoint with ``KINTO_FLUSH_ENDPOINT_ENABLED`` environment variable (fixes #588)
 
 
 3.0.1 (2016-05-20)

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SETTINGS = {
+    'flush_endpoint_enabled': False,
     'retry_after_seconds': 3,
     'cache_backend': 'kinto.core.cache.memory',
     'permission_backend': 'kinto.core.permission.memory',

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -59,18 +59,18 @@ def main(global_config, config=None, **settings):
 
     # Scan Kinto views.
     kwargs = {}
-    flush_enabled = asbool(settings.get('flush_endpoint_enabled'))
 
+    flush_enabled = asbool(settings.get('flush_endpoint_enabled'))
     if flush_enabled:
         config.add_api_capability(
             "flush_endpoint",
             description="The __flush__ endpoint can be used to remove all "
                         "data from all backends.",
             url="http://kinto.readthedocs.io/en/latest/configuration/"
-                "settings.html#activating-the-flush-endpoint"
-        )
+                "settings.html#activating-the-flush-endpoint")
     else:
         kwargs['ignore'] = 'kinto.views.flush'
+
     config.scan("kinto.views", **kwargs)
 
     app = config.make_wsgi_app()

--- a/kinto/tests/test_views_flush.py
+++ b/kinto/tests/test_views_flush.py
@@ -1,3 +1,4 @@
+import os
 import webtest
 from pyramid.config import Configurator
 
@@ -90,3 +91,10 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
         self.app.post('/__flush__', headers=self.headers, status=202)
         self.assertEqual(len(self.events), 1)
         self.assertTrue(isinstance(self.events[0], ServerFlushed))
+
+    def test_can_be_enabled_via_environment(self):
+        os.environ['KINTO_FLUSH_ENDPOINT_ENABLED'] = 'true'
+        extra = {'flush_endpoint_enabled': False}
+        app = self._get_test_app(settings=extra)
+        app.post('/__flush__', headers=self.headers)
+        os.environ.pop('KINTO_FLUSH_ENDPOINT_ENABLED')

--- a/kinto/tests/test_views_flush.py
+++ b/kinto/tests/test_views_flush.py
@@ -61,7 +61,7 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
     def get_app_settings(self, extra=None):
         if extra is None:
             extra = {}
-        extra.setdefault('kinto.flush_endpoint_enabled', True)
+        extra.setdefault('flush_endpoint_enabled', True)
         settings = super(FlushViewTest, self).get_app_settings(extra)
         return settings
 
@@ -69,7 +69,7 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
         self.events.append(event)
 
     def test_returns_404_if_not_enabled_in_configuration(self):
-        extra = {'kinto.flush_endpoint_enabled': False}
+        extra = {'flush_endpoint_enabled': False}
         app = self._get_test_app(settings=extra)
         app.post('/__flush__', headers=self.headers, status=404)
 


### PR DESCRIPTION
@Natim r?