### PR TITLE
Return JSON on __flush__ endpoint (fixes #1098)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ This document describes changes between each past release.
 - Prevent injections in the PostgreSQL permission backend (#1061)
 - Fix crash on ``If-Match: *`` (#1064)
 - Handle Integer overflow in querystring parameters. (#1076)
+- Flush endpoint now returns an empty JSON object instad of an HTML page (#1098)
 
 **Internal changes**
 

--- a/kinto/views/flush.py
+++ b/kinto/views/flush.py
@@ -1,5 +1,4 @@
 from cornice import Service
-from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from kinto.events import ServerFlushed
@@ -16,4 +15,6 @@ def flush_post(request):
     request.registry.cache.flush()
     event = ServerFlushed(request)
     request.registry.notify(event)
-    return httpexceptions.HTTPAccepted()
+
+    request.response.status = 202
+    return {}

--- a/tests/test_views_flush.py
+++ b/tests/test_views_flush.py
@@ -95,3 +95,7 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
         app = self.make_app(settings=extra)
         app.post('/__flush__', headers=self.headers)
         os.environ.pop('KINTO_FLUSH_ENDPOINT_ENABLED')
+
+    def test_flush_returns_json(self):
+        response = self.app.post('/__flush__', headers=self.headers, status=202)
+        self.assertEquals(response.json, {})


### PR DESCRIPTION
Fixes #1098 

Make `__flush__` return an empty JSON object instead of an HTML page to make it consistent with the rest of the API.

- [x] Add tests.
- [x] Add a changelog entry.

