### PR TITLE
Return 404 on non-existing objects for users with read permissions (fixes #918)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Protocol is now at version **1.13**. See `API changelog`_.
   unicode data (fixes #983)
 - Add missing ``ETag`` and ``Last-Modified`` headers on ``POST`` and ``DELETE``
   responses (#980)
+- Return 404 on non-existing objects for users with read permissions (fixes #918)
 
 **New features**
 

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -64,22 +64,19 @@ class AuthorizationPolicy(object):
             permission = create_permission
 
         object_id = context.permission_object_id
-        if self.get_bound_permissions is None:
-            bound_perms = [(object_id, permission)]
-        else:
-            bound_perms = self.get_bound_permissions(object_id, permission)
+        bound_perms = self._get_bound_permissions(object_id, permission)
 
         allowed = context.check_permission(principals, bound_perms)
 
         # Here we consider that parent URI is one path level above.
-        parent_uri = '/'.join(object_id.split('/')[:-1])
+        parent_uri = '/'.join(object_id.split('/')[:-1]) if object_id else None
 
         # If not allowed to delete/patch, and target object is missing, and
         # allowed to read the parent, then view is permitted (will raise 404
         # later anyway). See Kinto/kinto#918
         is_record_unknown = not context.on_collection and context.current_record is None
         if context.required_permission == "write" and is_record_unknown:
-            bound_perms = self.get_bound_permissions(parent_uri, "read")
+            bound_perms = self._get_bound_permissions(parent_uri, "read")
             allowed = context.check_permission(principals, bound_perms)
 
         # If not allowed on this collection, but some records are shared with
@@ -100,6 +97,11 @@ class AuthorizationPolicy(object):
             allowed = shared or allowed_to_create
 
         return allowed
+
+    def _get_bound_permissions(self, object_id, permission):
+        if self.get_bound_permissions is None:
+            return [(object_id, permission)]
+        return self.get_bound_permissions(object_id, permission)
 
     def principals_allowed_by_permission(self, context, permission):
         raise NotImplementedError()  # PRAGMA NOCOVER

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -1153,7 +1153,7 @@ class ShareableResource(UserResource):
             self.model.current_principal = Everyone
         else:
             self.model.current_principal = self.request.prefixed_userid
-        self.model.effective_principals = self.request.effective_principals
+        self.model.prefixed_principals = self.request.prefixed_principals
 
         if self.context:
             self.model.get_permission_object_id = functools.partial(

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -663,7 +663,7 @@ class UserResource(object):
             except ValueError as e:
                 error_details = {
                     'location': 'body',
-                    'description': 'JSON Patch operation failed'
+                    'description': 'JSON Patch operation failed: %s' % e
                 }
                 raise_invalid(self.request, **error_details)
 

--- a/kinto/core/resource/model.py
+++ b/kinto/core/resource/model.py
@@ -244,7 +244,7 @@ class ShareableModel(Model):
         self.get_permission_object_id = None
         # Current user main principal.
         self.current_principal = None
-        self.effective_principals = None
+        self.prefixed_principals = None
 
     def _allow_write(self, perm_object_id):
         """Helper to give the ``write`` permission to the current user.
@@ -257,7 +257,7 @@ class ShareableModel(Model):
         permissions = self.permission.get_object_permissions(perm_object_id)
         # Permissions are not returned if user only has read permission.
         writers = permissions.get('write', [])
-        principals = self.effective_principals + [self.current_principal]
+        principals = self.prefixed_principals + [self.current_principal]
         if len(set(writers) & set(principals)) == 0:
             permissions = {}
         # Insert the permissions values in the response.

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -37,6 +37,7 @@ class DummyRequest(mock.MagicMock):
             'system.Everyone',
             'system.Authenticated',
             'bob']
+        self.prefixed_principals = self.effective_principals + [self.prefixed_userid]
         self.json = {}
         self.validated = {}
         self.matchdict = {}

--- a/tests/core/resource/test_object_permissions.py
+++ b/tests/core/resource/test_object_permissions.py
@@ -71,7 +71,7 @@ class ObtainRecordPermissionTest(PermissionTest):
 
     def test_permissions_are_hidden_if_user_has_only_read_permission(self):
         self.resource.model.current_principal = 'account:readonly'
-        self.resource.model.effective_principals = []
+        self.resource.model.prefixed_principals = []
         result = self.resource.get()
         self.assertEqual(result['permissions'], {})
 

--- a/tests/test_views_objects_permissions.py
+++ b/tests/test_views_objects_permissions.py
@@ -249,6 +249,17 @@ class ChildrenCreationTest(PermissionsTest):
                            {'data': {'id': 'child', 'members': []}},
                            headers=self.bob_headers_safe_creation, status=403)
 
+    def test_delete_returns_404_on_unknown_if_only_allowed_to_read(self):
+        self.app.delete('/buckets/read/groups/g1',
+                        headers=self.bob_headers,
+                        status=404)
+
+    def test_patch_returns_404_on_unknown_if_only_allowed_to_read(self):
+        self.app.patch_json('/buckets/read/groups/g1',
+                            {'data': {'members': []}},
+                            headers=self.bob_headers,
+                            status=404)
+
 
 class ParentMetadataTest(PermissionsTest):
     def setUp(self):


### PR DESCRIPTION
Fixes #918 

This introduces a new hit on the permission backend for `DELETE`, `PATCH` on an object when `write` is not allowed. 