### PR TITLE
Fix permissions crash with history (#805, #842)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ This document describes changes between each past release.
   without such a field is treated as if it had '' as the value for this field.
   (fixes #815)
 
+**Bug fixes**
+
+- Fix crash in history plugin when target had no explicit permission defined (fixes #805, #842)
+
 **New features**
 
 - The storage backend now allows ``parent_id`` pattern matching in ``kinto.core.storage.get_all``. (#821)

--- a/kinto/core/permission/__init__.py
+++ b/kinto/core/permission/__init__.py
@@ -133,8 +133,7 @@ class PermissionBase(object):
         return len(authorized & principals) > 0
 
     def get_object_permissions(self, object_id, permissions=None):
-        perms = self.get_objects_permissions([object_id], permissions)
-        return perms[0] if perms else {}
+        return self.get_objects_permissions([object_id], permissions)[0]
 
     def get_objects_permissions(self, objects_ids, permissions=None):
         """Return a list of mapping, for each object id specified, with the

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -300,12 +300,13 @@ class Permission(PermissionBase):
             rows = result.fetchall()
 
         groupby_id = OrderedDict()
+        for object_id in objects_ids:
+            groupby_id[object_id] = {}
         for row in rows:
             object_id, permission, principal = (row['object_id'],
                                                 row['permission'],
                                                 row['principal'])
-            permissions = groupby_id.setdefault(object_id, {})
-            permissions.setdefault(permission, set()).add(principal)
+            groupby_id[object_id].setdefault(permission, set()).add(principal)
         return list(groupby_id.values())
 
     def replace_object_permissions(self, object_id, permissions):

--- a/kinto/core/permission/testing.py
+++ b/kinto/core/permission/testing.py
@@ -357,6 +357,14 @@ class PermissionTest(object):
             "read": {"user3"}
         })
 
+    def test_objects_permissions_returns_empty_if_unknown(self):
+        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
+        self.permission.add_principal_to_ace('/url/a/id/3', 'read', 'user3')
+        objects_permissions = self.permission.get_objects_permissions([
+            '/url/a/id/1', '/abc', '/url/a/id/3'])
+        self.assertEqual(objects_permissions, [
+            {"write": {"user1"}}, {}, {"read": {"user3"}}])
+
     def test_object_permissions_return_empty_dict(self):
         self.assertDictEqual(self.permission.get_object_permissions('abc'), {})
 

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -304,6 +304,17 @@ class HistoryViewTest(HistoryWebTest):
         assert entry['action'] == 'delete'
         assert entry['target']['data']['id'] in (self.record['id'], rid)
 
+    def test_does_not_track_records_during_massive_deletion(self):
+        body = {'data': {'pim': 'pam'}}
+        records_uri = self.collection_uri + '/records'
+        self.app.post_json(records_uri, body, headers=self.headers)
+
+        self.app.delete(self.collection_uri, headers=self.headers)
+
+        resp = self.app.get(self.history_uri, headers=self.headers)
+        deletion_entries = [e for e in resp.json['data'] if e['action'] == 'delete']
+        assert len(deletion_entries) == 1
+
 
 class FilteringTest(HistoryWebTest):
 


### PR DESCRIPTION
Fixes #805, Fixes #842 

The history plugin used to crash when the permissions of an object among the resouce event target had no permissions defined. I could reproduce in kinto-signer, where we create record programmatically without associating individual permissions on them (just a read on parent collection).

The problem came from the permission backend, `get_objects_permissions()` which would omit the missing objects from the results instead of return an empty permissions definition for them.

- [x] Add tests.
- [x] Add a changelog entry.

r? @Natim 
