### PR TITLE
Improvements on core.authorization and permission backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Protocol is now at version **1.8**. See `API changelog <http://kinto.readthedocs
 - Added ``get_objects_permissions()`` method in ``permission`` backend (#714)
 - Changed ``get_accessible_objects()``, ``get_authorized_principals()`` methods
   in ``permission`` backend (#714)
+- Simplified and improved the code quality of ``kinto.core.authorization``,
+  mainly by keeping usage of ``get_bound_permissions`` callback in one place only.
 
 
 3.2.0 (2016-06-14)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,10 @@ Protocol is now at version **1.8**. See `API changelog <http://kinto.readthedocs
   bound permissions is empty.
 - Bump ``last_modified`` on record when provided value is equal to previous
   in storage ``update()`` method (#713)
+- Added ``get_objects_permissions()`` method in ``permission`` backend (#714)
+- Changed ``get_accessible_objects()``, ``get_authorized_principals()`` methods
+  in ``permission`` backend (#714)
+
 
 3.2.0 (2016-06-14)
 ==================

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -143,12 +143,12 @@ class RouteFactory(core_authorization.RouteFactory):
 
 
 class BucketRouteFactory(RouteFactory):
-    def fetch_shared_records(self, perm, principals, get_bound_permissions):
+    def fetch_shared_records(self, perm, principals):
         """Buckets list is authorized even if no object is accessible for
         the current principals.
         """
         shared = super(BucketRouteFactory, self).fetch_shared_records(
-            perm, principals, get_bound_permissions)
+            perm, principals)
         if shared is None and Authenticated in principals:
             self.shared_ids = []
         return self.shared_ids

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -143,12 +143,12 @@ class RouteFactory(core_authorization.RouteFactory):
 
 
 class BucketRouteFactory(RouteFactory):
-    def fetch_shared_records(self, perm, principals):
+    def fetch_shared_records(self, perm, principals, get_bound_permissions):
         """Buckets list is authorized even if no object is accessible for
         the current principals.
         """
         shared = super(BucketRouteFactory, self).fetch_shared_records(
-            perm, principals)
+            perm, principals, get_bound_permissions)
         if shared is None and Authenticated in principals:
             self.shared_ids = []
         return self.shared_ids

--- a/kinto/core/permission/__init__.py
+++ b/kinto/core/permission/__init__.py
@@ -86,60 +86,49 @@ class PermissionBase(object):
         """
         raise NotImplementedError
 
-    def get_accessible_objects(self, principals, permission,
-                               object_id_match=None,
-                               get_bound_permissions=None):
-        """Return the list of objects id where the specified `principals`
-        have the specified `permission`.
+    def get_accessible_objects(self, principals, bound_permissions=None):
+        """Return the list of objects where the specified `principals`
+        have some permissions.
 
-        :param list principal: List of user principals
-        :param str permission: The permission to query.
-        :param str object_id_match: Filter object ids based on a pattern
-            (e.g. ``'*articles*'``).
-        :param function get_bound_permissions:
-            The methods to call in order to generate the list of permission to
-            verify against. (ie: if you can write, you can read)
-        :returns: The list of object ids
-        :rtype: set
+        If `bound_permissions` parameter is specified, the list is limited to
+        the specified object or permissions.
 
+        :param list principals: List of user principals
+        :param list bound_permissions: An optional list of tuples
+            (object_id, permission) to limit the results.
+            The object ids can be a pattern, (e.g. ``*``, ``'/my/articles*'``).
+
+        :returns: A mapping whose keys are the object_ids and the values are
+            the related list of permissions.
+        :rtype: dict
         """
         raise NotImplementedError
 
-    def get_authorized_principals(self, object_id, permission,
-                                  get_bound_permissions=None):
-        """Return the full set of authorized principals for a given
-        permission + object (bound permission).
+    def get_authorized_principals(self, bound_permissions):
+        """Return the full set of authorized principals for a list of bound
+        permissions (object + permission).
 
         :param str object_id: The object_id the permission is set to.
-        :param str permission: The permission to query.
-        :param function get_bound_permissions:
-            The methods to call in order to generate the list of permission to
-            verify against. (ie: if you can write, you can read)
-
+        :param list bound_permissions: An list of tuples
+            (object_id, permission) to be fetched.
         :returns: The list of user principals
         :rtype: set
 
         """
         raise NotImplementedError
 
-    def check_permission(self, object_id, permission, principals,
-                         get_bound_permissions=None):
+    def check_permission(self, principals, bound_permissions):
         """Test if a principal set have got a permission on an object.
 
-        :param str object_id:
-            The identifier of the object concerned by the permission.
-        :param str permission: The permission to test.
         :param set principals:
             A set of user principals to test the permission against.
-        :param function get_bound_permissions:
-            The method to call in order to generate the set of
-            permission to verify against. (ie: if you can write, you can read)
-
+        :param list bound_permissions: An list of tuples
+            (object_id, permission) to be checked.
+        :rtype: boolean
         """
         principals = set(principals)
-        authorized_principals = self.get_authorized_principals(
-            object_id, permission, get_bound_permissions)
-        return len(authorized_principals & principals) > 0
+        authorized = self.get_authorized_principals(bound_permissions)
+        return len(authorized & principals) > 0
 
     def get_object_permissions(self, object_id, permissions=None):
         """Return the set of principals for each object permission.

--- a/kinto/core/permission/__init__.py
+++ b/kinto/core/permission/__init__.py
@@ -131,7 +131,8 @@ class PermissionBase(object):
         return len(authorized & principals) > 0
 
     def get_object_permissions(self, object_id, permissions=None):
-        return self.get_objects_permissions([object_id], permissions)[0]
+        perms = self.get_objects_permissions([object_id], permissions)
+        return perms[0] if perms else {}
 
     def get_objects_permissions(self, objects_ids, permissions=None):
         """Return a list of mapping, for each object id specified, with the

--- a/kinto/core/permission/__init__.py
+++ b/kinto/core/permission/__init__.py
@@ -131,15 +131,18 @@ class PermissionBase(object):
         return len(authorized & principals) > 0
 
     def get_object_permissions(self, object_id, permissions=None):
-        """Return the set of principals for each object permission.
+        return self.get_objects_permissions([object_id], permissions)[0]
 
-        :param str object_id: The object_id the permission is set to.
-        :param list permissions: List of permissions to retrieve.
-                                 If not define will try to find them all.
-        :returns: The dictionnary with the list of user principals for
-                  each object permissions
-        :rtype: dict
+    def get_objects_permissions(self, objects_ids, permissions=None):
+        """Return a list of mapping, for each object id specified, with the
+        set of principals for each permission.
 
+        :param list objects_ids: The list of object_ids.
+        :param list permissions: Optional list of permissions to limit the
+            results. If not specified, retrieve all.
+        :returns: A list of dictionnaries with the list of user principals for
+            each object permission.
+        :rtype: list
         """
         raise NotImplementedError
 

--- a/kinto/core/permission/memory.py
+++ b/kinto/core/permission/memory.py
@@ -79,47 +79,39 @@ class Permission(PermissionBase):
         members = self._store.get(permission_key, set())
         return members
 
-    def get_accessible_objects(self, principals, permission,
-                               object_id_match=None,
-                               get_bound_permissions=None):
+    def get_accessible_objects(self, principals, bound_permissions=None):
         principals = set(principals)
-        if object_id_match is None:
-            object_id_match = '*'
+        if bound_permissions is not None:
+            bound_permissions = [(re.compile(obj_id.replace('*', '.*')), perm)
+                                 for (obj_id, perm) in bound_permissions]
 
-        keys = []
-        if get_bound_permissions is not None:
-            keys = get_bound_permissions(object_id_match, permission)
-            keys = [(re.compile(obj_id.replace('*', '.*')), p) for (obj_id, p)
-                    in keys if obj_id.endswith(object_id_match)]
-        if not keys:
-            object_id_match = object_id_match.replace('*', '.*')
-            keys = [(re.compile(object_id_match), permission)]
-
-        objects = set()
-        for obj_id, perm in keys:
-            for key, value in self._store.items():
-                if key.endswith(perm):
-                    if len(principals & value) > 0:
+        if bound_permissions is None:
+            candidates = self._store.items()
+        else:
+            candidates = []
+            for obj_id, perm in bound_permissions:
+                for key, value in self._store.items():
+                    if key.endswith(perm):
                         object_id = key.split(':')[1]
                         if obj_id.match(object_id):
-                            objects.add(object_id)
-        return objects
+                            candidates.append((obj_id, perm, value))
 
-    def get_authorized_principals(self, object_id, permission,
-                                  get_bound_permissions=None):
-        if get_bound_permissions is None:
-            keys = [(object_id, permission)]
-        else:
-            keys = get_bound_permissions(object_id, permission)
+        perms_by_object_id = {}
+        for object_id, perm, value in candidates:
+            if len(principals & value) > 0:
+                perms_by_object_id.setdefault(object_id, set()).add(perm)
+        return perms_by_object_id
+
+    def get_authorized_principals(self, bound_permissions):
         principals = set()
-        for obj_id, perm in keys:
+        for obj_id, perm in bound_permissions:
             principals |= self.get_object_permission_principals(obj_id, perm)
         return principals
 
     def get_object_permissions(self, object_id, permissions=None):
         if permissions is None:
             aces = [k for k in self._store.keys()
-                    if k.startswith('permission:%s:' % object_id)]
+                    if k.startswith('permission:%s' % object_id)]
         else:
             aces = ['permission:%s:%s' % (object_id, permission)
                     for permission in permissions]

