### PR TITLE
Update cornice swagger to 0.5.1 (fixes #1180)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colander==1.3.2
 colorama==0.3.7
 contextlib2==0.5.4
 cornice==2.4.0
-cornice-swagger==0.5.0
+cornice-swagger==0.5.1
 hupper==0.4.2
 iso8601==0.1.11
 jsonpatch==1.15

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIREMENTS = [
     'bcrypt',
     'colander >= 1.3.2',
     'cornice >= 2.4',
-    'cornice_swagger >= 0.5',
+    'cornice_swagger >= 0.5.1',
     'jsonschema',
     'jsonpatch',
     'logging-color-formatter >= 1.0.1',  # Message interpolations.


### PR DESCRIPTION
Fixes #1180

cornice_swagger 0.5.1 supports subpath and regex on pyramid routes.
