### PR TITLE
Speedup tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ This document describes changes between each past release.
 6.1.0 (unreleased)
 ------------------
 
+**Breaking changes**
+
+- ``get_app_settings()`` from ``kinto.core.testing.BaseWebTest`` is now a
+  class method (#1144)
+
 **Protocol**
 
 - Groups can now be created with a simple ``PUT`` (fixes #793)

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -514,9 +514,8 @@ class IgnoredFieldsTest(BaseWebTest, unittest.TestCase):
 
 
 class InvalidBodyTest(BaseWebTest, unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.invalid_body = "{'foo>}"
+
+    invalid_body = "{'foo>}"
 
     def setUp(self):
         super().setUp()
@@ -650,7 +649,8 @@ class InvalidPermissionsTest(BaseWebTest, unittest.TestCase):
 class CacheControlTest(BaseWebTest, unittest.TestCase):
     collection_url = '/toadstools'
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['toadstool_cache_expires_seconds'] = 3600
         settings['toadstool_read_principals'] = 'system.Everyone'

--- a/tests/core/support.py
+++ b/tests/core/support.py
@@ -21,18 +21,19 @@ class BaseWebTest(testing.BaseWebTest):
     It setups the database before each test and delete it after.
     """
 
-    api_prefix = "v0"
     entry_point = testapp
     principal = USER_PRINCIPAL
 
     authorization_policy = 'tests.core.support.AllowAuthorizationPolicy'
     collection_url = '/mushrooms'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.headers.update(testing.get_user_headers('mat'))
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.headers.update(testing.get_user_headers('mat'))
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         if extras is None:
             extras = {}
         extras.setdefault('project_name', 'myapp')
@@ -40,7 +41,7 @@ class BaseWebTest(testing.BaseWebTest):
         extras.setdefault('http_api_version', '0.1')
         extras.setdefault('project_docs', 'https://kinto.readthedocs.io/')
         extras.setdefault('multiauth.authorization_policy',
-                          self.authorization_policy)
+                          cls.authorization_policy)
         return super().get_app_settings(extras)
 
     def get_item_url(self, id=None):

--- a/tests/core/test_statsd.py
+++ b/tests/core/test_statsd.py
@@ -99,7 +99,9 @@ class StatsdClientTest(unittest.TestCase):
 
 @skip_if_no_statsd
 class TimingTest(BaseWebTest, unittest.TestCase):
-    def get_app_settings(self, *args, **kwargs):
+
+    @classmethod
+    def get_app_settings(cls, *args, **kwargs):
         settings = super().get_app_settings(*args, **kwargs)
         if not statsd.statsd_module:
             return settings

--- a/tests/core/test_views_heartbeat.py
+++ b/tests/core/test_views_heartbeat.py
@@ -23,6 +23,14 @@ class SuccessTest(BaseWebTest, unittest.TestCase):
 
 class FailureTest(BaseWebTest, unittest.TestCase):
 
+    def setUp(self):
+        self._heartbeats = {**self.app.app.registry.heartbeats}
+        super().setUp()
+
+    def tearDown(self):
+        self.app.app.registry.heartbeats = self._heartbeats
+        super().tearDown()
+
     def test_returns_storage_false_if_ko(self):
         self.app.app.registry.heartbeats['storage'] = lambda r: False
         response = self.app.get('/__heartbeat__', status=503)

--- a/tests/core/test_views_transaction.py
+++ b/tests/core/test_views_transaction.py
@@ -16,7 +16,9 @@ from .support import BaseWebTest, USER_PRINCIPAL
 
 
 class PostgreSQLTest(BaseWebTest):
-    def get_app_settings(self, extras=None):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         if sqlalchemy is not None:
             from .test_storage import PostgreSQLStorageTest
@@ -126,7 +128,9 @@ class TransactionTest(PostgreSQLTest, unittest.TestCase):
 
 
 class IntegrityConstraintTest(PostgreSQLTest, unittest.TestCase):
-    def get_app_settings(self, extras=None):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         if sqlalchemy is not None:
             settings.pop('storage_poolclass', None)  # Use real pool.
@@ -267,7 +271,8 @@ class TransactionEventsTest(PostgreSQLTest, unittest.TestCase):
 @skip_if_no_postgresql
 class WithoutTransactionTest(PostgreSQLTest, unittest.TestCase):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['transaction_per_request'] = False
         return settings

--- a/tests/plugins/test_admin.py
+++ b/tests/plugins/test_admin.py
@@ -20,9 +20,6 @@ class AdminViewTest(BaseWebTest, unittest.TestCase):
         with open(built_index, "w") as f:
             f.write("<html><script/></html>")
 
-    def setUp(self):
-        admin_views.admin_home_view.saved = None
-
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
@@ -31,10 +28,14 @@ class AdminViewTest(BaseWebTest, unittest.TestCase):
         except FileNotFoundError:
             pass
 
+    @classmethod
     def get_app_settings(self, extras=None):
         settings = super().get_app_settings(extras)
         settings['includes'] = 'kinto.plugins.admin'
         return settings
+
+    def setUp(self):
+        admin_views.admin_home_view.saved = None
 
     def test_capability_is_exposed(self):
         self.maxDiff = None

--- a/tests/plugins/test_default_bucket.py
+++ b/tests/plugins/test_default_bucket.py
@@ -14,7 +14,8 @@ from ..support import BaseWebTest, MINIMALIST_RECORD
 
 class DefaultBucketWebTest(BaseWebTest, unittest.TestCase):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['includes'] = 'kinto.plugins.default_bucket'
         return settings
@@ -282,7 +283,8 @@ class EventsTest(DefaultBucketWebTest):
         super().tearDown()
         del _events[:]
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings = {**settings, 'event_listeners': 'testevent',
                     'event_listeners.testevent.use': 'tests.plugins.test_default_bucket'}
@@ -339,7 +341,8 @@ class EventsTest(DefaultBucketWebTest):
 
 class ReadonlyDefaultBucket(DefaultBucketWebTest):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['readonly'] = True
         return settings

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -27,7 +27,8 @@ class PluginSetup(unittest.TestCase):
 
 class HistoryWebTest(support.BaseWebTest, unittest.TestCase):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['includes'] = 'kinto.plugins.history'
         return settings
@@ -527,7 +528,8 @@ class BulkTest(HistoryWebTest):
 
 class DefaultBucketTest(HistoryWebTest):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['includes'] = ('kinto.plugins.default_bucket '
                                 'kinto.plugins.history')
@@ -580,7 +582,8 @@ class DefaultBucketTest(HistoryWebTest):
 
 class PermissionsTest(HistoryWebTest):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['experimental_permissions_endpoint'] = 'true'
         return settings
@@ -714,7 +717,8 @@ class PermissionsTest(HistoryWebTest):
 
 class ExcludeResourcesTest(HistoryWebTest):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['history.exclude_resources'] = ('/buckets/a '
                                                  '/buckets/b/collections/a '

--- a/tests/plugins/test_quotas.py
+++ b/tests/plugins/test_quotas.py
@@ -41,6 +41,7 @@ class QuotaWebTest(support.BaseWebTest, unittest.TestCase):
     def setUpClass(cls):
         if not sqlalchemy:
             raise unittest.SkipTest("postgresql is not installed.")
+        super().setUpClass()
 
     def create_bucket(self):
         resp = self.app.put(self.bucket_uri, headers=self.headers)
@@ -60,7 +61,8 @@ class QuotaWebTest(support.BaseWebTest, unittest.TestCase):
         resp = self.app.put_json(self.record_uri, body, headers=self.headers)
         self.record = resp.json['data']
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
 
         # Setup the postgresql backend for transaction support.
@@ -788,7 +790,8 @@ class QuotaMaxBytesExceededSettingsListenerTest(
 
     error_message = "Bucket maximum total size exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.bucket_max_bytes'] = '150'
         return settings
@@ -800,7 +803,8 @@ class QuotaMaxBytesExceededBucketSettingsListenerTest(
 
     error_message = "Bucket maximum total size exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.bucket_test_max_bytes'] = '150'
         return settings
@@ -811,7 +815,8 @@ class QuotaMaxItemsExceededSettingsListenerTest(
 
     error_message = "Bucket maximum number of objects exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.bucket_max_items'] = '1'
         return settings
@@ -822,7 +827,8 @@ class QuotaMaxItemsExceededBucketSettingsListenerTest(
 
     error_message = "Bucket maximum number of objects exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.bucket_test_max_items'] = '1'
         return settings
@@ -834,7 +840,8 @@ class QuotaMaxBytesPerItemExceededListenerTest(
 
     error_message = "Maximum bytes per object exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.bucket_max_bytes_per_item'] = '55'
         return settings
@@ -846,7 +853,8 @@ class QuotaMaxBytesPerItemExceededBucketListenerTest(
 
     error_message = "Maximum bytes per object exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.bucket_test_max_bytes_per_item'] = '55'
         return settings
@@ -923,7 +931,8 @@ class QuotaMaxBytesExceededCollectionSettingsListenerTest(
 
     error_message = "Collection maximum size exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_max_bytes'] = '100'
         return settings
@@ -935,7 +944,8 @@ class QuotaMaxBytesExceededCollectionBucketSettingsListenerTest(
 
     error_message = "Collection maximum size exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_test_max_bytes'] = '100'
         return settings
@@ -947,7 +957,8 @@ class QuotaMaxBytesExceededBucketCollectionSettingsListenerTest(
 
     error_message = "Collection maximum size exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_test_col_max_bytes'] = '100'
         return settings
@@ -958,7 +969,8 @@ class QuotaMaxItemsExceededCollectionSettingsListenerTest(
 
     error_message = "Collection maximum number of objects exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_max_items'] = '1'
         return settings
@@ -969,7 +981,8 @@ class QuotaMaxItemsExceededCollectionBucketSettingsListenerTest(
 
     error_message = "Collection maximum number of objects exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_test_max_items'] = '1'
         return settings
@@ -980,7 +993,8 @@ class QuotaMaxItemsExceededBucketCollectionSettingsListenerTest(
 
     error_message = "Collection maximum number of objects exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_test_col_max_items'] = '1'
         return settings
@@ -991,7 +1005,8 @@ class QuotaMaxBytesPerItemExceededCollectionSettingsListenerTest(
 
     error_message = "Maximum bytes per object exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_max_bytes_per_item'] = '80'
         return settings
@@ -1003,7 +1018,8 @@ class QuotaMaxBytesPerItemExceededCollectionBucketSettingsListenerTest(
 
     error_message = "Maximum bytes per object exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_test_max_bytes_per_item'] = '80'
         return settings
@@ -1015,7 +1031,8 @@ class QuotaMaxBytesPerItemExceededBucketCollectionSettingsListenerTest(
 
     error_message = "Maximum bytes per object exceeded "
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['quotas.collection_test_col_max_bytes_per_item'] = '80'
         return settings

--- a/tests/support.py
+++ b/tests/support.py
@@ -18,11 +18,13 @@ class BaseWebTest(testing.BaseWebTest):
     entry_point = kinto_main
     principal = USER_PRINCIPAL
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.headers.update(testing.get_user_headers('mat'))
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.headers.update(testing.get_user_headers('mat'))
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = {**DEFAULT_SETTINGS}
         if extras is not None:
             settings.update(extras)

--- a/tests/swagger/support.py
+++ b/tests/swagger/support.py
@@ -12,21 +12,19 @@ from ..support import (BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_GROUP,
 
 class SwaggerTest(BaseWebTest, unittest.TestCase):
 
-    settings = {
-        'includes': [
-            'kinto.plugins.history',
-            'kinto.plugins.admin',
-        ]
-    }
-
     @classmethod
     def setUpClass(cls):
-        # FIXME: solve memory issues from generating the spec multiple times
-        app = BaseWebTest().make_app(settings=cls.settings)
-
-        cls.spec_dict = app.get('/__api__').json
+        super().setUpClass()
+        cls.spec_dict = cls.app.get('/__api__').json
         cls.spec = Spec.from_dict(cls.spec_dict)
         cls.resources = build_resources(cls.spec)
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings['includes'] = ['kinto.plugins.history',
+                                'kinto.plugins.admin']
+        return settings
 
     def setUp(self):
         super().setUp()
@@ -56,11 +54,6 @@ class SwaggerTest(BaseWebTest, unittest.TestCase):
         self.request.query = {}
         self.request._json = {}
         self.request.json = lambda: self.request._json
-
-    def get_app_settings(self, extras=None):
-        settings = super().get_app_settings(extras)
-        settings.update(self.settings)
-        return settings
 
     def cast_bravado_response(self, response):
         resp = OutgoingResponse()

--- a/tests/test_views_buckets.py
+++ b/tests/test_views_buckets.py
@@ -97,9 +97,10 @@ class BucketViewTest(BaseWebTest, unittest.TestCase):
 
 
 class BucketListTest(BaseWebTest, unittest.TestCase):
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['bucket_create_principals'] = self.principal
+        settings['bucket_create_principals'] = cls.principal
         return settings
 
     def test_can_list_buckets_by_default_if_allowed_to_create(self):
@@ -155,10 +156,10 @@ class BucketReadPermissionTest(BaseWebTest, unittest.TestCase):
                           bucket,
                           headers=self.headers)
 
-    def get_app_settings(self, extras=None):
-        settings = super(BucketReadPermissionTest,
-                         self).get_app_settings(extras)
-        # Give the right to list buckets (for self.principal and alice).
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        # Give the right to list buckets (for cls.principal and alice).
         settings['kinto.bucket_read_principals'] = Authenticated
         return settings
 
@@ -197,10 +198,11 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
         # Delete the bucket.
         self.app.delete(self.bucket_url, headers=self.headers)
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         # Give the permission to read, to get an explicit 404 once deleted.
-        settings['kinto.bucket_read_principals'] = self.principal
+        settings['kinto.bucket_read_principals'] = cls.principal
         return settings
 
     def test_buckets_can_be_deleted_in_bulk(self):

--- a/tests/test_views_collections_cache.py
+++ b/tests/test_views_collections_cache.py
@@ -5,7 +5,9 @@ from .support import (BaseWebTest, MINIMALIST_BUCKET,
 
 
 class GlobalSettingsTest(BaseWebTest, unittest.TestCase):
-    def get_app_settings(self, extras=None):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['kinto.record_cache_expires_seconds'] = 3600
         settings['kinto.record_read_principals'] = 'system.Everyone'
@@ -34,7 +36,9 @@ class GlobalSettingsTest(BaseWebTest, unittest.TestCase):
 
 
 class SpecificSettingsTest(BaseWebTest, unittest.TestCase):
-    def get_app_settings(self, extras=None):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['kinto.blog_record_cache_expires_seconds'] = '30'
         settings['kinto.browser_top500_record_cache_expires_seconds'] = '60'

--- a/tests/test_views_collections_schema.py
+++ b/tests/test_views_collections_schema.py
@@ -48,7 +48,9 @@ class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
 
 
 class BaseWebTestWithSchema(BaseWebTest):
-    def get_app_settings(self, extras=None):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['experimental_collection_schema_validation'] = 'True'
         return settings

--- a/tests/test_views_hello.py
+++ b/tests/test_views_hello.py
@@ -2,8 +2,7 @@ from kinto import __version__ as VERSION
 
 from kinto.core.testing import unittest
 
-from .support import (BaseWebTest, MINIMALIST_BUCKET,
-                      MINIMALIST_GROUP)
+from .support import BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_GROUP
 
 
 class HelloViewTest(BaseWebTest, unittest.TestCase):

--- a/tests/test_views_objects_permissions.py
+++ b/tests/test_views_objects_permissions.py
@@ -9,14 +9,15 @@ from .support import (BaseWebTest,
 
 class PermissionsTest(BaseWebTest, unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.alice_headers = {**self.headers, **get_user_headers('alice')}
-        self.bob_headers = {**self.headers, **get_user_headers('bob')}
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.alice_headers = {**cls.headers, **get_user_headers('alice')}
+        cls.bob_headers = {**cls.headers, **get_user_headers('bob')}
 
-        self.alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155e16'
+        cls.alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155e16'
                                 '812e3c64ff7ae053fe3542e2ca1570')
-        self.bob_principal = ('basicauth:c031ced27503f788b102ca54269a062ec737'
+        cls.bob_principal = ('basicauth:c031ced27503f788b102ca54269a062ec737'
                               '94bb075154c74a0d4311e74ca8b6')
 
 

--- a/tests/test_views_objects_permissions.py
+++ b/tests/test_views_objects_permissions.py
@@ -16,9 +16,9 @@ class PermissionsTest(BaseWebTest, unittest.TestCase):
         cls.bob_headers = {**cls.headers, **get_user_headers('bob')}
 
         cls.alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155e16'
-                                '812e3c64ff7ae053fe3542e2ca1570')
+                               '812e3c64ff7ae053fe3542e2ca1570')
         cls.bob_principal = ('basicauth:c031ced27503f788b102ca54269a062ec737'
-                              '94bb075154c74a0d4311e74ca8b6')
+                             '94bb075154c74a0d4311e74ca8b6')
 
 
 class BucketPermissionsTest(PermissionsTest):

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -12,7 +12,8 @@ RECORD_ID = 'd5db6e57-2c10-43e2-96c8-56602ef01435'
 
 class PermissionsViewTest(BaseWebTest, unittest.TestCase):
 
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['experimental_permissions_endpoint'] = 'True'
         return settings
@@ -151,13 +152,11 @@ class SettingsPermissionsTest(PermissionsViewTest):
     admin_headers = get_user_headers('admin')
     admin_principal = 'basicauth:bb7fe7b98e759578ef0de85b546dd57d21fe1e399390ad8dafc9886043a00e5c'  # NOQA
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def get_app_settings(self, extras=None):
+    @classmethod
+    def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings['bucket_write_principals'] = 'system.Authenticated'
-        settings['group_create_principals'] = self.admin_principal
+        settings['group_create_principals'] = cls.admin_principal
         settings['collection_write_principals'] = 'system.Authenticated'
         settings['record_create_principals'] = '/buckets/beers/groups/admins'
         return settings


### PR DESCRIPTION
I hadn't run the whole tests suite locally for a while. It became incredibly slow.

The Kinto app is initialized in every test method of the views tests (via `__init__`) and `kinto.main()` takes from 0.2 to 0.4 sec (!!). I tried to dig in and could not find obvious bottleneck. So I went for a more radical change: why do we have to initialize the app in every test whereas once per test case would be enough?

I hence moved app initialization to `setUpClass()` and the first attempt was quite successful: 

Before:
```
$ py.test -k tests/test_views_
Results (94.58s):
     200 passed
```

After:

```
$ py.test -k tests/test_views_
Results (21.61s):
     200 passed
```


The current approach introduces a **breaking change** since `get_app_settings()` is now a classmethod. But we could find a hack to introspect the test class and pick the test instance method if available (to avoid migrating every plugin just now).