### PR TITLE
Fix crash on If-Match: * (fixes #1063)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Prevent injections in the PostgreSQL permission backend
+- Fix crash on ``If-Match: *``
 
 **Internal changes**
 

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -838,7 +838,7 @@ class UserResource(object):
                 # Tombstones should not prevent creation.
                 return
             modified_since = -1  # Always raise.
-        elif if_match:
+        elif if_match and if_match != '*':
             modified_since = if_match
         else:
             # In case _raise_304_if_not_modified() did not raise.

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -196,6 +196,14 @@ class ModifiedMeanwhileTest(BaseTest):
                 'field': 'new'}}
         self.resource.collection_post()  # not raising.
 
+    def test_post_if_match_star_succeeds_if_record_does_exist(self):
+        self.validated['header']['If-Match'] = '*'
+        self.validated['body'] = {
+            'data': {
+                'id': self.resource.model.id_generator(),
+                'field': 'new'}}
+        self.resource.collection_post()  # not raising.
+
     def test_patch_returns_412_if_changed_meanwhile(self):
         self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,


### PR DESCRIPTION
Fixes #1063 

Fix crash and previous '400' by always ignoring precondition If-Match:*

- [x] Add tests.
- [x] Add a changelog entry.
