### PR TITLE
New cornice API for validation schemas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ This document describes changes between each past release.
 
 - Fixed showing of backend type twice in StatsD backend keys (fixes #857)
 
+**Internal changes**
+
+- Upgraded to Cornice 2.0 (#790)
+
 
 4.3.1 (2016-10-06)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ This document describes changes between each past release.
 **Internal changes**
 
 - Upgraded to Cornice 2.0 (#790)
-
+- Resource ``mapping`` attribute is now deprecated, use ``schema`` instead (#790)
 
 4.3.1 (2016-10-06)
 ------------------

--- a/docs/core/permission.rst
+++ b/docs/core/permission.rst
@@ -71,7 +71,7 @@ can be used instead.
 
     @resource.register()
     class Toadstool(resource.ShareableResource):
-        mapping = MushroomSchema()
+        schema = MushroomSchema
 
 
 With this alternative resource class, *Kinto-Core* will register the :term:`endpoints`
@@ -309,7 +309,7 @@ on the resource during registration.
 
     @resource.register(viewset=MyViewSet())
     class Resource(resource.UserResource):
-        mapping = BookmarkSchema()
+        schema = BookmarkSchema
 
 
 See more details about available customization in the :ref:`viewset section <viewset>`.

--- a/docs/core/quickstart.rst
+++ b/docs/core/quickstart.rst
@@ -173,7 +173,7 @@ Currently, only :rtd:`Colander <colander>` is supported, and it looks like this:
 
     @resource.register()
     class Mushroom(resource.UserResource):
-        mapping = MushroomSchema()
+        schema = MushroomSchema
 
 
 Enable middleware

--- a/docs/core/resource.rst
+++ b/docs/core/resource.rst
@@ -31,7 +31,7 @@ Full example
 
     @resource.register()
     class Bookmark(resource.UserResource):
-        mapping = BookmarkSchema()
+        schema = BookmarkSchema
 
         def process_record(self, new, old=None):
             new = super(Bookmark, self).process_record(new, old)
@@ -62,7 +62,7 @@ URLs can be specified during registration:
     @resource.register(collection_path='/user/bookmarks',
                        record_path='/user/bookmarks/{{id}}')
     class Bookmark(resource.UserResource):
-        mapping = BookmarkSchema()
+        schema = BookmarkSchema
 
 .. note::
 

--- a/docs/core/viewsets.rst
+++ b/docs/core/viewsets.rst
@@ -27,7 +27,7 @@ Viewsets defaults can be overriden by passing arguments to the
 
     @resource.register(collection_methods=('GET',))
     class Resource(resource.UserResource):
-        mapping = BookmarkSchema()
+        schema = BookmarkSchema
 
 
 Subclassing
@@ -52,7 +52,7 @@ can be subclassed and specified during registration:
 
     @resource.register(viewset=NoSchemaViewSet())
     class Resource(resource.UserResource):
-        mapping = BookmarkSchema()
+        schema = BookmarkSchema
 
 
 ViewSet class

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -100,8 +100,8 @@ class Service(CorniceService):
     default_cors_headers = ('Backoff', 'Retry-After', 'Alert',
                             'Content-Length')
 
-    def error_handler(self, error):
-        return errors.json_error_handler(error)
+    def error_handler(self, request):
+        return errors.json_error_handler(request)
 
     @classmethod
     def init_from_settings(cls, settings):

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -115,7 +115,7 @@ def http_error(httpexception, errno=None,
     return response
 
 
-def json_error_handler(errors):
+def json_error_handler(request):
     """Cornice JSON error handler, returning consistant JSON formatted errors
     from schema validation errors.
 
@@ -131,6 +131,7 @@ def json_error_handler(errors):
         Only the first error of the list is formatted in the response.
         (c.f. HTTP API).
     """
+    errors = request.errors
     assert len(errors) != 0
 
     sorted_errors = sorted(errors, key=lambda x: six.text_type(x['name']))
@@ -156,7 +157,7 @@ def json_error_handler(errors):
                           message=message,
                           details=errors)
     response.status = errors.status
-    response = reapply_cors(errors.request, response)
+    response = reapply_cors(request, response)
     return response
 
 
@@ -171,8 +172,7 @@ def raise_invalid(request, location='body', name=None, description=None,
     :raises: :class:`~pyramid:pyramid.httpexceptions.HTTPBadRequest`
     """
     request.errors.add(location, name, description, **kwargs)
-    request.errors.request = request  # Needed by json_error_handler to reapply_cors
-    response = json_error_handler(request.errors)
+    response = json_error_handler(request)
     raise response
 
 

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -761,7 +761,7 @@ class UserResource(object):
             if if_none_match == '*':
                 return
             error_details = {
-                'location': 'headers',
+                'location': 'header',
                 'description': "Invalid value for If-None-Match"
             }
             raise_invalid(self.request, **error_details)
@@ -805,7 +805,7 @@ class UserResource(object):
                 message = ("Invalid value for If-Match. The value should "
                            "be integer between double quotes.")
                 error_details = {
-                    'location': 'headers',
+                    'location': 'header',
                     'description': message
                 }
                 raise_invalid(self.request, **error_details)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -134,7 +134,7 @@ class UserResource(object):
     interacting the :mod:`kinto.core.storage` and :mod:`kinto.core.permission`
     backends."""
 
-    mapping = ResourceSchema()
+    mapping = ResourceSchema
     """Schema to validate records."""
 
     def __init__(self, request, context=None):
@@ -203,7 +203,7 @@ class UserResource(object):
 
     def _get_known_fields(self):
         """Return all the `field` defined in the ressource mapping."""
-        known_fields = [c.name for c in self.mapping.children] + \
+        known_fields = [c.name for c in self.mapping().children] + \
                        [self.model.id_field,
                         self.model.modified_field,
                         self.model.deleted_field]
@@ -641,7 +641,7 @@ class UserResource(object):
             updated.update(**changes)
 
         try:
-            return self.mapping.deserialize(updated)
+            return self.mapping().deserialize(updated)
         except colander.Invalid as e:
             # Transform the errors we got from colander into Cornice errors.
             # We could not rely on Service schema because the record should be

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -306,7 +306,7 @@ class UserResource(object):
             Add custom behaviour by overriding
             :meth:`kinto.core.resource.UserResource.process_record`
         """
-        new_record = self.request.validated.get('data', {})
+        new_record = self.request.validated['body'].get('data', {})
         try:
             # Since ``id`` does not belong to schema, it is not in validated
             # data. Must look up in body.
@@ -415,7 +415,7 @@ class UserResource(object):
                 self._raise_412_if_modified(existing)
 
         # If `data` is not provided, use existing record (or empty if creation)
-        post_record = self.request.validated.get('data', existing) or {}
+        post_record = self.request.validated['body'].get('data', existing) or {}
 
         record_id = post_record.setdefault(id_field, self.record_id)
         self._raise_400_if_id_mismatch(record_id, self.record_id)
@@ -1143,7 +1143,7 @@ class ShareableResource(UserResource):
         existing ACE is removed (using empty list).
         """
         new = super(ShareableResource, self).process_record(new, old)
-        permissions = self.request.validated.get('permissions', {})
+        permissions = self.request.validated['body'].get('permissions', {})
 
         annotated = new.copy()
 

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -134,7 +134,7 @@ class UserResource(object):
     interacting the :mod:`kinto.core.storage` and :mod:`kinto.core.permission`
     backends."""
 
-    mapping = ResourceSchema
+    schema = ResourceSchema
     """Schema to validate records."""
 
     def __init__(self, request, context=None):
@@ -202,8 +202,8 @@ class UserResource(object):
         return request.prefixed_userid
 
     def _get_known_fields(self):
-        """Return all the `field` defined in the ressource mapping."""
-        known_fields = [c.name for c in self.mapping().children] + \
+        """Return all the `field` defined in the ressource schema."""
+        known_fields = [c.name for c in self.schema().children] + \
                        [self.model.id_field,
                         self.model.modified_field,
                         self.model.deleted_field]
@@ -218,7 +218,7 @@ class UserResource(object):
         :rtype: bool
 
         """
-        if self.mapping.get_option('preserve_unknown'):
+        if self.schema.get_option('preserve_unknown'):
             return True
 
         known_fields = self._get_known_fields()
@@ -624,7 +624,7 @@ class UserResource(object):
         """
         for field, value in changes.items():
             has_changed = record.get(field, value) != value
-            if self.mapping.is_readonly(field) and has_changed:
+            if self.schema.is_readonly(field) and has_changed:
                 error_details = {
                     'name': field,
                     'description': 'Cannot modify {0}'.format(field)
@@ -641,7 +641,7 @@ class UserResource(object):
             updated.update(**changes)
 
         try:
-            return self.mapping().deserialize(updated)
+            return self.schema().deserialize(updated)
         except colander.Invalid as e:
             # Transform the errors we got from colander into Cornice errors.
             # We could not rely on Service schema because the record should be
@@ -851,7 +851,7 @@ class UserResource(object):
             root_fields = [f.split('.')[0] for f in fields]
             known_fields = self._get_known_fields()
             invalid_fields = set(root_fields) - set(known_fields)
-            preserve_unknown = self.mapping.get_option('preserve_unknown')
+            preserve_unknown = self.schema.get_option('preserve_unknown')
             if not preserve_unknown and invalid_fields:
                 error_msg = "Fields %s do not exist" % ','.join(invalid_fields)
                 error_details = {

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -36,11 +36,13 @@ class ResourceSchema(colander.MappingSchema):
         the accepted fields to the ones defined in the schema.
         """
 
-    def get_option(self, attr):
+    @classmethod
+    def get_option(cls, attr):
         default_value = getattr(ResourceSchema.Options, attr)
-        return getattr(self.Options, attr,  default_value)
+        return getattr(cls.Options, attr,  default_value)
 
-    def is_readonly(self, field):
+    @classmethod
+    def is_readonly(cls, field):
         """Return True if specified field name is read-only.
 
         :param str field: the field name in the schema
@@ -48,9 +50,9 @@ class ResourceSchema(colander.MappingSchema):
             ``False`` otherwise.
         :rtype: bool
         """
-        return field in self.get_option("readonly_fields")
+        return field in cls.get_option("readonly_fields")
 
-    def schema_type(self, **kw):
+    def schema_type(self):
         if self.get_option("preserve_unknown") is True:
             unknown = 'preserve'
         else:
@@ -75,7 +77,8 @@ class PermissionsSchema(colander.SchemaNode):
         self.known_perms = kwargs.pop('permissions', tuple())
         super(PermissionsSchema, self).__init__(*args, **kwargs)
 
-    def schema_type(self, **kw):
+    @staticmethod
+    def schema_type():
         return colander.Mapping(unknown='preserve')
 
     def deserialize(self, cstruct=colander.null):

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -104,7 +104,8 @@ class PermissionsSchema(colander.SchemaNode):
 
     def _get_node_principals(self, perm):
         principal = colander.SchemaNode(colander.String())
-        return colander.SchemaNode(colander.Sequence(), principal, name=perm)
+        return colander.SchemaNode(colander.Sequence(), principal, name=perm,
+                                   missing=colander.drop)
 
 
 class TimeStamp(colander.SchemaNode):

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -1,7 +1,7 @@
 import functools
 
 import colander
-from cornice.validators._colander import validator as colander_validator
+from cornice.validators import colander_validator
 from pyramid.settings import asbool
 
 from kinto.core import authorization
@@ -122,8 +122,11 @@ class ViewSet(object):
                 body = record_schema()
 
             validators = args.get('validators', [])
-            validators.append(colander_validator(RequestSchema))
+            validators.append(colander_validator)
+            args['schema'] = RequestSchema
             args['validators'] = validators
+        else:
+            args['schema'] = SimpleSchema
 
         return args
 

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -29,7 +29,7 @@ class DummyRequest(mock.MagicMock):
         self.registry.id_generators = defaultdict(generators.UUID4)
         self.GET = {}
         self.headers = {}
-        self.errors = cornice_errors.Errors(request=self)
+        self.errors = cornice_errors.Errors()
         self.authenticated_userid = 'bob'
         self.authn_type = 'basicauth'
         self.prefixed_userid = 'basicauth:bob'

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -1,6 +1,7 @@
 import colander
 import six
 
+from cornice.validators._colander import validator as colander_validator
 from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED
 
@@ -70,7 +71,8 @@ batch = Service(name="batch", path='/batch',
                 description="Batch operations")
 
 
-@batch.post(schema=BatchPayloadSchema, permission=NO_PERMISSION_REQUIRED)
+@batch.post(validators=(colander_validator(BatchRequest),),
+            permission=NO_PERMISSION_REQUIRED)
 def post_batch(request):
     requests = request.validated['body']['requests']
     batch_size = len(requests)

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -71,7 +71,7 @@ batch = Service(name="batch", path='/batch',
 
 @batch.post(schema=BatchPayloadSchema, permission=NO_PERMISSION_REQUIRED)
 def post_batch(request):
-    requests = request.validated['requests']
+    requests = request.validated['body']['requests']
     batch_size = len(requests)
 
     limit = request.registry.settings['batch_max_requests']

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -1,7 +1,7 @@
 import colander
 import six
 
-from cornice.validators._colander import validator as colander_validator
+from cornice.validators import colander_validator
 from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED
 
@@ -71,7 +71,8 @@ batch = Service(name="batch", path='/batch',
                 description="Batch operations")
 
 
-@batch.post(validators=(colander_validator(BatchRequest),),
+@batch.post(schema=BatchRequest,
+            validators=(colander_validator,),
             permission=NO_PERMISSION_REQUIRED)
 def post_batch(request):
     requests = request.validated['body']['requests']

--- a/kinto/plugins/history/views.py
+++ b/kinto/plugins/history/views.py
@@ -27,7 +27,7 @@ class HistorySchema(resource.ResourceSchema):
                    collection_methods=('GET',))
 class History(resource.ShareableResource):
 
-    mapping = HistorySchema()
+    mapping = HistorySchema
 
     def get_parent_id(self, request):
         self.bucket_id = request.matchdict['bucket_id']

--- a/kinto/plugins/history/views.py
+++ b/kinto/plugins/history/views.py
@@ -27,7 +27,7 @@ class HistorySchema(resource.ResourceSchema):
                    collection_methods=('GET',))
 class History(resource.ShareableResource):
 
-    mapping = HistorySchema
+    schema = HistorySchema
 
     def get_parent_id(self, request):
         self.bucket_id = request.matchdict['bucket_id']

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -34,7 +34,7 @@ class CollectionSchema(resource.ResourceSchema):
                    collection_path='/buckets/{{bucket_id}}/collections',
                    record_path='/buckets/{{bucket_id}}/collections/{{id}}')
 class Collection(resource.ShareableResource):
-    mapping = CollectionSchema()
+    mapping = CollectionSchema
     permissions = ('read', 'write', 'record:create')
 
     def get_parent_id(self, request):

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -34,7 +34,7 @@ class CollectionSchema(resource.ResourceSchema):
                    collection_path='/buckets/{{bucket_id}}/collections',
                    record_path='/buckets/{{bucket_id}}/collections/{{id}}')
 class Collection(resource.ShareableResource):
-    mapping = CollectionSchema
+    schema = CollectionSchema
     permissions = ('read', 'write', 'record:create')
 
     def get_parent_id(self, request):

--- a/kinto/views/groups.py
+++ b/kinto/views/groups.py
@@ -20,7 +20,7 @@ class GroupSchema(resource.ResourceSchema):
                    collection_path='/buckets/{{bucket_id}}/groups',
                    record_path='/buckets/{{bucket_id}}/groups/{{id}}')
 class Group(resource.ShareableResource):
-    mapping = GroupSchema()
+    mapping = GroupSchema
 
     def get_parent_id(self, request):
         bucket_id = request.matchdict['bucket_id']

--- a/kinto/views/groups.py
+++ b/kinto/views/groups.py
@@ -20,7 +20,7 @@ class GroupSchema(resource.ResourceSchema):
                    collection_path='/buckets/{{bucket_id}}/groups',
                    record_path='/buckets/{{bucket_id}}/groups/{{id}}')
 class Group(resource.ShareableResource):
-    mapping = GroupSchema
+    schema = GroupSchema
 
     def get_parent_id(self, request):
         bucket_id = request.matchdict['bucket_id']

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -97,7 +97,7 @@ class PermissionsSchema(resource.ResourceSchema):
                    permission=NO_PERMISSION_REQUIRED)
 class Permissions(resource.ShareableResource):
 
