### PR TITLE
Update kinto-admin to 1.13.1.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Now:
   is now mandatory (fixes #960).
 - ``get_app_settings()`` from ``kinto.core.testing.BaseWebTest`` is now a
   class method (#1144)
+- Upgraded the kinto-admin to version 1.13.1
 
 **Protocol**
 

--- a/kinto/plugins/admin/README.md
+++ b/kinto/plugins/admin/README.md
@@ -1,10 +1,4 @@
 # kinto-admin plugin setup
 
-Update the kinto-admin version you want to use in `package.json`, then:
-
-```
-$ npm install
-$ npm run build
-```
-
-And commit the updated `build` folder.
+Update the `kinto-admin` version you want in the `dependencies` section of the
+`package.json` file.

--- a/kinto/plugins/admin/package.json
+++ b/kinto/plugins/admin/package.json
@@ -7,7 +7,7 @@
     "react-scripts": "0.7.0"
   },
   "dependencies": {
-    "kinto-admin": "1.10.0",
+    "kinto-admin": "1.13.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"
   },


### PR DESCRIPTION
This upgrades the kinto-admin to [v1.13.1](https://github.com/Kinto/kinto-admin/releases/tag/v1.13.1), ensuring compatibility with Kinto server v7.x (current master). 