--- a/kinto/core/permission/memory.py
+++ b/kinto/core/permission/memory.py
@@ -108,19 +108,22 @@ class Permission(PermissionBase):
             principals |= self.get_object_permission_principals(obj_id, perm)
         return principals
 
-    def get_object_permissions(self, object_id, permissions=None):
-        if permissions is None:
-            aces = [k for k in self._store.keys()
-                    if k.startswith('permission:%s' % object_id)]
-        else:
-            aces = ['permission:%s:%s' % (object_id, permission)
-                    for permission in permissions]
-        permissions = {}
-        for ace in aces:
-            # Should work with stuff like 'permission:/url/id:record:create'.
-            permission = ace.split(':', 2)[2]
-            permissions[permission] = set(self._store[ace])
-        return permissions
+    def get_objects_permissions(self, objects_ids, permissions=None):
+        result = []
+        for object_id in objects_ids:
+            if permissions is None:
+                aces = [k for k in self._store.keys()
+                        if k.startswith('permission:%s' % object_id)]
+            else:
+                aces = ['permission:%s:%s' % (object_id, permission)
+                        for permission in permissions]
+            permissions = {}
+            for ace in aces:
+                # Should work with 'permission:/url/id:record:create'.
+                permission = ace.split(':', 2)[2]
+                permissions[permission] = set(self._store[ace])
+            result.append(permissions)
+        return result
 
     def replace_object_permissions(self, object_id, permissions):
         for permission, principals in permissions.items():

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -161,18 +161,12 @@ class Permission(PermissionBase):
             results = result.fetchall()
         return set([r['principal'] for r in results])
 