-    mapping = PermissionsSchema()
+    mapping = PermissionsSchema
 
     def __init__(self, request, context=None):
         super(Permissions, self).__init__(request, context)

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -97,7 +97,7 @@ class PermissionsSchema(resource.ResourceSchema):
                    permission=NO_PERMISSION_REQUIRED)
 class Permissions(resource.ShareableResource):
 
-    mapping = PermissionsSchema
+    schema = PermissionsSchema
 
     def __init__(self, request, context=None):
         super(Permissions, self).__init__(request, context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colander==1.3.1
 colorama==0.3.7
 contextlib2==0.5.4
-cornice==1.2.1
+cornice==2.0.1
 enum34==1.1.6
 functools32==3.2.3.post2
 futures==3.0.5

--- a/tests/core/resource/__init__.py
+++ b/tests/core/resource/__init__.py
@@ -19,7 +19,7 @@ class BaseTest(unittest.TestCase):
         self.storage = memory.Storage()
         self.resource = self.resource_class(request=self.get_request(),
                                             context=self.get_context())
-        self.resource.mapping = StrictSchema()
+        self.resource.mapping = StrictSchema
         self.model = self.resource.model
         self.patch_known_field = mock.patch.object(self.resource,
                                                    'is_known_field')

--- a/tests/core/resource/__init__.py
+++ b/tests/core/resource/__init__.py
@@ -19,7 +19,7 @@ class BaseTest(unittest.TestCase):
         self.storage = memory.Storage()
         self.resource = self.resource_class(request=self.get_request(),
                                             context=self.get_context())
-        self.resource.mapping = StrictSchema
+        self.resource.schema = StrictSchema
         self.model = self.resource.model
         self.patch_known_field = mock.patch.object(self.resource,
                                                    'is_known_field')

--- a/tests/core/resource/test_model.py
+++ b/tests/core/resource/test_model.py
@@ -24,7 +24,7 @@ class ModelTest(BaseTest):
 class CreateTest(BaseTest):
     def setUp(self):
         super(CreateTest, self).setUp()
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
 
     def test_new_records_are_linked_to_owner(self):
         resp = self.resource.collection_post()['data']
@@ -87,7 +87,7 @@ class IsolatedModelsTest(BaseTest):
         self.assertEquals(len(records), 0)
 
     def test_update_record_of_another_user_will_create_it(self):
-        self.resource.request.validated = {'data': {'some': 'record'}}
+        self.resource.request.validated = {'body': {'data': {'some': 'record'}}}
         self.resource.put()
         self.model.get_record(record_id=self.stored['id'],
                               parent_id='basicauth:alice')  # not raising

--- a/tests/core/resource/test_object_permissions.py
+++ b/tests/core/resource/test_object_permissions.py
@@ -44,7 +44,7 @@ class ObtainRecordPermissionTest(PermissionTest):
         self.permission.add_principal_to_ace(record_uri, 'read', 'account:readonly')
         self.permission.add_principal_to_ace(record_uri, 'write', 'basicauth:bob')
         self.resource.record_id = record_id
-        self.resource.request.validated = {'data': {}}
+        self.resource.request.validated = {'body': {'data': {}}}
         self.resource.request.path = record_uri
 
     def test_permissions_are_provided_in_record_get(self):
@@ -86,7 +86,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
                                              'read',
                                              'account:readonly')
         self.resource.record_id = record_id
