### PR TITLE
Add a test to show a problem in the history plugin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - TOX_ENV=py34
   - TOX_ENV=py27-raw
   - TOX_ENV=docs
-
 install:
   - pip install tox
 before_script:
@@ -42,3 +41,5 @@ matrix:
       script: flake8 kinto
     - env: TOX_ENV=pypy
       script: if [ "${TRAVIS_BRANCH}" = "master" ]; then tox -e $TOX_ENV; else true; fi;
+  allow_failures:
+    - env: TOX_ENV=pypy

--- a/kinto/plugins/history/listener.py
+++ b/kinto/plugins/history/listener.py
@@ -29,14 +29,17 @@ def on_resource_changed(event):
 
     targets = []
     for impacted in event.impacted_records:
+        # On POST .../records, the URI does not contain the newly created
+        # record id.
         target = impacted['new']
         obj_id = target['id']
-        # On POST .../records, the URI does not contain the newly created
-        # record id. Make sure it does:
-        if event_uri.endswith(obj_id):
-            uri = event_uri
+        parts = event_uri.split('/')
+        if resource_name in parts[-1]:
+            parts.append(obj_id)
         else:
-            uri = event_uri + '/' + obj_id
+            # Make sure the id is correct on grouped events.
+            parts[-1] = obj_id
+        uri = '/'.join(parts)
         targets.append((uri, target))
 
     # Prepare a list of object ids to be fetched from permission backend,

--- a/kinto/plugins/history/test_plugin.py
+++ b/kinto/plugins/history/test_plugin.py
@@ -324,6 +324,26 @@ class BulkTest(HistoryWebTest):
         assert entries[0]['uri'] == '/buckets/bid/collections/cid/records/c'
         assert entries[-2]['uri'] == '/buckets/bid/collections/cid'
 
+    def test_delete_on_collection(self):
+        body = {
+            'defaults': {
+                'method': 'DELETE',
+            },
+            'requests': [{
+                'path': '/buckets/bid/collections/cid/records/a',
+            }, {
+                'path': '/buckets/bid/collections/cid/records/b',
+            }, {
+                'path': '/buckets/bid/collections/cid/records/c',
+            }]
+        }
+        self.app.post_json('/batch', body, headers=self.headers)
+        resp = self.app.get('/buckets/bid/history', headers=self.headers)
+        entries = resp.json['data']
+        assert entries[0]['uri'] == '/buckets/bid/collections/cid/records/c'
+        assert entries[1]['uri'] == '/buckets/bid/collections/cid/records/b'
+        assert entries[2]['uri'] == '/buckets/bid/collections/cid/records/a'
+
 
 class DefaultBucketTest(HistoryWebTest):
 


### PR DESCRIPTION
While working on the quotas plugin, I used a similar way of going through the `impacted_record` list and I discovered a bug that applies to the history plugin too.