### PR TITLE
Pin Sphinx to 1.4 (ref #868)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx<1.5
 sphinx_rtd_theme
 sphinxcontrib-httpdomain
 kinto-redis

--- a/tox.ini
+++ b/tox.ini
@@ -48,10 +48,7 @@ deps =
 [testenv:docs]
 commands = sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
-    Sphinx
-    sphinx_rtd_theme
-    sphinxcontrib-httpdomain
-    kinto-redis
+    -rdocs/requirements.txt
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
Temporary fix for #868 

We should inherit another template in `docs/_templates/indexcontent.html` since `defindex.html` was removed in Sphinx 1.5a2