-        self.resource.request.validated = {'data': {}}
+        self.resource.request.validated = {'body': {'data': {}}}
         self.resource.request.path = self.record_uri
 
     def test_write_permission_is_given_to_creator_on_post(self):
@@ -106,7 +106,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
         request = self.get_request()
         # Simulate an anonymous PUT
         request.method = 'PUT'
-        request.validated = {'data': self.record}
+        request.validated = {'body': {'data': self.record}}
         request.prefixed_userid = None
         request.matchdict = {'id': self.record['id']}
         resource = self.resource_class(request=request,
@@ -118,14 +118,14 @@ class SpecifyRecordPermissionTest(PermissionTest):
         perms = {'write': ['jean-louis']}
         self.resource.request.method = 'POST'
         self.resource.context.object_uri = '/articles'
-        self.resource.request.validated = {'data': {}, 'permissions': perms}
+        self.resource.request.validated = {'body': {'data': {}, 'permissions': perms}}
         result = self.resource.collection_post()
         self.assertEqual(sorted(result['permissions']['write']),
                          ['basicauth:bob', 'jean-louis'])
 
     def test_permissions_are_replaced_with_put(self):
         perms = {'write': ['jean-louis']}
-        self.resource.request.validated['permissions'] = perms
+        self.resource.request.validated['body']['permissions'] = perms
         self.resource.request.method = 'PUT'
         result = self.resource.put()
         # In setUp() 'read' was set on this record.
@@ -134,7 +134,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
 
     def test_permissions_are_modified_with_patch(self):
         perms = {'write': ['jean-louis']}
-        self.resource.request.validated = {'permissions': perms}
+        self.resource.request.validated = {'body': {'permissions': perms}}
         self.resource.request.method = 'PATCH'
         result = self.resource.patch()
         permissions = result['permissions']
@@ -148,7 +148,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
                                              'jean-louis')
 
         perms = {'write': []}
