### PR TITLE
Implement JSON Merge Patch  (RFC 7396 #623)

### DIFF
--- a/docs/api/1.x/_details-patch-object.rst
+++ b/docs/api/1.x/_details-patch-object.rst
@@ -21,11 +21,19 @@ The provided values are merged with the existing object. For example:
 * ``{"a":"b"}`` + ``{"a":null}`` → ``{"a":null}`` : *attributes can't be removed with patch*
 * ``{"a": {"b":"c"}}`` + ``{"a":{"d":"e"}}`` → ``{"a":{"d":"e"}}`` : *sub-objects are replaced, not merged*
 
+`JSON merge <https://tools.ietf.org/html/rfc7396>`_
+is currently supported using ``Content-Type: application/merge-patch+json``. This provides
+support to merging sub-objects and removing attibutes. For example:
+
+* ``{"a":"b"}`` + ``{"a":null}`` → ``{}`` 
+* ``{"a": {"b":"c"}}`` + ``{"a":{"d":"e"}}`` → ``{"a":{"b:c", "d":"e"}}``
+* ``{}`` + ``{"a":{"b":{"c":null}}}`` → ``{"a":{"b":{}}}``
+
 .. note::
 
-    `JSON-Patch <http://jsonpatch.com>`_ or `JSON merge <https://tools.ietf.org/html/rfc7396>`_
-    are currently not supported. Any help is welcomed though!
-    See https://github.com/Kinto/kinto/issues/623
+    `JSON-Patch <http://jsonpatch.com>`_ 
+    is currently not supported. Any help is welcomed though!
+    See https://github.com/Kinto/kinto/issues/458
 
 
 Light response body

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,6 +11,15 @@ API
 Changelog
 ---------
 
+
+1.12 (2016-10-11)
+'''''''''''''''''
+
+- Add support to JSON merge ``patch`` when using 
+  ``Content-Type: application/merge-patch+json`` (as in RFC 7396).
+- When ``null`` argument is provided with merge ``patch``, the field is now
+  removed from the object.
+
 1.11 (2016-10-04)
 '''''''''''''''''
 

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -13,7 +13,7 @@ from kinto.authorization import RouteFactory
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # Implemented HTTP API Version
-HTTP_API_VERSION = '1.11'
+HTTP_API_VERSION = '1.12'
 
 # Main kinto logger
 logger = logging.getLogger(__name__)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -474,6 +474,9 @@ class UserResource(object):
 
         updated = self.apply_changes(existing, changes=changes)
 
+        # remove field if null attribute is passed (RFC 7396)
+        updated = {key: value for key, value in updated.items() if value}
+
         record_id = updated.setdefault(self.model.id_field,
                                        self.record_id)
         self._raise_400_if_id_mismatch(record_id, self.record_id)

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -7,7 +7,7 @@ from kinto.core import authorization
 from kinto.core.resource.schema import PermissionsSchema
 
 
-CONTENT_TYPES = ["application/json", "application/merge-patch+json"]
+CONTENT_TYPES = ["application/json"]
 
 
 class ViewSet(object):
@@ -49,7 +49,7 @@ class ViewSet(object):
     }
 
     default_patch_arguments = {
-        "content_type": CONTENT_TYPES,
+        "content_type": CONTENT_TYPES + ["application/merge-patch+json"],
     }
 
     default_collection_arguments = {}

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -7,7 +7,7 @@ from kinto.core import authorization
 from kinto.core.resource.schema import PermissionsSchema
 
 
-CONTENT_TYPES = ["application/json"]
+CONTENT_TYPES = ["application/json", "application/merge-patch+json"]
 
 
 class ViewSet(object):

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -82,6 +82,24 @@ def merge_dicts(a, b):
         else:
             a.setdefault(k, v)
 
+def recursive_update_dict(root, changes, ignores=()):
+    """Update recursively all the entries from a dict and it's children dicts.
+
+    :param dict root: root dictionary
+    :param dict changes: dictonary where changes should be made (default=root)
+    :returns dict newd: dictionary with removed entries of val.
+    """
+    if isinstance(changes, dict):
+        for k, v in changes.items():
+            if isinstance(v, dict):
+                if not k in root:
+                    root[k] = {}
+                recursive_update_dict(root[k], v, ignores)
+            elif v in ignores:
+                if k in root:
+                    root.pop(k)
+            else:
+                root[k] = v
 
 def synchronized(method):
     """Class method decorator to make sure two threads do not execute some code

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -82,6 +82,7 @@ def merge_dicts(a, b):
         else:
             a.setdefault(k, v)
 
+
 def recursive_update_dict(root, changes, ignores=()):
     """Update recursively all the entries from a dict and it's children dicts.
 
