### PR TITLE
Add check on account plugin to avoid conflict with default basicauth policy (fixes #1177)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 - Handle querystring parameters as JSON encoded values
   to avoid treating number as number where they should be strings. (#1217)
 
+**Internal changes**
+
+- Add check on account plugin to avoid conflict with default ``basicauth`` policy (fixes #1177)
+
 
 7.1.0 (2017-05-31)
 ------------------

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -1,4 +1,5 @@
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
+from pyramid.exceptions import ConfigurationError
 
 
 def includeme(config):
@@ -16,3 +17,12 @@ def includeme(config):
         'write': {'account': ['write']},
         'read': {'account': ['write', 'read']}
     }
+
+    # Add some safety to avoid weird behaviour with basicauth default policy.
+    settings = config.get_settings()
+    auth_policies = settings['multiauth.policies']
+    if 'basicauth' in auth_policies and 'account' in auth_policies:
+        if auth_policies.index('basicauth') < auth_policies.index('account'):
+            error_msg = ("'basicauth' should not be mentioned before 'account' "
+                         "in 'multiauth.policies' setting.")
+            raise ConfigurationError(error_msg)


### PR DESCRIPTION
Fixes #1177