-        self.resource.request.validated = {'permissions': perms}
+        self.resource.request.validated = {'body': {'permissions': perms}}
         self.resource.request.method = 'PATCH'
         result = self.resource.patch()
         permissions = result['permissions']
@@ -161,7 +161,7 @@ class SpecifyRecordPermissionTest(PermissionTest):
                                              'jean-louis')
 
         perms = {'read': []}
-        self.resource.request.validated = {'permissions': perms}
+        self.resource.request.validated = {'body': {'permissions': perms}}
         self.resource.request.method = 'PATCH'
         result = self.resource.patch()
         self.assertNotIn('read', result['permissions'])

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -130,7 +130,7 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertIsNotNone(error.headers.get('Last-Modified'))
 
     def test_create_returns_412_if_changed_meanwhile(self):
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.collection_post)
 
@@ -141,7 +141,7 @@ class ModifiedMeanwhileTest(BaseTest):
                           self.resource.put)
 
     def test_put_returns_412_if_changed_and_none_match_present(self):
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         self.resource.request.headers['If-None-Match'] = '"42"'
         self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
@@ -178,7 +178,7 @@ class ModifiedMeanwhileTest(BaseTest):
     def test_put_if_none_match_star_succeeds_if_record_does_not_exist(self):
         self.resource.request.headers.pop('If-Match')
         self.resource.request.headers['If-None-Match'] = '*'
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         self.resource.record_id = self.resource.model.id_generator()
         self.resource.put()  # not raising.
 
@@ -186,27 +186,28 @@ class ModifiedMeanwhileTest(BaseTest):
         self.model.delete_record(self.stored)
         self.resource.request.headers.pop('If-Match')
         self.resource.request.headers['If-None-Match'] = '*'
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         self.resource.record_id = self.stored['id']
         self.resource.put()  # not raising.
 
     def test_post_if_none_match_star_fails_if_record_exists(self):
         self.resource.request.headers.pop('If-Match')
         self.resource.request.headers['If-None-Match'] = '*'
-        self.resource.request.json = self.resource.request.validated = {
+        self.resource.request.json = {
             'data': {
                 'id': self.stored['id'],
                 'field': 'new'}}
+        self.resource.request.validated = {'body': self.resource.request.json}
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.collection_post)
 
     def test_post_if_none_match_star_succeeds_if_record_does_not_exist(self):
         self.resource.request.headers.pop('If-Match')
         self.resource.request.headers['If-None-Match'] = '*'
-        self.resource.request.validated = {
+        self.resource.request.validated = {'body': {
             'data': {
                 'id': self.resource.model.id_generator(),
-                'field': 'new'}}
+                'field': 'new'}}}
         self.resource.collection_post()  # not raising.
 
     def test_patch_returns_412_if_changed_meanwhile(self):

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -237,7 +237,7 @@ class ModifiedMeanwhileTest(BaseTest):
         with self.assertRaises(httpexceptions.HTTPBadRequest) as cm:
             self.resource.request.headers['If-Match'] = '123456'
             self.resource.collection_get()
