### PR TITLE
typo in collections documentation

### DIFF
--- a/docs/api/1.x/collections.rst
+++ b/docs/api/1.x/collections.rst
@@ -39,7 +39,7 @@ A collection is a mapping with the following attributes:
 List bucket collections
 =======================
 
-.. http:post:: /buckets/(bucket_id)/collections
+.. http:get:: /buckets/(bucket_id)/collections
 
    :synopsis: List bucket's readable collections
 


### PR DESCRIPTION
Fixes a typo in the API reference for collections
r? @natim

It's a GET to list collections. Example is correct.
