### PR TITLE
Adding a code of conduct badge.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of conduct
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details please see the [Mozilla Community Participation Guidelines] (https://www.mozilla.org/about/governance/policies/participation/) and [Developer Etiquette Guidelines] (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,11 @@
 Kinto
 =====
 
-|irc| |slack| |readthedocs| |pypi| |travis| |master-coverage|
+|coc| |irc| |slack| |readthedocs| |pypi| |travis| |master-coverage|
+
+.. |coc| image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
+    :target: https://github.com/Kinto/kinto/blob/master/CODE_OF_CONDUCT.md
+    :alt: Code of conduct
 
 .. |irc| image:: https://img.shields.io/badge/Live%20chat-%23kinto%20on%20freenode-blue.svg
     :target: https://kiwiirc.com/client/irc.freenode.net/?#kinto


### PR DESCRIPTION
While working on [mozilla/addons-server](https://github.com/mozilla/addons-server) I noticed this badge and I am planning on adding it on the Kinto repositories.