### PR TITLE
enable branch coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ create-wheel = yes
 [bdist_wheel]
 # python setup.py bdist_wheel --python-tag cp2.cp3
 python_tag=cp2.cp3
+
+[coverage:run]
+branch = True


### PR DESCRIPTION
Enables branch coverage with py.test and hopefully catch some bugs in the future or make no-cov situations explicit.

The current output of `make tests-once` on [this branch](b2ee23c40229583fef5231c75f34ecc85f621a5f):

```
---------- coverage: platform darwin, python 2.7.10-final-0 ----------
Name                                           Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------------
kinto/__init__.py                                 32      0      8      0   100%
kinto/__main__.py                                 89      0     32      1    99%   156->159
kinto/authorization.py                            43      0     16      0   100%
kinto/config/__init__.py                          44      0      6      0   100%
kinto/core/__init__.py                            53      0      8      0   100%
kinto/core/authentication.py                      22      0      4      0   100%
kinto/core/authorization.py                      127      0     44      1    99%   30->34
kinto/core/cache/__init__.py                      34      0      2      0   100%
kinto/core/cache/memory.py                        59      0     13      1    99%   41->exit
kinto/core/cache/postgresql/__init__.py           66      0     10      0   100%
kinto/core/cache/testing.py                      133      0      4      0   100%
kinto/core/decorators.py                          29      0      4      0   100%
kinto/core/errors.py                              66      0     18      0   100%
kinto/core/events.py                              94      0     36      2    98%   81->exit, 148->152
kinto/core/initialization.py                     325      0     84      1    99%   567->571
kinto/core/listeners/__init__.py                   5      0      0      0   100%
kinto/core/logs.py                                56      0     16      0   100%
kinto/core/permission/__init__.py                 52      0      2      0   100%
kinto/core/permission/memory.py                  116      0     46      1    99%   44->exit
kinto/core/cache/postgresql/__init__.py           66      0     10      0   100%
kinto/core/cache/testing.py                      133      0      4      0   100%
kinto/core/decorators.py                          29      0      4      0   100%
kinto/core/errors.py                              66      0     18      0   100%
kinto/core/events.py                              94      0     36      2    98%   81->exit, 148->152
kinto/core/initialization.py                     325      0     84      1    99%   567->571
kinto/core/listeners/__init__.py                   5      0      0      0   100%
kinto/core/logs.py                                56      0     16      0   100%
kinto/core/permission/__init__.py                 52      0      2      0   100%
kinto/core/permission/memory.py                  116      0     46      1    99%   44->exit
kinto/core/permission/postgresql/__init__.py     177      0     46      0   100%
kinto/core/permission/testing.py                 314      0     10      1    99%   24->26
kinto/core/resource/__init__.py                  525      0    168      3    99%   703->706, 852->exit, 912->915
kinto/core/resource/model.py                      85      0      4      0   100%
kinto/core/resource/schema.py                    144      0     28      1    99%   201->197
kinto/core/resource/viewset.py                   107      0     12      0   100%
kinto/core/schema.py                              53      0     10      1    98%   38->40
kinto/core/scripts.py                             46      0     10      1    98%   22->21
kinto/core/statsd.py                              41      0     12      0   100%
kinto/core/storage/__init__.py                    52      0      4      0   100%
kinto/core/storage/exceptions.py                  16      0      2      0   100%
kinto/core/storage/generators.py                  21      0      4      0   100%
kinto/core/storage/memory.py                     201      0     85      1    99%   368->372
kinto/core/storage/postgresql/__init__.py        325      0     94      2    99%   101->105, 127->113
kinto/core/storage/postgresql/client.py           63      0     18      1    99%   15->exit
kinto/core/storage/postgresql/pool.py             25      0      4      0   100%
kinto/core/storage/testing.py                    763      0     46      0   100%
kinto/core/testing.py                            108      0      8      2    98%   75->78, 166->169
kinto/core/utils.py                              252      0     82      6    98%   81->exit, 167->161, 223->226, 283->285, 287->290, 515->514
kinto/core/views/__init__.py                       0      0      0      0   100%
kinto/core/views/batch.py                         67      0     18      1    99%   62->61
kinto/core/views/errors.py                        66      0     24      0   100%
kinto/core/views/heartbeat.py                     38      0     10      0   100%
kinto/core/views/hello.py                         21      0      6      0   100%
kinto/core/views/swagger.py                       48      0     14      3    95%   47->45, 69->75, 81->79
kinto/core/views/version.py                       22      0      4      0   100%
kinto/events.py                                    3      0      0      0   100%
kinto/plugins/__init__.py                          0      0      0      0   100%
kinto/plugins/admin/__init__.py                   14      0      0      0   100%
kinto/plugins/admin/views.py                      10      0      0      0   100%
kinto/plugins/default_bucket/__init__.py         105      0     20      0   100%
kinto/plugins/history/__init__.py                 12      0      2      0   100%
kinto/plugins/history/listener.py                 71      0     22      0   100%
kinto/plugins/history/views.py                    32      0      8      0   100%
kinto/plugins/quotas/__init__.py                   9      0      2      0   100%
kinto/plugins/quotas/listener.py                 128      0     54      1    99%   160->133
kinto/plugins/quotas/utils.py                      4      0      0      0   100%
kinto/views/__init__.py                           22      0      0      0   100%
kinto/views/buckets.py                            19      0      4      0   100%
kinto/views/collections.py                        39      0      6      0   100%
kinto/views/contribute.py                          5      0      0      0   100%
kinto/views/flush.py                              12      0      0      0   100%
kinto/views/groups.py                             38      0     14      0   100%
kinto/views/permissions.py                        90      0     34      0   100%
kinto/views/records.py                            68      0     12      0   100%
------------------------------------------------------------------------------------------
TOTAL                                           5706      0   1254     31    99%
```

Kinto core is actually really close to having full branch coverage.

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.

r? @Natim or @leplatrem