-        expected_message = ('headers: Invalid value for If-Match. The value '
+        expected_message = ('header: Invalid value for If-Match. The value '
                             'should be integer between double quotes.')
         self.assertEquals(cm.exception.json['message'], expected_message)
 

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -197,12 +197,13 @@ class PatchTest(BaseTest):
         self.stored = self.model.create_record({})
         self.resource.record_id = self.stored['id']
         self.resource.request.json = {'data': {'position': 10}}
-        schema = ResourceSchema()
-        schema.add(colander.SchemaNode(colander.Boolean(), name='unread',
-                                       missing=colander.drop))
-        schema.add(colander.SchemaNode(colander.Int(), name='position',
-                                       missing=colander.drop))
-        self.resource.mapping = schema
+
+        class ArticleSchema(ResourceSchema):
+            unread = colander.SchemaNode(colander.Boolean(), missing=colander.drop)
+            position = colander.SchemaNode(colander.Int(), missing=colander.drop)
+
+        self.resource.mapping = ArticleSchema
+
         self.result = self.resource.patch()['data']
 
     def test_etag_is_provided(self):

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -41,25 +41,25 @@ class PutTest(BaseTest):
         self.resource.record_id = self.record['id']
 
     def test_etag_is_provided(self):
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         self.resource.put()
         self.assertIn('ETag', self.last_response.headers)
 
     def test_etag_contains_record_new_timestamp(self):
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         new = self.resource.put()['data']
         expected = ('"%s"' % new['last_modified'])
         self.assertEqual(expected, self.last_response.headers['ETag'])
 
     def test_returns_201_if_created(self):
         self.resource.record_id = self.resource.model.id_generator()
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         self.resource.put()
         self.assertEqual(self.last_response.status_code, 201)
 
     def test_relies_on_collection_create(self):
         self.resource.record_id = self.resource.model.id_generator()
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         with mock.patch.object(self.model, 'create_record') as patched:
             self.resource.put()
             self.assertEqual(patched.call_count, 1)
@@ -69,13 +69,13 @@ class PutTest(BaseTest):
         self.resource.record_id = record['id']
         self.resource.delete()['data']
 
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         with mock.patch.object(self.model, 'create_record') as patched:
             self.resource.put()
             self.assertEqual(patched.call_count, 1)
 
     def test_replace_record_returns_updated_fields(self):
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         result = self.resource.put()['data']
         self.assertEqual(self.record['id'], result['id'])
         self.assertNotEqual(self.record['last_modified'],
@@ -84,44 +84,44 @@ class PutTest(BaseTest):
 
     def test_last_modified_is_kept_if_present(self):
         new_last_modified = self.record['last_modified'] + 20
-        self.resource.request.validated = {'data': {
+        self.resource.request.validated = {'body': {'data': {
             'field': 'new',
             'last_modified': new_last_modified}
-        }
+        }}
         result = self.resource.put()['data']
         self.assertEqual(result['last_modified'], new_last_modified)
 
     def test_last_modified_is_dropped_if_same_as_previous(self):
-        self.resource.request.validated = {'data': {
+        self.resource.request.validated = {'body': {'data': {
             'field': 'new',
             'last_modified': self.record['last_modified']}
-        }
+        }}
         result = self.resource.put()['data']
         self.assertGreater(result['last_modified'],
                            self.record['last_modified'])
 
     def test_last_modified_is_dropped_if_lesser_than_existing(self):
         new_last_modified = self.record['last_modified'] - 20
-        self.resource.request.validated = {'data': {
+        self.resource.request.validated = {'body': {'data': {
             'field': 'new',
             'last_modified': new_last_modified}
-        }
+        }}
         result = self.resource.put()['data']
         self.assertNotEqual(result['last_modified'],
                             self.record['last_modified'])
 
     def test_cannot_replace_with_different_id(self):
-        self.resource.request.validated = {'data': {'id': 'abc'}}
+        self.resource.request.validated = {'body': {'data': {'id': 'abc'}}}
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.put)
 
     def test_last_modified_is_overwritten_on_replace(self):
-        self.resource.request.validated = {'data': {'last_modified': 123}}
+        self.resource.request.validated = {'body': {'data': {'last_modified': 123}}}
         result = self.resource.put()['data']
         self.assertNotEqual(result['last_modified'], 123)
 
     def test_storage_is_not_used_if_context_provides_current_record(self):
         self.resource.context.current_record = {'id': 'hola'}
-        self.resource.request.validated = {'data': {}}
+        self.resource.request.validated = {'body': {'data': {}}}
         with mock.patch.object(self.resource.model, 'get_record') as get:
             self.resource.put()
             self.assertFalse(get.called)
@@ -353,7 +353,7 @@ class UnknownRecordTest(BaseTest):
         super(UnknownRecordTest, self).setUp()
         self.unknown_id = '1cea99eb-5e3d-44ad-a53a-2fb68473b538'
         self.resource.record_id = self.unknown_id
-        self.resource.request.validated = {'data': {'field': 'new'}}
+        self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
 
     def test_get_record_unknown_raises_404(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.get)

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -202,7 +202,7 @@ class PatchTest(BaseTest):
             unread = colander.SchemaNode(colander.Boolean(), missing=colander.drop)
             position = colander.SchemaNode(colander.Int(), missing=colander.drop)
 
-        self.resource.mapping = ArticleSchema
+        self.resource.schema = ArticleSchema
 
         self.result = self.resource.patch()['data']
 
@@ -391,7 +391,7 @@ class ReadonlyFieldsTest(BaseTest):
     def setUp(self):
         super(ReadonlyFieldsTest, self).setUp()
         self.stored = self.model.create_record({'age': 32})
-        self.resource.mapping.Options.readonly_fields = ('age',)
+        self.resource.schema.Options.readonly_fields = ('age',)
         self.resource.record_id = self.stored['id']
 
     def assertReadonlyError(self, field):

--- a/tests/core/resource/test_sync.py
+++ b/tests/core/resource/test_sync.py
@@ -16,7 +16,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
     def setUp(self):
         super(SinceModifiedTest, self).setUp()
 
-        self.resource.request.validated = {'data': {}}
+        self.resource.request.validated = {'body': {'data': {}}}
 
         with mock.patch.object(self.model.storage,
                                '_bump_timestamp') as msec_mocked:

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -84,7 +84,7 @@ class ShareableResourcePermissionTest(AuthzAuthnTest):
         resp = self.app.put_json(object_uri, body, headers=self.headers)
         self.assertEqual(resp.json['permissions']['read'], ['group:readers'])
 
-    def test_data_are_not_modified_if_not_specified(self):
+    def test_data_is_always_required_when_schema_has_required_fields(self):
         body = {'data': MINIMALIST_RECORD,
                 'permissions': {'read': ['group:readers']}}
         resp = self.app.post_json(self.collection_url, body,
@@ -92,17 +92,20 @@ class ShareableResourcePermissionTest(AuthzAuthnTest):
         object_uri = self.get_item_url(resp.json['data']['id'])
 
         body.pop('data')
-        # With the current Cornice limitations, it is not possible to define
-        # a validator that makes sure that at least of `data` or `permissions`
-        # is specified in body.
-        # https://github.com/mozilla-services/cornice/pull/330
-        # Currently, only "schemaless" resources can have their permissions
-        # replaced via PUT with specifying the `data`.
-        # resp = self.app.put_json(object_uri, body, headers=self.headers)
-        # self.assertEqual(resp.json['data']['name'],
-        #                  MINIMALIST_RECORD['name'])
         resp = self.app.put_json(object_uri, body, headers=self.headers,
                                  status=400)
+
+    def test_data_is_not_required_when_schema_has_no_required_fields(self):
+        self.add_permission('/psilos', 'psilo:create')
+        body = {'data': MINIMALIST_RECORD,
+                'permissions': {'read': ['group:readers']}}
+        resp = self.app.post_json('/psilos', body,
+                                  headers=self.headers)
+        object_uri = '/psilos/' + resp.json['data']['id']
+
+        body.pop('data')
+        resp = self.app.put_json(object_uri, body, headers=self.headers)
+        self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
 
     def test_data_are_not_modified_if_not_specified_on_schemaless(self):
         self.add_permission('/spores', 'spore:create')

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -390,8 +390,8 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              '{"data": {"name": "ML"}, "datta": {}}',
                              headers=self.headers,
                              status=400)
-        self.assertIn('Unrecognized keys in mapping: "{u\'datta\':',
-                      resp.json['message'])
+        self.assertIn('Unrecognized keys in mapping', resp.json['message'])
+        self.assertIn('datta', resp.json['message'])
 
     def test_create_invalid_record_returns_400(self):
         self.app.post_json(self.collection_url,
@@ -634,8 +634,8 @@ class InvalidPermissionsTest(BaseWebTest, unittest.TestCase):
                 'permissions': {'read': ['book']}}
         resp = self.app.post_json('/mushrooms', body, headers=self.headers,
                                   status=400)
-        self.assertIn('Unrecognized keys in mapping: "{u\'permissions\':',
-                      resp.json['message'])
+        self.assertIn('Unrecognized keys in mapping', resp.json['message'])
+        self.assertIn('permissions', resp.json['message'])
 
     def test_create_invalid_body_returns_400(self):
         self.app.post_json(self.collection_url,

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -68,7 +68,7 @@ class ViewSetTest(unittest.TestCase):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = mock.MagicMock(mapping=colander.SchemaNode(colander.Int()))
+        resource = mock.MagicMock(mapping=mock.MagicMock())
         arguments = viewset.collection_arguments(resource, 'GET')
         schema = arguments['schema']
         self.assertEquals(schema.children[0], resource.mapping)
@@ -77,7 +77,7 @@ class ViewSetTest(unittest.TestCase):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = mock.MagicMock(mapping=colander.SchemaNode(colander.Int()))
+        resource = mock.MagicMock(mapping=mock.MagicMock())
         arguments = viewset.collection_arguments(resource, 'get')
         schema = arguments['schema']
         self.assertEquals(schema.children[0], resource.mapping)

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -68,19 +68,17 @@ class ViewSetTest(unittest.TestCase):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = mock.MagicMock(mapping=mock.MagicMock())
+        resource = mock.MagicMock()
         arguments = viewset.collection_arguments(resource, 'GET')
-        schema = arguments['schema']
-        self.assertEquals(schema.children[0], resource.mapping)
+        self.assertIn('schema', arguments)
 
     def test_schema_is_added_when_uppercase_method_matches(self):
         viewset = ViewSet(
             validate_schema_for=('GET', )
         )
-        resource = mock.MagicMock(mapping=mock.MagicMock())
+        resource = mock.MagicMock()
         arguments = viewset.collection_arguments(resource, 'get')
-        schema = arguments['schema']
-        self.assertEquals(schema.children[0], resource.mapping)
+        self.assertIn('schema', arguments)
 
     @mock.patch('kinto.core.resource.viewset.colander')
     def test_a_default_schema_is_added_when_method_doesnt_match(self, mocked):
@@ -88,15 +86,16 @@ class ViewSetTest(unittest.TestCase):
             validate_schema_for=('GET', )
         )
         resource = mock.MagicMock()
-        mocked.MappingSchema.return_value = mock.sentinel.default_schema
+        mocked.Mapping.return_value = mock.sentinel.default_schema
 
         arguments = viewset.collection_arguments(resource, 'POST')
-        self.assertEquals(arguments['schema'], mock.sentinel.default_schema)
+        self.assertEquals(arguments['schema'].schema_type(), mock.sentinel.default_schema)
         self.assertNotEqual(arguments['schema'], resource.mapping)
 
-        mocked.MappingSchema.assert_called_with(unknown='preserve')
+        mocked.Mapping.assert_called_with(unknown='preserve')
 
-    def test_class_parameters_are_used_for_collection_arguments(self):
+    @mock.patch('kinto.core.resource.viewset.SimpleSchema')
+    def test_class_parameters_are_used_for_collection_arguments(self, mocked):
         default_arguments = {
             'cors_headers': mock.sentinel.cors_headers,
         }
@@ -121,10 +120,11 @@ class ViewSetTest(unittest.TestCase):
         )
 
         arguments = viewset.collection_arguments(mock.MagicMock, 'get')
-        arguments.pop('schema')
+
         self.assertDictEqual(
             arguments,
             {
+                'schema': mocked,
                 'accept': mock.sentinel.accept,
                 'cors_headers': mock.sentinel.cors_headers,
                 'cors_origins': mock.sentinel.cors_origins,
@@ -132,7 +132,8 @@ class ViewSetTest(unittest.TestCase):
             }
         )
 
-    def test_default_arguments_are_used_for_record_arguments(self):
+    @mock.patch('kinto.core.resource.viewset.SimpleSchema')
+    def test_default_arguments_are_used_for_record_arguments(self, mocked):
         default_arguments = {
             'cors_headers': mock.sentinel.cors_headers,
         }
@@ -157,11 +158,12 @@ class ViewSetTest(unittest.TestCase):
         )
 
         arguments = viewset.record_arguments(mock.MagicMock, 'get')
-        arguments.pop('schema')
+
 
         self.assertDictEqual(
             arguments,
             {
+                'schema': mocked,
                 'accept': mock.sentinel.accept,
                 'cors_headers': mock.sentinel.cors_headers,
                 'cors_origins': mock.sentinel.record_cors_origins,
@@ -169,7 +171,8 @@ class ViewSetTest(unittest.TestCase):
             }
         )
 
-    def test_class_parameters_overwrite_each_others(self):
+    @mock.patch('kinto.core.resource.viewset.SimpleSchema')
+    def test_class_parameters_overwrite_each_others(self, mocked):
         # Some class parameters should overwrite each others.
         # The more specifics should prevail over the more generics.
         # Items annoted with a "<<" are the one that should prevail.
@@ -194,18 +197,20 @@ class ViewSetTest(unittest.TestCase):
         )
 
         arguments = viewset.record_arguments(mock.MagicMock, 'get')
-        arguments.pop('schema')
+
 
         self.assertDictEqual(
             arguments,
             {
+                'schema': mocked,
                 'cors_headers': mock.sentinel.default_cors_headers,
                 'error_handler': mock.sentinel.default_record_error_handler,
                 'cors_origins': mock.sentinel.record_get_cors_origin,
             }
         )
 
-    def test_service_arguments_arent_inherited_by_record_arguments(self):
+    @mock.patch('kinto.core.resource.viewset.SimpleSchema')
+    def test_service_arguments_arent_inherited_by_record_arguments(self, mocked):
         service_arguments = {
             'description': 'The little book of calm',
         }
@@ -222,10 +227,11 @@ class ViewSetTest(unittest.TestCase):
         )
 
         arguments = viewset.record_arguments(mock.MagicMock, 'get')
