### PR TITLE
Post #1116 fix: ensure default propagation in find_nested_value.

### DIFF
--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -209,7 +209,7 @@ def find_nested_value(d, path, default=None):
 
     # we have our root key, extract the new subpath and recur
     subpath = path.replace(root + '.', '', 1)
-    return find_nested_value(d.get(root), subpath)
+    return find_nested_value(d.get(root), subpath, default=default)
 
 
 class COMPARISON(Enum):

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -278,10 +278,11 @@ class FindNestedValueTest(unittest.TestCase):
         self.assertIsNone(find_nested_value(record, "x.a"))
 
     def test_fallback_default_value(self):
-        record = {"a": 42}
+        record = {"a": {"c": 42}}
         self.assertEqual(find_nested_value(record, "x", 1337), 1337)
         self.assertEqual(find_nested_value(record, "a.b", 1337), 1337)
         self.assertEqual(find_nested_value(record, "x.a", 1337), 1337)
+        self.assertEqual(find_nested_value(record, "a.c.d", 1337), 1337)
 
 
 class RecursiveUpdateDictTest(unittest.TestCase):


### PR DESCRIPTION
This addresses @glasserc review [comment](https://github.com/Kinto/kinto/pull/1116#discussion_r103474783) on #1116 which has been merged before I could update it with a proper fix. Here it is :)