### PR TITLE
Nit: simplify HeaderQuotedInteger validator

### DIFF
--- a/kinto/core/schema.py
+++ b/kinto/core/schema.py
@@ -107,9 +107,8 @@ class HeaderQuotedInteger(HeaderField):
     """Integer between "" used in precondition headers."""
 
     schema_type = colander.String
-    error_message = "The value should be integer between double quotes"
-    validator = colander.Any(colander.Regex('^"([0-9]+?)"$', msg=error_message),
-                             colander.Regex('\*'))
+    error_message = "The value should be integer between double quotes."
+    validator = colander.Regex('^"([0-9]+?)"$|\*', msg=error_message)
 
     def deserialize(self, cstruct=colander.null):
         param = super(HeaderQuotedInteger, self).deserialize(cstruct)

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -150,9 +150,8 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
         body = {'requests': [request, request]}
         resp = self.app.post_json('/batch', body, status=200)
         self.assertEqual(resp.json['responses'][1]['status'], 400)
-        self.assertEqual(resp.json['responses'][1]['body']['message'],
-                         ('If-Match in header: The value should be integer between '
-                          'double quotes; String does not match expected pattern'))
+        msg = 'If-Match in header: The value should be integer between double quotes.'
+        self.assertEqual(resp.json['responses'][1]['body']['message'], msg)
 
     def test_412_errors_are_forwarded(self):
         headers = self.headers.copy()


### PR DESCRIPTION
Swagger doesn't support Any type validators, so makes sense to use a composite regex instead.

Related to #1033 
