### PR TITLE
Prepare release 5.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-5.0.1 (unreleased)
+5.1.0 (2016-12-19)
 ------------------
 
 **Protocol**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,14 @@ Protocol is now at version **1.13**. See `API changelog`_.
 - Add a setting to limit the maximum number of bytes cached in the memory backend. (#610)
 - Add a setting to exclude certain resources from being tracked by history (fixes #964)
 
+**Backend changes**
+
+- ``storage.delete_all()`` now accepts ``sorting``, ``pagination_rules`` and ``limit``
+  parameters (#997)
+- ``permissions.get_accessible_objects()`` does not support Regexp and now accepts
+  a ``with_children`` parameter (#975)
+- ``cache.set()`` now logs a warning if ``ttl`` is ``None`` (#967)
+
 **Internal changes**
 
 - Remove usage of assert (fixes #954)

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,10 +11,11 @@ API
 Changelog
 ---------
 
-1.13 (unreleased)
+1.13 (2016-12-19)
 '''''''''''''''''
 
 - Add ``DELETE`` to the history endpoint.
+- Add a ``basicauth`` capability when activated on the server
 
 1.12 (2016-11-18)
 '''''''''''''''''

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ copyright = u'2015-2016 — Mozilla Services'
 # built documents.
 #
 # The short X.Y version.
-version = '5.0'
+version = '5.1'
 # The full version, including alpha/beta/rc tags.
-release = '5.0.0'
+release = '5.1.0'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ iso8601==0.1.11
 jsonpatch==1.14
 jsonpointer==1.10
 jsonschema==2.5.1
-newrelic==2.74.0.54
+newrelic==2.76.0.55
 PasteDeploy==1.5.2
 psycopg2==2.6.2
 pyramid==1.7.3
@@ -18,7 +18,7 @@ pyramid-tm==1.1.1
 python-dateutil==2.6.0
 raven==5.32.0
 repoze.lru==0.6
-requests==2.12.1
+requests==2.12.4
 simplejson==3.10.0
 six==1.10.0
 SQLAlchemy==1.1.4
@@ -32,5 +32,5 @@ waitress==1.0.1
 WebOb==1.6.3
 Werkzeug==0.11.11
 zope.deprecation==4.2.0
-zope.interface==4.3.2
+zope.interface==4.3.3
 zope.sqlalchemy==0.7.7

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='5.0.1.dev0',
+      version='5.1.0',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -30,7 +30,7 @@ class GetTest(BaseTest):
         # Create another one, bump collection timestamp.
         self.model.create_record({'field': 'value'})
         self.resource.get()
-        expected = ('"%s"' % record['last_modified'])
+        expected = '"%s"' % record['last_modified']
         self.assertEqual(expected, self.last_response.headers['ETag'])
 
 
@@ -48,7 +48,7 @@ class PutTest(BaseTest):
     def test_etag_contains_record_new_timestamp(self):
         self.resource.request.validated = {'body': {'data': {'field': 'new'}}}
         new = self.resource.put()['data']
-        expected = ('"%s"' % new['last_modified'])
+        expected = '"%s"' % new['last_modified']
         self.assertEqual(expected, self.last_response.headers['ETag'])
 
     def test_returns_201_if_created(self):
@@ -145,7 +145,7 @@ class DeleteTest(BaseTest):
         record = self.model.create_record({'field': 'value'})
         self.resource.record_id = record['id']
         deleted = self.resource.delete()
-        expected = ('"%s"' % deleted['data']['last_modified'])
+        expected = '"%s"' % deleted['data']['last_modified']
         self.assertEqual(expected, self.last_response.headers['ETag'])
 
     def test_delete_record_returns_stripped_record(self):
@@ -223,13 +223,13 @@ class PatchTest(BaseTest):
         self.assertIn('ETag', self.last_response.headers)
 
     def test_etag_contains_record_new_timestamp(self):
-        expected = ('"%s"' % self.result['last_modified'])
+        expected = '"%s"' % self.result['last_modified']
         self.assertEqual(expected, self.last_response.headers['ETag'])
 
     def test_etag_contains_old_timestamp_if_no_field_changed(self):
         self.resource.request.json = {'data': {'position': 10}}
         self.resource.patch()['data']
-        expected = ('"%s"' % self.result['last_modified'])
+        expected = '"%s"' % self.result['last_modified']
         self.assertEqual(expected, self.last_response.headers['ETag'])
 
     def test_modify_record_updates_timestamp(self):


### PR DESCRIPTION
**Step 1**
- [x] ~~Wait #990~~
- [x] Wait #991
- [x] Wait for new release of kinto-admin
- [x] Upgrade kinto-admin
- [x] Update changelog
- [x] Update version in docs/conf.py
- [x] Version dependencies
- [x] If the protocol was updated, upgrade API protocol in `docs/api/index.rst` and mention the new protocol version in `CHANGELOG.rst`
- [x] Update release date in `docs/api/index.rst`

**Step 2**
- [ ] Tag vX.Y.Z
- [ ] Publish on Pypi

**Step 3**
- [ ] Close milestone in Github
- [ ] Add entry in Github release page
- [ ] Create next milestone in Github
- [ ] Configure the version in ReadTheDocs
- [ ] Check that a Docker image was built
- [ ] Send mail to ML
- [ ] Tweet!
- [ ] Deploy new version on demo server
- [ ] Upgrade dependency in `kinto-dist` repo
- [ ] Upgrade version targetted in `kinto-heroku` repo
- [ ] Upgrade version of Kinto server for the tests of clients and plugins repos
  (_kinto-http.js, kinto-http.py, kinto-attachment, etc._)