### PR TITLE
make memory storage consistent with pg wrt bytes

### DIFF
--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -11,6 +11,7 @@ from kinto.core.utils import (COMPARISON, find_nested_value)
 
 import ujson
 
+
 def tree():
     return defaultdict(tree)
 

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -9,6 +9,7 @@ from kinto.core.storage import (
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD)
 from kinto.core.utils import (COMPARISON, find_nested_value)
 
+import ujson
 
 def tree():
     return defaultdict(tree)
@@ -150,6 +151,7 @@ class Storage(MemoryBasedStorage):
         self.set_record_timestamp(collection_id, parent_id, record,
                                   modified_field=modified_field)
         _id = record[id_field]
+        record = ujson.loads(ujson.dumps(record))
         self._store[parent_id][collection_id][_id] = record
         self._cemetery[parent_id][collection_id].pop(_id, None)
         return record
@@ -171,6 +173,7 @@ class Storage(MemoryBasedStorage):
                auth=None):
         record = {**record}
         record[id_field] = object_id
+        record = ujson.loads(ujson.dumps(record))
 
         self.set_record_timestamp(collection_id, parent_id, record,
                                   modified_field=modified_field)

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -1250,7 +1250,7 @@ class ParentRecordAccessTest:
         self.assertEqual(back_record['steak'], 'haché')
 
     def test_create_bytes_value_bad_encoding_raises(self):
-        self.assertRaises(Exception,
+        self.assertRaises(OverflowError,
                           self.create_record,
                           {'steak': 'haché'.encode(encoding='iso-8859-1')}
                           )
@@ -1274,7 +1274,7 @@ class ParentRecordAccessTest:
         record = self.create_record()
 
         new_record = {'steak': 'haché'.encode(encoding='iso-8859-1')}
-        self.assertRaises(Exception,
+        self.assertRaises(OverflowError,
                           self.storage.update,
                           object_id=record['id'],
                           record=new_record,

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -1238,7 +1238,7 @@ class ParentRecordAccessTest:
                                        **self.storage_kw)
         self.assertNotIn("another", not_updated)
 
-    def test_bytes_value_gets_back_str(self):
+    def test_create_bytes_value_gets_back_str(self):
         data = {'steak': 'haché'.encode(encoding='utf-8')}
         self.assertIsInstance(data['steak'], bytes)
 
@@ -1247,11 +1247,38 @@ class ParentRecordAccessTest:
         back_record = self.storage.get(object_id=record['id'],
                                        **self.storage_kw)
         self.assertIsInstance(back_record['steak'], str)
+        self.assertEqual(back_record['steak'], 'haché')
 
-    def test_bytes_value_bad_encoding_raises(self):
+    def test_create_bytes_value_bad_encoding_raises(self):
         self.assertRaises(Exception,
                            self.create_record,
                            {'steak': 'haché'.encode(encoding='iso-8859-1')}
+       )
+
+    def test_update_bytes_value_gets_back_str(self):
+        record = self.create_record()
+
+        new_record = {'steak': 'haché'.encode(encoding='utf-8')}
+        self.assertIsInstance(new_record['steak'], bytes)
+
+        self.storage.update(object_id=record['id'],
+                             record=new_record,
+                             **self.storage_kw)
+
+        back_record = self.storage.get(object_id=record['id'],
+                                       **self.storage_kw)
+        self.assertIsInstance(back_record['steak'], str)
+        self.assertEqual(back_record['steak'], 'haché')
+
+    def test_update_bytes_value_bad_encoding_raises(self):
+        record = self.create_record()
+
+        new_record = {'steak': 'haché'.encode(encoding='iso-8859-1')}
+        self.assertRaises(Exception,
+                           self.storage.update,
+                           object_id=record['id'],
+                           record=new_record,
+                           **self.storage_kw
        )
 
 

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -1251,9 +1251,9 @@ class ParentRecordAccessTest:
 
     def test_create_bytes_value_bad_encoding_raises(self):
         self.assertRaises(Exception,
-                           self.create_record,
-                           {'steak': 'haché'.encode(encoding='iso-8859-1')}
-       )
+                          self.create_record,
+                          {'steak': 'haché'.encode(encoding='iso-8859-1')}
+                          )
 
     def test_update_bytes_value_gets_back_str(self):
         record = self.create_record()
@@ -1262,8 +1262,8 @@ class ParentRecordAccessTest:
         self.assertIsInstance(new_record['steak'], bytes)
 
         self.storage.update(object_id=record['id'],
-                             record=new_record,
-                             **self.storage_kw)
+                            record=new_record,
+                            **self.storage_kw)
 
         back_record = self.storage.get(object_id=record['id'],
                                        **self.storage_kw)
@@ -1275,11 +1275,11 @@ class ParentRecordAccessTest:
 
         new_record = {'steak': 'haché'.encode(encoding='iso-8859-1')}
         self.assertRaises(Exception,
-                           self.storage.update,
-                           object_id=record['id'],
-                           record=new_record,
-                           **self.storage_kw
-       )
+                          self.storage.update,
+                          object_id=record['id'],
+                          record=new_record,
+                          **self.storage_kw
+                          )
 
 
 class StorageTest(ThreadMixin,

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -1238,6 +1238,22 @@ class ParentRecordAccessTest:
                                        **self.storage_kw)
         self.assertNotIn("another", not_updated)
 
+    def test_bytes_value_gets_back_str(self):
+        data = {'steak': 'haché'.encode(encoding='utf-8')}
+        self.assertIsInstance(data['steak'], bytes)
+
+        record = self.create_record(data)
+
+        back_record = self.storage.get(object_id=record['id'],
+                                       **self.storage_kw)
+        self.assertIsInstance(back_record['steak'], str)
+
+    def test_bytes_value_bad_encoding_raises(self):
+        self.assertRaises(Exception,
+                           self.create_record,
+                           {'steak': 'haché'.encode(encoding='iso-8859-1')}
+       )
+
 
 class StorageTest(ThreadMixin,
                   TimestampsTest,


### PR DESCRIPTION
Following #1227, make memory storage consistent with PostgreSQL storage:
 - bytes in records are interpreted as utf-8 encoded.
 - one always gets str back, not bytes.

Fixes #

- [ ] Add documentation.
- [X] Add tests.
- [ ] Add a changelog entry.
- [X] Add your name in the contributors file.
- [X] no HTTP API change

r? @glasserc @Natim 
