### PR TITLE
Crash when filtering numeric values as empty strings. #1194

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,7 +70,7 @@ Protocol is now at version **1.16**. See `API changelog`_.
   bucket (#1137)
 - Removed Structlog binding and bottlenecks (fixes #603)
 - Fixed Swagger output with subpath and regex in pyramid routes (fixes #1180)
-- Fixed Postgresql errors when trying to compare numeric value with an empty string. (fixes #1194)
+- Fixed Postgresql errors when specifying empty values in querystring numeric filters. (fixes #1194)
 
 **Internal changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,7 @@ Protocol is now at version **1.16**. See `API changelog`_.
   bucket (#1137)
 - Removed Structlog binding and bottlenecks (fixes #603)
 - Fixed Swagger output with subpath and regex in pyramid routes (fixes #1180)
+- Fixed Postgresql errors when trying to compare numeric value with an empty string. (fixes #1194)
 
 **Internal changes**
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 docutils<0.13
-Sphinx
+Sphinx<1.6
 sphinx_rtd_theme
 sphinxcontrib-httpdomain
 kinto-redis

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -703,7 +703,8 @@ class Storage(StorageBase):
                 sql_field = "coalesce({}, '')".format(column_name)
                 # Cast when comparing to number (eg. '4' < '12')
                 try:
-                    if is_numeric(value) or all([is_numeric(v) for v in value]):
+                    # all([]) is True while all(None) raises a TypeError.
+                    if is_numeric(value) or all([is_numeric(v) for v in value] or None):
                         sql_field = "({})::numeric".format(column_name)
                 except TypeError:  # not iterable
                     pass

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -703,8 +703,7 @@ class Storage(StorageBase):
                 sql_field = "coalesce({}, '')".format(column_name)
                 # Cast when comparing to number (eg. '4' < '12')
                 try:
-                    # all([]) is True while all(None) raises a TypeError.
-                    if is_numeric(value) or all([is_numeric(v) for v in value] or None):
+                    if value and (is_numeric(value) or all([is_numeric(v) for v in value])):
                         sql_field = "({})::numeric".format(column_name)
                 except TypeError:  # not iterable
                     pass

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -407,6 +407,7 @@ class BaseTestStorage:
         filters = [Filter('phone', "", utils.COMPARISON.EQ)]
         records, _ = self.storage.get_all(filters=filters,
                                           **self.storage_kw)
+        self.assertEqual(len(records), 0)
 
     def test_get_all_can_filter_with_float_values(self):
         for l in [10, 11.5, 8.5, 6, 7.5]:

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -401,6 +401,13 @@ class BaseTestStorage:
                                           **self.storage_kw)
         self.assertEqual(len(records), 1)
 
+    def test_get_all_can_filter_with_empty_numeric_strings(self):
+        for l in ["0566199093", "0781566199"]:
+            self.create_record({'phone': l})
+        filters = [Filter('phone', "", utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters,
+                                          **self.storage_kw)
+
     def test_get_all_can_filter_with_float_values(self):
         for l in [10, 11.5, 8.5, 6, 7.5]:
             self.create_record({'note': l})


### PR DESCRIPTION
Fixes #1194 

- [X] Add tests.
- [x] Add a changelog entry.
