### PR TITLE
Add permissions endpoint (fixes #600)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,12 @@ This document describes changes between each past release.
 3.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Protocol**
+
+- Add new endpoint ``GET /v1/permissions`` to retrieve the list of permissions
+  granted on every kind of object (#600).
+
+Protocol is now at version **1.8**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
 
 
 3.2.0 (2016-06-14)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,9 @@ This document describes changes between each past release.
 
 **Protocol**
 
-- Add new endpoint ``GET /v1/permissions`` to retrieve the list of permissions
+- Add new *experimental* endpoint ``GET /v1/permissions`` to retrieve the list of permissions
   granted on every kind of object (#600).
+  Requires setting ``kinto.experimental_permissions_endpoint`` to be set to ``true``.
 
 Protocol is now at version **1.8**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
 

--- a/docs/api/1.x/permissions.rst
+++ b/docs/api/1.x/permissions.rst
@@ -140,9 +140,8 @@ In this case the user ID is: ``basicauth:631c2d625ee5726172cf67c6750de10a3e1a04b
     user ID - this is an easy way to obtain that ID.
 
 
-
-Retrieve permissions
-====================
+Retrieve objects permissions
+============================
 
 .. http:get:: /(object url)
 
@@ -193,8 +192,8 @@ Retrieve permissions
         }
 
 
-Modify permissions
-==================
+Modify object permissions
+=========================
 
 An object's permissions can be modified at the same time as the object
 itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
@@ -331,4 +330,69 @@ itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
                     "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
                 ]
             }
