### PR TITLE
Prepare 3.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-3.0.2 (unreleased)
+3.0.2 (2016-05-24)
 ==================
 
 **Protocol**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Protocol is now at version **1.6**. See `API changelog <http://kinto.readthedocs
 - Fix principal added to ``write`` permission when a publicly writable object
   is created/edited (fixes #645)
 - Prevent client to cache and validate authenticated requests (fixes #635)
+- Fix bug that prevented startup if old Cliquet configuration values
+  were still around (#633)
 
 **Documentation**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-3.0.2 (2016-05-24)
+3.1.0 (2016-05-24)
 ==================
 
 **Protocol**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ copyright = u'2015-2016 — Mozilla Services'
 # built documents.
 #
 # The short X.Y version.
-version = '3.0'
+version = '3.1'
 # The full version, including alpha/beta/rc tags.
-release = '3.0.2'
+release = '3.1.0'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = u'2015-2016 — Mozilla Services'
 # The short X.Y version.
 version = '3.0'
 # The full version, including alpha/beta/rc tags.
-release = '3.0.1'
+release = '3.0.2'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-colander==1.2
+colander==1.3.1
 colorama==0.3.7
 contextlib2==0.5.3
 cornice==1.2.1
@@ -22,13 +22,13 @@ six==1.10.0
 SQLAlchemy==1.0.13
 statsd==3.2.1
 structlog==16.1.0
-transaction==1.5.0
+transaction==1.6.0
 translationstring==1.3
 ujson==1.35
 venusian==1.0
 waitress==0.9.0
-WebOb==1.6.0
-Werkzeug==0.11.9
+WebOb==1.6.1
+Werkzeug==0.11.10
 zope.deprecation==4.1.2
 zope.interface==4.1.3
 zope.sqlalchemy==0.7.6

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='3.0.2.dev0',
+      version='3.0.2',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='3.0.2',
+      version='3.1.0',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',


### PR DESCRIPTION
This is another incredibly minor release to ease transition to the 3.0 series of Kinto. It fixes a bug with the backwards compatibility with old Cliquet settings.

**Step 1**
```
$ git co -b prepare-X.X
$ prerelease
$ vim docs/conf.py
$ git ci -a --amend
$ git push origin prepare-X.X
```

* [ ] Merge remaining pull requests
* [x] Update changelog
* [x] Update version in docs/conf.py
* [x] Version dependencies
* [x] if the  protocol was updated, upgrade API protocol in docs/

**Step 2**
```
$ git co master
$ git merge --no-ff prepare-X.X
$ release
$ postrelease
```
* [x] Tag vX.Y.Z
* [x] Publish on Pypi

**Step 3**
* [ ] Close milestone in Github
* [x] Add entry in Github release page
* [ ] Create next milestone in Github
* [x] Configure the version in ReadTheDocs
* [ ] Update kinto version in kinto.js repo
* [ ] Upgrade demo server
* [ ] Upgrade kinto-dist
* [ ] Send mail to ML
* [ ] Tweet!

@Natim @leplatrem r?