### PR TITLE
Demonstrate problem with default_bucket and quotas plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ This document describes changes between each past release.
 
 - ``delete()`` method from cache backend now returns the deleted value (fixes #1231)
 
+**Bug fixes**
+
+- The ``default_bucket`` plugin no longer sends spurious "created"
+  events for buckets and collections that already exist. This causes
+  the ``quotas`` plugin to no longer leak "quota" when used with the
+  ``default_bucket`` plugin. (#1226)
+
 
 7.0.1 (2017-05-17)
 ------------------

--- a/tests/plugins/test_default_bucket.py
+++ b/tests/plugins/test_default_bucket.py
@@ -338,6 +338,20 @@ class EventsTest(DefaultBucketWebTest):
         assert _events[2].payload['uri'] == records_uri.replace('default',
                                                                 bucket_id)
 
+    def test_second_call_on_default_bucket_doesnt_send_create_events(self):
+        bucket_url = '/buckets/default'
+        self.app.get(bucket_url, headers=self.headers)
+        assert len(_events) == 1
+        self.app.get(bucket_url, headers=self.headers)
+        assert len(_events) == 1
+
+    def test_second_call_on_default_bucket_collection_doesnt_send_create_events(self):
+        collection_url = '/buckets/default/collections/articles'
+        self.app.get(collection_url, headers=self.headers)
+        assert len(_events) == 2
+        self.app.get(collection_url, headers=self.headers)
+        assert len(_events) == 2
+
 
 class ReadonlyDefaultBucket(DefaultBucketWebTest):
 


### PR DESCRIPTION
Fixes #1226.

- (n/a) Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @Natim