+        }
+
+
+List every permissions
+======================
+
+.. http:get:: /permissions
+
+    :synopsis: Retrieve the list of permissions granted on every kind of objects.
+
+    **Optional authentication**
+
+    **Example request**
+
+    .. sourcecode:: bash
+
+        $ http GET https://kinto.dev.mozaws.net/v1/permissions --auth token:bob-token
+
+    .. sourcecode:: http
+
+        GET /v1/permissions HTTP/1.1
+        Accept: */*
+        Accept-Encoding: gzip, deflate
+        Authorization: Basic Ym9iOg==
+        Connection: keep-alive
+        Host: localhost:8888
+        User-Agent: HTTPie/0.9.2
+
+    **Example response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Length: 487
+        Content-Type: application/json; charset=UTF-8
+        Date: Wed, 15 Jun 2016 16:00:22 GMT
+        Server: waitress
+
+        {
+            "data": [
+                {
+                    "bucket_id": "2f9b1aaa-552d-48e8-1b78-371dd08688b3",
+                    "collection_id": "test",
+                    "id": "test",
+                    "permissions": [
+                        "write",
+                        "read",
+                        "record:create"
+                    ],
+                    "resource_name": "collection",
+                    "uri": "/buckets/2f9b1aaa-552d-48e8-1b78-371dd08688b3/collections/test"
+                },
+                {
+                    "bucket_id": "2f9b1aaa-552d-48e8-1b78-371dd08688b3",
+                    "id": "2f9b1aaa-552d-48e8-1b78-371dd08688b3",
+                    "permissions": [
+                        "write",
+                        "read",
+                        "collection:create",
+                        "group:create"
+                    ],
+                    "resource_name": "bucket",
+                    "uri": "/buckets/2f9b1aaa-552d-48e8-1b78-371dd08688b3"
+                }
+            ]
         }

--- a/docs/api/1.x/permissions.rst
+++ b/docs/api/1.x/permissions.rst
@@ -336,6 +336,9 @@ itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
 List every permissions
 ======================
 
+**Requires setting** ``kinto.experimental_permissions_endpoint`` to ``True``.
+
+
 .. http:get:: /permissions
 
     :synopsis: Retrieve the list of permissions granted on every kind of objects.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,6 +11,13 @@ API
 Changelog
 ---------
 
+1.8 (unreleased)
+''''''''''''''''
+
+- Add new endpoint ``GET /v1/permissions`` to retrieve the list of permissions
+  granted on every kind of object.
+
+
 1.7 (unreleased)
 ''''''''''''''''
 

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -28,7 +28,8 @@ DEFAULT_SETTINGS = {
     'bucket_create_principals': Authenticated,
     'multiauth.authorization_policy': (
         'kinto.authorization.AuthorizationPolicy'),
-    'experimental_collection_schema_validation': 'False',
+    'experimental_collection_schema_validation': False,
+    'experimental_permissions_endpoint': False,
     'http_api_version': HTTP_API_VERSION
 }
 
@@ -60,7 +61,7 @@ def main(global_config, config=None, **settings):
     # Scan Kinto views.
     kwargs = {}
 
-    flush_enabled = asbool(settings.get('flush_endpoint_enabled'))
+    flush_enabled = asbool(settings['flush_endpoint_enabled'])
     if flush_enabled:
         config.add_api_capability(
             "flush_endpoint",
@@ -69,7 +70,14 @@ def main(global_config, config=None, **settings):
             url="http://kinto.readthedocs.io/en/latest/configuration/"
                 "settings.html#activating-the-flush-endpoint")
     else:
-        kwargs['ignore'] = 'kinto.views.flush'
+        kwargs['ignore'] = ['kinto.views.flush']
+
+    # Permissions endpoint enabled if permission backend is setup.
+    permissions_endpoint_enabled = (
+        asbool(settings['experimental_permissions_endpoint']) and
+        hasattr(config.registry, 'permission'))
+    if not permissions_endpoint_enabled:
+        kwargs.setdefault('ignore', []).append('kinto.views.permissions')
 
     config.scan("kinto.views", **kwargs)
 

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -365,7 +365,13 @@ def strip_uri_prefix(path):
 
 def view_lookup(request, uri):
     """
-    XXX
+    Look-up the specified `uri` and return the associated resource name
+    along the match dict.
+
+    :param request: the current request (used to obtain registry).
+    :param uri: a plural or object endpoint URI.
+    :rtype: tuple
+    :returns: the resource name and the associated matchdict.
     """
     api_prefix = '/%s' % request.upath_info.split('/')[1]
     q = request.registry.queryUtility

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -36,6 +36,7 @@ except ImportError:  # pragma: no cover
     sqlalchemy = None
 
 from pyramid import httpexceptions
+from pyramid.interfaces import IRoutesMapper
 from pyramid.request import Request, apply_request_extensions
 from pyramid.settings import aslist
 from pyramid.view import render_view_to_response
@@ -360,3 +361,19 @@ def strip_uri_prefix(path):
     Remove potential version prefix in URI.
     """
     return re.sub(r'^(/v\d+)?', '', six.text_type(path))
+
+
+def view_lookup(request, uri):
+    """
+    XXX
+    """
+    api_prefix = '/%s' % request.upath_info.split('/')[1]
+    q = request.registry.queryUtility
+    routes_mapper = q(IRoutesMapper)
+
+    fakerequest = Request.blank(path=api_prefix + uri)
+    info = routes_mapper(fakerequest)
+    matchdict, route = info['match'], info['route']
+    resource_name = route.name.replace('-record', '')\
+                              .replace('-collection', '')
+    return resource_name, matchdict

--- a/kinto/tests/test_views_objects_permissions.py
+++ b/kinto/tests/test_views_objects_permissions.py
@@ -1,0 +1,180 @@
+from .support import (BaseWebTest, unittest, get_user_headers,
+                      MINIMALIST_BUCKET, MINIMALIST_COLLECTION,
+                      MINIMALIST_GROUP, MINIMALIST_RECORD)
+
+
+class PermissionsTest(BaseWebTest, unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(PermissionsTest, self).__init__(*args, **kwargs)
+        self.alice_headers = self.headers.copy()
+        self.alice_headers.update(**get_user_headers('alice'))
+        self.alice_principal = ('basicauth:8df4b22019cc89d0bb679bc51373a9da56a'
+                                '7ae9978c52fbe684510c3d257c855')
+        self.bob_headers = self.headers.copy()
+        self.bob_headers.update(**get_user_headers('bob'))
+        self.bob_principal = ('basicauth:21364d1282b58b3af15a0d619d03122a318be'
+                              'e30c1a5a2d09c3b958e5f7fb71a')
+
+
+class BucketPermissionsTest(PermissionsTest):
+
+    def setUp(self):
+        bucket = MINIMALIST_BUCKET.copy()
+        bucket['permissions'] = {'read': [self.alice_principal]}
+        self.app.put_json('/buckets/sodas',
+                          bucket,
+                          headers=self.headers)
+
+    def test_creation_is_allowed_to_authenticated_by_default(self):
+        self.app.put_json('/buckets/beer',
+                          MINIMALIST_BUCKET,
+                          headers=self.headers)
+
+    def test_current_user_receives_write_permission_on_creation(self):
+        resp = self.app.put_json('/buckets/beer',
+                                 MINIMALIST_BUCKET,
+                                 headers=self.headers)
+        permissions = resp.json['permissions']
+        self.assertIn(self.principal, permissions['write'])
+
+    def test_can_read_if_allowed(self):
+        self.app.get('/buckets/sodas',
+                     headers=self.alice_headers)
+
+    def test_cannot_write_if_not_allowed(self):
+        self.app.put_json('/buckets/sodas',
+                          MINIMALIST_BUCKET,
+                          headers=self.alice_headers,
+                          status=403)
+
+
+class CollectionPermissionsTest(PermissionsTest):
+
+    def setUp(self):
+        bucket = MINIMALIST_BUCKET.copy()
+        bucket['permissions'] = {
+            'read': [self.alice_principal],
+            'write': [self.bob_principal]
+        }
+        self.app.put_json('/buckets/beer',
+                          bucket,
+                          headers=self.headers)
+        self.app.put_json('/buckets/beer/collections/barley',
+                          MINIMALIST_COLLECTION,
+                          headers=self.headers)
+
+    def test_read_is_allowed_if_read_on_bucket(self):
+        self.app.get('/buckets/beer/collections/barley',
+                     headers=self.alice_headers)
+
+    def test_read_is_allowed_if_write_on_bucket(self):
+        self.app.get('/buckets/beer/collections/barley',
+                     headers=self.bob_headers)
+
+    def test_cannot_read_if_not_allowed(self):
+        headers = self.headers.copy()
+        headers.update(**get_user_headers('jean-louis'))
+        self.app.get('/buckets/beer/collections/barley',
+                     headers=headers,
+                     status=403)
+
+    def test_cannot_write_if_not_allowed(self):
+        self.app.put_json('/buckets/beer/collections/barley',
+                          MINIMALIST_COLLECTION,
+                          headers=self.alice_headers,
+                          status=403)
+
+
+class GroupPermissionsTest(PermissionsTest):
+
+    def setUp(self):
+        bucket = MINIMALIST_BUCKET.copy()
+        bucket['permissions'] = {
+            'read': [self.alice_principal],
+            'write': [self.bob_principal]
+        }
+        self.app.put_json('/buckets/beer',
+                          bucket,
+                          headers=self.headers)
+
+        self.app.put_json('/buckets/beer/groups/moderators',
+                          MINIMALIST_GROUP,
+                          headers=self.headers)
+
+    def test_creation_is_allowed_if_write_on_bucket(self):
+        self.app.post_json('/buckets/beer/groups',
+                           MINIMALIST_GROUP,
+                           headers=self.headers)
+
+    def test_read_is_allowed_if_read_on_bucket(self):
+        self.app.get('/buckets/beer/groups/moderators',
+                     headers=self.alice_headers)
+
+    def test_read_is_allowed_if_write_on_bucket(self):
+        self.app.get('/buckets/beer/groups/moderators',
+                     headers=self.bob_headers)
+
+    def test_cannot_read_if_not_allowed(self):
+        headers = self.headers.copy()
+        headers.update(**get_user_headers('jean-louis'))
+        self.app.get('/buckets/beer/groups/moderators',
+                     headers=headers,
+                     status=403)
+
+    def test_cannot_write_if_not_allowed(self):
+        self.app.put_json('/buckets/beer/groups/moderators',
+                          MINIMALIST_GROUP,
+                          headers=self.alice_headers,
+                          status=403)
+
+    def test_creation_is_forbidden_is_no_write_on_bucket(self):
+        self.app.post_json('/buckets/beer/groups',
+                           MINIMALIST_GROUP,
+                           headers=self.alice_headers,
+                           status=403)
+
+
+class RecordPermissionsTest(PermissionsTest):
+
+    def setUp(self):
+        bucket = MINIMALIST_BUCKET.copy()
+        bucket['permissions'] = {'write': [self.alice_principal]}
+        self.app.put_json('/buckets/beer',
+                          bucket,
+                          headers=self.headers)
+
+        collection = MINIMALIST_COLLECTION.copy()
+        collection['permissions'] = {'write': [self.bob_principal]}
+        self.app.put_json('/buckets/beer/collections/barley',
+                          collection,
+                          headers=self.headers)
+
+    def test_creation_is_allowed_if_write_on_bucket(self):
+        self.app.post_json('/buckets/beer/collections/barley/records',
+                           MINIMALIST_RECORD,
+                           headers=self.alice_headers)
+
+    def test_creation_is_allowed_if_write_on_collection(self):
+        self.app.post_json('/buckets/beer/collections/barley/records',
+                           MINIMALIST_RECORD,
+                           headers=self.bob_headers)
+
+    def test_creation_is_forbidden_is_no_write_on_bucket_nor_collection(self):
+        headers = self.headers.copy()
+        headers.update(**get_user_headers('jean-louis'))
+        self.app.post_json('/buckets/beer/collections/barley/records',
+                           MINIMALIST_RECORD,
+                           headers=headers,
+                           status=403)
+
+    def test_record_permissions_are_modified_by_patch(self):
+        collection_url = '/buckets/beer/collections/barley/records'
+        resp = self.app.post_json(collection_url,
+                                  MINIMALIST_RECORD,
+                                  headers=self.headers)
+        record = resp.json['data']
+        resp = self.app.patch_json(collection_url + '/' + record['id'],
+                                   {'permissions': {'read': ['fxa:user']}},
+                                   headers=self.headers)
+        self.assertIn('fxa:user', resp.json['permissions']['read'])

--- a/kinto/tests/test_views_permissions.py
+++ b/kinto/tests/test_views_permissions.py
@@ -1,180 +1,57 @@
-from .support import (BaseWebTest, unittest, get_user_headers,
-                      MINIMALIST_BUCKET, MINIMALIST_COLLECTION,
-                      MINIMALIST_GROUP, MINIMALIST_RECORD)
+from .support import (BaseWebTest, unittest, MINIMALIST_RECORD,
+                      MINIMALIST_GROUP, MINIMALIST_BUCKET,
+                      MINIMALIST_COLLECTION, get_user_headers)
 
 
-class PermissionsTest(BaseWebTest, unittest.TestCase):
-
-    def __init__(self, *args, **kwargs):
-        super(PermissionsTest, self).__init__(*args, **kwargs)
-        self.alice_headers = self.headers.copy()
-        self.alice_headers.update(**get_user_headers('alice'))
-        self.alice_principal = ('basicauth:8df4b22019cc89d0bb679bc51373a9da56a'
-                                '7ae9978c52fbe684510c3d257c855')
-        self.bob_headers = self.headers.copy()
-        self.bob_headers.update(**get_user_headers('bob'))
-        self.bob_principal = ('basicauth:21364d1282b58b3af15a0d619d03122a318be'
-                              'e30c1a5a2d09c3b958e5f7fb71a')
+RECORD_ID = 'd5db6e57-2c10-43e2-96c8-56602ef01435'
 
 
-class BucketPermissionsTest(PermissionsTest):
+class PermissionsViewTest(BaseWebTest, unittest.TestCase):
 
     def setUp(self):
-        bucket = MINIMALIST_BUCKET.copy()
-        bucket['permissions'] = {'read': [self.alice_principal]}
-        self.app.put_json('/buckets/sodas',
-                          bucket,
+        super(PermissionsViewTest, self).setUp()
+        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
                           headers=self.headers)
-
-    def test_creation_is_allowed_to_authenticated_by_default(self):
-        self.app.put_json('/buckets/beer',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
-
-    def test_current_user_receives_write_permission_on_creation(self):
-        resp = self.app.put_json('/buckets/beer',
-                                 MINIMALIST_BUCKET,
-                                 headers=self.headers)
-        permissions = resp.json['permissions']
-        self.assertIn(self.principal, permissions['write'])
-
-    def test_can_read_if_allowed(self):
-        self.app.get('/buckets/sodas',
-                     headers=self.alice_headers)
-
-    def test_cannot_write_if_not_allowed(self):
-        self.app.put_json('/buckets/sodas',
-                          MINIMALIST_BUCKET,
-                          headers=self.alice_headers,
-                          status=403)
-
-
-class CollectionPermissionsTest(PermissionsTest):
-
-    def setUp(self):
-        bucket = MINIMALIST_BUCKET.copy()
-        bucket['permissions'] = {
-            'read': [self.alice_principal],
-            'write': [self.bob_principal]
-        }
-        self.app.put_json('/buckets/beer',
-                          bucket,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beer/collections/barley',
+        self.app.put_json('/buckets/beers/collections/barley',
                           MINIMALIST_COLLECTION,
                           headers=self.headers)
-
-    def test_read_is_allowed_if_read_on_bucket(self):
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=self.alice_headers)
-
-    def test_read_is_allowed_if_write_on_bucket(self):
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=self.bob_headers)
-
-    def test_cannot_read_if_not_allowed(self):
-        headers = self.headers.copy()
-        headers.update(**get_user_headers('jean-louis'))
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=headers,
-                     status=403)
-
-    def test_cannot_write_if_not_allowed(self):
-        self.app.put_json('/buckets/beer/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.alice_headers,
-                          status=403)
-
-
-class GroupPermissionsTest(PermissionsTest):
-
-    def setUp(self):
-        bucket = MINIMALIST_BUCKET.copy()
-        bucket['permissions'] = {
-            'read': [self.alice_principal],
-            'write': [self.bob_principal]
-        }
-        self.app.put_json('/buckets/beer',
-                          bucket,
-                          headers=self.headers)
-
-        self.app.put_json('/buckets/beer/groups/moderators',
+        self.app.put_json('/buckets/beers/groups/amateurs',
                           MINIMALIST_GROUP,
                           headers=self.headers)
-
-    def test_creation_is_allowed_if_write_on_bucket(self):
-        self.app.post_json('/buckets/beer/groups',
-                           MINIMALIST_GROUP,
+        self.app.put_json('/buckets/beers/collections/barley/records/' + RECORD_ID,  # noqa
+                           MINIMALIST_RECORD,
                            headers=self.headers)
 
-    def test_read_is_allowed_if_read_on_bucket(self):
-        self.app.get('/buckets/beer/groups/moderators',
-                     headers=self.alice_headers)
+        # Other user.
+        self.app.put_json('/buckets/water', MINIMALIST_BUCKET,
+                          headers=get_user_headers('alice'))
 
-    def test_read_is_allowed_if_write_on_bucket(self):
-        self.app.get('/buckets/beer/groups/moderators',
-                     headers=self.bob_headers)
+    def test_permissions_list_entries_for_current_principal(self):
+        resp = self.app.get('/permissions', headers=self.headers)
+        permissions = resp.json['data']
+        self.assertEqual(len(permissions), 4)
 
-    def test_cannot_read_if_not_allowed(self):
-        headers = self.headers.copy()
-        headers.update(**get_user_headers('jean-louis'))
-        self.app.get('/buckets/beer/groups/moderators',
-                     headers=headers,
-                     status=403)
+    def test_permissions_can_be_listed_anonymously(self):
+        self.app.patch_json('/buckets/beers/collections/barley',
+                            {'permissions': {'write': ['system.Everyone']}},
+                            headers=self.headers)
+        resp = self.app.get('/permissions')
+        permissions = resp.json['data']
+        self.assertEqual(len(permissions), 1)
 
-    def test_cannot_write_if_not_allowed(self):
-        self.app.put_json('/buckets/beer/groups/moderators',
-                          MINIMALIST_GROUP,
-                          headers=self.alice_headers,
-                          status=403)
+    def test_implicit_permissions_are_explicited(self):
+        resp = self.app.get('/permissions', headers=get_user_headers('alice'))
+        permissions = resp.json['data']
+        bucket_permissions = permissions[0]
+        self.assertEqual(sorted(bucket_permissions['permissions']),
+                         ['collection:create', 'read', 'write'])
 
-    def test_creation_is_forbidden_is_no_write_on_bucket(self):
-        self.app.post_json('/buckets/beer/groups',
-                           MINIMALIST_GROUP,
-                           headers=self.alice_headers,
-                           status=403)
-
-
-class RecordPermissionsTest(PermissionsTest):
-
-    def setUp(self):
-        bucket = MINIMALIST_BUCKET.copy()
-        bucket['permissions'] = {'write': [self.alice_principal]}
-        self.app.put_json('/buckets/beer',
-                          bucket,
-                          headers=self.headers)
-
-        collection = MINIMALIST_COLLECTION.copy()
-        collection['permissions'] = {'write': [self.bob_principal]}
-        self.app.put_json('/buckets/beer/collections/barley',
-                          collection,
-                          headers=self.headers)
-
-    def test_creation_is_allowed_if_write_on_bucket(self):
-        self.app.post_json('/buckets/beer/collections/barley/records',
-                           MINIMALIST_RECORD,
-                           headers=self.alice_headers)
-
-    def test_creation_is_allowed_if_write_on_collection(self):
-        self.app.post_json('/buckets/beer/collections/barley/records',
-                           MINIMALIST_RECORD,
-                           headers=self.bob_headers)
-
-    def test_creation_is_forbidden_is_no_write_on_bucket_nor_collection(self):
-        headers = self.headers.copy()
-        headers.update(**get_user_headers('jean-louis'))
-        self.app.post_json('/buckets/beer/collections/barley/records',
-                           MINIMALIST_RECORD,
-                           headers=headers,
-                           status=403)
-
-    def test_record_permissions_are_modified_by_patch(self):
-        collection_url = '/buckets/beer/collections/barley/records'
-        resp = self.app.post_json(collection_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        record = resp.json['data']
-        resp = self.app.patch_json(collection_url + '/' + record['id'],
-                                   {'permissions': {'read': ['fxa:user']}},
-                                   headers=self.headers)
-        self.assertIn('fxa:user', resp.json['permissions']['read'])
+    def test_object_details_are_provided(self):
+        resp = self.app.get('/permissions', headers=self.headers)
+        entries = resp.json['data']
+        for entry in entries:
+            if entry['resource_name'] == 'record':
+                record_permission = entry
+        self.assertEqual(record_permission['record_id'], RECORD_ID)
+        self.assertEqual(record_permission['collection_id'], 'barley')
+        self.assertEqual(record_permission['bucket_id'], 'beers')

--- a/kinto/tests/test_views_permissions.py
+++ b/kinto/tests/test_views_permissions.py
@@ -26,6 +26,12 @@ class PermissionsViewTest(BaseWebTest, unittest.TestCase):
         self.app.put_json('/buckets/water', MINIMALIST_BUCKET,
                           headers=get_user_headers('alice'))
 
+    def get_app_settings(self, additional_settings=None):
+        settings = super(PermissionsViewTest, self).get_app_settings(
+            additional_settings)
+        settings['experimental_permissions_endpoint'] = 'True'
+        return settings
+
     def test_permissions_list_entries_for_current_principal(self):
         resp = self.app.get('/permissions', headers=self.headers)
         permissions = resp.json['data']
@@ -44,7 +50,10 @@ class PermissionsViewTest(BaseWebTest, unittest.TestCase):
         permissions = resp.json['data']
         bucket_permissions = permissions[0]
         self.assertEqual(sorted(bucket_permissions['permissions']),
-                         ['collection:create', 'read', 'write'])
+                         ['collection:create',
+                          'group:create',
+                          'read',
+                          'write'])
 
     def test_object_details_are_provided(self):
         resp = self.app.get('/permissions', headers=self.headers)

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -1,0 +1,56 @@
+from cornice import Service
+from pyramid.request import Request
+from pyramid.interfaces import IRoutesMapper
+from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
+
+
+permissions = Service(name='permissions',
+                      description='List of user permissions',
+                      path='/permissions')
+
+
+@permissions.get(permission=NO_PERMISSION_REQUIRED)
+def permissions_get(request):
+    backend = request.registry.permission
+    # XXX : add setting «experimental» ?
+    # XXX : if backend is None, route should be ignored in kinto init
+
+    # Obtain current principals.
+    principals = request.effective_principals
+    if Authenticated in principals:
+        # XXX: since view does not require permission, had to do this:
+        userid = request.prefixed_userid
+        principals.append(userid)
+
+    # XXX should work with read and others
+    object_uris = backend.principals_accessible_objects(principals, 'write')
+
+    q = request.registry.queryUtility
+    routes_mapper = q(IRoutesMapper)
+
+    entries = []
+    for object_uri in object_uris:
+        # Obtain associated resource to object URI
+        # XXX: move to core.utils
+        # XXX: hard coded v1
+        fakerequest = Request.blank(path='/v1' + object_uri)
+        info = routes_mapper(fakerequest)
+        match, route = info['match'], info['route']
+        resource_name = route.name.replace('-record', '')
+        match['%s_id' % resource_name] = match.pop('id')
+
+        # XXX hard coded perms tree
+        # XXX: move to helper in authorization
+        permissions = ['read', 'write']
+        if resource_name == 'bucket':
+            permissions.append('collection:create')
+        elif resource_name == 'collection':
+            permissions.append('record:create')
+
+        entry = dict(uri=object_uri,
+                     resource_name=resource_name,
+                     permissions=permissions,
+                     **match)
+        entries.append(entry)
+
+    return {"data": entries}

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -1,8 +1,7 @@
-from cornice import Service
 from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
-from kinto.core import utils as core_utils
+from kinto.core import Service, utils as core_utils
 
 
 permissions = Service(name='permissions',

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -3,6 +3,8 @@ from pyramid.request import Request
 from pyramid.interfaces import IRoutesMapper
 from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
+from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
+
 
 permissions = Service(name='permissions',
                       description='List of user permissions',
@@ -12,8 +14,19 @@ permissions = Service(name='permissions',
 @permissions.get(permission=NO_PERMISSION_REQUIRED)
 def permissions_get(request):
     backend = request.registry.permission
-    # XXX : add setting «experimental» ?
+    # XXX : add setting experimental?
     # XXX : if backend is None, route should be ignored in kinto init
+
+    possible_perms = set([k.split(':', 1)[1]
+                          for k in PERMISSIONS_INHERITANCE_TREE.keys()])
+
+    perms_descending_tree = {}
+    for obtained_perm, obtained_from in PERMISSIONS_INHERITANCE_TREE.items():
+        for resource, perms in obtained_from.items():
+            for perm in perms:
+                perms_descending_tree.setdefault(resource, {})\
+                                     .setdefault(perm, set())\
+                                     .add(obtained_perm)
 
     # Obtain current principals.
     principals = request.effective_principals
@@ -22,34 +35,37 @@ def permissions_get(request):
         userid = request.prefixed_userid
         principals.append(userid)
 
-    # XXX should work with read and others
-    object_uris = backend.principals_accessible_objects(principals, 'write')
+    perms_by_object_uri = {}
+    for perm in possible_perms:
+        object_uris = backend.principals_accessible_objects(principals, perm)
+        for object_uri in object_uris:
+            perms_by_object_uri.setdefault(object_uri, []).append(perm)
 
+    api_prefix = '/%s' % request.upath_info.split('/')[1]
     q = request.registry.queryUtility
     routes_mapper = q(IRoutesMapper)
 
     entries = []
-    for object_uri in object_uris:
+    for object_uri, perms in perms_by_object_uri.items():
         # Obtain associated resource to object URI
         # XXX: move to core.utils
-        # XXX: hard coded v1
-        fakerequest = Request.blank(path='/v1' + object_uri)
+        fakerequest = Request.blank(path=api_prefix + object_uri)
         info = routes_mapper(fakerequest)
         match, route = info['match'], info['route']
-        resource_name = route.name.replace('-record', '')
+        resource_name = route.name.replace('-record', '')\
+                                  .replace('-collection', '')
         match['%s_id' % resource_name] = match.pop('id')
 
-        # XXX hard coded perms tree
-        # XXX: move to helper in authorization
-        permissions = ['read', 'write']
-        if resource_name == 'bucket':
-            permissions.append('collection:create')
-        elif resource_name == 'collection':
-            permissions.append('record:create')
+        permissions = set(perms)
+        for perm in perms:
+            obtained = perms_descending_tree[resource_name][perm]
+            shown = [p.split(':', 1)[1]
+                     for p in obtained if p.startswith(resource_name)]
+            permissions |= set(shown)
 
         entry = dict(uri=object_uri,
                      resource_name=resource_name,
-                     permissions=permissions,
+                     permissions=list(permissions),
                      **match)
         entries.append(entry)
 


### PR DESCRIPTION
I wanted to give a try to my proposition in #600.

This **can be thrown away** if the approach is wrong. It allowed me to figure out what pieces of code were necessary, especially regarding the permission backend API.

edit: ~~For example, the current code only works with `write` permissions.~~

> I renamed `test_views_permissions.py` to `test_views_objects_permissions.py` and it screwed the diff...

### Test it

```
$ KINTO_EXPERIMENTAL_PERMISSIONS_ENDPOINT=true kinto start --reload
```

```
$ echo {} | http PUT :8888/v1/buckets/default/collections/test --auth user:pass
```

```
$ http  :8888/v1/permissions --auth user:pass
```

```http
HTTP/1.1 200 OK
Content-Length: 431
Content-Type: application/json; charset=UTF-8
Date: Wed, 25 May 2016 16:20:34 GMT
Server: waitress

{
    "data": [
        {
            "bucket_id": "2f9b1aaa-552d-48e8-1b78-371dd08688b3", 
            "collection_id": "test", 
            "permissions": [
                "write", 
                "read", 
                "record:create"
            ], 
            "resource_name": "collection", 
            "uri": "/buckets/2f9b1aaa-552d-48e8-1b78-371dd08688b3/collections/test"
        }, 
        {
            "bucket_id": "2f9b1aaa-552d-48e8-1b78-371dd08688b3", 
            "permissions": [
                "write", 
                "read", 
                "collection:create", 
                "group:create"
            ], 
            "resource_name": "bucket", 
            "uri": "/buckets/2f9b1aaa-552d-48e8-1b78-371dd08688b3"
        }
    ]
}

```



