### PR TITLE
Fix crash with batch endpoint when list of requests contains trailing comma (fixes #1024)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ This document describes changes between each past release.
 5.3.0 (unreleased)
 ------------------
 
+**Bug fixes**
+
+- Fix crash with batch endpoint when list of requests contains trailing comma (fixes #1024)
+
 **Internal changes**
 
 - Cache backend transactions are not bound to the request/response cycle anymore (fixes #879)

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -54,12 +54,13 @@ class BatchPayloadSchema(colander.MappingSchema):
     def deserialize(self, cstruct=colander.null):
         """Preprocess received data to carefully merge defaults.
         """
-        defaults = cstruct.get('defaults')
-        requests = cstruct.get('requests')
-        if isinstance(defaults, dict) and isinstance(requests, list):
-            for request in requests:
-                if isinstance(request, dict):
-                    merge_dicts(request, defaults)
+        if cstruct is not colander.null:
+            defaults = cstruct.get('defaults')
+            requests = cstruct.get('requests')
+            if isinstance(defaults, dict) and isinstance(requests, list):
+                for request in requests:
+                    if isinstance(request, dict):
+                        merge_dicts(request, defaults)
         return super(BatchPayloadSchema, self).deserialize(cstruct)
 
 

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -100,6 +100,11 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         resp = self.app.post_json('/batch', body, status=400)
         self.assertIn('Recursive', resp.json['message'])
 
+    def test_batch_validates_json(self):
+        body =  """{"requests": [{"path": "/v0/"},]}"""
+        resp = self.app.post('/batch', body, status=400, headers={'Content-Type': 'application/json'})
+        self.assertIn('Invalid JSON', resp.json['message'])
+
     def test_responses_are_resolved_with_api_with_prefix(self):
         request = {'path': '/'}
         body = {'requests': [request]}

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -101,8 +101,9 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         self.assertIn('Recursive', resp.json['message'])
 
     def test_batch_validates_json(self):
-        body =  """{"requests": [{"path": "/v0/"},]}"""
-        resp = self.app.post('/batch', body, status=400, headers={'Content-Type': 'application/json'})
+        body = """{"requests": [{"path": "/v0/"},]}"""
+        resp = self.app.post('/batch', body, status=400,
+                             headers={'Content-Type': 'application/json'})
         self.assertIn('Invalid JSON', resp.json['message'])
 
     def test_responses_are_resolved_with_api_with_prefix(self):


### PR DESCRIPTION
Fixes #1024

