### PR TITLE
Convert readthedocs links to HTTPS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ This document describes changes between each past release.
 
 - Allow record IDs to be any string instead of just UUIDs (fixes #655).
 
-Protocol is now at version **1.7**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+Protocol is now at version **1.7**. See `API changelog <https://kinto.readthedocs.io/en/latest/api/>`_.
 
 **New features**
 
@@ -61,7 +61,7 @@ Protocol is now at version **1.7**. See `API changelog <http://kinto.readthedocs
 
 - Added the ``GET /contribute.json`` endpoint for open-source information (fixes #607)
 
-Protocol is now at version **1.6**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+Protocol is now at version **1.6**. See `API changelog <https://kinto.readthedocs.io/en/latest/api/>`_.
 
 
 **Bug fixes**
@@ -170,7 +170,7 @@ Protocol is now at version **1.6**. See `API changelog <http://kinto.readthedocs
 - Document how to configure the postgresql backend (#533)
 - Document how to upgrade Kinto (#537, #538)
 
-Protocol is now in version **1.5**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+Protocol is now in version **1.5**. See `API changelog <https://kinto.readthedocs.io/en/latest/api/>`_.
 
 
 2.0.0 (2016-03-08)
@@ -193,7 +193,7 @@ Protocol is now in version **1.5**. See `API changelog <http://kinto.readthedocs
 - Add the ``flush_endpoint``, ``schema`` and ``default_bucket`` to the capabilities
   if enabled in settings (#270)
 
-Protocol is now in version **1.4**. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+Protocol is now in version **1.4**. See `API changelog <https://kinto.readthedocs.io/en/latest/api/>`_.
 
 **Breaking changes**
 
@@ -223,7 +223,7 @@ Protocol is now in version **1.4**. See `API changelog <http://kinto.readthedocs
 - Monitor time of events listeners execution (mozilla-services/cliquet#503)
 - Added a new ``AfterResourceChanged`` event, that is sent only when the commit
   in database is done and successful.
-  `See more details <http://cliquet.readthedocs.io/en/latest/reference/notifications.html>`_.
+  `See more details <https://cliquet.readthedocs.io/en/latest/reference/notifications.html>`_.
 - Track execution time on StatsD for each authentication sub-policy (mozilla-services/cliquet#639)
 - Default console log renderer now has colours (mozilla-service/cliquet#671)
 - Output Kinto version with ``kinto --version`` (thanks @ayusharma)
@@ -311,7 +311,7 @@ Protocol is now in version **1.4**. See `API changelog <http://kinto.readthedocs
   root URL (#628). Clients can rely on this to detect optional features on the
   server (e.g. enabled plugins)
 
-Protocol is now version 1.3. See `API changelog <http://kinto.readthedocs.io/en/latest/api/>`_.
+Protocol is now version 1.3. See `API changelog <https://kinto.readthedocs.io/en/latest/api/>`_.
 
 **New features**
 
@@ -766,7 +766,7 @@ Settings
   to use PostgreSQL instead of *Redis* (see default ``config/kinto.ini``)
 - ``cliquet.basic_auth_enabled`` is now deprecated (`see *Cliquet*
   docs to enable authentication backends
-  <http://cliquet.readthedocs.io/en/latest/reference/configuration.html#basic-auth>`_)
+  <https://cliquet.readthedocs.io/en/latest/reference/configuration.html#basic-auth>`_)
 
 
 **Internal changes**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,5 +13,5 @@ Before doing so, here are a few guidelines:
 * [TravisCI integration tests](https://travis-ci.org/Kinto/kinto) should be
   green.
 * If you're interested, you can also check the [contributing
-  documentation](http://kinto.readthedocs.io/en/latest/community.html#how-to-contribute)
+  documentation](https://kinto.readthedocs.io/en/latest/community.html#how-to-contribute)
   which goes into more details.

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Kinto
     :target: https://travis-ci.org/Kinto/kinto
 
 .. |readthedocs| image:: https://readthedocs.org/projects/kinto/badge/?version=latest
-    :target: http://kinto.readthedocs.io/en/latest/
+    :target: https://kinto.readthedocs.io/en/latest/
     :alt: Documentation Status
 
 .. |master-coverage| image::
@@ -27,10 +27,10 @@ Kinto
 
 Kinto is a minimalist JSON storage service with synchronisation and sharing abilities.
 
-* `Online documentation <http://kinto.readthedocs.io/en/latest/>`_
-* `Tutorial <http://kinto.readthedocs.io/en/latest/tutorials/first-steps.html>`_
+* `Online documentation <https://kinto.readthedocs.io/en/latest/>`_
+* `Tutorial <https://kinto.readthedocs.io/en/latest/tutorials/first-steps.html>`_
 * `Issue tracker <https://github.com/Kinto/kinto/issues>`_
-* `Contributing <http://kinto.readthedocs.io/en/latest/community.html#how-to-contribute>`_
+* `Contributing <https://kinto.readthedocs.io/en/latest/community.html#how-to-contribute>`_
 * `Try our daily flushed instance at: https://kinto.dev.mozaws.net/v1/ <https://kinto.dev.mozaws.net/v1/>`_
 
 Requirements

--- a/docs/api/1.x/authentication.rst
+++ b/docs/api/1.x/authentication.rst
@@ -213,7 +213,7 @@ Some possible strategies:
 
 - Most likely, you would use an identity provider which will be in
   charge of user and token management (generate, refresh, validate, ...).
-  `See this example with Django <http://django-oauth-toolkit.readthedocs.io/en/latest/tutorial/tutorial_01.html>`_.
+  `See this example with Django <https://django-oauth-toolkit.readthedocs.io/en/latest/tutorial/tutorial_01.html>`_.
 
 You can also read our :ref:`tutorial about how to plug the Github authorisation backend <tutorial-github>`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ autodoc_member_order = 'bysource'
 
 extlinks = {
     'github': ('https://github.com/%s/', ''),
-    'rtd': ('http://%s.readthedocs.io', ''),
+    'rtd': ('https://%s.readthedocs.io', ''),
     'blog': ('http://www.servicedenuages.fr/%s', '')
 }
 
@@ -115,9 +115,9 @@ def setup(app):
 # -- Options for intersphinx --------------------------------------------------
 
 intersphinx_mapping = {
-    'colander': ('http://colander.readthedocs.io/en/latest/', None),
-    'cornice': ('http://cornice.readthedocs.io/en/latest/', None),
-    'pyramid': ('http://pyramid.readthedocs.io/en/latest/', None)
+    'colander': ('https://colander.readthedocs.io/en/latest/', None),
+    'cornice': ('https://cornice.readthedocs.io/en/latest/', None),
+    'pyramid': ('https://pyramid.readthedocs.io/en/latest/', None)
 }
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -214,7 +214,7 @@ Heka Logging
 ------------
 
 At Mozilla, applications log files follow a specific JSON schema, that is
-processed through `Heka <http://hekad.readthedocs.io>`_.
+processed through `Heka <https://hekad.readthedocs.io>`_.
 
 In order to enable Mozilla *Heka* logging output:
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -296,7 +296,7 @@ Handling exceptions with Sentry
 Requires the ``raven`` package.
 
 Sentry logging can be enabled `as explained in official documentation
-<http://raven.readthedocs.io/en/latest/integrations/pyramid.html#logger-setup>`_.
+<https://raven.readthedocs.io/en/latest/integrations/pyramid.html#logger-setup>`_.
 
 .. note::
 
@@ -633,7 +633,7 @@ Project information
 +=======================================+============================================+==========================================================================+
 | kinto.error_info_link                 | ``https://github.com/kinto/kinto/issues/`` | The HTTP link returned when uncaught errors are triggered on the server. |
 +---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| kinto.project_docs                    | ``http://kinto.readthedocs.io``            | The URL where the documentation of the Kinto instance can be found. Will |
+| kinto.project_docs                    | ``https://kinto.readthedocs.io``           | The URL where the documentation of the Kinto instance can be found. Will |
 |                                       |                                            | be returned in :ref:`the hello view <api-utilities>`.                    |
 +---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
 | kinto.project_version                 | ``''``                                     | The version of the project. Will be returned in :ref:`the hello view     |
@@ -649,5 +649,5 @@ Example:
 
 .. code-block:: ini
 
-    kinto.project_docs = https://project.rtfd.org/
+    kinto.project_docs = https://project.readthedocs.io/
     # kinto.project_version = 1.0

--- a/docs/core/ecosystem.rst
+++ b/docs/core/ecosystem.rst
@@ -148,7 +148,7 @@ features brought by plugins.
         if settings['flush_enabled']:
             config.add_api_capability("flush",
                                       description="Flush server using endpoint",
-                                      url="http://kinto.readthedocs.io/en/latest/configuration/settings.html#activating-the-flush-endpoint")
+                                      url="https://kinto.readthedocs.io/en/latest/configuration/settings.html#activating-the-flush-endpoint")
 
         return config.make_wsgi_app()
 

--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -2,7 +2,7 @@ Kinto-Core
 ##########
 
     Kinto-core is the heart of the `Kinto project
-    <http://kinto.readthedocs.org/>`_, and also serves as a handy
+    <https://kinto.readthedocs.io/>`_, and also serves as a handy
     toolkit for building Kinto-based backends.
 
 Table of contents

--- a/docs/core/reference/configuration.rst
+++ b/docs/core/reference/configuration.rst
@@ -26,7 +26,7 @@ Project info
 .. code-block:: ini
 
     kinto.project_name = project
-    kinto.project_docs = https://project.rtfd.org/
+    kinto.project_docs = https://project.readthedocs.io/
     # kinto.project_version = 1.3-stable
     # kinto.http_api_version = 1.0
 
@@ -194,7 +194,7 @@ Requires the ``raven`` package, or *Kinto-Core* installed with
 ``pip install kinto[monitoring]``.
 
 Sentry logging can be enabled, `as explained in official documentation
-<http://raven.readthedocs.io/en/latest/integrations/pyramid.html#logger-setup>`_.
+<https://raven.readthedocs.io/en/latest/integrations/pyramid.html#logger-setup>`_.
 
 .. note::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -172,7 +172,7 @@ There are three conflict resolution strategies:
 * MANUAL (default): handle them on your own.
 
 There is, of course, a convenient API to handle conflict one by one
-http://kintojs.readthedocs.io/en/latest/api/#resolving-conflicts-manually
+https://kintojs.readthedocs.io/en/latest/api/#resolving-conflicts-manually
 
 Would you recommend Redis or PostgreSQL?
 --------------------------------------
@@ -194,7 +194,7 @@ What about aggregation/reporting around data, is Kinto ready for that?
 No, and it will not. This is something that should be done on top of Kinto, with
 ElasticSearch for instance. In order to do this, you could listen to the events that
 Kinto triggers and send the data to your ElasticSearch cluster.
-`There is a tutorial <http://kinto.readthedocs.io/en/latest/tutorials/write-plugin.html>`_
+`There is a tutorial <https://kinto.readthedocs.io/en/latest/tutorials/write-plugin.html>`_
 for that in the documentation.
 
 Say I wanted to move all my Kinto data out of the database, would the best way to be via the backend?

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -54,7 +54,7 @@ def main(global_config, config=None, **settings):
         config.add_api_capability(
             "schema",
             description="Validates collection records with JSON schemas.",
-            url="http://kinto.readthedocs.io/en/latest/api/1.x/"
+            url="https://kinto.readthedocs.io/en/latest/api/1.x/"
                 "collections.html#collection-json-schema")
 
     # Scan Kinto views.
@@ -66,7 +66,7 @@ def main(global_config, config=None, **settings):
             "flush_endpoint",
             description="The __flush__ endpoint can be used to remove all "
                         "data from all backends.",
-            url="http://kinto.readthedocs.io/en/latest/configuration/"
+            url="https://kinto.readthedocs.io/en/latest/configuration/"
                 "settings.html#activating-the-flush-endpoint")
     else:
         kwargs['ignore'] = 'kinto.views.flush'

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -14,7 +14,7 @@ use = egg:kinto
 #
 # Backends.
 #
-# http://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
 #
 kinto.storage_backend = {storage_backend}
 kinto.storage_url = {storage_url}
@@ -26,7 +26,7 @@ kinto.permission_url = {permission_url}
 #
 # Auth configuration.
 #
-# http://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
 #
 kinto.userid_hmac_secret = {secret}
 multiauth.policies = basicauth
@@ -60,7 +60,7 @@ kinto.includes = kinto.plugins.default_bucket
 #
 # Client cache headers
 #
-# http://kinto.readthedocs.io/en/latest/configuration/settings.html#client-caching
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#client-caching
 #
 # Every bucket objects objects and list
 # kinto.bucket_cache_expires_seconds = 3600
@@ -83,7 +83,7 @@ kinto.includes = kinto.plugins.default_bucket
 #
 # Production settings
 #
-# http://kinto.readthedocs.io/en/latest/configuration/production.html
+# https://kinto.readthedocs.io/en/latest/configuration/production.html
 #
 # kinto.statsd_url = udp://localhost:8125
 # kinto.statsd_prefix = kinto-prod

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -926,7 +926,7 @@ class UserResource(object):
                     if param == '_to':
                         message = ('_to is now deprecated, '
                                    'you should use _before instead')
-                        url = ('http://kinto.rtfd.org/en/2.4.0/api/resource'
+                        url = ('https://kinto.readthedocs.io/en/2.4.0/api/resource'
                                '.html#list-of-available-url-parameters')
                         send_alert(self.request, message, url)
                     operator = COMPARISON.LT

--- a/kinto/plugins/default_bucket/__init__.py
+++ b/kinto/plugins/default_bucket/__init__.py
@@ -196,5 +196,5 @@ def includeme(config):
         "default_bucket",
         description="The default bucket is an alias for a personal"
                     " bucket where collections are created implicitly.",
-        url="http://kinto.readthedocs.io/en/latest/api/1.x/"
+        url="https://kinto.readthedocs.io/en/latest/api/1.x/"
             "buckets.html#personal-bucket-default")

--- a/kinto/tests/core/resource/test_sync.py
+++ b/kinto/tests/core/resource/test_sync.py
@@ -49,7 +49,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
                 'code': 'soft-eol',
                 'message': ('_to is now deprecated, '
                             'you should use _before instead'),
-                'url': ('http://kinto.rtfd.org/en/2.4.0/api/resource'
+                'url': ('https://kinto.readthedocs.io/en/2.4.0/api/resource'
                         '.html#list-of-available-url-parameters')
             })
 

--- a/kinto/tests/core/support.py
+++ b/kinto/tests/core/support.py
@@ -104,7 +104,7 @@ class BaseWebTest(object):
 
         settings['project_name'] = 'myapp'
         settings['project_version'] = '0.0.1'
-        settings['project_docs'] = 'https://kinto.rtfd.org/'
+        settings['project_docs'] = 'https://kinto.readthedocs.io/'
         settings['multiauth.authorization_policy'] = self.authorization_policy
 
         if additional_settings is not None:

--- a/kinto/tests/core/test_views_hello.py
+++ b/kinto/tests/core/test_views_hello.py
@@ -12,7 +12,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(response.json['url'], 'http://localhost/v0/')
         self.assertEqual(response.json['project_name'], 'myapp')
         self.assertEqual(response.json['project_docs'],
-                         'https://kinto.rtfd.org/')
+                         'https://kinto.readthedocs.io/')
 
     def test_does_not_escape_forward_slashes(self):
         response = self.app.get('/')

--- a/kinto/tests/test_configuration/test.ini
+++ b/kinto/tests/test_configuration/test.ini
@@ -14,7 +14,7 @@ use = egg:kinto
 #
 # Backends.
 #
-# http://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
 #
 kinto.storage_backend = storage_backend
 kinto.storage_url = storage_url
@@ -26,7 +26,7 @@ kinto.permission_url = permission_url
 #
 # Auth configuration.
 #
-# http://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
 #
 kinto.userid_hmac_secret = secret
 multiauth.policies = basicauth
@@ -60,7 +60,7 @@ kinto.includes = kinto.plugins.default_bucket
 #
 # Client cache headers
 #
-# http://kinto.readthedocs.io/en/latest/configuration/settings.html#client-caching
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#client-caching
 #
 # Every bucket objects objects and list
 # kinto.bucket_cache_expires_seconds = 3600
@@ -83,7 +83,7 @@ kinto.includes = kinto.plugins.default_bucket
 #
 # Production settings
 #
-# http://kinto.readthedocs.io/en/latest/configuration/production.html
+# https://kinto.readthedocs.io/en/latest/configuration/production.html
 #
 # kinto.statsd_url = udp://localhost:8125
 # kinto.statsd_prefix = kinto-prod

--- a/kinto/tests/test_views_hello.py
+++ b/kinto/tests/test_views_hello.py
@@ -32,7 +32,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.assertIn('schema', capabilities)
         expected = {
             "description": "Validates collection records with JSON schemas.",
-            "url": "http://kinto.readthedocs.io/en/latest/api/1.x/"
+            "url": "https://kinto.readthedocs.io/en/latest/api/1.x/"
                    "collections.html#collection-json-schema",
         }
         self.assertEqual(expected, capabilities['schema'])
@@ -55,7 +55,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         expected = {
             "description": "The __flush__ endpoint can be used to remove "
                            "all data from all backends.",
-            "url": "http://kinto.readthedocs.io/en/latest/configuration/"
+            "url": "https://kinto.readthedocs.io/en/latest/configuration/"
                    "settings.html#activating-the-flush-endpoint"
         }
         self.assertEqual(expected, capabilities['flush_endpoint'])

--- a/talks/2015.07.pybcn/slides.rst
+++ b/talks/2015.07.pybcn/slides.rst
@@ -246,7 +246,7 @@ Using:
     {
         "data": [
             {
-                "url": "http://cliquet.readthedocs.io",
+                "url": "https://cliquet.readthedocs.io",
                 "id": "cc103eb5-0c80-40ec-b6f5-dad12e7d975e",
                 "last_modified": 1437034418940,
             }

--- a/talks/2015.10.pyconfr/slides.rst
+++ b/talks/2015.10.pyconfr/slides.rst
@@ -272,7 +272,7 @@ Use Cliquet abstractions with Pyramid or Cornice !
     {
         "data": [
             {
-                "url": "http://cliquet.readthedocs.io",
+                "url": "https://cliquet.readthedocs.io",
                 "id": "cc103eb5-0c80-40ec-b6f5-dad12e7d975e",
                 "last_modified": 1437034418940,
             }


### PR DESCRIPTION
Because security.

Also I was just running my `.org` -> `.io` converter but then realized you've already done that bit, just not the HTTPS.