-    def get_authorized_principals(self, object_id, permission,
-                                  get_bound_permissions=None):
+    def get_authorized_principals(self, bound_permissions):
         # XXX: this method is not used, except in test suites :(
-        if get_bound_permissions is None:
-            perms = [(object_id, permission)]
-        else:
-            perms = get_bound_permissions(object_id, permission)
-
-        if not perms:
+        if not bound_permissions:
             return set()
 
-        perms_values = ','.join(["('%s', '%s')" % p for p in perms])
+        perm_values = ','.join(["('%s', '%s')" % p for p in bound_permissions])
         query = """
         WITH required_perms AS (
           VALUES %s
@@ -180,68 +174,63 @@ class Permission(PermissionBase):
         SELECT principal
           FROM required_perms JOIN access_control_entries
             ON (object_id = column1 AND permission = column2);
-        """ % perms_values
+        """ % perm_values
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query)
             results = result.fetchall()
         return set([r['principal'] for r in results])
 
-    def get_accessible_objects(self, principals, permission,
-                               object_id_match=None,
-                               get_bound_permissions=None):
-        placeholders = {'permission': permission}
-
-        if object_id_match is None:
-            object_id_match = '*'
-
-        perms = []
-        if get_bound_permissions is not None:
-            perms = get_bound_permissions(object_id_match, permission)
-        if not perms:
-            perms = [(object_id_match, permission)]
-
-        perms = [(o.replace('*', '.*'), p) for (o, p) in perms
-                 if o.endswith(object_id_match)]
-        perms_values = ','.join(["('%s', '%s')" % p for p in perms])
+    def get_accessible_objects(self, principals, bound_permissions=None):
         principals_values = ','.join(["('%s')" % p for p in principals])
-        query = """
-        WITH required_perms AS (
-          VALUES %(perms)s
-        ),
-        user_principals AS (
-          VALUES %(principals)s
-        ),
-        potential_objects AS (
-          SELECT object_id, required_perms.column1 AS pattern
-            FROM access_control_entries
-            JOIN user_principals
-              ON (principal = user_principals.column1)
-            JOIN required_perms
-              ON (permission = required_perms.column2)
-        )
-        SELECT object_id
-          FROM potential_objects
-         WHERE object_id ~ pattern;
-        """ % dict(perms=perms_values,
-                   principals=principals_values)
+        if bound_permissions is None:
+            query = """
+            WITH user_principals AS (
+              VALUES %(principals)s
+            )
+            SELECT object_id, permission
+              FROM access_control_entries
+              JOIN user_principals
+                ON (principal = user_principals.column1);
+            """ % dict(principals=principals_values)
+        else:
+            perms = [(o.replace('*', '.*'), p) for (o, p) in bound_permissions]
+            perms_values = ','.join(["('%s', '%s')" % p for p in perms])
+            query = """
+            WITH required_perms AS (
+              VALUES %(perms)s
+            ),
+            user_principals AS (
+              VALUES %(principals)s
+            ),
+            potential_objects AS (
+              SELECT object_id, required_perms.column1 AS pattern
+                FROM access_control_entries
+                JOIN user_principals
+                  ON (principal = user_principals.column1)
+                JOIN required_perms
+                  ON (permission = required_perms.column2)
+            )
+            SELECT object_id, permission
+              FROM potential_objects
+             WHERE object_id ~ pattern;
+            """ % dict(perms=perms_values,
+                       principals=principals_values)
 
         with self.client.connect(readonly=True) as conn:
-            result = conn.execute(query, placeholders)
+            result = conn.execute(query)
             results = result.fetchall()
-        return set([r['object_id'] for r in results])
 
-    def check_permission(self, object_id, permission, principals,
-                         get_bound_permissions=None):
-        if get_bound_permissions is None:
-            perms = [(object_id, permission)]
-        else:
-            perms = get_bound_permissions(object_id, permission)
+        perms_by_id = {}
+        for r in results:
+            perms_by_id.setdefault(r['object_id'], set()).add(r['permission'])
+        return perms_by_id
 
-        if not perms:
+    def check_permission(self, principals, bound_permissions):
+        if not bound_permissions:
             return False
 
-        perms_values = ','.join(["('%s', '%s')" % p for p in perms])
         principals_values = ','.join(["('%s')" % p for p in principals])
+        perm_values = ','.join(["('%s', '%s')" % p for p in bound_permissions])
         query = """
         WITH required_perms AS (
           VALUES %(perms)s
@@ -257,7 +246,7 @@ class Permission(PermissionBase):
         SELECT COUNT(*) AS matched
           FROM required_principals JOIN allowed_principals
             ON (required_principals.column1 = principal);
-        """ % dict(perms=perms_values, principals=principals_values)
+        """ % dict(perms=perm_values, principals=principals_values)
 
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query)

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import os
 
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 
 from kinto.core import logger
 from kinto.core.permission import PermissionBase

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -203,7 +203,7 @@ class Permission(PermissionBase):
               VALUES %(principals)s
             ),
             potential_objects AS (
-              SELECT object_id, required_perms.column1 AS pattern
+              SELECT object_id, permission, required_perms.column1 AS pattern
                 FROM access_control_entries
                 JOIN user_principals
                   ON (principal = user_principals.column1)
@@ -256,14 +256,16 @@ class Permission(PermissionBase):
     def get_objects_permissions(self, objects_ids, permissions=None):
         query = """
         WITH required_object_ids AS (
-          VALUES %(object_ids)s
+          VALUES %(objects_ids)s
         )
         SELECT object_id, permission, principal
             FROM required_object_ids JOIN access_control_entries
-              ON (object_id = column1)
-            %(permissions_condition)s;
+              ON (object_id = column2)
+              %(permissions_condition)s
+        ORDER BY column1 ASC;
         """
-        obj_ids_values = ','.join(["('%s')" % p for p in objects_ids])
+        obj_ids_values = ','.join(["(%s, '%s')" % t
+                                   for t in enumerate(objects_ids)])
         safeholders = {
             'objects_ids': obj_ids_values,
             'permissions_condition': ''

--- a/kinto/core/permission/redis.py
+++ b/kinto/core/permission/redis.py
@@ -89,7 +89,10 @@ class Permission(PermissionBase):
     def get_accessible_objects(self, principals, bound_permissions=None):
         principals = set(principals)
 
-        keys = ['permission:%s:%s' % (o, p) for (o, p) in bound_permissions]
+        if bound_permissions:
+            keys = ['permission:%s:%s' % op for op in bound_permissions]
+        else:
+            keys = ['permission:*']
 
         perms_by_id = dict()
         for key_pattern in keys:
@@ -111,7 +114,7 @@ class Permission(PermissionBase):
 
     @wrap_redis_error
     def get_objects_permissions(self, objects_ids, permissions=None):
-        result = []
+        objects_perms = []
         for object_id in objects_ids:
             if permissions is not None:
                 keys = ['permission:%s:%s' % (object_id, permission)
@@ -130,8 +133,8 @@ class Permission(PermissionBase):
             for i, result in enumerate(results):
                 permission = keys[i].split(':', 2)[-1]
                 permissions[permission] = self._decode_set(result)
-            result.append(permissions)
-        return result
+            objects_perms.append(permissions)
+        return objects_perms
 
     @wrap_redis_error
     def replace_object_permissions(self, object_id, permissions):

--- a/kinto/tests/core/test_permission.py
+++ b/kinto/tests/core/test_permission.py
@@ -27,7 +27,7 @@ class PermissionBaseTest(unittest.TestCase):
             (self.permission.add_principal_to_ace, '', '', ''),
             (self.permission.remove_principal_from_ace, '', '', ''),
             (self.permission.get_object_permission_principals, '', ''),
-            (self.permission.get_object_permissions, ''),
+            (self.permission.get_objects_permissions, ''),
             (self.permission.replace_object_permissions, '', {}),
             (self.permission.delete_object_permissions, ''),
             (self.permission.get_accessible_objects, [], ''),

--- a/kinto/tests/core/test_permission.py
+++ b/kinto/tests/core/test_permission.py
@@ -325,7 +325,7 @@ class BaseTestPermission(object):
         per_object_ids = self.permission.get_accessible_objects(
             ['user1'],
             [('*url1*', 'write')])
-        self.assertEquals(per_object_ids.keys(), ['/url1/id'])
+        self.assertEquals(sorted(per_object_ids.keys()), ['/url1/id'])
 
     def test_accessible_objects_several_bound_permissions(self):
         self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')

--- a/kinto/tests/core/test_permission.py
+++ b/kinto/tests/core/test_permission.py
@@ -335,7 +335,7 @@ class BaseTestPermission(object):
             ['user1'],
             [('/url/a/id/*', 'read'),
              ('/url/a/id/*', 'write')])
-        self.assertEquals(per_object_ids.keys(),
+        self.assertEquals(sorted(per_object_ids.keys()),
                           ['/url/a/id/1', '/url/a/id/2'])
 
     def test_accessible_objects_without_match(self):

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -32,17 +32,8 @@ def permissions_get(request):
         principals.append(userid)
 
     # Query every possible permission of the current user from backend.
-    # Since there is no "full-list" method, we query for each possible
-    # permission (read, write, group:create, collection:create, record:create).
-    # XXX: could be optimized into one call to backend when needed.
-    possible_perms = set([k.split(':', 1)[1]
-                          for k in PERMISSIONS_INHERITANCE_TREE.keys()])
     backend = request.registry.permission
-    perms_by_object_uri = {}
-    for perm in possible_perms:
-        object_uris = backend.get_accessible_objects(principals, perm)
-        for object_uri in object_uris:
-            perms_by_object_uri.setdefault(object_uri, []).append(perm)
+    perms_by_object_uri = backend.get_accessible_objects(principals)
 
     entries = []
     for object_uri, perms in perms_by_object_uri.items():


### PR DESCRIPTION
* [x] Refactor and simplify permissions methods to get rid of the callback `get_bound_permissions`
* [x] Rework `get_accessible_objects()` to obtain every objects in a single call (c.f. GET /permissions endpoint)
* [x] Add `get_objects_permissions()` to retrieve the permissions set for a list of objects ids
* [x] Update changelog
* [x] Make tests pass