### PR TITLE
Remove pypy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,3 @@ matrix:
     - env: ACTION=loadtest_simulation
       before_script: echo 'Simulation'
       script: make loadtest-check-simulation
-    - env: TOX_ENV=pypy
-      script: if [ "${TRAVIS_BRANCH}" = "master" ]; then tox -e $TOX_ENV; else true; fi;
-  allow_failures:
-    - env: TOX_ENV=pypy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
-5.4.0 (unreleased)
+6.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Internal changes**
+
+- Remove pypy supports. (#1049)
 
 
 5.3.1 (2017-01-30)

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -162,10 +162,3 @@ memory.
 To fix this, increase the open file limit for non-root user::
 
   $ ulimit -n 1024
-
-
-ERROR: InterpreterNotFound: pypy
-================================
-
-You need to install `Pypy <http://pypy.org/>`_ so that it can be found
-by tox.

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -12,25 +12,7 @@ from binascii import hexlify
 from six.moves.urllib import parse as urlparse
 from enum import Enum
 
-# ujson is not installable with pypy
-try:  # pragma: no cover
-    import ujson as json  # NOQA
-
-    def json_serializer(v, **kw):
-        return json.dumps(v, escape_forward_slashes=False)
-
-except ImportError:  # pragma: no cover
-    import json  # NOQA
-
-    json_serializer = json.dumps
-
-try:
-    # Register psycopg2cffi as psycopg2
-    from psycopg2cffi import compat
-except ImportError:  # pragma: no cover
-    pass
-else:  # pragma: no cover
-    compat.register()
+import ujson as json  # NOQA
 
 try:
     import sqlalchemy
@@ -45,6 +27,10 @@ from pyramid.settings import aslist
 from pyramid.view import render_view_to_response
 from cornice import cors
 from colander import null
+
+
+def json_serializer(v, **kw):
+    return json.dumps(v, escape_forward_slashes=False)
 
 
 def strip_whitespace(v):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,3 @@ create-wheel = yes
 [bdist_wheel]
 # python setup.py bdist_wheel --python-tag cp2.cp3
 python_tag=cp2.cp3
-# pypy setup.py bdist_wheel --python-tag pp2.pp3
-# python_tag=pp2.pp3

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import platform
 import codecs
 import os
 from setuptools import setup, find_packages
@@ -17,8 +16,6 @@ README = read_file('README.rst')
 CHANGELOG = read_file('CHANGELOG.rst')
 CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
 
-installed_with_pypy = platform.python_implementation() == 'PyPy'
-
 REQUIREMENTS = [
     'colander',
     'colorama',
@@ -26,7 +23,7 @@ REQUIREMENTS = [
     'jsonschema',
     'jsonpatch',
     'python-dateutil',
-    'pyramid>1.7,<1.8',
+    'pyramid >1.7,<1.8',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'ruamel.yaml',
     'transaction',
@@ -36,24 +33,14 @@ REQUIREMENTS = [
     'structlog >= 16.1.0',
     'enum34',
     'waitress',
+    'ujson >= 1.35'
 ]
 
-if installed_with_pypy:
-    # We install psycopg2cffi instead of psycopg2 when dealing with pypy
-    # Note: JSONB support landed after psycopg2cffi 2.7.0
-    POSTGRESQL_REQUIRES = [
-        'SQLAlchemy',
-        'psycopg2cffi>2.7.0',
-        'zope.sqlalchemy',
-    ]
-else:
-    # ujson is not pypy compliant, as it uses the CPython C API
-    REQUIREMENTS.append('ujson >= 1.35')
-    POSTGRESQL_REQUIRES = [
-        'SQLAlchemy',
-        'psycopg2>2.5',
-        'zope.sqlalchemy',
-    ]
+POSTGRESQL_REQUIRES = [
+    'SQLAlchemy',
+    'psycopg2 > 2.5',
+    'zope.sqlalchemy',
+]
 
 REDIS_REQUIRES = [
     'kinto_redis'
@@ -102,7 +89,6 @@ setup(name='kinto',
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: Implementation :: CPython",
-          "Programming Language :: Python :: Implementation :: PyPy",
           "Topic :: Internet :: WWW/HTTP",
           "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
           "License :: OSI Approved :: Apache Software License"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py27-raw,py34,py36,pypy,flake8
+envlist = py27,py27-raw,py34,py36,flake8
 skip_missing_interpreters = True
 
 [testenv]
@@ -36,15 +36,6 @@ deps =
     pytest-sugar
     webtest
     werkzeug
-
-[testenv:pypy]
-passenv = TRAVIS
-deps =
-    -rdev-requirements.txt
-    psycopg2cffi
-    newrelic
-    raven
-    statsd
 
 [testenv:docs]
 commands = sphinx-build -a -W -n -b html -d docs/_build/doctrees docs docs/_build/html


### PR DESCRIPTION
Remove PYPY supports.

This is the first step before removing supports for py27 alltogether.