### PR TITLE
Update required version of cornice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colander==1.3.1
 colorama==0.3.7
 contextlib2==0.5.4
-cornice==2.0.1
+cornice==2.1.0
 enum34==1.1.6
 functools32==3.2.3.post2
 futures==3.0.5


### PR DESCRIPTION
Fixes https://travis-ci.org/Kinto/kinto.js/jobs/175754469.

Cornice was updated to 2.1.0 in setup.py back in #904, but this didn't touch the version in requirements.txt, which is now inconsistent with the rest of the project. This meant that `pserve` refused to run it.

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @leplatrem 
