### PR TITLE
Use nitpicky mode on documentation tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     statsd
 
 [testenv:docs]
-commands = sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+commands = sphinx-build -a -W -n -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     -rdocs/requirements.txt
 


### PR DESCRIPTION
Since we try to support and use it to compile the documentation locally, I guess it makes sense to test for it as well.