### PR TITLE
Pin SQLAlchemy to <1.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ requests
 sphinx_rtd_theme
 sphinxcontrib-httpdomain
 Sphinx
-SQLAlchemy
+SQLAlchemy<1.1.0b1
 tox
 unittest2
 WebTest

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pyramid==1.7
 pyramid-multiauth==0.8.0
 pyramid-tm==0.12.1
 python-dateutil==2.5.3
-raven==5.19.0
+raven==5.21.0
 redis==2.10.5
 repoze.lru==0.6
 requests==2.10.0
@@ -23,7 +23,7 @@ six==1.10.0
 SQLAlchemy==1.0.13
 statsd==3.2.1
 structlog==16.1.0
-transaction==1.6.0
+transaction==1.6.1
 translationstring==1.3
 ujson==1.35
 venusian==1.0
@@ -31,5 +31,5 @@ waitress==0.9.0
 WebOb==1.6.1
 Werkzeug==0.11.10
 zope.deprecation==4.1.2
-zope.interface==4.1.3
+zope.interface==4.2.0
 zope.sqlalchemy==0.7.6

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if installed_with_pypy:
     # We install psycopg2cffi instead of psycopg2 when dealing with pypy
     # Note: JSONB support landed after psycopg2cffi 2.7.0
     POSTGRESQL_REQUIRES = [
-        'SQLAlchemy<1.1',  # zopefoundation/zope.sqlalchemy#15
+        'SQLAlchemy==1.0',  # zopefoundation/zope.sqlalchemy#15
         'psycopg2cffi>2.7.0',
         'zope.sqlalchemy',
     ]
@@ -45,7 +45,7 @@ else:
     # ujson is not pypy compliant, as it uses the CPython C API
     REQUIREMENTS.append('ujson >= 1.35')
     POSTGRESQL_REQUIRES = [
-        'SQLAlchemy<1.1',  # zopefoundation/zope.sqlalchemy#15
+        'SQLAlchemy==1.0',  # zopefoundation/zope.sqlalchemy#15
         'psycopg2>2.5',
         'zope.sqlalchemy',
     ]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if installed_with_pypy:
     # We install psycopg2cffi instead of psycopg2 when dealing with pypy
     # Note: JSONB support landed after psycopg2cffi 2.7.0
     POSTGRESQL_REQUIRES = [
-        'SQLAlchemy==1.0',  # zopefoundation/zope.sqlalchemy#15
+        'SQLAlchemy<1.1.0b1',  # zopefoundation/zope.sqlalchemy#15
         'psycopg2cffi>2.7.0',
         'zope.sqlalchemy',
     ]
@@ -45,7 +45,7 @@ else:
     # ujson is not pypy compliant, as it uses the CPython C API
     REQUIREMENTS.append('ujson >= 1.35')
     POSTGRESQL_REQUIRES = [
-        'SQLAlchemy==1.0',  # zopefoundation/zope.sqlalchemy#15
+        'SQLAlchemy<1.1.0b1',  # zopefoundation/zope.sqlalchemy#15
         'psycopg2>2.5',
         'zope.sqlalchemy',
     ]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if installed_with_pypy:
     # We install psycopg2cffi instead of psycopg2 when dealing with pypy
     # Note: JSONB support landed after psycopg2cffi 2.7.0
     POSTGRESQL_REQUIRES = [
-        'SQLAlchemy',
+        'SQLAlchemy<1.1',  # zopefoundation/zope.sqlalchemy#15
         'psycopg2cffi>2.7.0',
         'zope.sqlalchemy',
     ]
@@ -45,7 +45,7 @@ else:
     # ujson is not pypy compliant, as it uses the CPython C API
     REQUIREMENTS.append('ujson >= 1.35')
     POSTGRESQL_REQUIRES = [
-        'SQLAlchemy',
+        'SQLAlchemy<1.1',  # zopefoundation/zope.sqlalchemy#15
         'psycopg2>2.5',
         'zope.sqlalchemy',
     ]


### PR DESCRIPTION
Builds fail because the transaction adapter for SQLAlchemy is not compatible with SQLAlchemy 1.1 (currently beta)

See https://github.com/zopefoundation/zope.sqlalchemy/issues/15

@Natim r?