### PR TITLE
Remove enum backport since we are now Python 3.5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ colorama==0.3.7
 contextlib2==0.5.4
 cornice==2.4.0
 cornice-swagger==0.5.0
-enum34==1.1.6
 hupper==0.4.2
 iso8601==0.1.11
 jsonpatch==1.15


### PR DESCRIPTION
It's the same as https://github.com/Kinto/kinto/pull/1111 😂 
r? @Natim