@@ -100,6 +101,7 @@ def recursive_update_dict(root, changes, ignores=()):
                     root.pop(k)
             else:
                 root[k] = v
+
 
 def synchronized(method):
     """Class method decorator to make sure two threads do not execute some code

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -93,7 +93,7 @@ def recursive_update_dict(root, changes, ignores=()):
     if isinstance(changes, dict):
         for k, v in changes.items():
             if isinstance(v, dict):
-                if not k in root:
+                if k not in root:
                     root[k] = {}
                 recursive_update_dict(root[k], v, ignores)
             elif v in ignores:

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -258,12 +258,7 @@ class PatchTest(BaseTest):
         result = self.resource.patch()['data']
         self.assertIn('a', result)
         self.assertNotIn('b', result['a'])
-        self.resource.request.json = {'data': {'aa': {'bb':{'cc':None}}}}
-        result = self.resource.patch()['data']
-        self.assertIn('aa', result)
-        self.assertIn('bb', result['aa'])
-        self.assertNotIn('cc', result['aa']['bb'])
-        self.resource.request.json = {'data': {'aa': {'bb':{'cc':None}}}}
+        self.resource.request.json = {'data': {'aa': {'bb': {'cc': None}}}}
         result = self.resource.patch()['data']
         self.assertIn('aa', result)
         self.assertIn('bb', result['aa'])

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -227,6 +227,15 @@ class PatchTest(BaseTest):
         self.assertEquals(self.stored['id'], self.result['id'])
         self.assertEquals(self.result['position'], 10)
 
+    def test_patch_removes_attribute_if_none(self):
+        self.resource.request.json = {'data': {'field': 'aaa'}}
+        self.resource.patch()['data']
+        self.resource.request.json = {'data': {'field': None}}
+        result = self.resource.patch()['data']
+        self.assertEquals('field' in result.keys(), False)
+        result = self.resource.get()['data']
+        self.assertEquals('field' in result.keys(), False)
+
     def test_record_timestamp_is_not_updated_if_none_for_missing_field(self):
         self.resource.request.json = {'data': {'polo': None}}
         result = self.resource.patch()['data']

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -227,14 +227,84 @@ class PatchTest(BaseTest):
         self.assertEquals(self.stored['id'], self.result['id'])
         self.assertEquals(self.result['position'], 10)
 
+    def test_patch_updates_attributes_recursively(self):
+        header = self.resource.request.headers
+        header['Content-Type'] = 'application/merge-patch+json'
+        self.resource.request.json = {'data': {'a': {'b': 'bbb',
+                                                     'c': 'ccc'}}}
+        self.resource.patch()
+        self.resource.request.json = {'data': {'a': {'b': 'aaa',
+                                                     'c': None}}}
+        result = self.resource.patch()['data']
+        self.assertEqual(result['a']['b'], 'aaa')
+
     def test_patch_removes_attribute_if_none(self):
+        header = self.resource.request.headers
+        header['Content-Type'] = 'application/merge-patch+json'
         self.resource.request.json = {'data': {'field': 'aaa'}}
-        self.resource.patch()['data']
+        self.resource.patch()
         self.resource.request.json = {'data': {'field': None}}
         result = self.resource.patch()['data']
-        self.assertEquals('field' in result.keys(), False)
+        self.assertNotIn('field', result)
         result = self.resource.get()['data']
-        self.assertEquals('field' in result.keys(), False)
+        self.assertNotIn('field', result)
+
+    def test_patch_removes_attributes_recursively_if_none(self):
+        header = self.resource.request.headers
+        header['Content-Type'] = 'application/merge-patch+json'
+        self.resource.request.json = {'data': {'a': {'b': 'aaa'}}}
+        self.resource.patch()
+        self.resource.request.json = {'data': {'a': {'b': None}}}
+        result = self.resource.patch()['data']
+        self.assertIn('a', result)
+        self.assertNotIn('b', result['a'])
+        self.resource.request.json = {'data': {'aa': {'bb':{'cc':None}}}}
+        result = self.resource.patch()['data']
+        self.assertIn('aa', result)
+        self.assertIn('bb', result['aa'])
+        self.assertNotIn('cc', result['aa']['bb'])
+        self.resource.request.json = {'data': {'aa': {'bb':{'cc':None}}}}
+        result = self.resource.patch()['data']
+        self.assertIn('aa', result)
+        self.assertIn('bb', result['aa'])
+        self.assertNotIn('cc', result['aa']['bb'])
+
+    def test_patch_doesnt_remove_attribute_if_false(self):
+        header = self.resource.request.headers
+        header['Content-Type'] = 'application/merge-patch+json'
+        self.resource.request.json = {'data': {'field': 0}}
+        result = self.resource.patch()['data']
+        self.assertIn('field', result)
+        self.resource.request.json = {'data': {'field': False}}
+        result = self.resource.patch()['data']
+        self.assertIn('field', result)
+        self.resource.request.json = {'data': {'field': {}}}
+        result = self.resource.patch()['data']
+        self.assertIn('field', result)
+
+    def test_patch_doesnt_remove_attribute_if_not_merge_header(self):
+        header = self.resource.request.headers
+        header['Content-Type'] = 'application/json'
+        self.resource.request.json = {'data': {'field': 'aaa'}}
+        self.resource.patch()
+        self.resource.request.json = {'data': {'field': None}}
+        result = self.resource.patch()['data']
+        self.assertIn('field', result)
+        result = self.resource.get()['data']
+        self.assertIn('field', result)
+
+    def test_patch_doesnt_remove_previously_inserted_nones(self):
+        header = self.resource.request.headers
+        header['Content-Type'] = 'application/json'
+        self.resource.request.json = {'data': {'field': 'aaa'}}
+        result = self.resource.patch()['data']
+        self.resource.request.json = {'data': {'field': None}}
+        result = self.resource.patch()['data']
+        self.assertIn('field', result)
+        header['Content-Type'] = 'application/merge-patch+json'
+        self.resource.request.json = {'data': {'position': 10}}
+        result = self.resource.patch()['data']
+        self.assertIn('field', result)
 
     def test_record_timestamp_is_not_updated_if_none_for_missing_field(self):
         self.resource.request.json = {'data': {'polo': None}}

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -227,7 +227,7 @@ class PatchTest(BaseTest):
         self.assertEquals(self.stored['id'], self.result['id'])
         self.assertEquals(self.result['position'], 10)
 
-    def test_patch_updates_attributes_recursively(self):
+    def test_merge_patch_updates_attributes_recursively(self):
         header = self.resource.request.headers
         header['Content-Type'] = 'application/merge-patch+json'
         self.resource.request.json = {'data': {'a': {'b': 'bbb',
@@ -238,7 +238,7 @@ class PatchTest(BaseTest):
         result = self.resource.patch()['data']
         self.assertEqual(result['a']['b'], 'aaa')
 
-    def test_patch_removes_attribute_if_none(self):
+    def test_merge_patch_removes_attribute_if_none(self):
         header = self.resource.request.headers
         header['Content-Type'] = 'application/merge-patch+json'
         self.resource.request.json = {'data': {'field': 'aaa'}}
@@ -249,7 +249,7 @@ class PatchTest(BaseTest):
         result = self.resource.get()['data']
         self.assertNotIn('field', result)
 
-    def test_patch_removes_attributes_recursively_if_none(self):
+    def test_merge_patch_removes_attributes_recursively_if_none(self):
         header = self.resource.request.headers
         header['Content-Type'] = 'application/merge-patch+json'
         self.resource.request.json = {'data': {'a': {'b': 'aaa'}}}
@@ -264,7 +264,7 @@ class PatchTest(BaseTest):
         self.assertIn('bb', result['aa'])
         self.assertNotIn('cc', result['aa']['bb'])
 
-    def test_patch_doesnt_remove_attribute_if_false(self):
+    def test_merge_patch_doesnt_remove_attribute_if_false(self):
         header = self.resource.request.headers
         header['Content-Type'] = 'application/merge-patch+json'
         self.resource.request.json = {'data': {'field': 0}}
@@ -288,7 +288,7 @@ class PatchTest(BaseTest):
         result = self.resource.get()['data']
         self.assertIn('field', result)
 
-    def test_patch_doesnt_remove_previously_inserted_nones(self):
+    def test_merge_patch_doesnt_remove_previously_inserted_nones(self):
         header = self.resource.request.headers
         header['Content-Type'] = 'application/json'
         self.resource.request.json = {'data': {'field': 'aaa'}}

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -444,16 +444,6 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                            headers=self.headers,
                            status=200)
 
-    def test_200_if_header_matches_json_patch(self):
-        headers = self.headers.copy()
-        headers['Content-Type'] = 'application/merge-patch+json'
-        record = MINIMALIST_RECORD.copy()
-        record['id'] = self.record['id']
-        self.app.post_json(self.collection_url,
-                           {'data': record},
-                           headers=self.headers,
-                           status=200)
-
     def test_invalid_accept_header_on_collections_returns_406(self):
         headers = self.headers.copy()
         headers['Accept'] = 'text/plain'
@@ -462,12 +452,8 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=406)
         self.assertEqual(resp.json['code'], 406)
-        messages = (
-            "Accept header should be one of " +
-            "['application/merge-patch+json', 'application/json']",
-            "Accept header should be one of " +
-            "['application/json', 'application/merge-patch+json']")
-        self.assertIn(resp.json['message'], messages)
+        message = "Accept header should be one of ['application/json']"
+        self.assertEqual(resp.json['message'], message)
 
     def test_invalid_content_type_header_on_collections_returns_415(self):
         headers = self.headers.copy()
@@ -477,11 +463,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=415)
         self.assertEqual(resp.json['code'], 415)
-        messages = (
-            "Content-Type header should be one of " +
-            "['application/merge-patch+json', 'application/json']",
-            "Content-Type header should be one of " +
-            "['application/json', 'application/merge-patch+json']")
+        messages = "Content-Type header should be one of ['application/json']"
         self.assertIn(resp.json['message'], messages)
 
     def test_invalid_accept_header_on_record_returns_406(self):
@@ -491,12 +473,8 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                             headers=headers,
                             status=406)
         self.assertEqual(resp.json['code'], 406)
-        messages = (
-            "Accept header should be one of " +
-            "['application/merge-patch+json', 'application/json']",
-            "Accept header should be one of " +
-            "['application/json', 'application/merge-patch+json']")
-        self.assertIn(resp.json['message'], messages)
+        message = "Accept header should be one of ['application/json']"
+        self.assertEqual(resp.json['message'], message)
 
     def test_invalid_content_type_header_on_record_returns_415(self):
         headers = self.headers.copy()

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -443,7 +443,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                            {'data': record},
                            headers=self.headers,
                            status=200)
-    
+
     def test_200_if_header_matches_json_patch(self):
         headers = self.headers.copy()
         headers['Content-Type'] = 'application/merge-patch+json'

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -463,8 +463,8 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=415)
         self.assertEqual(resp.json['code'], 415)
-        messages = "Content-Type header should be one of ['application/json']"
-        self.assertIn(resp.json['message'], messages)
+        message = "Content-Type header should be one of ['application/json']"
+        self.assertEqual(resp.json['message'], message)
 
     def test_invalid_accept_header_on_record_returns_406(self):
         headers = self.headers.copy()

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -452,7 +452,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=406)
         self.assertEqual(resp.json['code'], 406)
-        message = u"Accept header should be one of ['application/json', 'application/merge-patch+json']"
+        message = "Accept header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
     def test_invalid_content_type_header_on_collections_returns_415(self):
@@ -463,7 +463,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=415)
         self.assertEqual(resp.json['code'], 415)
-        message = u"Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
+        message = "Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
     def test_invalid_accept_header_on_record_returns_406(self):
@@ -473,7 +473,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                             headers=headers,
                             status=406)
         self.assertEqual(resp.json['code'], 406)
-        message = u"Accept header should be one of ['application/json', 'application/merge-patch+json']"
+        message = "Accept header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
     def test_invalid_content_type_header_on_record_returns_415(self):
@@ -484,7 +484,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                                    headers=headers,
                                    status=415)
         self.assertEqual(resp.json['code'], 415)
-        message = u"Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
+        message = "Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
 

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -443,6 +443,16 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                            {'data': record},
                            headers=self.headers,
                            status=200)
+    
+    def test_200_if_header_matches_json_patch(self):
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'application/merge-patch+json'
+        record = MINIMALIST_RECORD.copy()
+        record['id'] = self.record['id']
+        self.app.post_json(self.collection_url,
+                           {'data': record},
+                           headers=self.headers,
+                           status=200)
 
     def test_invalid_accept_header_on_collections_returns_406(self):
         headers = self.headers.copy()
@@ -452,8 +462,12 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=406)
         self.assertEqual(resp.json['code'], 406)
-        message = "Accept header should be one of ['application/json', 'application/merge-patch+json']"
-        self.assertEqual(resp.json['message'], message)
+        messages = (
+            "Accept header should be one of " +
+            "['application/merge-patch+json', 'application/json']",
+            "Accept header should be one of " +
+            "['application/json', 'application/merge-patch+json']")
+        self.assertIn(resp.json['message'], messages)
 
     def test_invalid_content_type_header_on_collections_returns_415(self):
         headers = self.headers.copy()
@@ -463,8 +477,12 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=415)
         self.assertEqual(resp.json['code'], 415)
-        message = "Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
-        self.assertEqual(resp.json['message'], message)
+        messages = (
+            "Content-Type header should be one of " +
+            "['application/merge-patch+json', 'application/json']",
+            "Content-Type header should be one of " +
+            "['application/json', 'application/merge-patch+json']")
+        self.assertIn(resp.json['message'], messages)
 
     def test_invalid_accept_header_on_record_returns_406(self):
         headers = self.headers.copy()
@@ -473,8 +491,12 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                             headers=headers,
                             status=406)
         self.assertEqual(resp.json['code'], 406)
-        message = "Accept header should be one of ['application/json', 'application/merge-patch+json']"
-        self.assertEqual(resp.json['message'], message)
+        messages = (
+            "Accept header should be one of " +
+            "['application/merge-patch+json', 'application/json']",
+            "Accept header should be one of " +
+            "['application/json', 'application/merge-patch+json']")
+        self.assertIn(resp.json['message'], messages)
 
     def test_invalid_content_type_header_on_record_returns_415(self):
         headers = self.headers.copy()
@@ -484,8 +506,12 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                                    headers=headers,
                                    status=415)
         self.assertEqual(resp.json['code'], 415)
-        message = "Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
-        self.assertEqual(resp.json['message'], message)
+        messages = (
+            "Content-Type header should be one of " +
+            "['application/merge-patch+json', 'application/json']",
+            "Content-Type header should be one of " +
+            "['application/json', 'application/merge-patch+json']")
+        self.assertIn(resp.json['message'], messages)
 
 
 class IgnoredFieldsTest(BaseWebTest, unittest.TestCase):

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -452,7 +452,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=406)
         self.assertEqual(resp.json['code'], 406)
-        message = "Accept header should be one of ['application/json']"
+        message = u"Accept header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
     def test_invalid_content_type_header_on_collections_returns_415(self):
@@ -463,7 +463,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                              headers=headers,
                              status=415)
         self.assertEqual(resp.json['code'], 415)
-        message = "Content-Type header should be one of ['application/json']"
+        message = u"Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
     def test_invalid_accept_header_on_record_returns_406(self):
@@ -473,7 +473,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                             headers=headers,
                             status=406)
         self.assertEqual(resp.json['code'], 406)
-        message = "Accept header should be one of ['application/json']"
+        message = u"Accept header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
     def test_invalid_content_type_header_on_record_returns_415(self):
@@ -484,7 +484,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
                                    headers=headers,
                                    status=415)
         self.assertEqual(resp.json['code'], 415)
-        message = "Content-Type header should be one of ['application/json']"
+        message = u"Content-Type header should be one of ['application/json', 'application/merge-patch+json']"
         self.assertEqual(resp.json['message'], message)
 
 


### PR DESCRIPTION
Fixes #623 

- [x] Add tests.
- [x] Add a changelog entry.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

Let me know if I got it wrong or there's something missing! 

Obs: Should this increase API_VERSION or be included on the API entry docs?