### PR TITLE
Added the GET /contribute.json endpoint for open-source information (fixes #607)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ This document describes changes between each past release.
 3.0.2 (unreleased)
 ==================
 
+**Protocol**
+
+- Added the ``GET /contribute.json`` endpoint for open-source information (fixes #607)
+
+Protocol is now in version **1.6**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+
+
 **Bug fixes**
 
 - Fix internal storage filtering when an empty list of values is provided.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ This document describes changes between each past release.
 
 - Added the ``GET /contribute.json`` endpoint for open-source information (fixes #607)
 
-Protocol is now in version **1.6**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+Protocol is now at version **1.6**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
 
 
 **Bug fixes**

--- a/docs/api/1.x/utilities.rst
+++ b/docs/api/1.x/utilities.rst
@@ -79,3 +79,11 @@ always return 200.
 This endpoint is suitable for a load balancer membership test.
 It the load balancer cannot obtain a response from this endpoint, it will
 stop sending traffic to the instance and replace it.
+
+.. _api-utilities-contribute:
+
+GET /contribute.json
+====================
+
+The returned value is a JSON mapping containing open source contribution
+information as advocated by https://www.contributejson.org

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,6 +11,12 @@ API
 Changelog
 ---------
 
+1.6 (unreleased)
+''''''''''''''''
+
+- Added the ``GET /contribute.json`` endpoint for open-source information.
+
+
 1.5 (2016-04-21)
 ''''''''''''''''
 

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -94,6 +94,14 @@ If you are proposing a feature:
   rough idea. This is a volunteer-driven project, and contributions
   are welcome :)
 
+Contribute.json
+---------------
+
+*Kinto* implements the ``GET /contribute.json`` endpoint which provides
+structured open source contribution information.
+
+See :ref:`API docs <api-utilities-contribute>`.
+
 
 Hack
 ====

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -12,7 +12,7 @@ from kinto.authorization import RouteFactory
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # Implemented HTTP API Version
-HTTP_API_VERSION = '1.5'
+HTTP_API_VERSION = '1.6'
 
 # Main kinto logger
 logger = logging.getLogger(__name__)

--- a/kinto/tests/test_views_contribute.py
+++ b/kinto/tests/test_views_contribute.py
@@ -1,0 +1,13 @@
+from kinto import __version__ as VERSION
+
+from .support import BaseWebTest, unittest
+
+
+class ContributeViewTest(BaseWebTest, unittest.TestCase):
+
+    def test_returns_info_about_project(self):
+        response = self.app.get('/contribute.json')
+        keys = sorted(response.json.keys())
+        expected = ['description', 'keywords', 'name', 'participate',
+                    'repository', 'urls']
+        self.assertEqual(keys, expected)

--- a/kinto/tests/test_views_contribute.py
+++ b/kinto/tests/test_views_contribute.py
@@ -1,5 +1,3 @@
-from kinto import __version__ as VERSION
-
 from .support import BaseWebTest, unittest
 
 

--- a/kinto/views/contribute.py
+++ b/kinto/views/contribute.py
@@ -1,0 +1,34 @@
+from cornice import Service
+from pyramid.security import NO_PERMISSION_REQUIRED
+
+
+contribute = Service(name='contribute.json',
+                     description='Open-source information',
+                     path='/contribute.json')
+
+
+@contribute.get(permission=NO_PERMISSION_REQUIRED)
+def contribute_get(request):
+    return {
+        "name": "kinto",
+        "description": "A minimalist JSON storage service.",
+        "repository": {
+            "url": "https://github.com/Kinto/kinto",
+            "license": "Apache License (2.0)"
+        },
+        "participate": {
+            "docs": "https://kinto.readthedocs.io/",
+            "mailing-list": "kinto@mozilla.org",
+            "irc": "irc://irc.freenode.net/#kinto",
+        },
+        "keywords": [
+            "JSON",
+            "Python",
+            "Offline",
+            "Sync",
+            "Storage",
+        ],
+        "urls": {
+            "dev": "https://kinto.dev.mozaws.net/v1/"
+        }
+    }


### PR DESCRIPTION
I wonder where to put the API endpoint docs ? in Utilities ?

@Natim @glasserc r?