-        arguments.pop('schema')
+
         self.assertDictEqual(
             arguments,
             {
+                'schema': mocked,
                 'cors_headers': mock.sentinel.cors_headers,
             }
         )

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -90,7 +90,7 @@ class ViewSetTest(unittest.TestCase):
 
         arguments = viewset.collection_arguments(resource, 'POST')
         self.assertEquals(arguments['schema'].schema_type(), mock.sentinel.default_schema)
-        self.assertNotEqual(arguments['schema'], resource.mapping)
+        self.assertNotEqual(arguments['schema'], resource.schema)
 
         mocked.Mapping.assert_called_with(unknown='preserve')
 
@@ -363,6 +363,17 @@ class ShareableViewSetTest(unittest.TestCase):
         viewset = ShareableViewSet()
         args = viewset.get_service_arguments()
         self.assertEqual(args['factory'], authorization.RouteFactory)
+
+    def test_mapping_is_deprecated(self):
+        viewset = ShareableViewSet(
+            validate_schema_for=('GET', )
+        )
+        resource = mock.MagicMock()
+        resource.mapping = mock.MagicMock()
+        with mock.patch('kinto.core.resource.viewset.warnings') as mocked:
+            arguments = viewset.collection_arguments(resource, 'GET')
+            msg = "Resource `mapping` is deprecated, use `schema`"
+            mocked.warn.assert_called_with(msg, DeprecationWarning)
 
 
 class RegisterTest(unittest.TestCase):

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -1,4 +1,3 @@
-import colander
 import mock
 from pyramid import exceptions
 from pyramid import testing
