### PR TITLE
Clear timestamps table when deleting parents (fixes #1223)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 7.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix removal of timestamps when parent object is deleted (fixes #1233)
 
 
 7.0.1 (2017-05-17)

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -503,23 +503,11 @@ class Storage(StorageBase):
                       modified_field=DEFAULT_MODIFIED_FIELD,
                       auth=None):
         delete_tombstones = """
-        WITH delete_tombstones AS (
-            DELETE
-            FROM deleted
-            WHERE {parent_id_filter_tombstones}
-                  {collection_id_filter}
-                  {conditions_filter}
-            RETURNING parent_id
-        ),
-        delete_timestamps AS (
-            DELETE
-            FROM timestamps
-            WHERE {parent_id_filter_timestamps}
-            RETURNING parent_id
-        )
-        SELECT * FROM delete_tombstones
-        UNION
-        SELECT * FROM delete_timestamps
+        DELETE
+        FROM deleted
+        WHERE {parent_id_filter}
+              {collection_id_filter}
+              {conditions_filter}
         """
         id_field = id_field or self.id_field
         modified_field = modified_field or self.modified_field
@@ -529,18 +517,10 @@ class Storage(StorageBase):
         safeholders = defaultdict(str)
         # Handle parent_id as a regex only if it contains *
         if '*' in parent_id:
-            safeholders['parent_id_filter_tombstones'] = 'parent_id LIKE :parent_id'
+            safeholders['parent_id_filter'] = 'parent_id LIKE :parent_id'
             placeholders['parent_id'] = parent_id.replace('*', '%')
         else:
-            safeholders['parent_id_filter_tombstones'] = 'parent_id = :parent_id'
-
-        # If purging everything from a parent_id, then it means we won't have
-        # anything left for this resource. We can wipe out timestamps.
-        if collection_id is None and before is None:
-            safeholders['parent_id_filter_timestamps'] = safeholders['parent_id_filter_tombstones']
-        else:
-            safeholders['parent_id_filter_timestamps'] = '0 = 1'  # never true.
-
+            safeholders['parent_id_filter'] = 'parent_id = :parent_id'
         # If collection is None, remove it from query.
         if collection_id is None:
             safeholders['collection_id_filter'] = ''
@@ -554,7 +534,18 @@ class Storage(StorageBase):
 
         with self.client.connect() as conn:
             result = conn.execute(delete_tombstones.format_map(safeholders), placeholders)
