### PR TITLE
Clear the logger when you configure it

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -27,6 +27,7 @@ from kinto.core import statsd
 from kinto.core import cache
 from kinto.core import storage
 from kinto.core import permission
+from kinto.core import logs
 from kinto.core.logs import logger
 from kinto.core.events import ResourceRead, ResourceChanged, ACTIONS
 
@@ -330,6 +331,7 @@ def setup_logging(config):
             structlog.processors.format_exc_info,
             renderer,
         ])
+    logs.reset_logger()
 
     def on_new_request(event):
         request = event.request

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -331,7 +331,15 @@ def setup_logging(config):
             structlog.processors.format_exc_info,
             renderer,
         ])
-    logs.reset_logger()
+
+    # Hack to work around https://github.com/hynek/structlog/issues/71.
+    #
+    # This clears a magic field in the logger so that it will regenerate
+    # the right kind of logger on its next use.
+    #
+    # Otherwise, the logging_factory field of the logger will be
+    # outdated and you may get strange behavior.
+    logger._logger = None
 
     def on_new_request(event):
         request = event.request

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -27,7 +27,6 @@ from kinto.core import statsd
 from kinto.core import cache
 from kinto.core import storage
 from kinto.core import permission
-from kinto.core import logs
 from kinto.core.logs import logger
 from kinto.core.events import ResourceRead, ResourceChanged, ACTIONS
 

--- a/kinto/core/logs.py
+++ b/kinto/core/logs.py
@@ -10,19 +10,6 @@ from kinto.core import utils
 logger = structlog.get_logger()
 
 
-def reset_logger():
-    """Hack to work around https://github.com/hynek/structlog/issues/71.
-
-    This clears a magic field in the logger so that it will regenerate
-    the right kind of logger on its next use.
-
-    Do this when you call structlog.configure(). Otherwise, some parts
-    of the logger will be outdated and you may get strange behavior.
-
-    """
-    logger._logger = None
-
-
 def decode_value(value):
     try:
         return six.text_type(value)

--- a/kinto/core/logs.py
+++ b/kinto/core/logs.py
@@ -10,6 +10,19 @@ from kinto.core import utils
 logger = structlog.get_logger()
 
 
+def reset_logger():
+    """Hack to work around https://github.com/hynek/structlog/issues/71.
+
+    This clears a magic field in the logger so that it will regenerate
+    the right kind of logger on its next use.
+
+    Do this when you call structlog.configure(). Otherwise, some parts
+    of the logger will be outdated and you may get strange behavior.
+
+    """
+    logger._logger = None
+
+
 def decode_value(value):
     try:
         return six.text_type(value)


### PR DESCRIPTION
This is another ugly solution to #628 that relies on knowledge of the internals of the structlog library. The fundamental problem in https://github.com/hynek/structlog/issues/71 is that calling `configure` updates the `processors` variable globally, but the log proxy object has already set a `_logger` attribute based on a previous value of the `logger_class` parameter. If we clear that _logger variable, it will generate a new one on the next time around.