### PR TITLE
fix #1224: exception in accounts plugin authentication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ This document describes changes between each past release.
   the ``quotas`` plugin to no longer leak "quota" when used with the
   ``default_bucket`` plugin. (#1226)
 - Do not allow to reuse deletion tokens (fixes #1171)
+- ``accounts`` plugin: fix exception on authentication. (#1224)
 
 
 7.0.1 (2017-05-17)

--- a/kinto/plugins/accounts/authentication.py
+++ b/kinto/plugins/accounts/authentication.py
@@ -13,7 +13,7 @@ def account_check(username, password, request):
     except storage_exceptions.RecordNotFoundError:
         return None
 
-    hashed = existing['password']
+    hashed = existing['password'].encode(encoding='utf-8')
     pwd_str = password.encode(encoding='utf-8')
     if hashed == bcrypt.hashpw(pwd_str, hashed):
         return True  # Match! Return anything but None.

--- a/kinto/plugins/accounts/views.py
+++ b/kinto/plugins/accounts/views.py
@@ -89,9 +89,11 @@ class Account(resource.ShareableResource):
     def process_record(self, new, old=None):
         new = super(Account, self).process_record(new, old)
 
-        # Store password safely in database.
+        # Store password safely in database as str
+        # (bcrypt.hashpw returns base64 bytes).
         pwd_str = new["password"].encode(encoding='utf-8')
-        new["password"] = bcrypt.hashpw(pwd_str, bcrypt.gensalt())
+        hashed = bcrypt.hashpw(pwd_str, bcrypt.gensalt())
+        new["password"] = hashed.decode(encoding='utf-8')
 
         # Administrators can reach other accounts and anonymous have no
         # selected_userid. So do not try to enforce.


### PR DESCRIPTION
Unicode-objects must be encoded before hashing.

Fixes #1224 

- [X] Add a changelog entry.
- [X] Add your name in the contributors file.

r? @Natim
