### PR TITLE
Handle querystring parameters as JSON encoded values. Fixes #1217

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ This document describes changes between each past release.
 7.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Handle querystring parameters as JSON encoded values
+  to avoid treating number as number where they should be strings. (#1217)
 
 
 7.1.0 (2017-05-31)

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -1,4 +1,3 @@
-import ast
 import collections
 import hashlib
 import hmac
@@ -11,7 +10,7 @@ from binascii import hexlify
 from urllib.parse import unquote
 from enum import Enum
 
-import ujson as json  # NOQA
+import ujson as json
 
 try:
     import sqlalchemy
@@ -114,14 +113,13 @@ def native_value(value):
     :returns: the value coerced to python type
     """
     if isinstance(value, str):
-        if value.lower() in ['on', 'true', 'yes']:
-            value = True
-        elif value.lower() in ['off', 'false', 'no']:
-            value = False
         try:
-            return ast.literal_eval(value)
-        except (TypeError, ValueError, SyntaxError):
-            pass
+            value = json.loads(value)
+        except ValueError:
+            try:
+                value = json.loads('"{}"'.format(value))
+            except ValueError:
+                return value
     return value
 
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -33,8 +33,23 @@ class NativeValueTest(unittest.TestCase):
     def test_simple_string(self):
         self.assertEqual(native_value('value'), 'value')
 
+    def test_defined_string(self):
+        self.assertEqual(native_value('"value"'), 'value')
+
+    def test_null_value(self):
+        self.assertEqual(native_value('null'), None)
+
+    def test_defined_null_as_text_value(self):
+        self.assertEqual(native_value('"null"'), 'null')
+
     def test_integer(self):
         self.assertEqual(native_value('7'), 7)
+
+    def test_defined_integer_as_text_value(self):
+        self.assertEqual(native_value('"7"'), '7')
+
+    def test_defined_simple_quote_string_as_text_value(self):
+        self.assertEqual(native_value("'7'"), "'7'")
 
     def test_zero_and_one_coerce_to_integers(self):
         self.assertEqual(native_value('1'), 1)
@@ -44,12 +59,12 @@ class NativeValueTest(unittest.TestCase):
         self.assertEqual(native_value('3.14'), 3.14)
 
     def test_true_values(self):
-        true_strings = ['True', 'on', 'true', 'yes']
+        true_strings = ['true']
         true_values = [native_value(s) for s in true_strings]
         self.assertTrue(all(true_values))
 
     def test_false_values(self):
-        false_strings = ['False', 'off', 'false', 'no']
+        false_strings = ['false']
         false_values = [native_value(s) for s in false_strings]
         self.assertFalse(any(false_values))
 


### PR DESCRIPTION
Fixes #1217 

- [X] Add tests.
- [x] Add a changelog entry.