### PR TITLE
Fix failing tests on master

### DIFF
--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -74,8 +74,7 @@ class FormattedErrorMixin(object):
         if isinstance(errno, Enum):
             errno = errno.value
 
-        self.assertEqual(response.headers['Content-Type'],
-                         'application/json; charset=UTF-8')
+        self.assertIn('application/json', response.headers['Content-Type'])
         self.assertEqual(response.json['code'], code)
         self.assertEqual(response.json['errno'], errno)
         self.assertEqual(response.json['error'], error)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ REQUIREMENTS = [
     'python-dateutil',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'transaction < 2',  # 2.X is incompatible with pyramid_tm
-    'pyramid_tm',
+    'pyramid_tm < 1.1.0',
     'requests',
     'six',
     'structlog >= 16.1.0',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIREMENTS = [
     'jsonpatch',
     'python-dateutil',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
+    'transaction < 2',  # 2.X is incompatible with pyramid_tm
     'pyramid_tm',
     'requests',
     'six',


### PR DESCRIPTION
* The charset was removed from content-type response (?)
* Transaction 2.0 is not fully supported by pyramid_tm: see https://github.com/Pylons/pyramid_tm/pull/52