### PR TITLE
Drop (unused) notion of unique fields in kinto.core

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ This document describes changes between each past release.
 - Redis listener is not part of the core anymore. (#712)
   Use ``kinto.event_listeners.redis.use = kinto_redis.listeners`` instead of
   ``kinto.event_listeners.redis.use = kinto.core.listeners.redis``
-  
+- Notion of unique fields was dropped from ``kinto.core`` resources.
+
 **Protocol**
 
 - Added a ``/__version__`` endpoint with the version that has been deployed. (#747)

--- a/docs/api/1.x/_details-patch-object.rst
+++ b/docs/api/1.x/_details-patch-object.rst
@@ -39,10 +39,3 @@ See :ref:`api-permissions-payload`.
 .. ----------------
 
 .. If a read-only field is modified, a |status-400| error is returned.
-
-
-.. Conflicts
-.. ---------
-
-.. If changing a object field violates a field unicity constraint, a |status-409|
-.. error response is returned (see :ref:`error channel <error-responses>`).

--- a/docs/api/1.x/_details-post-list.rst
+++ b/docs/api/1.x/_details-post-list.rst
@@ -33,23 +33,3 @@ In the JSON request payloads, an optional ``permissions`` attribute can be provi
 The :ref:`current user id <api-current-userid>` **is always added** among the ``write`` principals.
 
 See :ref:`api-permissions-payload`.
-
-.. Feature of Kinto.core not used in Kinto
-
-.. Conflicts
-.. ---------
-
-.. Since some fields can be defined as unique per collection, some conflicts
-.. may appear when creating records.
-
-.. .. note::
-
-..     Empty values are not taken into account for field unicity.
-
-.. .. note::
-
-..     Deleted records are not taken into account for field unicity.
-
-.. If a conflict occurs, an error response is returned with status |status-409|.
-.. A ``details`` attribute in the response provides the offending record and
-.. field name. See :ref:`dedicated section about errors <error-responses>`.

--- a/docs/api/1.x/_status-patch-object.rst
+++ b/docs/api/1.x/_status-patch-object.rst
@@ -7,6 +7,5 @@ HTTP Status Codes
 * |status-403|: The user is not allowed to perform the operation, or the resource is not accessible
 * |status-403|: The object does not exist or was deleted
 * |status-406|: The client doesn't accept supported responses Content-Type.
-* |status-409|: If modifying this object violates a field unicity constraint
 * |status-412|: Record changed since value in ``If-Match`` header
 * |status-415|: The client request was not sent with a correct Content-Type.

--- a/docs/api/1.x/_status-post-list.rst
+++ b/docs/api/1.x/_status-post-list.rst
@@ -7,6 +7,5 @@ HTTP Status Codes
 * |status-401|: The request is missing authentication headers
 * |status-403|: The user is not allowed to perform the operation, or the resource is not accessible
 * |status-406|: The client doesn't accept supported responses Content-Type
-* |status-409|: Unicity constraint on fields is violated
 * |status-412|: List has changed since value in ``If-Match`` header
 * |status-415|: The client request was not sent with a correct Content-Type

--- a/docs/api/1.x/_status-put-object.rst
+++ b/docs/api/1.x/_status-put-object.rst
@@ -7,6 +7,5 @@ HTTP Status Code
 * |status-401|: The request is missing authentication headers
 * |status-403|: The user is not allowed to perform the operation, or the resource is not accessible
 * |status-406|: The client doesn't accept supported responses Content-Type.
-* |status-409|: If replacing this object violates a field unicity constraint
 * |status-412|: Record was changed or deleted since value in ``If-Match`` header.
 * |status-415|: The client request was not sent with a correct Content-Type.

--- a/docs/api/1.x/errors.rst
+++ b/docs/api/1.x/errors.rst
@@ -76,34 +76,6 @@ provided in the ``details`` field:
     }
 
 
-Conflict errors
-===============
-
-When a record violates unicity constraints, a |status-409| error response
-is returned.
-
-Additional information about conflicting record and field name will be
-provided in the ``details`` field.
-
-::
-
-    {
-        "code": 409,
-        "errno": 122,
-        "error": "Conflict",
-        "message": "Conflict of field url on record eyjafjallajokull"
-        "info": "https://server/docs/api.html#errors",
-        "details": {
-            "field": "url",
-            "record": {
-                "id": "eyjafjallajokull",
-                "last_modified": 1430140411480,
-                "url": "http://mozilla.org"
-            }
-        }
-    }
-
-
 Validation errors
 =================
 

--- a/docs/core/quickstart.rst
+++ b/docs/core/quickstart.rst
@@ -200,7 +200,7 @@ Resource customization
 ----------------------
 
 See :ref:`the resource documentation <resource>` to specify custom URLs,
-schemaless resources, read-only fields, unicity constraints, record pre-processing...
+schemaless resources, read-only fields, record pre-processing...
 
 
 Advanced initialization

--- a/docs/core/resource.rst
+++ b/docs/core/resource.rst
@@ -27,7 +27,6 @@ Full example
 
         class Options:
             readonly_fields = ('device',)
-            unique_fields = ('url',)
 
 
     @resource.register()
@@ -85,8 +84,8 @@ Override the base schema to add extra fields using the `Colander API <http://doc
         genre = colander.SchemaNode(colander.String(),
                                     validator=colander.OneOf(['Sci-Fi', 'Comedy']))
 
-See the :ref:`resource schema options <resource-schema>` to define *schema-less* resources or specify rules
-for unicity or readonly.
+See the :ref:`resource schema options <resource-schema>` to define *schema-less*
+resources or specify rules like readonly fields.
 
 
 .. _resource-permissions:
@@ -136,10 +135,8 @@ a custom model can be plugged-in:
 
 
     class TrackedModel(resource.Model):
-        def create_record(self, record, parent_id=None, unique_fields=None):
-            record = super(TrackedModel, self).create_record(record,
-                                                             parent_id,
-                                                             unique_fields)
+        def create_record(self, record, parent_id=None):
+            record = super(TrackedModel, self).create_record(record, parent_id)
             trackid = index.track(record)
             record['trackid'] = trackid
             return record

--- a/kinto/core/resource/model.py
+++ b/kinto/core/resource/model.py
@@ -141,7 +141,7 @@ class Model(object):
                                 modified_field=self.modified_field,
                                 auth=self.auth)
 
-    def create_record(self, record, parent_id=None, unique_fields=None):
+    def create_record(self, record, parent_id=None):
         """Create a record in the collection.
 
         Override to perform actions or post-process records after their
@@ -157,7 +157,6 @@ class Model(object):
 
         :param dict record: record to store
         :param str parent_id: optional filter for parent id
-        :param tuple unique_fields: list of fields that should remain unique
 
         :returns: the newly created record.
         :rtype: dict
@@ -167,12 +166,11 @@ class Model(object):
                                    parent_id=parent_id,
                                    record=record,
                                    id_generator=self.id_generator,
-                                   unique_fields=unique_fields,
                                    id_field=self.id_field,
                                    modified_field=self.modified_field,
                                    auth=self.auth)
 
-    def update_record(self, record, parent_id=None, unique_fields=None):
+    def update_record(self, record, parent_id=None):
         """Update a record in the collection.
 
         Override to perform actions or post-process records after their
@@ -180,17 +178,14 @@ class Model(object):
 
         .. code-block:: python
 
-            def update_record(self, record, parent_id=None,unique_fields=None):
-                record = super(MyModel, self).update_record(record,
-                                                            parent_id,
-                                                            unique_fields)
+            def update_record(self, record, parent_id=None):
+                record = super(MyModel, self).update_record(record, parent_id)
                 subject = 'Record {} was changed'.format(record[self.id_field])
                 send_email(subject)
                 return record
 
         :param dict record: record to store
         :param str parent_id: optional filter for parent id
-        :param tuple unique_fields: list of fields that should remain unique
         :returns: the updated record.
         :rtype: dict
         """
@@ -200,7 +195,6 @@ class Model(object):
                                    parent_id=parent_id,
                                    object_id=record_id,
                                    record=record,
-                                   unique_fields=unique_fields,
                                    id_field=self.id_field,
                                    modified_field=self.modified_field,
                                    auth=self.auth)
@@ -279,15 +273,13 @@ class ShareableModel(Model):
         annotated[self.permissions_field] = permissions
         return annotated
 
-    def create_record(self, record, parent_id=None, unique_fields=None):
+    def create_record(self, record, parent_id=None):
         """Create record and set specified permissions.
 
         The current principal is added to the owner (``write`` permission).
         """
         permissions = record.pop(self.permissions_field, {})
-        record = super(ShareableModel, self).create_record(record,
-                                                           parent_id,
-                                                           unique_fields)
+        record = super(ShareableModel, self).create_record(record, parent_id)
         record_id = record[self.id_field]
         perm_object_id = self.get_permission_object_id(record_id)
         self.permission.replace_object_permissions(perm_object_id, permissions)
@@ -298,7 +290,7 @@ class ShareableModel(Model):
         annotated[self.permissions_field] = permissions
         return annotated
 
-    def update_record(self, record, parent_id=None, unique_fields=None):
+    def update_record(self, record, parent_id=None):
         """Update record and the specified permissions.
 
         If no permissions is specified, the current permissions are not
@@ -307,9 +299,7 @@ class ShareableModel(Model):
         The current principal is added to the owner (``write`` permission).
         """
         permissions = record.pop(self.permissions_field, {})
-        record = super(ShareableModel, self).update_record(record,
-                                                           parent_id,
-                                                           unique_fields)
+        record = super(ShareableModel, self).update_record(record, parent_id)
         record_id = record[self.id_field]
         perm_object_id = self.get_permission_object_id(record_id)
         self.permission.replace_object_permissions(perm_object_id, permissions)

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -19,14 +19,8 @@ class ResourceSchema(colander.MappingSchema):
                 reference = colander.SchemaNode(colander.String())
 
                 class Options:
-                    unique_fields = ('reference',)
+                    readonly_fields = ('reference',)
         """
-        unique_fields = tuple()
-        """Fields that must have unique values for the user collection.
-        During records creation and modification, a conflict error will be
-        raised if unicity is about to be violated.
-        """
-
         readonly_fields = tuple()
         """Fields that cannot be updated. Values for fields will have to be
         provided either during record creation, through default values using

--- a/kinto/core/storage/__init__.py
+++ b/kinto/core/storage/__init__.py
@@ -69,7 +69,7 @@ class StorageBase(object):
         raise NotImplementedError
 
     def create(self, collection_id, parent_id, record, id_generator=None,
-               unique_fields=None, id_field=DEFAULT_ID_FIELD,
+               id_field=DEFAULT_ID_FIELD,
                modified_field=DEFAULT_MODIFIED_FIELD,
                auth=None):
         """Create the specified `object` in this `collection_id` for this `parent_id`.
@@ -84,8 +84,7 @@ class StorageBase(object):
 
         :param str collection_id: the collection id.
         :param str parent_id: the collection parent.
-
-        :param dict object: the object to create.
+        :param dict record: the object to create.
 
         :returns: the newly created object.
         :rtype: dict
@@ -112,7 +111,7 @@ class StorageBase(object):
         raise NotImplementedError
 
     def update(self, collection_id, parent_id, object_id, record,
-               unique_fields=None, id_field=DEFAULT_ID_FIELD,
+               id_field=DEFAULT_ID_FIELD,
                modified_field=DEFAULT_MODIFIED_FIELD,
                auth=None):
         """Overwrite the `object` with the specified `object_id`.
@@ -124,13 +123,10 @@ class StorageBase(object):
 
             This will update the collection timestamp.
 
-        :raises: :exc:`kinto.core.storage.exceptions.UnicityError`
-
         :param str collection_id: the collection id.
         :param str parent_id: the collection parent.
-
         :param str object_id: unique identifier of the object
-        :param dict object: the object to update or create.
+        :param dict record: the object to update or create.
 
         :returns: the updated object.
         :rtype: dict

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -6,7 +6,7 @@ import six
 
 from kinto.core import logger
 from kinto.core.storage import (
-    StorageBase, exceptions, Filter,
+    StorageBase, exceptions,
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD)
 from kinto.core.storage.postgresql.client import create_from_config
 from kinto.core.utils import COMPARISON, json
@@ -215,12 +215,20 @@ class Storage(StorageBase):
         return record['last_modified']
 
     def create(self, collection_id, parent_id, record, id_generator=None,
-               unique_fields=None, id_field=DEFAULT_ID_FIELD,
+               id_field=DEFAULT_ID_FIELD,
                modified_field=DEFAULT_MODIFIED_FIELD,
                auth=None):
         id_generator = id_generator or self.id_generator
         record = record.copy()
-        record_id = record.setdefault(id_field, id_generator())
+        if id_field in record:
+            # Raise unicity error if record with same id already exists.
+            try:
+                existing = self.get(collection_id, parent_id, record[id_field])
+                raise exceptions.UnicityError(id_field, existing)
+            except exceptions.RecordNotFoundError:
+                pass
+        else:
+            record[id_field] = id_generator()
 
         query = """
         WITH delete_potential_tombstone AS (
@@ -235,16 +243,12 @@ class Storage(StorageBase):
                 from_epoch(:last_modified))
         RETURNING id, as_epoch(last_modified) AS last_modified;
         """
-        placeholders = dict(object_id=record_id,
+        placeholders = dict(object_id=record[id_field],
                             parent_id=parent_id,
                             collection_id=collection_id,
                             last_modified=record.get(modified_field),
                             data=json.dumps(record))
         with self.client.connect() as conn:
-            # Check that it does violate the resource unicity rules.
-            self._check_unicity(conn, collection_id, parent_id, record,
-                                unique_fields, id_field, modified_field,
-                                for_creation=True)
             result = conn.execute(query, placeholders)
             inserted = result.fetchone()
 
@@ -278,7 +282,7 @@ class Storage(StorageBase):
         return record
 
     def update(self, collection_id, parent_id, object_id, record,
-               unique_fields=None, id_field=DEFAULT_ID_FIELD,
+               id_field=DEFAULT_ID_FIELD,
                modified_field=DEFAULT_MODIFIED_FIELD,
                auth=None):
         query_create = """
@@ -313,9 +317,6 @@ class Storage(StorageBase):
         record[id_field] = object_id
 
         with self.client.connect() as conn:
-            # Check that it does violate the resource unicity rules.
-            self._check_unicity(conn, collection_id, parent_id, record,
-                                unique_fields, id_field, modified_field)
             # Create or update ?
             query = """
             SELECT id FROM records
@@ -719,70 +720,6 @@ class Storage(StorageBase):
 
         safe_sql = 'ORDER BY %s' % (', '.join(sorts))
         return safe_sql, holders
-
-    def _check_unicity(self, conn, collection_id, parent_id, record,
-                       unique_fields, id_field, modified_field,
-                       for_creation=False):
-        """Check that no existing record (in the current transaction snapshot)
-        violates the resource unicity rules.
-        """
-        # If id is provided by client, check that no record conflicts.
-        if for_creation and id_field in record:
-            unique_fields = (unique_fields or tuple()) + (id_field,)
-
-        if not unique_fields:
-            return
-
-        query = """
-        SELECT id
-          FROM records
-         WHERE parent_id = :parent_id
-           AND collection_id = :collection_id
-           AND (%(conditions_filter)s)
-           AND %(condition_record)s
-         LIMIT 1;
-        """
-        safeholders = dict()
-        placeholders = dict(parent_id=parent_id,
-                            collection_id=collection_id)
-
-        # Transform each field unicity into a query condition.
-        filters = []
-        for field in set(unique_fields):
-            value = record.get(field)
-            if value is None:
-                continue
-            sql, holders = self._format_conditions(
-                [Filter(field, value, COMPARISON.EQ)],
-                id_field,
-                modified_field,
-                prefix=field)
-            filters.append(sql)
-            placeholders.update(**holders)
-
-        # All unique fields are empty in record
-        if not filters:
-            return
-
-        safeholders['conditions_filter'] = ' OR '.join(filters)
-
-        # If record is in database, then exclude it of unicity check.
-        if not for_creation:
-            object_id = record[id_field]
-            sql, holders = self._format_conditions(
-                [Filter(id_field, object_id, COMPARISON.NOT)],
-                id_field,
-                modified_field)
-            safeholders['condition_record'] = sql
-            placeholders.update(**holders)
-        else:
-            safeholders['condition_record'] = 'TRUE'
-
-        result = conn.execute(query % safeholders, placeholders)
-        if result.rowcount > 0:
-            existing = result.fetchone()
-            record = self.get(collection_id, parent_id, existing['id'])
-            raise exceptions.UnicityError(unique_fields[0], record)
 
 
 def load_from_config(config):

--- a/kinto/plugins/default_bucket/test_plugin.py
+++ b/kinto/plugins/default_bucket/test_plugin.py
@@ -162,7 +162,8 @@ class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
         with mock.patch.object(self.storage, 'get',
                                wraps=self.storage.get) as patched:
             self.app.post_json('/batch', batch, headers=self.headers)
-            self.assertEqual(patched.call_count, 0)
+            # Called twice only: bucket + collection ids unicity.
+            self.assertEqual(patched.call_count, 2)
 
     def test_parent_collection_is_taken_from_the_one_checked_in_batch(self):
         # Create it first.
@@ -179,7 +180,8 @@ class DefaultBucketViewTest(FormattedErrorMixin, BaseWebTest,
         with mock.patch.object(self.storage, 'get',
                                wraps=self.storage.get) as patched:
             self.app.post_json('/batch', batch, headers=self.headers)
-            self.assertEqual(patched.call_count, 0)
+            # Called twice only: bucket + collection ids unicity.
+            self.assertEqual(patched.call_count, 2)
 
     def test_collection_id_is_validated(self):
         collection_url = '/buckets/default/collections/__files__/records'

--- a/kinto/tests/core/test_storage.py
+++ b/kinto/tests/core/test_storage.py
@@ -121,14 +121,12 @@ class BaseTestStorage(object):
         super(BaseTestStorage, self).tearDown()
         self.storage.flush()
 
-    def create_record(self, record=None, id_generator=None,
-                      unique_fields=None, **kwargs):
+    def create_record(self, record=None, id_generator=None, **kwargs):
         record = record or self.record
         kw = self.storage_kw.copy()
         kw.update(**kwargs)
         return self.storage.create(record=record,
                                    id_generator=id_generator,
-                                   unique_fields=unique_fields,
                                    **kw)
 
     def test_raises_backend_error_if_error_occurs_on_client(self):
@@ -687,89 +685,6 @@ class TimestampsTest(object):
         self.assertGreater(timestamp, timestamp_before)
 
 
-class FieldsUnicityTest(object):
-    def test_does_not_fail_if_no_unique_fields_at_all(self):
-        self.create_record({'phone': '0033677'})
-        self.create_record({'phone': '0033677'}, unique_fields=tuple())
-
-    def test_cannot_insert_duplicate_field(self):
-        self.create_record({'phone': '0033677'})
-        self.assertRaises(exceptions.UnicityError,
-                          self.create_record,
-                          {'phone': '0033677'},
-                          unique_fields=('phone',))
-
-    def test_unicity_exception_gives_record_and_field(self):
-        record = self.create_record({'phone': '0033677'})
-        try:
-            self.create_record({'phone': '0033677'},
-                               unique_fields=('phone',))
-        except exceptions.UnicityError as e:
-            error = e
-        self.assertEqual(error.field, 'phone')
-        self.assertDictEqual(error.record, record)
-
-    def test_unicity_is_by_parent_id(self):
-        self.create_record({'phone': '0033677'})
-        self.create_record({'phone': '0033677'},
-                           unique_fields=('phone',),
-                           parent_id=self.other_parent_id,
-                           auth=self.other_auth)  # not raising
-
-    def test_unicity_is_for_non_null_values(self):
-        r = self.create_record({'phone': None}, unique_fields=('phone',))
-        # not raising with None value
-        self.create_record({'phone': None}, unique_fields=('phone',))
-        self.storage.update(object_id=r['id'], record={'phone': None},
-                            unique_fields=('phone',), **self.storage_kw)
-
-    def test_unicity_does_not_apply_to_deleted_records(self):
-        record = self.create_record({'phone': '0033677'})
-        self.storage.delete(object_id=record['id'], **self.storage_kw)
-        self.create_record({'phone': None}, unique_fields=('phone',))
-
-    def test_unicity_applies_to_one_of_all_fields_specified(self):
-        self.create_record({'phone': 'abc', 'line': '1'})
-        self.assertRaises(exceptions.UnicityError,
-                          self.create_record,
-                          {'phone': 'efg', 'line': '1'},
-                          unique_fields=('phone', 'line'))
-
-    def test_updating_with_same_id_does_not_raise_unicity_error(self):
-        record = self.create_record({'phone': '0033677'})
-        self.storage.update(object_id=record['id'],
-                            record=record,
-                            unique_fields=('phone',),
-                            **self.storage_kw)
-
-    def test_updating_raises_unicity_error(self):
-        self.create_record({'phone': 'number'})
-        record = self.create_record({'phone': '0033677'})
-        self.assertRaises(exceptions.UnicityError,
-                          self.storage.update,
-                          object_id=record['id'],
-                          record={'phone': 'number'},
-                          unique_fields=('phone',),
-                          **self.storage_kw)
-
-    def test_unicity_detection_supports_special_characters(self):
-        record = self.create_record()
-        values = ['b', 'http://moz.org', u"#131 \u2014 ujson",
-                  "C:\\\\win32\\hosts"]
-        for value in values:
-            self.create_record({'phone': value})
-            try:
-                error = None
-                self.storage.update(object_id=record['id'],
-                                    record={'phone': value},
-                                    unique_fields=('phone',),
-                                    **self.storage_kw)
-            except exceptions.UnicityError as e:
-                error = e
-            msg = 'UnicityError not raised with %s' % value
-            self.assertIsNotNone(error, msg)
-
-
 class DeletedRecordsTest(object):
     def _get_last_modified_filters(self):
         start = self.storage.collection_timestamp(**self.storage_kw)
@@ -1208,7 +1123,6 @@ class ParentRecordAccessTest(object):
 
 
 class StorageTest(ThreadMixin,
-                  FieldsUnicityTest,
                   TimestampsTest,
                   DeletedRecordsTest,
                   ParentRecordAccessTest,


### PR DESCRIPTION
Originally, for the reading list service, we had the notion of *unique fields*, because we wanted to ensure that stored articles were «unique».

The whole code in charge of this can be removed, mainly because:
* it was never used beyond that original use-case
* it is useless when data is encrypted
* it requires to scan the collection on each create/update before checking
* it allows to remove quite a lot of code

- [x] Update documentation.
- [x] Update tests.
- [x] Add a changelog entry.

r? @Natim 

