### PR TITLE
Enforce the permission endpoint when the admin plugin is included (fixes #1059)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ This document describes changes between each past release.
 
 Protocol is now at version **1.16**. See `API changelog`_.
 
+**New features**
+
+- Enforce the permission endpoint when the admin plugin is included (fixes #1059)
+
 **Bug fixes**
 
 - Fix Memory backend sometimes show empty permissions (#1045)

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -79,8 +79,9 @@ def main(global_config, config=None, **settings):
         kwargs['ignore'] = ['kinto.views.flush']
 
     # Permissions endpoint enabled if permission backend is setup.
+    is_admin_enabled = 'kinto.plugins.admin' in settings['includes']
     permissions_endpoint_enabled = (
-        asbool(settings['experimental_permissions_endpoint']) and
+        (is_admin_enabled or asbool(settings['experimental_permissions_endpoint'])) and
         hasattr(config.registry, 'permission'))
     if permissions_endpoint_enabled:
         config.add_api_capability(

--- a/tests/plugins/test_admin.py
+++ b/tests/plugins/test_admin.py
@@ -50,6 +50,11 @@ class AdminViewTest(BaseWebTest, unittest.TestCase):
         }
         self.assertEqual(expected, capabilities['admin'])
 
+    def test_permission_endpoint_is_enabled_with_admin(self):
+        resp = self.app.get('/')
+        capabilities = resp.json['capabilities']
+        assert 'permissions_endpoint' in capabilities
+
     def test_admin_index_cat_be_reached(self):
         self.maxDiff = None
         resp = self.app.get('/admin/')


### PR DESCRIPTION
Fixes #1059