-            return result.rowcount
+            deleted = result.rowcount
+
+            # If purging everything from a parent_id, then clear timestamps.
+            if collection_id is None and before is None:
+                delete_timestamps = """
+                DELETE
+                FROM timestamps
+                WHERE {parent_id_filter}
+                """
+                conn.execute(delete_timestamps.format_map(safeholders), placeholders)
+
+        return deleted
 
     def get_all(self, collection_id, parent_id, filters=None, sorting=None,
                 pagination_rules=None, limit=None, include_deleted=False,

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -160,31 +160,6 @@ BEFORE INSERT ON deleted
 FOR EACH ROW EXECUTE PROCEDURE bump_timestamp();
 
 --
--- Purge timestamps of objects that were deleted and purged.
---
-DROP TRIGGER IF EXISTS tgr_deleted_purge ON deleted;
-
-CREATE OR REPLACE FUNCTION purge_timestamps()
-RETURNS trigger AS $$
-BEGIN
-  WITH existing AS (
-    SELECT parent_id, collection_id FROM records GROUP BY parent_id, collection_id
-    UNION
-    SELECT parent_id, collection_id FROM deleted GROUP BY parent_id, collection_id
-  )
-  DELETE FROM timestamps AS t
-  WHERE (parent_id, collection_id) NOT IN (
-    SELECT parent_id, collection_id FROM existing GROUP BY parent_id, collection_id
-  );
-  RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER tgr_deleted_purge
-AFTER DELETE ON deleted
-FOR EACH STATEMENT EXECUTE PROCEDURE purge_timestamps();
-
---
 -- Metadata table
 --
 CREATE TABLE IF NOT EXISTS metadata (

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -989,15 +989,19 @@ class DeletedRecordsTest:
         before1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
         # Different parent_id with record.
         before2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
+        # Different parent_id without record.
+        before3 = self.storage.collection_timestamp(parent_id='ijk', collection_id='c')
 
         self.storage.delete_all(parent_id='/abc/*', collection_id=None, with_deleted=False)
         self.storage.purge_deleted(parent_id='/abc/*', collection_id=None)
 
         after1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
         after2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
+        after3 = self.storage.collection_timestamp(parent_id='ijk', collection_id='c')
 
         self.assertNotEqual(before1, after1)
         self.assertEqual(before2, after2)
+        self.assertEqual(before3, after3)
 
     def test_purge_deleted_works_when_no_tombstones(self):
         num_removed = self.storage.purge_deleted(**self.storage_kw)

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -981,6 +981,23 @@ class DeletedRecordsTest:
                                                  collection_id=None)
         self.assertEqual(num_removed, 2)
 
+    def test_purge_deleted_removes_timestamps_by_parent_id(self):
+        self.create_record(parent_id='abc', collection_id='c')
+        self.create_record(parent_id='abc', collection_id='c')
+        self.create_record(parent_id='efg', collection_id='c')
+
+        before1 = self.storage.collection_timestamp(parent_id='abc', collection_id='c')
+        before2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
+
+        self.storage.delete_all(parent_id='ab*', collection_id=None)
+        self.storage.purge_deleted(parent_id='ab*', collection_id=None)
+
+        after1 = self.storage.collection_timestamp(parent_id='abc', collection_id='c')
+        after2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
+
+        self.assertNotEqual(before1, after1)
+        self.assertEqual(before2, after2)
+
     def test_purge_deleted_works_when_no_tombstones(self):
         num_removed = self.storage.purge_deleted(**self.storage_kw)
         self.assertEqual(num_removed, 0)

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -982,17 +982,18 @@ class DeletedRecordsTest:
         self.assertEqual(num_removed, 2)
 
     def test_purge_deleted_removes_timestamps_by_parent_id(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='abc', collection_id='c')
+        self.create_record(parent_id='/abc/a', collection_id='c')
+        self.create_record(parent_id='/abc/a', collection_id='c')
         self.create_record(parent_id='efg', collection_id='c')
 
-        before1 = self.storage.collection_timestamp(parent_id='abc', collection_id='c')
+        before1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
+        # Different parent_id with record.
         before2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
 
-        self.storage.delete_all(parent_id='ab*', collection_id=None)
-        self.storage.purge_deleted(parent_id='ab*', collection_id=None)
+        self.storage.delete_all(parent_id='/abc/*', collection_id=None, with_deleted=False)
+        self.storage.purge_deleted(parent_id='/abc/*', collection_id=None)
 
-        after1 = self.storage.collection_timestamp(parent_id='abc', collection_id='c')
+        after1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
         after2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
 
         self.assertNotEqual(before1, after1)

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -984,20 +984,20 @@ class DeletedRecordsTest:
     def test_purge_deleted_removes_timestamps_by_parent_id(self):
         self.create_record(parent_id='/abc/a', collection_id='c')
         self.create_record(parent_id='/abc/a', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
+        self.create_record(parent_id='/efg', collection_id='c')
 
         before1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
         # Different parent_id with record.
-        before2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
+        before2 = self.storage.collection_timestamp(parent_id='/efg', collection_id='c')
         # Different parent_id without record.
-        before3 = self.storage.collection_timestamp(parent_id='ijk', collection_id='c')
+        before3 = self.storage.collection_timestamp(parent_id='/ijk', collection_id='c')
 
         self.storage.delete_all(parent_id='/abc/*', collection_id=None, with_deleted=False)
         self.storage.purge_deleted(parent_id='/abc/*', collection_id=None)
 
         after1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
-        after2 = self.storage.collection_timestamp(parent_id='efg', collection_id='c')
-        after3 = self.storage.collection_timestamp(parent_id='ijk', collection_id='c')
+        after2 = self.storage.collection_timestamp(parent_id='/efg', collection_id='c')
+        after3 = self.storage.collection_timestamp(parent_id='/ijk', collection_id='c')
 
         self.assertNotEqual(before1, after1)
         self.assertEqual(before2, after2)

--- a/tests/test_views_buckets.py
+++ b/tests/test_views_buckets.py
@@ -190,10 +190,11 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers)
         self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
                           headers=self.headers)
-        r = self.app.post_json(self.collection_url + '/records',
-                               MINIMALIST_RECORD,
-                               headers=self.headers)
-        record_id = r.json['data']['id']
+        resp = self.app.post_json(self.collection_url + '/records',
+                                  MINIMALIST_RECORD,
+                                  headers=self.headers)
+        record_id = resp.json['data']['id']
+        self.previous_ts = resp.headers['ETag']
         self.record_url = self.collection_url + '/records/{}'.format(record_id)
         # Delete the bucket.
         self.app.delete(self.bucket_url, headers=self.headers)
@@ -235,6 +236,17 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get('{}/collections?_since=0'.format(self.bucket_url),
                             headers=self.headers)
         self.assertEqual(len(resp.json['data']), 0)
+
+    def test_timestamps_are_refreshed_when_collection_is_recreated(self):
+        # Kinto/kinto#1223
+        # Recreate with same name.
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
+                          headers=self.headers)
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
+                          headers=self.headers)
+        resp = self.app.get(self.collection_url + '/records', headers=self.headers)
+        records_ts = resp.headers['ETag']
+        self.assertNotEqual(self.previous_ts, records_ts)
 
     def test_every_groups_are_deleted_too(self):
         self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,


### PR DESCRIPTION
Fixes #1223 

- [x] Fail to reproduce in tests
- [x] Succeed to reproduce in tests
- [x] Fix bug
- [ ] Add a changelog entry.
