### PR TITLE
Filter out records that don't have a field when filtering on MAX with memory storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ This document describes changes between each past release.
   the ``If-None-Match: *`` header is provided and the ``create`` permission is granted.
 - The ``permissions`` attribute is now empty in the response if the user has not the permission
   to write on the object (fixes #123)
+- Filtering records now works the same on the memory and postgresql backends:
+  if we're comparing to a number, the filter will now filter out records that
+  don't have this field. If we're comparing to anything else, the record
+  without such a field is treated as if it had '' as the value for this field.
+  (fixes #815)
 
 **New features**
 

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -329,13 +329,16 @@ def apply_filters(records, filters):
             if f.operator in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 right, left = left, right
             else:
-                # Python3 cannot compare None to other value.
                 if left is None:
-                    if f.operator in (COMPARISON.GT, COMPARISON.MIN):
+                    right_is_number = (
+                        isinstance(right, (int, float)) and
+                        right not in (True, False))
+                    if right_is_number:
+                        # Python3 cannot compare None to a number.
                         matches = False
                         continue
-                    elif f.operator in (COMPARISON.LT, COMPARISON.MAX):
-                        continue  # matches = matches and True
+                    else:
+                        left = ''  # To mimic what we do for postgresql.
             matches = matches and operators[f.operator](left, right)
         if matches:
             yield record

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -343,14 +343,20 @@ class BaseTestStorage(object):
             self.create_record({'code': l})
 
         sorting = [Sort('code', 1)]
-        filters = [Filter('code', 0, utils.COMPARISON.MIN),
-                   Filter('code', 10, utils.COMPARISON.MAX)]
+        filters = [Filter('code', 10, utils.COMPARISON.MAX)]
         records, _ = self.storage.get_all(sorting=sorting, filters=filters,
                                           **self.storage_kw)
         self.assertEqual(records[0]['code'], 1)
         self.assertEqual(records[1]['code'], 6)
         self.assertEqual(records[2]['code'], 10)
         self.assertEqual(len(records), 3)
+
+        filters = [Filter('code', 10, utils.COMPARISON.LT)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
+                                          **self.storage_kw)
+        self.assertEqual(records[0]['code'], 1)
+        self.assertEqual(records[1]['code'], 6)
+        self.assertEqual(len(records), 2)
 
     def test_get_all_can_filter_with_numeric_strings(self):
         for l in ["0566199093", "0781566199"]:


### PR DESCRIPTION
Fixes #815

This does a bit more than just dealing with the MAX use case: we should now be closer to what we do with the postgresql backend: if we're comparing to a number, we can't include any records that don't have the given filtered field. If we're comparing to a string, then records that don't have this field will just be treated as if they had an empty string for this field. See what we do for postgresql here: https://github.com/Kinto/kinto/blob/54572a2d9aa4a56fdf49cf463324dd2dee8260a3/kinto/core/storage/postgresql/__init__.py#L658