@@ -159,7 +158,6 @@ class ViewSetTest(unittest.TestCase):
 
         arguments = viewset.record_arguments(mock.MagicMock, 'get')
 
-
         self.assertDictEqual(
             arguments,
             {
@@ -197,7 +195,6 @@ class ViewSetTest(unittest.TestCase):
         )
 
         arguments = viewset.record_arguments(mock.MagicMock, 'get')
-
 
         self.assertDictEqual(
             arguments,
@@ -371,7 +368,7 @@ class ShareableViewSetTest(unittest.TestCase):
         resource = mock.MagicMock()
         resource.mapping = mock.MagicMock()
         with mock.patch('kinto.core.resource.viewset.warnings') as mocked:
-            arguments = viewset.collection_arguments(resource, 'GET')
+            viewset.collection_arguments(resource, 'GET')
             msg = "Resource `mapping` is deprecated, use `schema`"
             mocked.warn.assert_called_with(msg, DeprecationWarning)
 

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -249,34 +249,34 @@ class BatchSchemaTest(unittest.TestCase):
         request = {'path': '/'}
         defaults = {'foo': 'bar'}
         batch_payload = {'requests': [request], 'defaults': defaults}
-        result = self.schema.deserialize(self.schema.unflatten(batch_payload))
+        result = self.schema.deserialize(batch_payload)
         self.assertNotIn('foo', result['requests'][0])
 
     def test_defaults_can_be_specified_empty(self):
         request = {'path': '/'}
         defaults = {}
         batch_payload = {'requests': [request], 'defaults': defaults}
-        self.schema.deserialize(self.schema.unflatten(batch_payload))
+        self.schema.deserialize(batch_payload)
 
     def test_defaults_path_is_applied_to_requests(self):
         request = {'method': 'GET'}
         defaults = {'path': '/'}
         batch_payload = {'requests': [request], 'defaults': defaults}
-        result = self.schema.deserialize(self.schema.unflatten(batch_payload))
+        result = self.schema.deserialize(batch_payload)
         self.assertEqual(result['requests'][0]['path'], '/')
 
     def test_defaults_body_is_applied_to_requests(self):
         request = {'path': '/'}
         defaults = {'body': {'json': 'payload'}}
         batch_payload = {'requests': [request], 'defaults': defaults}
-        result = self.schema.deserialize(self.schema.unflatten(batch_payload))
+        result = self.schema.deserialize(batch_payload)
         self.assertEqual(result['requests'][0]['body'], {'json': 'payload'})
 
     def test_defaults_headers_are_applied_to_requests(self):
         request = {'path': '/'}
         defaults = {'headers': {'Content-Type': 'text/html'}}
         batch_payload = {'requests': [request], 'defaults': defaults}
-        result = self.schema.deserialize(self.schema.unflatten(batch_payload))
+        result = self.schema.deserialize(batch_payload)
         self.assertEqual(result['requests'][0]['headers']['Content-Type'],
                          'text/html')
 
@@ -284,7 +284,7 @@ class BatchSchemaTest(unittest.TestCase):
         request = {'path': '/', 'headers': {'Authorization': 'me'}}
         defaults = {'headers': {'Authorization': 'you', 'Accept': '*/*'}}
         batch_payload = {'requests': [request], 'defaults': defaults}
-        result = self.schema.deserialize(self.schema.unflatten(batch_payload))
+        result = self.schema.deserialize(batch_payload)
         self.assertEqual(result['requests'][0]['headers'],
                          {'Authorization': 'me', 'Accept': '*/*'})
 

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -301,7 +301,7 @@ class BatchServiceTest(unittest.TestCase):
         self.request = DummyRequest()
 
     def post(self, validated):
-        self.request.validated = validated
+        self.request.validated = {'body': validated}
         return self.view(self.request)
 
     def test_returns_empty_list_of_responses_if_requests_empty(self):

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -145,7 +145,7 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         resp = self.app.post_json('/batch', body, status=200)
         self.assertEqual(resp.json['responses'][1]['status'], 400)
         self.assertEqual(resp.json['responses'][1]['body']['message'],
-                         ('headers: Invalid value for If-Match. The value '
+                         ('header: Invalid value for If-Match. The value '
                           'should be integer between double quotes.'))
 
     def test_412_errors_are_forwarded(self):

--- a/tests/core/testapp/views.py
+++ b/tests/core/testapp/views.py
@@ -13,12 +13,12 @@ class MushroomSchema(resource.ResourceSchema):
 
 @resource.register()
 class Mushroom(resource.UserResource):
-    mapping = MushroomSchema()
+    mapping = MushroomSchema
 
 
 @resource.register()
 class Toadstool(resource.ShareableResource):
-    mapping = MushroomSchema()
+    mapping = MushroomSchema
 
 
 class StrictSchema(resource.ResourceSchema):
@@ -28,7 +28,7 @@ class StrictSchema(resource.ResourceSchema):
 
 @resource.register()
 class Moisture(resource.ShareableResource):
-    mapping = StrictSchema()
+    mapping = StrictSchema
 
 
 class PsilocybinSchema(resource.ResourceSchema):
@@ -40,7 +40,7 @@ class PsilocybinSchema(resource.ResourceSchema):
 
 @resource.register()
 class Psilo(resource.ShareableResource):
-    mapping = PsilocybinSchema()
+    mapping = PsilocybinSchema
 
 
 @resource.register()

--- a/tests/core/testapp/views.py
+++ b/tests/core/testapp/views.py
@@ -13,12 +13,12 @@ class MushroomSchema(resource.ResourceSchema):
 
 @resource.register()
 class Mushroom(resource.UserResource):
-    mapping = MushroomSchema
+    schema = MushroomSchema
 
 
 @resource.register()
 class Toadstool(resource.ShareableResource):
-    mapping = MushroomSchema
+    schema = MushroomSchema
 
 
 class StrictSchema(resource.ResourceSchema):
@@ -28,7 +28,7 @@ class StrictSchema(resource.ResourceSchema):
 
 @resource.register()
 class Moisture(resource.ShareableResource):
-    mapping = StrictSchema
+    schema = StrictSchema
 
 
 class PsilocybinSchema(resource.ResourceSchema):
@@ -40,7 +40,7 @@ class PsilocybinSchema(resource.ResourceSchema):
 
 @resource.register()
 class Psilo(resource.ShareableResource):
-    mapping = PsilocybinSchema
+    schema = PsilocybinSchema
 
 
 @resource.register()

--- a/tests/test_views_collections_schema.py
+++ b/tests/test_views_collections_schema.py
@@ -25,7 +25,7 @@ class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
     def test_schema_should_be_json_schema(self):
         newschema = SCHEMA.copy()
         newschema['type'] = 'Washmachine'
-        self.app.put_json(BUCKET_URL, headers=self.headers)
+        self.app.put(BUCKET_URL, headers=self.headers)
         self.app.put(COLLECTION_URL, headers=self.headers)
         resp = self.app.put_json(COLLECTION_URL,
                                  {'data': {'schema': newschema}},
@@ -56,8 +56,8 @@ class BaseWebTestWithSchema(BaseWebTest):
 
     def setUp(self):
         super(BaseWebTestWithSchema, self).setUp()
-        self.app.put_json(BUCKET_URL, headers=self.headers)
-        self.app.put_json(COLLECTION_URL, headers=self.headers)
+        self.app.put(BUCKET_URL, headers=self.headers)
+        self.app.put(COLLECTION_URL, headers=self.headers)
 
 
 class MissingSchemaTest(BaseWebTestWithSchema, unittest.TestCase):

--- a/tests/test_views_groups.py
+++ b/tests/test_views_groups.py
@@ -253,7 +253,7 @@ class InvalidGroupTest(BaseWebTest, unittest.TestCase):
                                  invalid,
                                  headers=self.headers,
                                  status=400)
-        self.assertEqual(resp.json['message'], "data is missing")
+        self.assertEqual(resp.json['message'], "data in body: Required")
 
     def test_groups_must_have_members_attribute(self):
         invalid = {'data': {'alias': 'admins'}}


### PR DESCRIPTION
See https://github.com/mozilla-services/cornice/pull/376

* [x] Convert code to usage of `colander_validator(schema)`
* [x] Switch to `request.validated['body']`
* [x] Do not instantiate mapping at class level
* [x] Discussion about mandatory/facultative `data` on «replacing» `PUT` and make it consistent ->  #793 
* [x] Rework viewset tests
* [x] Fix tests about validation error messages (e.g. `data is missing` → `data in body: Required`)
* [x] Rename `resource.mapping` to `resource.schema` and deprecated usage of `mapping` with instantiate schema in viewset
* [x] error_handler and request attribute (#800)