### PR TITLE
Run tests with Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ after_success:
 
 matrix:
   include:
-    - python: 3.5
+    - python: 3.6
       env:
-        - TOX_ENV=py35
+        - TOX_ENV=py36
     - env: ACTION=loadtest_tutorial
       before_script: echo 'Tutorial'
       script: make loadtest-check-tutorial

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py27-raw,py34,py35,pypy,flake8
+envlist = py27,py27-raw,py34,py36,pypy,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
I am not sure if we should keep py34/py35 I guess we could.