### PR TITLE
The docs talks about an not existing setting.

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -661,7 +661,7 @@ allowed to do and which data can be managed.
 
 .. code-block :: ini
 
-    kinto.permissions_endpoint_enabled = true
+    kinto.experimental_permissions_endpoint = true
 
 Then, issue a ``GET`` request to the ``/permissions`` endpoint to get the
 list of the user permissions on the server ressources.

--- a/kinto/plugins/admin/.gitignore
+++ b/kinto/plugins/admin/.gitignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
`permissions_endpoint_enabled` does not exist and is called `experimental_permissions_endpoint`

r? @leplatrem 