### PR TITLE
Fix 400 with data.id in default bucket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fix loss of data attributes when permissions are replaced with ``PUT`` (fixes #601)
+- Fix 400 response when posting data with ``id: "default"`` in default bucket.
+
+**Internal changes**
+
+- Renamed some permission backend methods for consistency with other classes (fixes #608)
 
 
 3.1.0 (2016-05-24)

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -254,8 +254,12 @@ def build_request(original, dict_obj):
     path = path.encode('utf-8')
 
     method = dict_obj.get('method') or 'GET'
+
     headers = dict(original.headers)
     headers.update(**dict_obj.get('headers') or {})
+    # Body can have different length, do not use original header.
+    headers.pop('Content-Length', None)
+
     payload = dict_obj.get('body') or ''
 
     # Payload is always a dict (from ``BatchRequestSchema.body``).

--- a/kinto/plugins/default_bucket/__init__.py
+++ b/kinto/plugins/default_bucket/__init__.py
@@ -126,6 +126,13 @@ def default_bucket(request):
     querystring = request.url[(request.url.index(request.path) +
                                len(request.path)):]
 
+    try:
+        # If 'id' is provided as 'default', replace with actual bucket id.
+        body = request.json
+        body['data']['id'] = body['data']['id'].replace('default', bucket_id)
+    except:
+        body = request.body
+
     # Make sure bucket exists
     create_bucket(request, bucket_id)
 
@@ -135,7 +142,7 @@ def default_bucket(request):
     subrequest = build_request(request, {
         'method': request.method,
         'path': path + querystring,
-        'body': request.body
+        'body': body,
     })
     subrequest.bound_data = request.bound_data
 

--- a/kinto/plugins/default_bucket/test_plugin.py
+++ b/kinto/plugins/default_bucket/test_plugin.py
@@ -130,6 +130,12 @@ class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
                             headers=self.headers)
         self.assertEquals(resp.json['data'][0]['id'], 'default')
 
+    def test_bucket_id_in_body_can_be_default(self):
+        self.app.put_json('/buckets/default',
+                          {'data': {'id': 'default'}},
+                          headers=self.headers,
+                          status=201)
+
     def test_default_bucket_objects_are_checked_only_once_in_batch(self):
         batch = {'requests': []}
         nb_create = 25


### PR DESCRIPTION
It can look hacky, but it remains confined in the default plugin, and prevents clients to have code like `if id == "default"`

@Natim r?