### PR TITLE
Custom Forbidden/Not found messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ This document describes changes between each past release.
 - The ``--backend`` command-line option for ``kinto init`` is not accepted as first
   parameter anymore
 - Improved parts of the FAQ (#744)
+- Improve 404 and 403 error handling to make them customizable. (#748)
 
 
 3.3.1 (2016-07-19)

--- a/kinto/core/views/errors.py
+++ b/kinto/core/views/errors.py
@@ -1,12 +1,8 @@
-from functools import wraps
-
 from pyramid import httpexceptions
 from pyramid.httpexceptions import HTTPTemporaryRedirect
 from pyramid.settings import asbool
 from pyramid.security import forget, NO_PERMISSION_REQUIRED, Authenticated
-from pyramid.view import (
-    forbidden_view_config, notfound_view_config, view_config
-)
+from pyramid.view import view_config
 
 from kinto.core.errors import http_error, ERRORS
 from kinto.core.logs import logger

--- a/kinto/core/views/errors.py
+++ b/kinto/core/views/errors.py
@@ -14,20 +14,6 @@ from kinto.core.storage import exceptions as storage_exceptions
 from kinto.core.utils import reapply_cors, encode_header
 
 
-def cors(view):
-    """Decorator to make sure CORS headers are correctly processed."""
-
-    @wraps(view)
-    def wrap_view(request, *args, **kwargs):
-        response = view(request, *args, **kwargs)
-
-        # We need to re-apply the CORS checks done by Cornice, since we're
-        # recreating the response from scratch.
-        return reapply_cors(request, response)
-
-    return wrap_view
-
-
 @view_config(context=httpexceptions.HTTPForbidden,
              permission=NO_PERMISSION_REQUIRED)
 def authorization_required(response, request):

--- a/kinto/tests/core/test_views_errors.py
+++ b/kinto/tests/core/test_views_errors.py
@@ -48,6 +48,19 @@ class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
             response, 404, ERRORS.MISSING_RESOURCE, "Not Found",
             "The resource you are looking for could not be found.")
 
+    def test_404_can_be_overridded(self):
+        custom_404 = http_error(httpexceptions.HTTPNotFound(),
+                                errno=ERRORS.MISSING_RESOURCE,
+                                message="Customized.")
+        with mock.patch(
+                'kinto.tests.core.testapp.views.Mushroom._extract_filters',
+                side_effect=custom_404):
+            response = self.app.get(self.sample_url, headers=self.headers,
+                                    status=404)
+        self.assertFormattedError(
+            response, 404, ERRORS.MISSING_RESOURCE, "Not Found",
+            "Customized.")
+
     def test_401_is_valid_formatted_error(self):
         response = self.app.get(self.sample_url, status=401)
         self.assertFormattedError(
@@ -61,6 +74,19 @@ class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
         self.assertFormattedError(
             response, 403, ERRORS.FORBIDDEN, "Forbidden",
             "This user cannot access this resource.")
+
+    def test_403_can_be_overridded(self):
+        custom_403 = http_error(httpexceptions.HTTPForbidden(),
+                                errno=ERRORS.FORBIDDEN,
+                                message="Customized.")
+        with mock.patch(
+                'kinto.tests.core.testapp.views.Mushroom._extract_filters',
+                side_effect=custom_403):
+            response = self.app.get(self.sample_url,
+                                    headers=self.headers, status=403)
+        self.assertFormattedError(
+            response, 403, ERRORS.FORBIDDEN, "Forbidden",
+            "Customized.")
 
     def test_405_is_valid_formatted_error(self):
         response = self.app.patch(self.sample_url,


### PR DESCRIPTION
Currently there are forced in `core/views/errors.py`.

One can not do:

```python
raise core_errors.http_error(httpexceptions.HTTPForbidden(), message="Nope dude")
```

- [ ] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.



