### PR TITLE
delete() method from cache backend now returns the deleted value (fixes #1231)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 7.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New feature**
+
+- ``delete()`` method from cache backend now returns the deleted value (fixes #1231)
 
 
 7.0.1 (2017-05-17)

--- a/kinto/core/cache/memory.py
+++ b/kinto/core/cache/memory.py
@@ -82,6 +82,7 @@ class Cache(CacheBase):
         self._created_at.pop(key, None)
         value = self._store.pop(key, None)
         self._quota -= size_of(key, value)
+        return value
 
 
 def load_from_config(config):

--- a/kinto/core/cache/postgresql/__init__.py
+++ b/kinto/core/cache/postgresql/__init__.py
@@ -150,9 +150,13 @@ class Cache(CacheBase):
                 return json.loads(value)
 
     def delete(self, key):
-        query = "DELETE FROM cache WHERE key = :key"
+        query = "DELETE FROM cache WHERE key = :key RETURNING value;"
         with self.client.connect() as conn:
-            conn.execute(query, dict(key=self.prefix + key))
+            result = conn.execute(query, dict(key=self.prefix + key))
+            if result.rowcount > 0:
+                value = result.fetchone()['value']
+                return json.loads(value)
+        return None
 
 
 def load_from_config(config):

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -107,12 +107,14 @@ class CacheTest:
 
     def test_delete_removes_the_record(self):
         self.cache.set('foobar', 'toto', 42)
-        self.cache.delete('foobar')
-        retrieved = self.cache.get('foobar')
-        self.assertIsNone(retrieved)
+        returned = self.cache.delete('foobar')
+        self.assertEqual(returned, 'toto')
+        missing = self.cache.get('foobar')
+        self.assertIsNone(missing)
 
     def test_delete_does_not_fail_if_record_is_unknown(self):
-        self.cache.delete('foobar')
+        returned = self.cache.delete('foobar')
+        self.assertIsNone(returned)
 
     def test_expire_expires_the_value(self):
         self.cache.set('foobar', 'toto', 42)


### PR DESCRIPTION
Fixes #1231
