### PR TITLE
Filter/Sort plural endpoint by sub-object (ref #345)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,10 +18,11 @@ This document describes changes between each past release.
 - Redis listener is not part of the core anymore. (#712)
   Use ``kinto.event_listeners.redis.use = kinto_redis.listeners`` instead of
   ``kinto.event_listeners.redis.use = kinto.core.listeners.redis``
-  
+
 **Protocol**
 
 - Added a ``/__version__`` endpoint with the version that has been deployed. (#747)
+- Allow sub-object filtering on plural endpoints (e.g ``?person.name=Eliot``) (#345)
 
 **New features**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ This document describes changes between each past release.
 
 - Added a ``/__version__`` endpoint with the version that has been deployed. (#747)
 - Allow sub-object filtering on plural endpoints (e.g ``?person.name=Eliot``) (#345)
+- Allow sub-object sorting on plural endpoints (e.g ``?_sort=person.name``) (#345)
 
 **New features**
 

--- a/docs/api/1.x/filtering.rst
+++ b/docs/api/1.x/filtering.rst
@@ -17,6 +17,10 @@ the response.
 ..
 .. * ``/collection?field=1,2``
 
+**Sub-objects**
+
+* ``/collection?field.subfield=value``
+
 **Minimum and maximum**
 
 Prefix field name with ``min_`` or ``max_``:

--- a/docs/api/1.x/sorting.rst
+++ b/docs/api/1.x/sorting.rst
@@ -7,15 +7,13 @@ Plural endpoints support sorting of their contained elements. For
 example, you can sort the records in a collection. To do this, provide
 an additional query parameter specifying the sort key.
 
-* ``/collection?_sort=-last_modified,field``
+* ``/collection?_sort=field,-last_modified``
 
-  Sorts according to ``last_modified`` descending, with ties being
-  broken according to ``field`` ascending.
-
-.. note::
-
-    Ordering on a boolean field gives ``true`` values first.
+Sorts according to ``field`` ascending, with ties being
+broken according to ``last_modified`` descending.
 
 .. note::
 
-    Will return an error if a field is unknown.
+    * Sort order is ``-last_modified`` by default
+    * Sorting by sub-object is possible (e.g. ``?_sort=field.subfield``)
+    * Ordering on a boolean field gives ``true`` values first.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -16,6 +16,8 @@ Changelog
 
 - Add new endpoint ``GET /__version__`` to retrieve the information
   about the deployed version.
+- Allow sub-object filtering on plural endpoints (e.g ``?person.name=Eliot``)
+
 
 1.8 (2016-07-19)
 ''''''''''''''''

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -17,7 +17,7 @@ Changelog
 - Add new endpoint ``GET /__version__`` to retrieve the information
   about the deployed version.
 - Allow sub-object filtering on plural endpoints (e.g ``?person.name=Eliot``)
-
+- Allow sub-object sorting on plural endpoints (e.g ``?_sort=person.name``)
 
 1.8 (2016-07-19)
 ''''''''''''''''

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -956,7 +956,7 @@ class UserResource(object):
                 )
                 continue
 
-            m = re.match(r'^(min|max|not|lt|gt|in|exclude)_(\w+)$', param)
+            m = re.match(r'^(min|max|not|lt|gt|in|exclude)_([\w\.]+)$', param)
             if m:
                 keyword, field = m.groups()
                 operator = getattr(COMPARISON, keyword.upper())

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -994,7 +994,7 @@ class UserResource(object):
         modified_field_used = self.model.modified_field in specified
         for field in specified:
             field = field.strip()
-            m = re.match(r'^([\-+]?)(\w+)$', field)
+            m = re.match(r'^([\-+]?)([\w\.]+)$', field)
             if m:
                 order, field = m.groups()
 

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -86,11 +86,16 @@ class MemoryBasedStorage(StorageBase):
         for record in records:
             matches = True
             for f in filters:
-                left = record.get(f.field)
                 right = f.value
+                left = record
+                subfields = f.field.split('.')
+                for subfield in subfields:
+                    if not isinstance(left, dict):
+                        break
+                    left = left.get(subfield)
+
                 if f.operator in (COMPARISON.IN, COMPARISON.EXCLUDE):
-                    right = left
-                    left = f.value
+                    right, left = left, right
                 else:
                     # Python3 cannot compare None to other value.
                     if left is None:

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -389,7 +389,13 @@ def apply_sorting(records, sorting):
 
     def column(first, record, name):
         empty = first.get(name, float('inf'))
-        return record.get(name, empty)
+        subfields = name.split('.')
+        value = record
+        for subfield in subfields:
+            value = value.get(subfield, empty)
+            if not isinstance(value, dict):
+                break
+        return value
 
     for sort in reversed(sorting):
         result = sorted(result,

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -716,9 +716,15 @@ class Storage(StorageBase):
             elif sort.field == modified_field:
                 sql_field = 'last_modified'
             else:
-                field_holder = 'sort_field_%s' % i
-                holders[field_holder] = sort.field
-                sql_field = 'data->(:%s)' % field_holder
+                # Subfields: ``person.name`` becomes ``data->person->>name``
+                subfields = sort.field.split('.')
+                sql_field = 'data'
+                for j, subfield in enumerate(subfields):
+                    # Safely escape field name
+                    field_holder = 'sort_field_%s_%s' % (i, j)
+                    holders[field_holder] = subfield
+                    # Use ->> to convert the last level to text.
+                    sql_field += '->(:%s)' % field_holder
 
             sql_direction = 'ASC' if sort.direction > 0 else 'DESC'
             sql_sort = "%s %s" % (sql_field, sql_direction)

--- a/kinto/tests/core/resource/test_sort.py
+++ b/kinto/tests/core/resource/test_sort.py
@@ -114,3 +114,31 @@ class SortingTest(BaseTest):
         self.assertEqual(result['data'][1]['status'], 0)
         self.assertGreater(result['data'][0]['last_modified'],
                            result['data'][1]['last_modified'])
+
+
+class SubobjectSortingTest(BaseTest):
+    def setUp(self):
+        super(SubobjectSortingTest, self).setUp()
+        self.patch_known_field.start()
+
+        indices = list(range(20))
+        random.shuffle(indices)
+
+        for i in indices:
+            record = {
+                'party': {'candidate': 'Marie', 'voters': i},
+                'location': 'Creuse'
+            }
+            self.model.create_record(record)
+
+    def test_records_can_be_sorted_by_subobjects(self):
+        self.resource.request.GET = {'_sort': 'party.voters'}
+        result = self.resource.collection_get()
+        values = [item['party']['voters'] for item in result['data']]
+        self.assertEqual(sorted(values), values)
+
+    def test_subobjects_sorting_is_ignored_if_not_object(self):
+        self.resource.request.GET = {'_sort': 'location.city'}
+        result = self.resource.collection_get()
+        values = [item['party']['voters'] for item in result['data']]
+        self.assertNotEqual(sorted(values), values)

--- a/kinto/tests/core/test_storage.py
+++ b/kinto/tests/core/test_storage.py
@@ -373,6 +373,17 @@ class BaseTestStorage(object):
                                           **self.storage_kw)
         self.assertTrue(records[0]['id'] < records[-1]['id'])
 
+    def test_get_all_handle_sorting_on_subobject(self):
+        for x in range(10):
+            record = dict(**self.record)
+            record["person"] = dict(age=x)
+            self.create_record(record)
+        sorting = [Sort('person.age', 1)]
+        records, _ = self.storage.get_all(sorting=sorting,
+                                          **self.storage_kw)
+        self.assertLess(records[0]['person']['age'],
+                        records[-1]['person']['age'])
+
     def test_get_all_can_filter_with_list_of_values(self):
         for l in ['a', 'b', 'c']:
             self.create_record({'code': l})

--- a/kinto/tests/core/test_storage.py
+++ b/kinto/tests/core/test_storage.py
@@ -457,6 +457,14 @@ class BaseTestStorage(object):
                                           **self.storage_kw)
         self.assertEqual(len(records), 1)
 
+    def test_get_all_can_filter_by_subobjects_values(self):
+        for l in ['a', 'b', 'c']:
+            self.create_record({'code': {'sub': l}})
+        filters = [Filter('code.sub', 'a', utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters,
+                                          **self.storage_kw)
+        self.assertEqual(len(records), 1)
+
     def test_get_all_handle_a_pagination_rules(self):
         for x in range(10):
             record = dict(self.record)


### PR DESCRIPTION
Fixes #345 

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

- [x] Support subobject sorting

r? @

