### PR TITLE
Fix DeprecationWarning message

### DIFF
--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -11,7 +11,7 @@ class TimeStamp(TimeStamp):
     """This schema is deprecated, you shoud use `kinto.core.schema.TimeStamp` instead."""
 
     def __init__(self, *args, **kwargs):
-        message = ("`kinto.core.resource.schema.TimeStamp` is deprecated, ",
+        message = ("`kinto.core.resource.schema.TimeStamp` is deprecated, "
                    "use `kinto.core.schema.TimeStamp` instead.")
         warnings.warn(message, DeprecationWarning)
         super(TimeStamp, self).__init__(*args, **kwargs)
@@ -21,7 +21,7 @@ class URL(URL):
     """This schema is deprecated, you shoud use `kinto.core.schema.URL` instead."""
 
     def __init__(self, *args, **kwargs):
-        message = ("`kinto.core.resource.schema.URL` is deprecated, ",
+        message = ("`kinto.core.resource.schema.URL` is deprecated, "
                    "use `kinto.core.schema.URL` instead.")
         warnings.warn(message, DeprecationWarning)
         super(URL, self).__init__(*args, **kwargs)

--- a/tests/core/resource/test_schema.py
+++ b/tests/core/resource/test_schema.py
@@ -11,14 +11,14 @@ class DepracatedSchemasTest(unittest.TestCase):
     def test_resource_timestamp_is_depracated(self):
         with mock.patch('kinto.core.resource.schema.warnings') as mocked:
             schema.TimeStamp()
-            message = ("`kinto.core.resource.schema.TimeStamp` is deprecated, ",
+            message = ("`kinto.core.resource.schema.TimeStamp` is deprecated, "
                        "use `kinto.core.schema.TimeStamp` instead.")
             mocked.warn.assert_called_with(message, DeprecationWarning)
 
     def test_resource_URL_is_depracated(self):
         with mock.patch('kinto.core.resource.schema.warnings') as mocked:
             schema.URL()
-            message = ("`kinto.core.resource.schema.URL` is deprecated, ",
+            message = ("`kinto.core.resource.schema.URL` is deprecated, "
                        "use `kinto.core.schema.URL` instead.")
             mocked.warn.assert_called_with(message, DeprecationWarning)
 


### PR DESCRIPTION
Fixes: https://github.com/mozilla-services/kinto-fxa/issues/46

Message was a tuple instead of a string, which raises a problem with Python 2.x.
