### PR TITLE
Fix the failing pypy test on Travis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ This document describes changes between each past release.
 
 **Internal changes**
 
+- Fixed a failing pypy test by changing the way it was mocking
+  `transaction.manager.commit` (fixes #755)
 - Moved storage/cache/permissions base tests to ``kinto.core.*.testing`` (fixes #801)
 - Now fails with an explicit error when StatsD is configured but not installed.
 

--- a/tests/core/test_views_transaction.py
+++ b/tests/core/test_views_transaction.py
@@ -172,7 +172,10 @@ class TransactionEventsTest(PostgreSQLTest, unittest.TestCase):
 
         app = self.make_app_with_subscribers([(events.ResourceChanged,
                                                store_record)])
-        with mock.patch('pyramid_tm.transaction.manager.commit') as mocked:
+        # We want to patch the following method so that it raises an exception,
+        # to make sure the rollback is happening correctly.
+        to_patch = 'transaction._manager.ThreadTransactionManager.commit'
+        with mock.patch(to_patch) as mocked:
             mocked.side_effect = ValueError
             self.send_batch_create(app, status=500)
         resp = app.get('/mushrooms', headers=self.headers)


### PR DESCRIPTION
Fix #755 

After quite a few trial and errors, it seems mocking "deeper" fixes the issue. Go figure.