### PR TITLE
Permissions endpoint can now be filtered, sorted and paginated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,10 @@ This document describes changes between each past release.
 4.0.1 (2016-08-22)
 ------------------
 
+**New features**
+
+- Permissions endpoint (``GET /permissions``) can now be filtered, sorted and paginated.
+
 **Bug fixes**
 
 - Return 400 error response when history is filtered with unknown field

--- a/docs/api/1.x/permissions.rst
+++ b/docs/api/1.x/permissions.rst
@@ -445,3 +445,17 @@ List every permissions
                 }
             ]
         }
+
+List of available URL parameters
+--------------------------------
+
+- ``<prefix?><field name>``: :doc:`filter <filtering>` by value(s)
+- ``_sort``: :doc:`order list <sorting>`
+- ``_limit``: :doc:`pagination max size <pagination>`
+- ``_token``: :doc:`pagination token <pagination>`
+- ``_fields``: :doc:`filter the fields of the records <selecting_fields>`
+
+
+Filtering, sorting, partial responses and paginating can all be combined together.
+
+* ``?_sort=-last_modified&_limit=100&_fields=title``

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -4,7 +4,7 @@ import logging
 import kinto.core
 from pyramid.config import Configurator
 from pyramid.settings import asbool
-from pyramid.security import Authenticated
+from pyramid.security import Authenticated, Everyone
 
 from kinto.authorization import RouteFactory
 
