### PR TITLE
Make sure request.GET does not fail with a 500 in case of UnicodeDecodeError.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,7 @@ Protocol is now at version **1.16**. See `API changelog`_.
 - Removed Structlog binding and bottlenecks (fixes #603)
 - Fixed Swagger output with subpath and regex in pyramid routes (fixes #1180)
 - Fixed Postgresql errors when specifying empty values in querystring numeric filters. (fixes #1194)
-- Catch UnicodeDecodeError in case of request wrong encoding (fixes #1195)
+- Return a 400 Bad Request instead of crashing when the querystring contains bad characters. (fixes #1195)
 
 **Internal changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,7 @@ Protocol is now at version **1.16**. See `API changelog`_.
 - Removed Structlog binding and bottlenecks (fixes #603)
 - Fixed Swagger output with subpath and regex in pyramid routes (fixes #1180)
 - Fixed Postgresql errors when specifying empty values in querystring numeric filters. (fixes #1194)
+- Catch UnicodeDecodeError in case of request wrong encoding (fixes #1195)
 
 **Internal changes**
 

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -196,7 +196,9 @@ def send_alert(request, message=None, url=None, code='soft-eol'):
 
 
 def request_GET(request):
-    """Catches a UnicodeDecode error in request.GET in case a wrong request was received."""
+    """Catches a UnicodeDecode error in request.GET in case a wrong request was received.
+    Fixing a webob long term issue: https://github.com/Pylons/webob/issues/161
+    """
     try:
         return request.GET
     except UnicodeDecodeError as e:

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -1,4 +1,5 @@
 import colander
+import logging
 from pyramid import httpexceptions
 from enum import Enum
 
@@ -202,8 +203,11 @@ def request_GET(request):
     try:
         return request.GET
     except UnicodeDecodeError as e:
+        querystring = request.environ.get('QUERY_STRING', '')
+        logger = logging.getLogger(__name__)
+        logger.warn('Error decoding QUERY_STRING: %s' % querystring)
         raise http_error(
             httpexceptions.HTTPBadRequest(),
             errno=ERRORS.INVALID_PARAMETERS,
             message="A request with an incorrect encoding in the querystring was"
-            "received. Please make sure your requests are encoded in UTF-8")
+            "received. Please make sure your requests are encoded in UTF-8: %s" % querystring)

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -193,3 +193,15 @@ def send_alert(request, message=None, url=None, code='soft-eol'):
         'message': message,
         'url': url
     })
+
+
+def request_GET(request):
+    """Catches a UnicodeDecode error in request.GET in case a wrong request was received."""
+    try:
+        return request.GET
+    except UnicodeDecodeError as e:
+        raise http_error(
+            httpexceptions.HTTPBadRequest(),
+            errno=ERRORS.INVALID_PARAMETERS,
+            message="A request with an incorrect encoding in the querystring was"
+            "received. Please make sure your requests are encoded in UTF-8")

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -205,7 +205,7 @@ def request_GET(request):
     except UnicodeDecodeError as e:
         querystring = request.environ.get('QUERY_STRING', '')
         logger = logging.getLogger(__name__)
-        logger.warn('Error decoding QUERY_STRING: %s' % querystring)
+        logger.warn('Error decoding QUERY_STRING: %s' % request.environ)
         raise http_error(
             httpexceptions.HTTPBadRequest(),
             errno=ERRORS.INVALID_PARAMETERS,

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -336,7 +336,7 @@ def setup_logging(config):
         request.log_context(agent=request.headers.get('User-Agent'),
                             path=request_path,
                             method=request.method,
-                            querystring=dict(request.GET),
+                            querystring=dict(errors.request_GET(request)),
                             lang=request.headers.get('Accept-Language'),
                             uid=None,
                             authn_type=None,

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -12,7 +12,7 @@ from pyramid.httpexceptions import (HTTPNotModified, HTTPPreconditionFailed,
                                     HTTPNotFound, HTTPServiceUnavailable)
 
 from kinto.core import Service
-from kinto.core.errors import http_error, raise_invalid, send_alert, ERRORS
+from kinto.core.errors import http_error, raise_invalid, send_alert, ERRORS, request_GET
 from kinto.core.events import ACTIONS
 from kinto.core.storage import exceptions as storage_exceptions, Filter, Sort
 from kinto.core.utils import (
@@ -1062,7 +1062,7 @@ class UserResource:
         """Build the Next-Page header from where we stopped."""
         token = self._build_pagination_token(sorting, last_record, offset)
 
-        params = {**self.request.GET, '_limit': limit, '_token': token}
+        params = {**request_GET(self.request), '_limit': limit, '_token': token}
 
         service = self.request.current_service
         next_page_url = self.request.route_url(service.name, _query=params,


### PR DESCRIPTION
Fixes #1195

- [x] Add tests.
- [x] Add a changelog entry.

r? @leplatrem 
