### PR TITLE
Fix put permissions (fixes #661)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ This document describes changes between each past release.
   it won't work if the port is hard-coded in your existing ``.ini`` file. Replace
   it by ``%(http_port)s`` or regenerate a new configuration file with ``kinto init``.
 
+**Bug fixes**
+
+- Fix loss of data attributes when permissions are replaced with ``PUT`` (fixes #601)
+
 
 3.1.0 (2016-05-24)
 ==================

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -413,7 +413,8 @@ class UserResource(object):
             if existing:
                 self._raise_412_if_modified(existing)
 
-        post_record = self.request.validated['data']
+        # If `data` is not provided, use existing record (or empty if creation)
+        post_record = self.request.validated.get('data', existing) or {}
 
         record_id = post_record.setdefault(id_field, self.record_id)
         self._raise_400_if_id_mismatch(record_id, self.record_id)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -303,7 +303,7 @@ class UserResource(object):
             :meth:`kinto.core.resource.UserResource.process_record`
         """
         existing = None
-        new_record = self.request.validated['data']
+        new_record = self.request.validated.get('data', {})
         try:
             id_field = self.model.id_field
             # Since ``id`` does not belong to schema, look up in body.

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -115,14 +115,6 @@ class ViewSet(object):
         else:
             record_mapping = resource_cls.mapping
 
-            try:
-                record_mapping.deserialize({})
-                # Empty data accepted.
-                record_mapping.missing = colander.drop
-                record_mapping.default = {}
-            except colander.Invalid:
-                pass
-
         class PayloadSchema(colander.MappingSchema):
             data = record_mapping
 
@@ -200,7 +192,14 @@ class ShareableViewSet(ViewSet):
         if method.lower() not in map(str.lower, self.validate_schema_for):
             return schema
 
-        if method.lower() == 'patch':
+        try:
+            empty_allowed = False
+            schema.deserialize({"data": {}})
+            empty_allowed = True
+        except colander.Invalid:
+            pass
+
+        if empty_allowed or method.lower() == 'patch':
             # Data is optional when patching permissions.
             schema.children[-1].missing = colander.drop
 

--- a/kinto/tests/core/resource/test_views.py
+++ b/kinto/tests/core/resource/test_views.py
@@ -93,6 +93,7 @@ class ShareableResourcePermissionTest(AuthzAuthnTest):
         # With the current Cornice limitations, it is not possible to define
         # a validator that makes sure that at least of `data` or `permissions`
         # is specified in body.
+        # https://github.com/mozilla-services/cornice/pull/330
         # Currently, only "schemaless" resources can have their permissions
         # replaced via PUT with specifying the `data`.
         # resp = self.app.put_json(object_uri, body, headers=self.headers)

--- a/kinto/tests/core/resource/test_views.py
+++ b/kinto/tests/core/resource/test_views.py
@@ -82,6 +82,18 @@ class ShareableResourcePermissionTest(AuthzAuthnTest):
         resp = self.app.put_json(object_uri, body, headers=self.headers)
         self.assertEqual(resp.json['permissions']['read'], ['group:readers'])
 
+    def test_data_are_not_modified_if_not_specified(self):
+        body = {'data': MINIMALIST_RECORD,
+                'permissions': {'read': ['group:readers']}}
+        resp = self.app.post_json(self.collection_url, body,
+                                  headers=self.headers)
+        object_uri = self.get_item_url(resp.json['data']['id'])
+
+        body.pop('data')
+        resp = self.app.put_json(object_uri, body, headers=self.headers)
+
+        self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
+
     def test_permissions_can_be_modified_using_patch(self):
         body = {'data': MINIMALIST_RECORD,
                 'permissions': {'read': ['group:readers']}}

--- a/kinto/tests/core/resource/test_views.py
+++ b/kinto/tests/core/resource/test_views.py
@@ -90,9 +90,16 @@ class ShareableResourcePermissionTest(AuthzAuthnTest):
         object_uri = self.get_item_url(resp.json['data']['id'])
 
         body.pop('data')
-        resp = self.app.put_json(object_uri, body, headers=self.headers)
-
-        self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
+        # With the current Cornice limitations, it is not possible to define
+        # a validator that makes sure that at least of `data` or `permissions`
+        # is specified in body.
+        # Currently, only "schemaless" resources can have their permissions
+        # replaced via PUT with specifying the `data`.
+        # resp = self.app.put_json(object_uri, body, headers=self.headers)
+        # self.assertEqual(resp.json['data']['name'],
+        #                  MINIMALIST_RECORD['name'])
+        resp = self.app.put_json(object_uri, body, headers=self.headers,
+                                 status=400)
 
     def test_data_are_not_modified_if_not_specified_on_schemaless(self):
         self.add_permission('/spores', 'spore:create')

--- a/kinto/tests/core/resource/test_views.py
+++ b/kinto/tests/core/resource/test_views.py
@@ -94,6 +94,20 @@ class ShareableResourcePermissionTest(AuthzAuthnTest):
 
         self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
 
+    def test_data_are_not_modified_if_not_specified_on_schemaless(self):
+        self.add_permission('/spores', 'spore:create')
+        body = {'data': MINIMALIST_RECORD,
+                'permissions': {'read': ['group:readers']}}
+        resp = self.app.post_json('/spores', body,
+                                  headers=self.headers)
+        object_uri = '/spores/' + resp.json['data']['id']
+        self.add_permission(object_uri, 'write')
+
+        body.pop('data')
+        resp = self.app.put_json(object_uri, body, headers=self.headers)
+
+        self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
+
     def test_permissions_can_be_modified_using_patch(self):
         body = {'data': MINIMALIST_RECORD,
                 'permissions': {'read': ['group:readers']}}

--- a/kinto/tests/test_views_collections_schema.py
+++ b/kinto/tests/test_views_collections_schema.py
@@ -147,10 +147,10 @@ class RecordsValidationTest(BaseWebTestWithSchema, unittest.TestCase):
         self.assertEqual(resp.json['details'][0]['name'], 'title')
 
     def test_records_of_other_bucket_are_not_impacted(self):
-        self.app.put_json('/buckets/blog', headers=self.headers)
-        self.app.put_json('/buckets/blog/collections/articles',
+        self.app.put_json('/buckets/cms', headers=self.headers)
+        self.app.put_json('/buckets/cms/collections/articles',
                           headers=self.headers)
-        self.app.post_json('/buckets/blog/collections/articles/records',
+        self.app.post_json('/buckets/cms/collections/articles/records',
                            {'data': {'body': '<h1>Without title</h1>'}},
                            headers=self.headers)
 

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -178,6 +178,14 @@ class GroupManagementTest(BaseWebTest, unittest.TestCase):
         self.app.put_json(group_url, MINIMALIST_GROUP,
                           headers=headers, status=201)
 
+    def test_groups_data_is_optional_with_patch(self):
+        valid = {'permissions': {'write': ['github:me']}}
+        self.app.put_json(self.group_url, MINIMALIST_GROUP,
+                          headers=self.headers)
+        self.app.patch_json(self.group_url,
+                            valid,
+                            headers=self.headers)
+
 
 class InvalidGroupTest(BaseWebTest, unittest.TestCase):
 
@@ -187,8 +195,8 @@ class InvalidGroupTest(BaseWebTest, unittest.TestCase):
         super(InvalidGroupTest, self).setUp()
         self.create_bucket('beers')
 
-    def test_groups_data_is_required(self):
-        invalid = {}
+    def test_groups_data_is_required_with_put(self):
+        invalid = {'permissions': {'write': ['github:me']}}
         resp = self.app.put_json(self.group_url,
                                  invalid,
                                  headers=self.headers,

--- a/kinto/tests/test_views_groups.py
+++ b/kinto/tests/test_views_groups.py
@@ -187,16 +187,18 @@ class InvalidGroupTest(BaseWebTest, unittest.TestCase):
         super(InvalidGroupTest, self).setUp()
         self.create_bucket('beers')
 
-    def test_groups_must_have_members_attribute(self):
+    def test_groups_data_is_required(self):
         invalid = {}
         resp = self.app.put_json(self.group_url,
                                  invalid,
                                  headers=self.headers,
                                  status=400)
-        self.assertEqual(resp.json['message'],
-                         "data is missing")
-        self.assertDictEqual(resp.json['details'][0], {
-            "description": "data is missing",
-            "location": "body",
-            "name": "data"
-        })
+        self.assertEqual(resp.json['message'], "data is missing")
+
+    def test_groups_must_have_members_attribute(self):
+        invalid = {'data': {'alias': 'admins'}}
+        resp = self.app.put_json(self.group_url,
+                                 invalid,
+                                 headers=self.headers,
+                                 status=400)
+        self.assertIn('data.members in body', resp.json['message'])


### PR DESCRIPTION
This fix only works with schemaless resources (groups, collections, records).

On resource with schema (eg. group with its `members` attribute), trying to replace the permissions with a `PUT` without `data` will result in a 400 response.

As explained in code comments, this cannot be done better without cleaning the way Cornice manages Colander schemas.

At least, this prevents the data from being implicitly lost, which is a good first step IMO

@almet || @Natim r?