### PR TITLE
Fix crash in authorization policy when object ids contain unicode (fixes #931)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ This document describes changes between each past release.
 - Fix bug when two subfields are selected in partial responses (fixes #920)
 - Fix crash in permission endpoint when merging permissions from settings and from
   permissions backend (fixes #926)
+- Fix crash in authorization policy when object ids contain unicode (fixes #931)
 
 **Internal changes**
 

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -1,5 +1,6 @@
 import functools
 
+import six
 from pyramid.settings import aslist
 from pyramid.security import IAuthorizationPolicy, Authenticated
 from zope.interface import implementer
@@ -234,8 +235,8 @@ class RouteFactory(object):
         required_permission = self.method_permissions.get(method)
 
         # For create permission, the object id is the plural endpoint.
-        plural_endpoint = service.collection_path.decode('utf-8')
-        collection_path = plural_endpoint.format(**request.matchdict)
+        collection_path = six.text_type(service.collection_path)
+        collection_path = collection_path.format(**request.matchdict)
 
         # In the case of a "PUT", check if the targetted record already
         # exists, return "write" if it does, "create" otherwise.

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -234,7 +234,8 @@ class RouteFactory(object):
         required_permission = self.method_permissions.get(method)
 
         # For create permission, the object id is the plural endpoint.
-        collection_path = service.collection_path.format(**request.matchdict)
+        plural_endpoint = service.collection_path.decode('utf-8')
+        collection_path = plural_endpoint.format(**request.matchdict)
 
         # In the case of a "PUT", check if the targetted record already
         # exists, return "write" if it does, "create" otherwise.

--- a/tests/test_views_objects_permissions.py
+++ b/tests/test_views_objects_permissions.py
@@ -77,6 +77,11 @@ class CollectionPermissionsTest(PermissionsTest):
                           MINIMALIST_COLLECTION,
                           headers=self.headers)
 
+    def test_passing_unicode_on_parent_id_is_supported(self):
+        self.app.get('/buckets/block%C2%93%C2%96sts/collections/barley',
+                     headers=self.alice_headers,
+                     status=403)
+
     def test_read_is_allowed_if_read_on_bucket(self):
         self.app.get('/buckets/beer/collections/barley',
                      headers=self.alice_headers)


### PR DESCRIPTION
Fixes #931 

r? @Natim 
