### PR TITLE
document 400 on get object requests

### DIFF
--- a/docs/api/1.x/_status-get-object.rst
+++ b/docs/api/1.x/_status-get-object.rst
@@ -3,6 +3,7 @@ HTTP Status Codes
 
 * |status-200|: The request was processed
 * |status-304|: Object did not change since value in ``If-None-Match`` header
+* |status-400|: The request header is invalid
 * |status-401|: The request is missing authentication headers
 * |status-403|: The user is not allowed to perform the operation, or the resource is not accessible
 * |status-404|: The object does not exist or was deleted


### PR DESCRIPTION
400 is possible on GET objects with invalid headers, example:

```http
$ http get localhost:8888/v1/buckets/b1 If-Match:111 -a aaa:aaa
HTTP/1.1 400 Bad Request
Access-Control-Expose-Headers: Retry-After, Content-Length, Alert, Backoff
Content-Length: 293
Content-Type: application/json; charset=UTF-8
Date: Fri, 09 Dec 2016 01:11:30 GMT
Server: waitress

{
    "code": 400,
    "details": [
        {
            "description": "Invalid value for If-Match. The value should be integer between double quotes.",
            "location": "header",
            "name": null
        }
    ],
    "errno": 107,
    "error": "Invalid parameters",
    "message": "header: Invalid value for If-Match. The value should be integer between double quotes."
}
```

