### PR TITLE
Don't use logger

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -485,10 +485,7 @@ def load_default_settings(config, default_settings):
         if unprefixed in CONTAIN_CLIQUET_MODULE_NAMES and \
                 value.startswith('cliquet.'):
             new_value = value.replace('cliquet.', 'kinto.core.')
-            logger.warn(
-                "Backend settings referring to cliquet are DEPRECATED. "
-                "Please update your {} setting to {} (was: {}).".format(
-                    key, new_value, value))
+            settings_deprecated_warning(key, value, new_value)
             value = new_value
 
         # Override settings from OS env values.
@@ -500,6 +497,14 @@ def load_default_settings(config, default_settings):
         settings[unprefixed] = from_env
 
     config.add_settings(settings)
+
+
+def settings_deprecated_warning(key, value, new_value):
+    logger.warn(
+        "WARNING: "
+        "Backend settings referring to cliquet are DEPRECATED. "
+        "Please update your {} setting to {} (was: {}).".format(
+            key, new_value, value))
 
 
 def initialize(config, version=None, project_name='', default_settings=None):

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -500,7 +500,7 @@ def load_default_settings(config, default_settings):
 
 
 def settings_deprecated_warning(key, value, new_value):
-    logger.warn(
+    print(
         "WARNING: "
         "Backend settings referring to cliquet are DEPRECATED. "
         "Please update your {} setting to {} (was: {}).".format(

--- a/kinto/tests/core/test_initialization.py
+++ b/kinto/tests/core/test_initialization.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 import webtest
+from cStringIO import StringIO
 
 from pyramid.config import Configurator
 from pyramid.events import NewRequest
@@ -8,6 +9,7 @@ from pyramid.exceptions import ConfigurationError
 
 import kinto.core
 from kinto.core import initialization
+from kinto.core.initialization import settings_deprecated_warning
 from .support import unittest
 
 
@@ -180,6 +182,16 @@ class ProjectSettingsTest(unittest.TestCase):
                                            'kinto.core.permission.memory')
             self.assertEqual(new_settings['permission_backend'],
                              'kinto.core.permission.memory')
+
+
+class WarningTest(unittest.TestCase):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_settings_deprecated_warning(self, stdout):
+        settings_deprecated_warning('logging_renderer',
+                                    'cliquet.permission.memory',
+                                    'kinto.core.permission.memory')
+        # Exact form of the warning isn't important
+        assert stdout.getvalue().startswith("WARNING:")
 
 
 class ApplicationWrapperTest(unittest.TestCase):

--- a/kinto/tests/core/test_initialization.py
+++ b/kinto/tests/core/test_initialization.py
@@ -175,7 +175,8 @@ class ProjectSettingsTest(unittest.TestCase):
         settings = {
             'kinto.permission_backend': 'cliquet.permission.memory'
         }
-        with mock.patch('kinto.core.initialization.settings_deprecated_warning') as mocked:
+        with mock.patch('kinto.core.initialization.' +
+                        'settings_deprecated_warning') as mocked:
             new_settings = self.settings(settings)
             mocked.assert_called_once_with('kinto.permission_backend',
                                            'cliquet.permission.memory',

--- a/kinto/tests/core/test_initialization.py
+++ b/kinto/tests/core/test_initialization.py
@@ -173,15 +173,11 @@ class ProjectSettingsTest(unittest.TestCase):
         settings = {
             'kinto.permission_backend': 'cliquet.permission.memory'
         }
-        with mock.patch('kinto.core.logger.warn') as mocked:
+        with mock.patch('kinto.core.initialization.settings_deprecated_warning') as mocked:
             new_settings = self.settings(settings)
-            warning_message = ''.join([
-                "Backend settings referring to cliquet are DEPRECATED. ",
-                "Please update your kinto.permission_backend setting to ",
-                "kinto.core.permission.memory ",
-                "(was: cliquet.permission.memory).",
-                ])
-            mocked.assert_called_once_with(warning_message)
+            mocked.assert_called_once_with('kinto.permission_backend',
+                                           'cliquet.permission.memory',
+                                           'kinto.core.permission.memory')
             self.assertEqual(new_settings['permission_backend'],
                              'kinto.core.permission.memory')
 

--- a/kinto/tests/core/test_initialization.py
+++ b/kinto/tests/core/test_initialization.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 import webtest
-from cStringIO import StringIO
+from StringIO import StringIO
 
 from pyramid.config import Configurator
 from pyramid.events import NewRequest

--- a/kinto/tests/core/test_initialization.py
+++ b/kinto/tests/core/test_initialization.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 import webtest
-from StringIO import StringIO
+from six.moves import StringIO
 
 from pyramid.config import Configurator
 from pyramid.events import NewRequest


### PR DESCRIPTION
This is the clumsy way to fix #628 -- we don't use logger during setup, and instead just print warnings to stdout.