### PR TITLE
Replaced insecure calls to random with more secure SystemRandom

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ This document describes changes between each past release.
 - The ``delete_object_permissions()`` of the permission backend now supports
   URI patterns (eg. ``/bucket/id*``)
 - Refactor handling of prefixed user id among request principals
+- Replaced insecure use of ``random.random()`` and ``random.choice(...)`` with
+  more secure ``random.SystemRandom().random()`` and
+  ``random.SystemRandom().choice(...)``. (#955)
 
 
 5.0.0 (2016-11-18)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -38,6 +38,7 @@ Contributors
 * Mathieu Agopian <mathieu@agopian.info>
 * Mathieu Leplatre <mathieu@mozilla.com>
 * Maxime Warnier <marmax@gmail.com>
+* Michael Charlton <m.charlton@mac.com>
 * Michiel de Jong <michiel@unhosted.org>
 * Mo Valipour <valipour@gmail.com>
 * Nicolas Hoizey <nicolas@hoizey.com>

--- a/kinto/core/cache/__init__.py
+++ b/kinto/core/cache/__init__.py
@@ -84,7 +84,7 @@ def heartbeat(backend):
         # No specific case for readonly mode because the cache should
         # continue to work in that mode.
         try:
-            if random.random() < _HEARTBEAT_DELETE_RATE:
+            if random.SystemRandom().random() < _HEARTBEAT_DELETE_RATE:
                 backend.delete(_HEARTBEAT_KEY)
             else:
                 backend.set(_HEARTBEAT_KEY, 'alive', _HEARTBEAT_TTL_SECONDS)

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -63,9 +63,9 @@ class CacheTest(object):
         self.client_error_patcher.start()
         ping = heartbeat(self.cache)
         self.assertFalse(ping(self.request))
-        with mock.patch('kinto.core.cache.random.random', return_value=0.6):
+        with mock.patch('kinto.core.cache.random.SystemRandom.random', return_value=0.6):
             self.assertFalse(ping(self.request))
-        with mock.patch('kinto.core.cache.random.random', return_value=0.4):
+        with mock.patch('kinto.core.cache.random.SystemRandom.random', return_value=0.4):
             self.assertFalse(ping(self.request))
 
     def test_ping_returns_true_if_available(self):

--- a/kinto/core/storage/__init__.py
+++ b/kinto/core/storage/__init__.py
@@ -259,7 +259,7 @@ def heartbeat(backend):
                 backend.get_all(_HEARTBEAT_COLLECTION_ID, _HEART_PARENT_ID,
                                 auth=auth)
             else:
-                if random.random() < _HEARTBEAT_DELETE_RATE:
+                if random.SystemRandom().random() < _HEARTBEAT_DELETE_RATE:
                     backend.delete_all(_HEARTBEAT_COLLECTION_ID,
                                        _HEART_PARENT_ID, auth=auth)
                 else:

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -98,22 +98,22 @@ class BaseTestStorage(object):
         request.registry.settings = {'readonly': 'false'}
         ping = heartbeat(self.storage)
 
-        with mock.patch('kinto.core.storage.random.random', return_value=0.7):
+        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
             ping(request)
 
         self.client_error_patcher.start()
-        with mock.patch('kinto.core.storage.random.random', return_value=0.7):
+        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
             self.assertFalse(ping(request))
-        with mock.patch('kinto.core.storage.random.random', return_value=0.5):
+        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.5):
             self.assertFalse(ping(request))
 
     def test_ping_returns_true_when_working(self):
         request = DummyRequest()
         request.headers['Authorization'] = 'Basic bWF0OjI='
         ping = heartbeat(self.storage)
-        with mock.patch('kinto.core.storage.random.random', return_value=0.7):
+        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
             self.assertTrue(ping(request))
-        with mock.patch('kinto.core.storage.random.random', return_value=0.5):
+        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.5):
             self.assertTrue(ping(request))
 
     def test_ping_returns_true_when_working_in_readonly_mode(self):

--- a/kinto/views/__init__.py
+++ b/kinto/views/__init__.py
@@ -8,11 +8,11 @@ from kinto.core.errors import http_error, ERRORS
 
 class NameGenerator(generators.Generator):
     def __call__(self):
-        ascii_letters = ('abcdefghijklmopqrstuvwxyz'
-                         'ABCDEFGHIJKLMOPQRSTUVWXYZ')
-        alphabet = ascii_letters + string.digits + '-_'
-        letters = [random.choice(ascii_letters + string.digits)]
-        letters += [random.choice(alphabet) for x in range(7)]
+        alpha_num = string.ascii_letters + string.digits
+        alphabet = alpha_num + '-_'
+        letters = [random.SystemRandom().choice(alpha_num)]
+        letters += [random.SystemRandom().choice(alphabet) for x in range(7)]
+
         return ''.join(letters)
 
 


### PR DESCRIPTION
Fixes #

- [ ] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @

See - 'Use os.urandom rather than random.choice or random.random #955'
SystemRandom, according to the docs, calls os.urandom under the hood and
provides the same 'choice' and 'random' API calls that 'random' provides.