### PR TITLE
Remove JSON Patch type from viewset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ This document describes changes between each past release.
 - Request headers and querystrings are now validated using cornice schemas (#873).
 - JSON Patch format is now validated using cornice (#880).
 - Upgraded to Kinto-Admin 1.8.0
+- Remove JSON Patch content-type from accepted types on the viewset, since it is handled
+  in a separate view (#1031).
 
 
 5.2.0 (2017-01-11)

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -11,8 +11,7 @@ from kinto.core.resource.schema import PermissionsSchema, RequestSchema
 
 CONTENT_TYPES = ["application/json"]
 
-PATCH_CONTENT_TYPES = ["application/json-patch+json",
-                       "application/merge-patch+json"]
+PATCH_CONTENT_TYPES = ["application/merge-patch+json"]
 
 
 class StrictSchema(colander.MappingSchema):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIREMENTS = [
     'ruamel.yaml',
     'transaction',
     'pyramid_tm',
-    'requests',
+    'requests < 2.13.0',
     'six',
     'structlog >= 16.1.0',
     'enum34',

--- a/tests/core/resource/__init__.py
+++ b/tests/core/resource/__init__.py
@@ -29,8 +29,9 @@ class BaseTest(unittest.TestCase):
     def tearDown(self):
         mock.patch.stopall()
 
-    def get_request(self):
+    def get_request(self, resource_name=''):
         request = DummyRequest(method='GET')
+        request.current_resource_name = resource_name
         request.registry.storage = self.storage
         return request
 


### PR DESCRIPTION
We use a separate view for handling JSON Patch, so it doesn't make much sense to keep it on the accepted types for the regular JSON view.

r? @leplatrem 