@@ -27,6 +27,7 @@ DEFAULT_SETTINGS = {
     'storage_backend': 'kinto.core.storage.memory',
     'project_docs': 'https://kinto.readthedocs.io/',
     'bucket_create_principals': Authenticated,
+    'permissions_read_principals': Everyone,
     'multiauth.authorization_policy': (
         'kinto.authorization.AuthorizationPolicy'),
     'experimental_collection_schema_validation': False,

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -171,6 +171,7 @@ def raise_invalid(request, location='body', name=None, description=None,
     :raises: :class:`~pyramid:pyramid.httpexceptions.HTTPBadRequest`
     """
     request.errors.add(location, name, description, **kwargs)
+    request.errors.request = request  # Needed by json_error_handler to reapply_cors
     response = json_error_handler(request.errors)
     raise response
 

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -118,8 +118,7 @@ def register_resource(resource_cls, settings=None, viewset=None, depth=1,
             service = register_service('record', config.registry.settings)
             config.add_cornice_service(service)
 
-    info = venusian.attach(resource_cls, callback, category='pyramid',
-                           depth=depth)
+    info = venusian.attach(resource_cls, callback, category='pyramid', depth=depth)
     return callback
 
 

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -1,65 +1,121 @@
+import colander
 from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
-from kinto.core import Service, utils as core_utils
+from kinto.core import utils as core_utils, resource
+from kinto.core.storage.memory import extract_record_set
 
 
-permissions = Service(name='permissions',
-                      description='List of user permissions',
-                      path='/permissions')
+class PermissionsModel(object):
+    id_field = 'id'
+    modified_field = 'last_modified'
+    deleted_field = 'deleted'
 
+    def __init__(self, request):
+        self.request = request
 
-@permissions.get(permission=NO_PERMISSION_REQUIRED)
-def permissions_get(request):
-    # Invert the permissions inheritance tree.
-    perms_descending_tree = {}
-    for obtained, obtained_from in PERMISSIONS_INHERITANCE_TREE.items():
-        on_resource, obtained_perm = obtained.split(':', 1)
-        for from_resource, perms in obtained_from.items():
+    def timestamp(self, parent_id=None):
+        return -1
+
+    def get_records(self, filters=None, sorting=None, pagination_rules=None,
+                    limit=None, include_deleted=False, parent_id=None):
+        # Invert the permissions inheritance tree.
+        perms_descending_tree = {}
+        for obtained, obtained_from in PERMISSIONS_INHERITANCE_TREE.items():
+            on_resource, obtained_perm = obtained.split(':', 1)
+            for from_resource, perms in obtained_from.items():
+                for perm in perms:
+                    perms_descending_tree.setdefault(from_resource, {})\
+                                         .setdefault(perm, {})\
+                                         .setdefault(on_resource, set())\
+                                         .add(obtained_perm)
+
+        # Obtain current principals.
+        principals = self.request.effective_principals
+        if Authenticated in principals:
+            # Since this view does not require any permission (can be used to
+            # obtain public users permissions), we have to add the prefixed
+            # userid among the principals
+            # (see :mod:`kinto.core.authentication`)
+            userid = self.request.prefixed_userid
+            principals.append(userid)
+
+        # Query every possible permission of the current user from backend.
+        backend = self.request.registry.permission
+        perms_by_object_uri = backend.get_accessible_objects(principals)
+
+        entries = []
+        for object_uri, perms in perms_by_object_uri.items():
+            try:
+                # Obtain associated resource from object URI
+                resource_name, matchdict = core_utils.view_lookup(self.request,
+                                                                  object_uri)
+            except ValueError:
+                # Skip permissions entries that are not linked to an object URI
+                continue
+
+            # For consistency with event payloads, prefix id with resource name
+            matchdict[resource_name + '_id'] = matchdict.get('id')
+
+            # Expand implicit permissions using descending tree.
+            permissions = set(perms)
             for perm in perms:
-                perms_descending_tree.setdefault(from_resource, {})\
-                                     .setdefault(perm, {})\
-                                     .setdefault(on_resource, set())\
-                                     .add(obtained_perm)
+                obtained = perms_descending_tree[resource_name][perm]
+                # Related to same resource only and not every sub-objects.
+                # (e.g "bucket:write" gives "bucket:read" but not "group:read")
+                permissions |= obtained[resource_name]
 
-    # Obtain current principals.
-    principals = request.effective_principals
-    if Authenticated in principals:
-        # Since this view does not require any permission (can be used to
-        # obtain public users permissions), we have to add the prefixed userid
-        # among the principals (see :mode:`kinto.core.authentication`)
-        userid = request.prefixed_userid
-        principals.append(userid)
+            entry = dict(uri=object_uri,
+                         resource_name=resource_name,
+                         permissions=list(permissions),
+                         **matchdict)
+            entries.append(entry)
 
-    # Query every possible permission of the current user from backend.
-    backend = request.registry.permission
-    perms_by_object_uri = backend.get_accessible_objects(principals)
+        return extract_record_set(entries, filters=filters, sorting=sorting,
+                                  pagination_rules=pagination_rules,
+                                  limit=limit)
 
-    entries = []
-    for object_uri, perms in perms_by_object_uri.items():
-        try:
-            # Obtain associated resource from object URI
-            resource_name, matchdict = core_utils.view_lookup(request,
-                                                              object_uri)
-        except ValueError:
-            # Skip permissions entries that are not linked to an object URI.
-            continue
 
-        # For consistency with events payloads, prefix id with resource name
-        matchdict[resource_name + '_id'] = matchdict.get('id')
+class PermissionsSchema(resource.ResourceSchema):
+    uri = colander.SchemaNode(colander.String())
+    resource_name = colander.SchemaNode(colander.String())
+    permissions = colander.Sequence(colander.SchemaNode(colander.String()))
+    bucket_id = colander.SchemaNode(colander.String())
+    collection_id = colander.SchemaNode(colander.String(),
+                                        missing=colander.drop)
+    group_id = colander.SchemaNode(colander.String(),
+                                   missing=colander.drop)
+    record_id = colander.SchemaNode(colander.String(),
+                                    missing=colander.drop)
 
-        # Expand implicit permissions using descending tree.
-        permissions = set(perms)
-        for perm in perms:
-            obtained = perms_descending_tree[resource_name][perm]
-            # Related to same resource only and not every sub-objects.
-            # (e.g "bucket:write" gives "bucket:read" but not "group:read")
-            permissions |= obtained[resource_name]
+    class Options:
+        preserve_unknown = False
 
-        entry = dict(uri=object_uri,
-                     resource_name=resource_name,
-                     permissions=list(permissions),
-                     **matchdict)
-        entries.append(entry)
 
-    return {"data": entries}
+@resource.register(name='permissions',
+                   description='List of user permissions',
+                   collection_path='/permissions',
+                   record_path=None,
+                   collection_methods=('GET',),
+                   permission=NO_PERMISSION_REQUIRED)
+class Permissions(resource.UserResource):
+
+    mapping = PermissionsSchema()
+
+    def __init__(self, request, context=None):
+        super(Permissions, self).__init__(request, context)
+        self.model = PermissionsModel(request)
+
+    def _extract_sorting(self, limit):
+        # Permissions entries are not stored with timestamp, so do not
+        # force it.
+        result = super(Permissions, self)._extract_sorting(limit)
+        without_last_modified = [s for s in result
+                                 if s.field != self.model.modified_field]
+        return without_last_modified
+
+    def _extract_filters(self, queryparams=None):
+        result = super(Permissions, self)._extract_filters(queryparams)
+        without_last_modified = [s for s in result
+                                 if s.field != self.model.modified_field]
+        return without_last_modified

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -98,7 +98,7 @@ class PermissionsSchema(resource.ResourceSchema):
                    record_path=None,
                    collection_methods=('GET',),
                    permission=NO_PERMISSION_REQUIRED)
-class Permissions(resource.UserResource):
+class Permissions(resource.ShareableResource):
 
     mapping = PermissionsSchema()
 

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -14,9 +14,6 @@ class PermissionsModel(object):
     def __init__(self, request):
         self.request = request
 
-    def timestamp(self, parent_id=None):
-        return -1
-
     def get_records(self, filters=None, sorting=None, pagination_rules=None,
                     limit=None, include_deleted=False, parent_id=None):
         # Invert the permissions inheritance tree.

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -67,3 +67,26 @@ class PermissionsViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(record_permission['record_id'], RECORD_ID)
         self.assertEqual(record_permission['collection_id'], 'barley')
         self.assertEqual(record_permission['bucket_id'], 'beers')
+
+    def test_permissions_list_can_be_filtered(self):
+        resp = self.app.get('/permissions?in_resource_name=bucket,collection',
+                            headers=self.headers)
+        permissions = resp.json['data']
+        self.assertEqual(len(permissions), 2)
+
+    def test_filtering_with_unknown_field_is_not_supported(self):
+        self.app.get('/permissions?movie=bourne',
+                     headers=self.headers,
+                     status=400)
+
+    def test_permissions_fields_can_be_selected(self):
+        resp = self.app.get('/permissions?_fields=uri',
+                            headers=self.headers)
+        self.assertNotIn('resource_name', resp.json['data'][0])
+
+    def test_permissions_list_can_be_paginated(self):
+        resp = self.app.get('/permissions?_limit=2',
+                            headers=self.headers)
+        self.assertEqual(resp.headers['Total-Records'], '4')
+        self.assertIn('Next-Page', resp.headers)
+        self.assertEqual(len(resp.json['data']), 2)


### PR DESCRIPTION
Ref #600 #653 

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Find a way to allow GET as anonymous `#needhelp`
- [ ] Approach may be a bit too hacky (c.f `last_modified` missing from perm entries)

feedback? @Natim 

