### PR TITLE
Prevent 500 if timestamp is to big in QueryString.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,13 @@ This document describes changes between each past release.
 
 **Breaking changes**
 
-- Upgraded to PostgreSQL 9.5
+- Upgraded to PostgreSQL 9.5  (#1056)
 
 **Bug fixes**
 
-- Prevent injections in the PostgreSQL permission backend
-- Fix crash on ``If-Match: *``
+- Prevent injections in the PostgreSQL permission backend. (#1061)
+- Fix crash on ``If-Match: *`` (#1064)
+- Handle Integer overflow in querystring parameters. (#1076)
 
 **Internal changes**
 
@@ -27,7 +28,7 @@ This document describes changes between each past release.
 - Request schemas (including validation and deserialization) are now isolated by method
   and endpoint type (#1047).
 - Move generic API schemas (e.g TimeStamps and HeaderFields) from `kinto.core.resource.schema`
-  to a sepate file on `kinto.core.schema`.
+  to a sepate file on `kinto.core.schema`. (#1054)
 
 
 5.3.2 (2017-01-31)

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -212,18 +212,19 @@ class QuerySchema(colander.MappingSchema):
 class CollectionQuerySchema(QuerySchema):
     """Querystring schema used with collections."""
 
-    _limit = QueryField(colander.Integer())
+    _limit = QueryField(colander.Integer(),
+                        validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
     _sort = FieldList()
     _token = QueryField(colander.String())
     _since = QueryField(colander.Integer(),
-                        validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
+                        validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
     _to = QueryField(colander.Integer(),
-                     validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
+                     validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
     _before = QueryField(colander.Integer(),
-                         validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
+                         validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
     id = QueryField(colander.String())
     last_modified = QueryField(colander.Integer(),
-                               validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
+                               validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
 
 
 class RecordGetQuerySchema(QuerySchema):

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -6,6 +6,8 @@ from kinto.core.schema import (Any, HeaderField, QueryField, HeaderQuotedInteger
                                FieldList, TimeStamp, URL)
 from kinto.core.utils import native_value
 
+POSTGRESQL_MAX_INTEGER_VALUE = 9223372036854775807
+
 
 class TimeStamp(TimeStamp):
     """This schema is deprecated, you shoud use `kinto.core.schema.TimeStamp` instead."""
@@ -213,11 +215,15 @@ class CollectionQuerySchema(QuerySchema):
     _limit = QueryField(colander.Integer())
     _sort = FieldList()
     _token = QueryField(colander.String())
-    _since = QueryField(colander.Integer())
-    _to = QueryField(colander.Integer())
-    _before = QueryField(colander.Integer())
+    _since = QueryField(colander.Integer(),
+                        validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
+    _to = QueryField(colander.Integer(),
+                     validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
+    _before = QueryField(colander.Integer(),
+                         validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
     id = QueryField(colander.String())
-    last_modified = QueryField(colander.Integer())
+    last_modified = QueryField(colander.Integer(),
+                               validator=colander.Range(max=POSTGRESQL_MAX_INTEGER_VALUE))
 
 
 class RecordGetQuerySchema(QuerySchema):

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -6,7 +6,9 @@ from kinto.core.schema import (Any, HeaderField, QueryField, HeaderQuotedInteger
                                FieldList, TimeStamp, URL)
 from kinto.core.utils import native_value
 
-POSTGRESQL_MAX_INTEGER_VALUE = 9223372036854775807
+POSTGRESQL_MAX_INTEGER_VALUE = 2**64 / 2
+
+POSITIVE_BIG_INTEGER = colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE)
 
 
 class TimeStamp(TimeStamp):
@@ -212,19 +214,14 @@ class QuerySchema(colander.MappingSchema):
 class CollectionQuerySchema(QuerySchema):
     """Querystring schema used with collections."""
 
-    _limit = QueryField(colander.Integer(),
-                        validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
+    _limit = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
     _sort = FieldList()
     _token = QueryField(colander.String())
-    _since = QueryField(colander.Integer(),
-                        validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
-    _to = QueryField(colander.Integer(),
-                     validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
-    _before = QueryField(colander.Integer(),
-                         validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
+    _since = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
+    _to = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
+    _before = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
     id = QueryField(colander.String())
-    last_modified = QueryField(colander.Integer(),
-                               validator=colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE))
+    last_modified = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
 
 
 class RecordGetQuerySchema(QuerySchema):

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import warnings
 
 import colander
@@ -6,9 +7,9 @@ from kinto.core.schema import (Any, HeaderField, QueryField, HeaderQuotedInteger
                                FieldList, TimeStamp, URL)
 from kinto.core.utils import native_value
 
-POSTGRESQL_MAX_INTEGER_VALUE = 2**64 / 2
+POSTGRESQL_MAX_INTEGER_VALUE = 2**64 // 2
 
-POSITIVE_BIG_INTEGER = colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE)
+positive_big_integer = colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE)
 
 
 class TimeStamp(TimeStamp):
@@ -214,14 +215,14 @@ class QuerySchema(colander.MappingSchema):
 class CollectionQuerySchema(QuerySchema):
     """Querystring schema used with collections."""
 
-    _limit = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
+    _limit = QueryField(colander.Integer(), validator=positive_big_integer)
     _sort = FieldList()
     _token = QueryField(colander.String())
-    _since = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
-    _to = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
-    _before = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
+    _since = QueryField(colander.Integer(), validator=positive_big_integer)
+    _to = QueryField(colander.Integer(), validator=positive_big_integer)
+    _before = QueryField(colander.Integer(), validator=positive_big_integer)
     id = QueryField(colander.String())
-    last_modified = QueryField(colander.Integer(), validator=POSITIVE_BIG_INTEGER)
+    last_modified = QueryField(colander.Integer(), validator=positive_big_integer)
 
 
 class RecordGetQuerySchema(QuerySchema):

--- a/tests/core/resource/test_filter.py
+++ b/tests/core/resource/test_filter.py
@@ -1,7 +1,6 @@
 from pyramid import httpexceptions
 
 from kinto.core.errors import ERRORS
-from kinto.core.resource.schema import POSTGRESQL_MAX_INTEGER_VALUE
 from . import BaseTest
 
 

--- a/tests/core/resource/test_filter.py
+++ b/tests/core/resource/test_filter.py
@@ -1,6 +1,7 @@
 from pyramid import httpexceptions
 
 from kinto.core.errors import ERRORS
+from kinto.core.resource.schema import POSTGRESQL_MAX_INTEGER_VALUE
 from . import BaseTest
 
 

--- a/tests/core/resource/test_schema.py
+++ b/tests/core/resource/test_schema.py
@@ -294,7 +294,7 @@ class CollectionQuerySchemaTest(unittest.TestCase):
 
     def setUp(self):
         self.schema = schema.CollectionQuerySchema()
-        self.record = {
+        self.querystring = {
             '_limit': '2',
             '_sort': 'toto,tata',
             '_token': 'abc',
@@ -305,8 +305,8 @@ class CollectionQuerySchemaTest(unittest.TestCase):
             'last_modified': '9874'
         }
 
-    def test_decode_valid_record(self):
-        deserialized = self.schema.deserialize(self.record)
+    def test_decode_valid_querystring(self):
+        deserialized = self.schema.deserialize(self.querystring)
         self.assertEquals(deserialized, {
             '_limit': 2,
             '_sort': ['toto', 'tata'],
@@ -318,22 +318,52 @@ class CollectionQuerySchemaTest(unittest.TestCase):
             'last_modified': 9874
         })
 
+    def test_raises_invalid_for_to_big_integer_in_limit(self):
+        querystring = self.querystring.copy()
+        querystring['_limit'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
+
     def test_raises_invalid_for_to_big_integer_in_since(self):
-        record = self.record.copy()
-        record['_since'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
-        self.assertRaises(colander.Invalid, self.schema.deserialize, record)
+        querystring = self.querystring.copy()
+        querystring['_since'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_to(self):
-        record = self.record.copy()
-        record['_to'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
-        self.assertRaises(colander.Invalid, self.schema.deserialize, record)
+        querystring = self.querystring.copy()
+        querystring['_to'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_before(self):
-        record = self.record.copy()
-        record['_before'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
-        self.assertRaises(colander.Invalid, self.schema.deserialize, record)
+        querystring = self.querystring.copy()
+        querystring['_before'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_last_modified(self):
-        record = self.record.copy()
-        record['last_modified'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
-        self.assertRaises(colander.Invalid, self.schema.deserialize, record)
+        querystring = self.querystring.copy()
+        querystring['last_modified'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
+
+    def test_raises_invalid_for_negative_integer_in_limit(self):
+        querystring = self.querystring.copy()
+        querystring['_limit'] = -1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
+
+    def test_raises_invalid_for_negative_integer_in_since(self):
+        querystring = self.querystring.copy()
+        querystring['_since'] = -1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
+
+    def test_raises_invalid_for_negative_integer_in_to(self):
+        querystring = self.querystring.copy()
+        querystring['_to'] = -1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
+
+    def test_raises_invalid_for_negative_integer_in_before(self):
+        querystring = self.querystring.copy()
+        querystring['_before'] = -1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
+
+    def test_raises_invalid_for_negative_integer_in_last_modified(self):
+        querystring = self.querystring.copy()
+        querystring['last_modified'] = -1
+        self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)


### PR DESCRIPTION
Fixes #1067 

- [x] Add tests.
- [x] Add a changelog entry.

r? @leplatrem
