### PR TITLE
Fixes #706 added warning if https is not enabled

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -40,6 +40,7 @@ Contributors
 * Rémy Hubscher <rhubscher@mozilla.com>
 * Shweta Oak <oakshweta11@gmail.com>
 * Sofia Utsch <sofia.utsch@gmail.com>
+* Surya Prashanth <prashantsurya@ymail.com>
 * SwhGo_oN
 * Tarek Ziade <tarek@mozilla.com>
 * Taylor Zane Glaeser <tzglaeser@gmail.com>

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -549,6 +549,10 @@ def initialize(config, version=None, project_name='', default_settings=None):
     if not project_name:
         warnings.warn('No value specified for `project_name`')
 
+    http_scheme = settings.get('kinto.http_scheme')
+    if http_scheme != 'https':
+        warnings.warn('HTTPS is not enabled')
+
     kinto_core_defaults = DEFAULT_SETTINGS.copy()
 
     if default_settings:


### PR DESCRIPTION
Fixes #706 

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @

