### PR TITLE
Clarify If-Match behavior (fixes #1072)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ This document describes changes between each past release.
 6.0.0 (unreleased)
 ------------------
 
+**Protocol**
+
+- Fixed ``If-Match`` behavior to match the RFC 2616 specification (#1102).
+
+Protocol is now at version **1.15**. See `API changelog`_.
+
 **Breaking changes**
 
 - Remove Python 2.7 support and upgrade to Python 3.5. (#1050)

--- a/docs/api/1.x/timestamps.rst
+++ b/docs/api/1.x/timestamps.rst
@@ -81,27 +81,42 @@ the ``If-None-Match: *`` request header.
 
 The following table gives a summary of the expected behaviour of a resource:
 
-+-----------------------------+-------------+--------------+---------------+---------------+
-|                             | POST        | PUT          | PATCH         | DELETE        |
-+=============================+=============+==============+===============+===============+
-|| **If-Match: "timestamp"**                                                               |
-+-----------------------------+-------------+--------------+---------------+---------------+
-| Changed meanwhile           | ``HTTP 412``| ``HTTP 412`` | ``HTTP 412``  | ``HTTP 412``  |
-+-----------------------------+-------------+--------------+---------------+---------------+
-| Not changed                 | Create      | Overwrite    | Modify        | Delete        |
-+-----------------------------+-------------+--------------+---------------+---------------+
-|| **If-None-Match: ***                                                                    |
-+-----------------------------+-------------+--------------+---------------+---------------+
-| Id exists                   | ``HTTP 412``| ``HTTP 412`` | No effect     | No effect     |
-+-----------------------------+-------------+--------------+---------------+---------------+
-| Id unknown                  | Create      | Create       | No effect     | No effect     |
-+-----------------------------+-------------+--------------+---------------+---------------+
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+|                             | GET         | POST        | PUT         | PATCH       | DELETE      |
++=============================+=============+=============+=============+=============+=============+
+|| **If-Match: "timestamp"**                                                                        |
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+| Not changed                 | Fetch       | Fetch       | Overwrite   | Modify      | Delete      |
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+| Changed meanwhile           | ``HTTP 412``| ``HTTP 412``| ``HTTP 412``| ``HTTP 412``| ``HTTP 412``|
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+|| **If-Match: ***                                                                                  |
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+| Id exists                   | Fetch       | Fetch       | Overwrite   | Modify      | Delete      |
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+| Id unknown                  | ``HTTP 412``| ``HTTP 412``| ``HTTP 412``| ``HTTP 412``| ``HTTP 412``|
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+|| **If-None-Match: ***                                                                             |
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+| Id exists                   | ``HTTP 412``| ``HTTP 412``| ``HTTP 412``| ``HTTP 412``| ``HTTP 412``|
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+| Id unknown                  | No effect   | Create      | Create      | No effect   | No effect   |
++-----------------------------+-------------+-------------+-------------+-------------+-------------+
+
 
 When the client receives a |status-412|, it can then choose to:
 
 * overwrite by repeating the request without concurrency control;
 * reconcile the resource by fetching, merging and repeating the request.
 
+
+.. note::
+
+    ``If-Match`` and ``If-None-Match`` headers on Kinto work slightly different
+    from what `the specification expects <https://tools.ietf.org/html/rfc7232#section-3>`_
+    for these precondition headers. Instead of comparing if ``ETag`` is exactly the
+    same, as the specification suggests, it just checks if the ``ETag`` is newer
+    or older in order to simplify the synchronization behavior.
 
 Replication
 ===========

--- a/docs/api/1.x/timestamps.rst
+++ b/docs/api/1.x/timestamps.rst
@@ -110,15 +110,6 @@ When the client receives a |status-412|, it can then choose to:
 * reconcile the resource by fetching, merging and repeating the request.
 
 
-.. note::
-
-    ``If-Match`` and ``If-None-Match`` headers on Kinto work slightly different from what
-    `their RFC specification expects <https://tools.ietf.org/html/rfc7232#section-3>`_.
-    Instead of comparing if the current
-    ``ETag`` is exactly the same as the value provided on the header,
-    the current implementation just checks if the ``ETag`` is newer or older
-    in order to simplify the synchronization behavior on clients.
-
 Replication
 ===========
 

--- a/docs/api/1.x/timestamps.rst
+++ b/docs/api/1.x/timestamps.rst
@@ -112,11 +112,12 @@ When the client receives a |status-412|, it can then choose to:
 
 .. note::
 
-    ``If-Match`` and ``If-None-Match`` headers on Kinto work slightly different
-    from what `the specification expects <https://tools.ietf.org/html/rfc7232#section-3>`_
-    for these precondition headers. Instead of comparing if ``ETag`` is exactly the
-    same, as the specification suggests, it just checks if the ``ETag`` is newer
-    or older in order to simplify the synchronization behavior.
+    ``If-Match`` and ``If-None-Match`` headers on Kinto work slightly different from what
+    `their RFC specification expects <https://tools.ietf.org/html/rfc7232#section-3>`_.
+    Instead of comparing if the current
+    ``ETag`` is exactly the same as the value provided on the header,
+    the current implementation just checks if the ``ETag`` is newer or older
+    in order to simplify the synchronization behavior on clients.
 
 Replication
 ===========

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,7 +11,14 @@ API
 Changelog
 ---------
 
-1.14 (Unreleased)
+1.15 (Unreleased)
+'''''''''''''''''
+- ``If-Match`` and ``If-None-Match`` precondition headers now check if ``ETag`` is
+  equal or not equal to the provided value (as in RFC 2616). Previous versions
+  asserted then to be greater or lower.
+- ``If-Match`` now raises ``412`` if a record doesn't exist.
+
+1.14 (2017-01-11)
 '''''''''''''''''
 
 - Add an OpenAPI 2.0 specification on ``GET /__api__`` endpoint.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,9 +13,9 @@ Changelog
 
 1.15 (Unreleased)
 '''''''''''''''''
-- ``If-Match`` and ``If-None-Match`` precondition headers now check if ``ETag`` is
-  equal or not equal to the provided value (as in RFC 2616). Previous versions
-  asserted then to be greater or lower.
+- If-Match and If-None-Match precondition headers now check the ETag for
+  strict equality. Previous versions would allow requests if they seemed
+  to be more recent than the current version.
 - ``If-Match`` now raises ``412`` if a record doesn't exist.
 
 1.14 (2017-01-11)

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -13,7 +13,7 @@ from kinto.authorization import RouteFactory
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # Implemented HTTP API Version
-HTTP_API_VERSION = '1.14'
+HTTP_API_VERSION = '1.15'
 
 # Main kinto logger
 logger = logging.getLogger(__name__)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -815,7 +815,7 @@ class UserResource:
         else:
             current_timestamp = self.model.timestamp()
 
-        if current_timestamp <= if_none_match:
+        if current_timestamp == if_none_match:
             response = HTTPNotModified()
             self._add_timestamp_header(response, timestamp=current_timestamp)
             raise response
@@ -858,7 +858,7 @@ class UserResource:
         else:
             current_timestamp = self.model.timestamp()
 
-        if current_timestamp > modified_since:
+        if current_timestamp != modified_since:
             error_msg = 'Resource was modified meanwhile'
             details = {'existing': record} if record else {}
             response = http_error(HTTPPreconditionFailed(),

--- a/tests/core/resource/test_model.py
+++ b/tests/core/resource/test_model.py
@@ -62,6 +62,7 @@ class DeleteModelTest(BaseTest):
 class IsolatedModelsTest(BaseTest):
     def setUp(self):
         super().setUp()
+        self.resource.request.validated = {'header': {}, 'querystring': {}}
         self.stored = self.model.create_record({}, parent_id='bob')
         self.resource.record_id = self.stored['id']
 
@@ -81,7 +82,7 @@ class IsolatedModelsTest(BaseTest):
         self.assertEquals(len(records), 0)
 
     def test_update_record_of_another_user_will_create_it(self):
-        self.resource.request.validated = {'body': {'data': {'some': 'record'}}}
+        self.resource.request.validated['body'] = {'data': {'some': 'record'}}
         self.resource.put()
         self.model.get_record(record_id=self.stored['id'],
                               parent_id='basicauth:alice')  # not raising

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -54,11 +54,18 @@ class NotModifiedTest(BaseTest):
 class ModifiedMeanwhileTest(BaseTest):
     def setUp(self):
         super().setUp()
+
+        # Create a record using model (will have an incremented last_modified)
         self.stored = self.model.create_record({})
-        self.resource.collection_get()
+        # Update the record we just created (will set last_modified with the server ETag)
+        self.resource.record_id = self.stored['id']
+        self.resource.put()
+        # Update our record with last_modified provided by the server
+        self.stored['last_modified'] = int(self.last_response.headers['ETag'][1:-1])
+
         self.validated = self.resource.request.validated
-        current = self.last_response.headers['ETag'][1:-1]
-        previous = int(current) - 10
+        self.current = int(self.last_response.headers['ETag'][1:-1])
+        previous = self.current - 10
         self.validated['header']['If-Match'] = previous
 
     def test_preconditions_errors_are_json_formatted(self):
@@ -76,9 +83,13 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.collection_get)
 
-    def test_collection_returns_200_if_if_match_is_superior(self):
-        current = self.last_response.headers['ETag'][1:-1]
-        self.validated['header']['If-Match'] = int(current) + 10
+    def test_collection_returns_412_if_if_match_is_superior(self):
+        self.validated['header']['If-Match'] = self.current + 10
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
+                          self.resource.collection_get)
+
+    def test_collection_returns_200_if_if_match_is_equal(self):
+        self.validated['header']['If-Match'] = self.current
         self.resource.collection_get()
 
     def test_412_errors_on_collection_do_not_provide_existing_record(self):
@@ -97,21 +108,20 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertIsNotNone(error.headers.get('Last-Modified'))
 
     def test_412_errors_on_record_provide_existing_data(self):
-        self.resource.record_id = self.stored['id']
         try:
             self.resource.put()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertEqual(error.json['details']['existing'],
-                         self.stored)
+        print(error.json['details']['existing'])
+        print(self.stored)
+        self.assertDictEqual(error.json['details']['existing'],
+                             self.stored)
 
     def test_single_record_returns_412_if_changed_meanwhile(self):
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.get)
 
     def test_412_on_single_record_has_last_modified_timestamp(self):
-        self.resource.record_id = self.stored['id']
         try:
             self.resource.get()
         except httpexceptions.HTTPPreconditionFailed as e:
@@ -125,7 +135,6 @@ class ModifiedMeanwhileTest(BaseTest):
                           self.resource.collection_post)
 
     def test_put_returns_412_if_changed_meanwhile(self):
-        self.resource.record_id = self.stored['id']
         self.model.delete_record(self.stored)
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
@@ -133,7 +142,6 @@ class ModifiedMeanwhileTest(BaseTest):
     def test_put_returns_412_if_changed_and_none_match_present(self):
         self.validated['body'] = {'data': {'field': 'new'}}
         self.validated['header']['If-None-Match'] = 42
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
@@ -147,21 +155,18 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertNotIn('1970', error.headers['Last-Modified'])
 
     def test_put_returns_412_if_deleted_meanwhile(self):
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
     def test_put_if_none_match_star_fails_if_record_exists(self):
         self.validated['header'].pop('If-Match')
         self.validated['header']['If-None-Match'] = '*'
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
     def test_get_if_none_match_star_fails_if_record_exists(self):
         self.validated['header'].pop('If-Match')
         self.validated['header']['If-None-Match'] = '*'
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.get)
 
@@ -177,7 +182,6 @@ class ModifiedMeanwhileTest(BaseTest):
         self.validated['header'].pop('If-Match')
         self.validated['header']['If-None-Match'] = '*'
         self.validated['body'] = {'data': {'field': 'new'}}
-        self.resource.record_id = self.stored['id']
         self.resource.put()  # not raising.
 
     def test_post_if_none_match_star_fails_if_record_exists(self):
@@ -228,7 +232,6 @@ class ModifiedMeanwhileTest(BaseTest):
 
     def test_put_if_match_star_succeeds_if_record_exists(self):
         self.validated['header']['If-Match'] = '*'
-        self.resource.record_id = self.stored['id']
         self.resource.put()
 
     def test_patch_if_match_star_succeeds_if_record_exists(self):
@@ -238,12 +241,10 @@ class ModifiedMeanwhileTest(BaseTest):
                 'id': self.stored['id'],
                 'field': 'new'}}
         self.validated['body'] = self.resource.request.json
-        self.resource.record_id = self.stored['id']
         self.resource.patch()
 
     def test_delete_if_match_star_succeeds_if_record_exists(self):
         self.validated['header']['If-Match'] = '*'
-        self.resource.record_id = self.stored['id']
         self.resource.delete()
 
     def test_put_if_match_star_fails_if_record_does_not_exist(self):
@@ -255,10 +256,15 @@ class ModifiedMeanwhileTest(BaseTest):
                           self.resource.put)
 
     def test_put_if_fails_if_record_does_not_exist(self):
-        self.validated['header']['If-Match'] += 10  # wouldn't raise on existing
+        self.validated['header']['If-Match'] = self.current  # wouldn't raise on existing
         self.resource.request.json = {'data': {'field': 'new'}}
         self.validated['body'] = self.resource.request.json
         self.resource.record_id = self.resource.model.id_generator()
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
+                          self.resource.put)
+
+    def test_put_if_fails_if_if_match_is_superior(self):
+        self.validated['header']['If-Match'] += self.current + 10
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
@@ -271,13 +277,11 @@ class ModifiedMeanwhileTest(BaseTest):
         self.resource.collection_delete()
 
     def test_patch_returns_412_if_changed_meanwhile(self):
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.patch)
 
     def test_patch_returns_last_modified_if_changed_meanwhile(self):
         self.resource.timestamp = 0
-        self.resource.record_id = self.stored['id']
         try:
             self.resource.patch()
         except httpexceptions.HTTPPreconditionFailed as e:
@@ -285,7 +289,6 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertNotIn('1970', error.headers['Last-Modified'])
 
     def test_delete_returns_412_if_changed_meanwhile(self):
-        self.resource.record_id = self.stored['id']
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.delete)
 

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -243,7 +243,7 @@ class ModifiedMeanwhileTest(BaseTest):
                           self.resource.put)
 
     def test_put_if_fails_if_record_does_not_exist(self):
-        self.validated['header']['If-Match'] = '123'
+        self.validated['header']['If-Match'] += 10  # wouldn't raise on existing
         self.resource.request.json = {'data': {'field': 'new'}}
         self.validated['body'] = self.resource.request.json
         self.resource.record_id = self.resource.model.id_generator()

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -200,13 +200,55 @@ class ModifiedMeanwhileTest(BaseTest):
                 'field': 'new'}}
         self.resource.collection_post()  # not raising.
 
-    def test_post_if_match_star_succeeds_if_record_does_exist(self):
+    def test_get_if_match_star_succeeds_if_record_exists(self):
         self.validated['header']['If-Match'] = '*'
-        self.validated['body'] = {
+        self.resource.record_id = self.stored['id']
+        self.resource.get()
+
+    def test_post_if_match_star_succeeds_if_record_exists(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.request.json = {
             'data': {
-                'id': self.resource.model.id_generator(),
+                'id': self.stored['id'],
                 'field': 'new'}}
-        self.resource.collection_post()  # not raising.
+        self.validated['body'] = self.resource.request.json
+        self.resource.collection_post()
+
+    def test_put_if_match_star_succeeds_if_record_exists(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.record_id = self.stored['id']
+        self.resource.put()
+
+    def test_patch_if_match_star_succeeds_if_record_exists(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.request.json = {
+            'data': {
+                'id': self.stored['id'],
+                'field': 'new'}}
+        self.validated['body'] = self.resource.request.json
+        self.resource.record_id = self.stored['id']
+        self.resource.patch()
+
+    def test_delete_if_match_star_succeeds_if_record_exists(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.record_id = self.stored['id']
+        self.resource.delete()
+
+    def test_put_if_match_star_fails_if_record_does_not_exist(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.request.json = {'data': {'field': 'new'}}
+        self.validated['body'] = self.resource.request.json
+        self.resource.record_id = self.resource.model.id_generator()
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
+                          self.resource.put)
+
+    def test_put_if_fails_if_record_does_not_exist(self):
+        self.validated['header']['If-Match'] = '123'
+        self.resource.request.json = {'data': {'field': 'new'}}
+        self.validated['body'] = self.resource.request.json
+        self.resource.record_id = self.resource.model.id_generator()
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
+                          self.resource.put)
 
     def test_patch_returns_412_if_changed_meanwhile(self):
         self.resource.record_id = self.stored['id']

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -255,7 +255,7 @@ class ModifiedMeanwhileTest(BaseTest):
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
 
-    def test_put_if_fails_if_record_does_not_exist(self):
+    def test_put_if_match_current_fails_if_record_does_not_exist(self):
         self.validated['header']['If-Match'] = self.current  # wouldn't raise on existing
         self.resource.request.json = {'data': {'field': 'new'}}
         self.validated['body'] = self.resource.request.json

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -200,6 +200,18 @@ class ModifiedMeanwhileTest(BaseTest):
                 'field': 'new'}}
         self.resource.collection_post()  # not raising.
 
+    def test_get_if_none_match_star_fails_on_collections(self):
+        self.validated['header'].pop('If-Match')
+        self.validated['header']['If-None-Match'] = '*'
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
+                          self.resource.collection_get)
+
+    def test_delete_if_none_match_star_fails_on_collections(self):
+        self.validated['header'].pop('If-Match')
+        self.validated['header']['If-None-Match'] = '*'
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
+                          self.resource.collection_delete)
+
     def test_get_if_match_star_succeeds_if_record_exists(self):
         self.validated['header']['If-Match'] = '*'
         self.resource.record_id = self.stored['id']
@@ -249,6 +261,14 @@ class ModifiedMeanwhileTest(BaseTest):
         self.resource.record_id = self.resource.model.id_generator()
         self.assertRaises(httpexceptions.HTTPPreconditionFailed,
                           self.resource.put)
+
+    def test_get_if_match_star_suceed_on_collections(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.collection_get()
+
+    def test_delete_if_match_star_suceed_on_collections(self):
+        self.validated['header']['If-Match'] = '*'
+        self.resource.collection_delete()
 
     def test_patch_returns_412_if_changed_meanwhile(self):
         self.resource.record_id = self.stored['id']


### PR DESCRIPTION
Fixes #1072

This tries to clarify some inaccuracies on the `If-Match` and  `If-None-Match` custom headers behavior and make them a little more similar to what the spec expects.

Proposed changes:
1. If-Match raise on with non-existing records (including Tombstones)
2. If-Match:* succeeds if the record exist.
3. If-Match and If-None-Match a assume a collection is a resource that always exists.

Some implications:
1. 1 and 3 implies that `If-Match: *` on a collection will always succeed.
2. 3 and the current behavior for `If-None-Match: *` implies this on collection will always fail (the current implementation just ignores it)

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.