### PR TITLE
Prevent storing bytes in cache (fixes #1142)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 This document describes changes between each past release.
 
-6.1.0 (unreleased)
+7.0.0 (unreleased)
 ------------------
 
 **Protocol**
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 - Groups can now be created with a simple ``PUT`` (fixes #793)
 
 Protocol is now at version **1.16**. See `API changelog`_.
+
+**Breaking changes**
+
+- Forbid storing bytes in the cache backend. (#1143)
 
 **Bug fixes**
 

--- a/kinto/core/cache/memory.py
+++ b/kinto/core/cache/memory.py
@@ -56,6 +56,8 @@ class Cache(CacheBase):
 
     @synchronized
     def set(self, key, value, ttl=None):
+        if isinstance(value, bytes):
+            raise TypeError("a string-like object is required, not 'bytes'")
         self._clean_expired()
         self._clean_oversized()
         if ttl is not None:

--- a/kinto/core/cache/postgresql/__init__.py
+++ b/kinto/core/cache/postgresql/__init__.py
@@ -121,6 +121,9 @@ class Cache(CacheBase):
             conn.execute(query, dict(ttl=ttl, key=self.prefix + key))
 
     def set(self, key, value, ttl=None):
+        if isinstance(value, bytes):
+            raise TypeError("a string-like object is required, not 'bytes'")
+
         if ttl is None:
             logger.warning("No TTL for cache key '{}'".format(key))
         query = """

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -101,7 +101,7 @@ class CacheTest:
         self.assertEqual(*setget('foobar', {'b': [1, 2]}))
         self.assertEqual(*setget('foobar', 3.14))
 
-    def test_bytes_are_converted_to_unicode(self):
+    def test_bytes_cannot_be_stored_in_the_cache(self):
         with pytest.raises(TypeError):
             self.cache.set('test', b'foo')
 

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -100,6 +100,10 @@ class CacheTest:
         self.assertEqual(*setget('foobar', {'b': [1, 2]}))
         self.assertEqual(*setget('foobar', 3.14))
 
+    def test_bytes_are_converted_to_unicode(self):
+        self.cache.set('test', b'foo')
+        assert self.cache.get('test') == 'foo'
+
     def test_delete_removes_the_record(self):
         self.cache.set('foobar', 'toto')
         self.cache.delete('foobar')

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 import time
 
 from pyramid import testing
@@ -101,8 +102,8 @@ class CacheTest:
         self.assertEqual(*setget('foobar', 3.14))
 
     def test_bytes_are_converted_to_unicode(self):
-        self.cache.set('test', b'foo')
-        assert self.cache.get('test') == 'foo'
+        with pytest.raises(TypeError):
+            self.cache.set('test', b'foo')
 
     def test_delete_removes_the_record(self):
         self.cache.set('foobar', 'toto')


### PR DESCRIPTION
I wonder if we should do it like that or rather to raise an error when trying to cache bytes.

Fixes #1142 

- [x] Add tests.
- [x] Add a changelog entry.

r? @leplatrem 
