### PR TITLE
Fix bucket cascade deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ This document describes changes between each past release.
 - Do not allow to reuse deletion tokens (fixes #1171)
 - ``accounts`` plugin: fix exception on authentication. (#1224)
 - Fix crash with JSONSchema validation of unknown required properties (fixes #1243)
+- Fix bug on bucket deletion where other buckets could be deleted too if their id
+  started with the same id
 
 
 7.0.1 (2017-05-17)

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -63,4 +63,4 @@ def on_collections_deleted(event):
                            with_deleted=False)
         storage.purge_deleted(collection_id=None,
                               parent_id=parent_id)
-        permission.delete_object_permissions(parent_id + '*')
+        permission.delete_object_permissions(parent_id)

--- a/tests/test_views_buckets.py
+++ b/tests/test_views_buckets.py
@@ -273,3 +273,14 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
         headers = {**self.headers, 'If-None-Match': '*'}
         self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
                           headers=headers, status=201)
+
+    def test_does_not_delete_buckets_with_similar_names(self):
+        self.app.put("/buckets/a", headers=self.headers)
+        body = {"permissions": {"read": ["system.Everyone"]}}
+        resp = self.app.put_json("/buckets/ab", body, headers=self.headers)
+        before = resp.json
+
+        self.app.delete("/buckets/a", headers=self.headers)
+
+        resp = self.app.get("/buckets/ab", headers=self.headers, status=200)
+        self.assertEqual(resp.json, before)


### PR DESCRIPTION
This one is pretty heavy (deleting `/buckets/a` would also wipe out `/buckets/a-staging`).