### PR TITLE
Fix events for default bucket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ Protocol is now at version **1.8**. See `API changelog <http://kinto.readthedocs
 - Fix crash with PostgreSQL storage backend is configured as read-only and reaching
   the records endpoint of an unknown collection (fixes #693, related #558)
 
+**Internal changes**
+
+- Resource events constructors signatures were changed (#704). The event payload is now
+  built immediately when event is fired instead of during transactoin commit.
+
 
 3.2.0 (2016-06-14)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,11 +21,12 @@ Protocol is now at version **1.8**. See `API changelog <http://kinto.readthedocs
   Regression introduced in 3.2.0 with #655.
 - Fix crash with PostgreSQL storage backend is configured as read-only and reaching
   the records endpoint of an unknown collection (fixes #693, related #558)
+- Fix events payloads for actions in the default bucket (fixes #704)
 
 **Internal changes**
 
-- Resource events constructors signatures were changed (#704). The event payload is now
-  built immediately when event is fired instead of during transactoin commit.
+- Resource events constructors signatures were changed. The event payload is now
+  built immediately when event is fired instead of during transactoin commit (#704).
 
 
 3.2.0 (2016-06-14)

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -337,6 +337,10 @@ def follow_subrequest(request, subrequest, **kwargs):
 
 
 def encode_header(value, encoding='utf-8'):
+    return _encoded(value, encoding)
+
+
+def _encoded(value, encoding='utf-8'):
     """Make sure the value is of type ``str`` in both PY2 and PY3."""
     value_type = type(value)
     if value_type != str:
@@ -374,8 +378,8 @@ def view_lookup(request, uri):
     :returns: the resource name and the associated matchdict.
     """
     api_prefix = '/%s' % request.upath_info.split('/')[1]
-    # Path should be bytes
-    path = (api_prefix + uri).encode('utf-8')
+    # Path should be bytes in PY2, and unicode in PY3
+    path = _encoded(api_prefix + uri)
 
     q = request.registry.queryUtility
     routes_mapper = q(IRoutesMapper)

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -374,10 +374,13 @@ def view_lookup(request, uri):
     :returns: the resource name and the associated matchdict.
     """
     api_prefix = '/%s' % request.upath_info.split('/')[1]
+    # Path should be bytes
+    path = (api_prefix + uri).encode('utf-8')
+
     q = request.registry.queryUtility
     routes_mapper = q(IRoutesMapper)
 
-    fakerequest = Request.blank(path=api_prefix + uri)
+    fakerequest = Request.blank(path=path)
     info = routes_mapper(fakerequest)
     matchdict, route = info['match'], info['route']
     resource_name = route.name.replace('-record', '')\

--- a/kinto/plugins/default_bucket/__init__.py
+++ b/kinto/plugins/default_bucket/__init__.py
@@ -29,12 +29,15 @@ def create_bucket(request, bucket_id):
     if bucket_id in already_created:
         return
 
+    backup_matchdict = request.matchdict
+    request.matchdict = dict(id=bucket_id)
     bucket_uri = instance_uri(request, 'bucket', id=bucket_id)
     bucket = resource_create_object(request=request,
                                     resource_cls=Bucket,
                                     uri=bucket_uri,
                                     resource_name='bucket',
                                     obj_id=bucket_id)
+    request.matchdict = backup_matchdict
     already_created[bucket_id] = bucket
 
 
@@ -62,8 +65,7 @@ def create_collection(request, bucket_id):
 
     backup_matchdict = request.matchdict
     request.matchdict = dict(bucket_id=bucket_id,
-                             id=collection_id,
-                             **request.matchdict)
+                             id=collection_id)
     collection = resource_create_object(request=request,
                                         resource_cls=Collection,
                                         uri=collection_uri,

--- a/kinto/plugins/default_bucket/test_plugin.py
+++ b/kinto/plugins/default_bucket/test_plugin.py
@@ -265,18 +265,27 @@ class EventsTest(BaseWebTest, unittest.TestCase):
         assert payload['action'] == 'create'
 
     def test_events_sent_on_bucket_and_collection_creation(self):
-        records_uri = '/buckets/default/collections/articles/records'
-        self.app.get(records_uri, headers=self.headers)
+        records_uri = '/buckets/default/collections/articles/records/implicit'
+        body = {"data": {"implicit": "creations"}}
+        self.app.put_json(records_uri, body, headers=self.headers)
 
-        assert len(_events) == 2
+        assert len(_events) == 3
 
-        # XXX: Could not achieve a behaviour the payload uri reflect the
-        # underlying created object.
-        # resp = self.app.get('/', headers=self.headers)
-        # bucket_id = resp.json['user']['bucket']
-        # assert _events[0].payload['uri'] == '/buckets/%s' % bucket_id
-        # assert _events[1].payload['uri'] == (
-        #     '/buckets/%s/collections/articles' % bucket_id)
+        # Implicit creation of bucket
+        resp = self.app.get('/', headers=self.headers)
+        bucket_id = resp.json['user']['bucket']
+        assert 'subpath' not in _events[0].payload
+        assert _events[0].payload['resource_name'] == 'bucket'
+        assert _events[0].payload['bucket_id'] == bucket_id
+
+        # Implicit creation of collection
+        assert 'subpath' not in _events[1].payload
+        assert _events[1].payload['resource_name'] == 'collection'
+        assert _events[1].payload['bucket_id'] == bucket_id
+        assert _events[1].payload['collection_id'] == 'articles'
+
+        # Creation of record
+        assert _events[2].payload['resource_name'] == 'record'
 
 
 class ReadonlyDefaultBucket(BaseWebTest, unittest.TestCase):

--- a/kinto/plugins/default_bucket/test_plugin.py
+++ b/kinto/plugins/default_bucket/test_plugin.py
@@ -275,17 +275,26 @@ class EventsTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get('/', headers=self.headers)
         bucket_id = resp.json['user']['bucket']
         assert 'subpath' not in _events[0].payload
-        assert _events[0].payload['resource_name'] == 'bucket'
+        assert _events[0].payload['action'] == 'create'
         assert _events[0].payload['bucket_id'] == bucket_id
+        assert _events[0].payload['uri'] == '/buckets/%s' % bucket_id
 
         # Implicit creation of collection
         assert 'subpath' not in _events[1].payload
+        assert _events[1].payload['action'] == 'create'
         assert _events[1].payload['resource_name'] == 'collection'
         assert _events[1].payload['bucket_id'] == bucket_id
         assert _events[1].payload['collection_id'] == 'articles'
+        assert _events[1].payload['uri'] == ('/buckets/%s/collections'
+                                             '/articles') % bucket_id
 
         # Creation of record
+        assert _events[2].payload['action'] == 'create'
         assert _events[2].payload['resource_name'] == 'record'
+        assert _events[2].payload['bucket_id'] == bucket_id
+        assert _events[2].payload['collection_id'] == 'articles'
+        assert _events[2].payload['uri'] == records_uri.replace('default',
+                                                                bucket_id)
 
 
 class ReadonlyDefaultBucket(BaseWebTest, unittest.TestCase):

--- a/kinto/tests/core/test_listeners.py
+++ b/kinto/tests/core/test_listeners.py
@@ -44,8 +44,8 @@ class ListenerSetupTest(unittest.TestCase):
 
     def test_callback_called_when_action_is_not_filtered(self):
         config = self.make_app()
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-        config.registry.notify(event)
+        ev = ResourceChanged({'action': ACTIONS.CREATE.value}, [], Request())
+        config.registry.notify(ev)
 
         self.assertTrue(self.redis_mocked.return_value.called)
 
@@ -53,15 +53,15 @@ class ListenerSetupTest(unittest.TestCase):
         config = self.make_app({
             'event_listeners.redis.actions': 'delete',
         })
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-        config.registry.notify(event)
+        ev = ResourceChanged({'action': ACTIONS.CREATE.value}, [], Request())
+        config.registry.notify(ev)
 
         self.assertFalse(self.redis_mocked.return_value.called)
 
     def test_callback_called_when_resource_is_not_filtered(self):
         config = self.make_app()
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-        event.payload['resource_name'] = 'mushroom'
+        event = ResourceChanged({'action': ACTIONS.CREATE.value,
+                                 'resource_name': 'mushroom'}, [], Request())
         config.registry.notify(event)
 
         self.assertTrue(self.redis_mocked.return_value.called)
@@ -70,15 +70,15 @@ class ListenerSetupTest(unittest.TestCase):
         config = self.make_app({
             'event_listeners.redis.resources': 'toad',
         })
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-        event.payload['resource_name'] = 'mushroom'
+        event = ResourceChanged({'action': ACTIONS.CREATE.value,
+                                 'resource_name': 'mushroom'}, [], Request())
         config.registry.notify(event)
 
         self.assertFalse(self.redis_mocked.return_value.called)
 
     def test_callback_is_not_called_on_read_by_default(self):
         config = self.make_app()
-        event = ResourceRead(ACTIONS.READ, 123456, [], Request())
+        event = ResourceRead({'action': ACTIONS.READ.value}, [], Request())
         config.registry.notify(event)
 
         self.assertFalse(self.redis_mocked.return_value.called)
@@ -87,7 +87,7 @@ class ListenerSetupTest(unittest.TestCase):
         config = self.make_app({
             'event_listeners.redis.actions': 'read',
         })
-        event = ResourceRead(ACTIONS.READ, 123456, [], Request())
+        event = ResourceRead({'action': ACTIONS.READ.value}, [], Request())
         config.registry.notify(event)
 
         self.assertTrue(self.redis_mocked.return_value.called)
@@ -96,10 +96,10 @@ class ListenerSetupTest(unittest.TestCase):
         config = self.make_app({
             'event_listeners.redis.actions': 'read create delete',
         })
-        event = ResourceRead(ACTIONS.READ, 123456, [], Request())
-        config.registry.notify(event)
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-        config.registry.notify(event)
+        ev = ResourceRead({'action': ACTIONS.READ.value}, [], Request())
+        config.registry.notify(ev)
+        ev = ResourceChanged({'action': ACTIONS.CREATE.value}, [], Request())
+        config.registry.notify(ev)
 
         self.assertEqual(self.redis_mocked.return_value.call_count, 2)
 
@@ -125,21 +125,22 @@ class ListenerSetupTest(unittest.TestCase):
         self.assertTrue(self.redis_mocked.called)
 
         # Action filtering is read from ENV.
-        event = ResourceChanged(ACTIONS.DELETE, 123456, [], Request())
-        event.payload['resource_name'] = 'toad'
+        event = ResourceChanged({'action': ACTIONS.DELETE.value,
+                                 'resource_name': 'toad'}, [], Request())
         config.registry.notify(event)
         self.assertTrue(self.redis_mocked.return_value.called)
 
         self.redis_mocked.reset_mock()
 
         # Action filtering is read from ENV.
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
+        event = ResourceChanged({'action': ACTIONS.CREATE.value},
+                                [], Request())
         config.registry.notify(event)
         self.assertFalse(self.redis_mocked.return_value.called)
 
         # Resource filtering is read from ENV.
-        event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-        event.payload['resource_name'] = 'mushroom'
+        event = ResourceChanged({'action': ACTIONS.CREATE.value,
+                                 'resource_name': 'mushroom'}, [], Request())
         config.registry.notify(event)
         self.assertFalse(self.redis_mocked.return_value.called)
 
@@ -199,6 +200,10 @@ class ListenerCalledTest(unittest.TestCase):
         self._redis = create_from_config(self.config, prefix='events_')
         self._size = 0
 
+        self.sample_event = ResourceChanged({'action': ACTIONS.CREATE.value},
+                                            [],
+                                            Request())
+
     def _save_redis(self):
         self._size = self._redis.llen('kinto.core.events')
 
@@ -225,8 +230,7 @@ class ListenerCalledTest(unittest.TestCase):
     def test_redis_is_notified(self):
         with self.redis_listening():
             # let's trigger an event
-            event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-            self.notify(event)
+            self.notify(self.sample_event)
             self.assertTrue(self.has_redis_changed())
 
         # okay, we should have the first event in Redis
@@ -238,8 +242,8 @@ class ListenerCalledTest(unittest.TestCase):
         with self.redis_listening():
             # an event with a bad JSON should silently break and send nothing
             # date time objects cannot be dumped
-            event2 = ResourceChanged(ACTIONS.CREATE,
-                                     datetime.now(),
+            event2 = ResourceChanged({'action': ACTIONS.CREATE.value,
+                                      'somedate': datetime.now()},
                                      [],
                                      Request())
             self.notify(event2)
@@ -251,8 +255,7 @@ class ListenerCalledTest(unittest.TestCase):
             self._save_redis()
 
             with broken_redis():
-                event = ResourceChanged(ACTIONS.CREATE, 123456, [], Request())
-                self.config.registry.notify(event)
+                self.config.registry.notify(self.sample_event)
 
             self.assertFalse(self.has_redis_changed())
 

--- a/kinto/tests/core/test_listeners.py
+++ b/kinto/tests/core/test_listeners.py
@@ -2,8 +2,8 @@
 import json
 import os
 import uuid
-from contextlib import contextmanager
 from datetime import datetime
+from contextlib import contextmanager
 
 import mock
 from pyramid import testing


### PR DESCRIPTION
Default bucket is very hacky, let's add some hacks so that resource events triggered from there become consistent with usual bucket/collection/record.

* [x] Build event payload when event is fired instead of when committed
* [x] Fix `resource_name` attribute in events of default bucket
* [x] Fix payload attributes (eg. `subpath`)
* [x] Fix URI (*note: request.path is readonly*) 