### PR TITLE
Fix crash in PostgreSQL backend when specified bound permissions is empty (fixes #906)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ This document describes changes between each past release.
 - Fixed showing of backend type twice in StatsD backend keys (fixes #857)
 - Fix crash when querystring parameter contains null string (fixes #882)
 - Fix crash when redirection path contains CRLF character (fixes #887)
+- Fix crash in PostgreSQL backend when specified bound permissions is empty (fixes #906)
 - Permissions endpoint now exposes the user permissions defined in settings (fixes #909)
 - Fix bug when two subfields are selected in partial responses (fixes #920)
 

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -212,6 +212,8 @@ class Permission(PermissionBase):
               JOIN user_principals
                 ON (principal = user_principals.column1);
             """ % dict(principals=principals_values)
+        elif not bound_permissions:
+            return {}
         else:
             perms = [(o.replace('*', '.*'), p) for (o, p) in bound_permissions]
             perms_values = ','.join(["('%s', '%s')" % p for p in perms])

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -203,6 +203,9 @@ class Permission(PermissionBase):
     def get_accessible_objects(self, principals, bound_permissions=None):
         principals_values = ','.join(["('%s')" % p for p in principals])
         if bound_permissions is None:
+            # Return all objects on which the specified principals have some
+            # permissions.
+            # (e.g. permissions endpoint which lists everything)
             query = """
             WITH user_principals AS (
               VALUES %(principals)s
@@ -212,7 +215,10 @@ class Permission(PermissionBase):
               JOIN user_principals
                 ON (principal = user_principals.column1);
             """ % dict(principals=principals_values)
-        elif not bound_permissions:
+        elif len(bound_permissions) == 0:
+            # If the list of object permissions to filter on is empty, then
+            # do not bother querying the backend. The result will be empty.
+            # (e.g. root object /buckets)
             return {}
         else:
             perms = [(o.replace('*', '.*'), p) for (o, p) in bound_permissions]

--- a/kinto/core/permission/testing.py
+++ b/kinto/core/permission/testing.py
@@ -288,6 +288,10 @@ class PermissionTest(object):
                           set(['write', 'record:create']))
         self.assertEquals(per_object_ids['id2'], set(['read']))
 
+    def test_accessible_objects_supports_empty_list(self):
+        per_object_ids = self.permission.get_accessible_objects(['user1', 'group'], [])
+        self.assertEquals(per_object_ids, {})
+
     def test_accessible_objects_from_permission(self):
         self.permission.add_principal_to_ace('id1', 'write', 'user1')
         self.permission.add_principal_to_ace('id1', 'read', 'user1')


### PR DESCRIPTION
I could reproduce the syntax error of #906 in a test. I still wonder how that would occur in real life though.

Fixes #906 

r? @Natim 