### PR TITLE
Remove kinto.id_generator from docs (fixes #757)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This document describes changes between each past release.
 **Internal changes**
 
 - Fix documentation of errors codes (fixes #766)
+- ``kinto.id_generator`` was removed from documentation since it does not
+  behave as expected (fixes #757, thanks @doplumi)
 
 
 4.0.0 (2016-08-17)

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -52,9 +52,6 @@ Feature settings
 |                                                 |              | more elements than defined by the                                         |
 |                                                 |              | ``kinto.storage_max_fetch_size`` setting.                                 |
 +-------------------------------------------------+--------------+---------------------------------------------------------------------------+
-| kinto.id_generator                              | ``UUID4``    | The Python *dotted* location of the generator class that should be used   |
-|                                                 |              | to generate identifiers on a POST on a records endpoint.                  |
-+-------------------------------------------------+--------------+---------------------------------------------------------------------------+
 | kinto.<object-type>_id_generator                | ``UUID4``    | The Python *dotted* location of the generator class that should be used   |
 |                                                 |              | to generate identifiers on a POST endpoint.                               |
 |                                                 |              | Object type is one of ``bucket``, ``collection``, ``group``, ``record``.  |

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -95,5 +95,5 @@ def main(global_config, config=None, **settings):
 
     app = config.make_wsgi_app()
 
-    # Install middleware (idempotent if disabled)
+    # Install middleware (no-op if disabled)
     return kinto.core.install_middlewares(app, settings)

--- a/kinto/core/storage/__init__.py
+++ b/kinto/core/storage/__init__.py
@@ -36,6 +36,7 @@ class StorageBase(object):
     """
 
     id_generator = generators.UUID4()
+    """Id generator used when no one is provided for create."""
 
     def initialize_schema(self, dry_run=False):
         """Create every necessary objects (like tables or indices) in the


### PR DESCRIPTION
Fixes #757 

I was trying to fix the expected behaviour of the `kinto.id_generator` setting, which should override every id default generators.

The problem I face is that we currently have no way to distinguish between default settings and specified settings at the place we consume them. Since I can't tell if the setting was defined in .ini or not, I can't do much :(

I thus decided to remove `kinto.id_generator` from docs :)