### PR TITLE
Allow JSON filtering and clarify sort order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ This document describes changes between each past release.
 
 - Handle querystring parameters as JSON encoded values
   to avoid treating number as number where they should be strings. (#1217)
+- Introduce ``has_`` filter operator (fixes #344).
+- Several changes to the handling of NULLs and how the full range of
+  JSON values is compared in a storage backend (PR #1258). Combined
+  with #1252, this should fix #1215, #1216, #1217 and #1257, as well as
+  possibly some others.
 
 
 7.1.0 (2017-05-31)

--- a/docs/api/1.x/filtering.rst
+++ b/docs/api/1.x/filtering.rst
@@ -9,9 +9,38 @@ be expressed by query parameters. Elements of the plural endpoint
 (such as records) that do not match the predicates are omitted from
 the response.
 
+Most filters are expressed using a query parameter of the form
+``[operator_]field=value``. The (optional) operator is one from the
+list below. The field name can be simple or a dotted field
+name. Values can be any JSON encoded value (e.g. ``24``, ``"hello"``,
+``[1, 2, 4]``, ``{"flavor": "strawberry"}``, ``true``, or
+``null``). Anything not recognized as a JSON value is interpreted as a
+string.
+
 **Single value**
 
 * ``/collection?field=value``
+
+Examples:
+
+* ``/collection?author=2``
+
+  Matches any record whose ``author`` field is equal to the number 2.
+
+* ``/collection?author="Ben"``
+
+  Matches any record whose ``author`` field is equal to the string Ben.
+
+* ``/collection?author=Ben``
+
+  Same as the previous example, but relying on the behavior that
+  anything that isn't JSON is a string.
+
+* ``/collection?author="2.0"``
+
+  Matches any record whose ``author`` field is equal to the string
+  value ``"2.0"``. This is useful if your records contain something
+  numeric-ish but not quite numeric, like a version number.
 
 .. **Multiple values**
 ..
@@ -21,20 +50,31 @@ the response.
 
 * ``/collection?field.subfield=value``
 
-**Minimum and maximum**
+**Comparison**
 
-Prefix field name with ``min_`` or ``max_``:
+The filters ``lt`` and ``gt`` are available to compare against values.
 
-* ``/collection?min_field=4000``
+* ``/collection?gt_orders=100``
 
-.. note::
+  Retrieve any records whose ``orders`` field is (strictly) greater
+  than 100.
 
-    The lower and upper bounds are inclusive (*i.e equivalent to
-    greater or equal*).
+This bound is exclusive (i.e., in the previous example, it would not
+retrieve a record whose ``orders`` field was equal to 100. To check
+"less than or equal", use ``min``. To check "greater than or equal",
+use ``max``.
 
-.. note::
+* ``/collection?min_orders=100``
 
-   ``lt_`` and ``gt_`` can also be used to exclude the bound.
+  Retrieve any records whose ``orders`` field is greater than or equal
+  to 100.
+
+At the present time, the comparison order between values of different
+types is not defined. For example, if you have a record like
+``{"author": 1}`` and another like ``{"author": "2"}``, requesting
+``/collection?gt_author=1`` may return the second one, or it may
+not. However, a comparison operator will match whatever order you get
+by sorting, and the ordering will include all records.
 
 **Multiple values**
 
@@ -60,9 +100,13 @@ Prefix field name with ``like_``:
 
 * ``/collection?like_field=foo``
 
-.. note::
+**Field existence**
 
-    Will return an error if a field is unknown.
+You can request records that have a certain field (for example, ``author``) using ``has_author=true`` or those that don't have that field by using ``has_author=false``.
+
+* ``/collection?has_field=true``
+
+Note that a record like ``{"author": null}`` still counts as "having" that field.
 
 .. note::
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -16,6 +16,8 @@ Changelog
 
 - Groups can now be created with a simple ``PUT`` (fixes #793)
 - Batch requests now raise ``400`` on unknown attributes (#1163).
+- New ``has_`` filter operator (fixes #344).
+- JSON values are now accepted as filter values (fixes #1215, #1216, and #1217).
 
 1.15 (2017-03-03)
 '''''''''''''''''

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -374,16 +374,19 @@ def schwartz_transform(value):
         return (0, value)
     if isinstance(value, str):
         return (1, value)
+    if isinstance(value, bool):
+        # This has to be before Number, because bools are a subclass
+        # of int :(
+        return (3, value)
     if isinstance(value, numbers.Number):
         return (2, value)
-    if isinstance(value, bool):
-        return (3, value)
     if isinstance(value, abc.Sequence):
         return (4, value)
     if isinstance(value, abc.Mapping):
         return (5, value)
-    if value == MISSING:
+    if value is MISSING:
         return (6, value)
+    raise ValueError("Unknown value: {}".format(value))   # pragma: no cover
 
 
 def apply_sorting(records, sorting):

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -346,8 +346,8 @@ def apply_filters(records, filters):
             if f.operator in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 right, left = left, right
             elif f.operator not in (COMPARISON.LIKE, COMPARISON.HAS):
-                left = schwartz_transform(left)
-                right = schwartz_transform(right)
+                left = schwartzian_transform(left)
+                right = schwartzian_transform(right)
 
             if f.operator == COMPARISON.HAS:
                 matches = left != MISSING if f.value else left == MISSING
@@ -357,7 +357,7 @@ def apply_filters(records, filters):
             yield record
 
 
-def schwartz_transform(value):
+def schwartzian_transform(value):
     """Decorate a value with a tag that enforces the Postgres sort order.
 
     The sort order, per https://www.postgresql.org/docs/9.6/static/datatype-json.html, is:
@@ -398,7 +398,7 @@ def apply_sorting(records, sorting):
         return result
 
     def column(record, name):
-        return schwartz_transform(find_nested_value(record, name, default=MISSING))
+        return schwartzian_transform(find_nested_value(record, name, default=MISSING))
 
     for sort in reversed(sorting):
         result = sorted(result,

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -1,6 +1,8 @@
 import re
 import operator
 from collections import defaultdict
+from collections import abc
+import numbers
 
 from kinto.core import utils
 from kinto.core.decorators import synchronized
@@ -10,6 +12,13 @@ from kinto.core.storage import (
 from kinto.core.utils import (COMPARISON, find_nested_value)
 
 import ujson
+
+
+class Missing():
+    pass
+
+
+MISSING = Missing()
 
 
 def tree():
@@ -332,24 +341,45 @@ def apply_filters(records, filters):
                 if isinstance(right, int):
                     right = str(right)
 
-            left = find_nested_value(record, f.field)
+            left = find_nested_value(record, f.field, MISSING)
 
             if f.operator in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 right, left = left, right
-            else:
-                if left is None:
-                    right_is_number = (
-                        isinstance(right, (int, float)) and
-                        right not in (True, False))
-                    if right_is_number:
-                        # Python3 cannot compare None to a number.
-                        matches = False
-                        continue
-                    else:
-                        left = ''  # To mimic what we do for postgresql.
+            elif f.operator != COMPARISON.LIKE:
+                left = schwartz_transform(left)
+                right = schwartz_transform(right)
             matches = matches and operators[f.operator](left, right)
         if matches:
             yield record
+
+
+def schwartz_transform(value):
+    """Decorate a value with a tag that enforces the Postgres sort order.
+
+    The sort order, per https://www.postgresql.org/docs/9.6/static/datatype-json.html, is:
+
+    Object > Array > Boolean > Number > String > Null
+
+    Note that there are more interesting rules for comparing objects
+    and arrays but we probably don't need to be that compatible.
+
+    MISSING represents what would be a SQL NULL, which is "bigger"
+    than everything else.
+    """
+    if value is None:
+        return (0, value)
+    if isinstance(value, str):
+        return (1, value)
+    if isinstance(value, numbers.Number):
+        return (2, value)
+    if isinstance(value, bool):
+        return (3, value)
+    if isinstance(value, abc.Sequence):
+        return (4, value)
+    if isinstance(value, abc.Mapping):
+        return (5, value)
+    if value == MISSING:
+        return (6, value)
 
 
 def apply_sorting(records, sorting):
@@ -360,14 +390,12 @@ def apply_sorting(records, sorting):
     if not result:
         return result
 
-    first_record = result[0]
-
-    def column(first, record, name):
-        return find_nested_value(record, name, default=float('inf'))
+    def column(record, name):
+        return schwartz_transform(find_nested_value(record, name, default=MISSING))
 
     for sort in reversed(sorting):
         result = sorted(result,
-                        key=lambda r: column(first_record, r, sort.field),
+                        key=lambda r: column(r, sort.field),
                         reverse=(sort.direction < 0))
 
     return result

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -345,10 +345,14 @@ def apply_filters(records, filters):
 
             if f.operator in (COMPARISON.IN, COMPARISON.EXCLUDE):
                 right, left = left, right
-            elif f.operator != COMPARISON.LIKE:
+            elif f.operator not in (COMPARISON.LIKE, COMPARISON.HAS):
                 left = schwartz_transform(left)
                 right = schwartz_transform(right)
-            matches = matches and operators[f.operator](left, right)
+
+            if f.operator == COMPARISON.HAS:
+                matches = left != MISSING if f.value else left == MISSING
+            else:
+                matches = matches and operators[f.operator](left, right)
         if matches:
             yield record
 

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -718,7 +718,7 @@ class Storage(StorageBase):
                 # For the IN operator, let psycopg escape the values list.
                 # Otherwise JSON-ify the native value (e.g. True -> 'true')
                 if not isinstance(value, str):
-                    value = json.dumps(value).strip('"')
+                    value = json.dumps(value)
             else:
                 # If not all numeric, fallback to string comparison.
                 if not all([is_numeric(v) for v in value]):

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -757,13 +757,17 @@ class Storage(StorageBase):
                 # Operand should be a string.
                 value = '%{}%'.format(value)
 
-            # Safely escape value
-            value_holder = '{}_value_{}'.format(prefix, i)
-            holders[value_holder] = value
+            if filtr.operator == COMPARISON.HAS:
+                operator = 'IS NOT NULL' if filtr.value else 'IS NULL'
+                cond = "{} {}".format(sql_field, operator)
+            else:
+                # Safely escape value
+                value_holder = '{}_value_{}'.format(prefix, i)
+                holders[value_holder] = value
 
-            sql_operator = operators.setdefault(filtr.operator,
-                                                filtr.operator.value)
-            cond = "{} {} :{}".format(sql_field, sql_operator, value_holder)
+                sql_operator = operators.setdefault(filtr.operator,
+                                                    filtr.operator.value)
+                cond = "{} {} :{}".format(sql_field, sql_operator, value_holder)
             conditions.append(cond)
 
         safe_sql = ' AND '.join(conditions)

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -7,7 +7,7 @@ from kinto.core.storage import (
     StorageBase, exceptions,
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD)
 from kinto.core.storage.postgresql.client import create_from_config
-from kinto.core.utils import COMPARISON, json, is_numeric
+from kinto.core.utils import COMPARISON, json
 
 
 logger = logging.getLogger(__name__)

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -477,12 +477,18 @@ class BaseTestStorage:
         self.create_record({"name": "Mathieu"})
         filters = [Filter("name", "Fanny", utils.COMPARISON.GT)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
-        self.assertEqual(len(records), 1)  # None is not greater than "Fanny"
-        self.assertEqual(records[0]["name"], "Mathieu")
+        # NULLs compare as greater than everything
+        self.assertEqual(len(records), 2)
+        # But we aren't clear on what the order will be
+        mathieu_record = records[0] if 'name' in records[0] else records[1]
+        haha_record = records[1] if 'name' in records[0] else records[0]
+        self.assertEqual(mathieu_record["name"], "Mathieu")
+        self.assertEqual(haha_record["title"], "haha")
 
         filters = [Filter("name", "Fanny", utils.COMPARISON.LT)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
-        self.assertEqual(len(records), 2)  # None is less than "Fanny"
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["name"], "Alexis")
 
     def test_get_all_can_filter_with_none_values(self):
         self.create_record({"name": "Alexis", "salary": None})

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -359,9 +359,9 @@ class BaseTestStorage:
         sorting = [Sort('author', 1)]
         records, _ = self.storage.get_all(sorting=sorting, **self.storage_kw)
         # Some interesting values to compare against
-        VALUES = ['A', 'Z', '', 0, 4]
+        values = ['A', 'Z', '', 0, 4]
 
-        for value in VALUES:
+        for value in values:
             # Together, these filters should provide the entire list
             filter_less = Filter('author', value, utils.COMPARISON.LT)
             filter_min = Filter('author', value, utils.COMPARISON.MIN)
@@ -378,7 +378,7 @@ class BaseTestStorage:
                                  value, smaller_records, greater_records, records))
 
         # Same test but with MAX and GT
-        for value in VALUES:
+        for value in values:
             # Together, these filters should provide the entire list
             filter_less = Filter('author', value, utils.COMPARISON.MAX)
             filter_min = Filter('author', value, utils.COMPARISON.GT)

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -585,7 +585,22 @@ class BaseTestStorage:
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["flavor"], "blueberry")
 
+    def test_get_all_supports_has(self):
+        self.create_record({"flavor": "strawberry"})
+        self.create_record({"flavor": "blueberry", "author": None})
+        self.create_record({"flavor": "raspberry", "author": ""})
+        self.create_record({"flavor": "watermelon", "author": "hello"})
+        self.create_record({"flavor": "pineapple", "author": "null"})
+        filters = [Filter("author", True, utils.COMPARISON.HAS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
+        self.assertEqual(len(records), 4)
+        self.assertEqual(sorted([r['flavor'] for r in records]),
+                         ["blueberry", "pineapple", "raspberry", "watermelon"])
 
+        filters = [Filter("author", False, utils.COMPARISON.HAS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["flavor"], "strawberry")
 
     def test_get_all_can_filter_by_subobjects_values(self):
         for l in ['a', 'b', 'c']:

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -354,6 +354,7 @@ class BaseTestStorage:
         self.create_record({'flavor': 'strawberry'})
         self.create_record({'flavor': 'blueberry', 'author': None})
         self.create_record({'flavor': 'raspberry', 'author': 1})
+        self.create_record({'flavor': 'orange', 'author': True})
         self.create_record({'flavor': 'watermelon', 'author': 'Ethan'})
         sorting = [Sort('author', 1)]
         records, _ = self.storage.get_all(sorting=sorting, **self.storage_kw)

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -228,6 +228,7 @@ class COMPARISON(Enum):
     IN = 'in'
     EXCLUDE = 'exclude'
     LIKE = 'like'
+    HAS = 'has'
 
 
 def reapply_cors(request, response):

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -57,14 +57,6 @@ def classname(obj):
     return obj.__class__.__name__.lower()
 
 
-def is_numeric(value):
-    """Check if the provided value is a numeric value.
-
-    :rtype: bool
-    """
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
-
-
 def merge_dicts(a, b):
     """Merge b into a recursively, without overwriting values.
 

--- a/tests/core/resource/test_filter.py
+++ b/tests/core/resource/test_filter.py
@@ -12,12 +12,12 @@ class FilteringTest(BaseTest):
         records = [
             {'title': 'MoFo', 'status': 0, 'favorite': True},
             {'title': 'MoFo', 'status': 1, 'favorite': False},
-            {'title': 'MoFo', 'status': 2, 'favorite': False},
-            {'title': 'MoFo', 'status': 0, 'favorite': False},
+            {'title': 'MoFo', 'status': 2, 'favorite': False, 'sometimes': 'available'},
+            {'title': 'MoFo', 'status': 0, 'favorite': False, 'sometimes': None},
             {'title': 'MoFo', 'status': 1, 'favorite': True},
             {'title': 'MoFo', 'status': 2, 'favorite': False},
             {'title': 'Foo', 'status': 3, 'favorite': False},
-            {'title': 'Bar', 'status': 3, 'favorite': False},
+            {'title': 'Bar', 'status': 3, 'favorite': False, 'sometimes': 'present'},
         ]
         for r in records:
             self.model.create_record(r)
@@ -174,6 +174,19 @@ class FilteringTest(BaseTest):
         result = self.resource.collection_get()
         values = [item['status'] for item in result['data']]
         self.assertEqual(sorted(values), [1, 1, 2, 2, 3, 3])
+
+    def test_has_values(self):
+        self.validated['querystring'] = {'has_sometimes': True}
+        result = self.resource.collection_get()
+        values = [item['sometimes'] for item in result['data']]
+        assert None in values
+        self.assertEqual(sorted([v for v in values if v]), ['available', 'present'])
+
+    def test_has_values_false(self):
+        self.validated['querystring'] = {'has_sometimes': False}
+        result = self.resource.collection_get()
+        values = ['sometimes' in item for item in result['data']]
+        self.assertEqual(sorted(values), [False, False, False, False, False])
 
     def test_include_returns_400_if_value_has_wrong_type(self):
         self.validated['querystring'] = {'in_id': [0, 1]}

--- a/tests/core/resource/test_filter.py
+++ b/tests/core/resource/test_filter.py
@@ -224,3 +224,62 @@ class SubobjectFilteringTest(BaseTest):
         result = self.resource.collection_get()
         values = [item['party']['voters'] for item in result['data']]
         self.assertEqual(sorted(values), [1, 2, 3])
+
+
+class JSONFilteringTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.validated = self.resource.request.validated
+        self.patch_known_field.start()
+        records = [
+            {
+                "id": "strawberry",
+                "flavor": "strawberry",
+                "orders": [],
+                "attributes": {"ibu": 25, "seen_on": "2017-06-01"},
+                "author": None,
+            },
+            {"id": "blueberry-1", "flavor": "blueberry", "orders": [1]},
+            {"id": "blueberry-2", "flavor": "blueberry", "orders": ""},
+            {"id": "raspberry-1", "flavor": "raspberry", "attributes": {}},
+            {"id": "raspberry-2", "flavor": "raspberry", "attributes": []},
+            {
+                "id": "raspberry-3",
+                "flavor": "raspberry",
+                "attributes": {"ibu": 25, "seen_on": "2017-06-01", "price": 9.99},
+            },
+            {"id": "watermelon-1", "flavor": "watermelon", "author": "null"},
+            {"id": "watermelon-2", "flavor": "watermelon", "author": 0},
+        ]
+        for r in records:
+            self.model.create_record(r)
+
+    def test_filter_by_empty_array(self):
+        self.validated['querystring'] = {'orders': []}
+        result = self.resource.collection_get()
+        assert len(result['data']) == 1
+        assert result['data'][0]['id'] == 'strawberry'
+
+    def test_filter_by_nonempty_array(self):
+        self.validated['querystring'] = {'orders': [1]}
+        result = self.resource.collection_get()
+        assert len(result['data']) == 1
+        assert result['data'][0]['id'] == 'blueberry-1'
+
+    def test_filter_by_empty_object(self):
+        self.validated['querystring'] = {'attributes': {}}
+        result = self.resource.collection_get()
+        assert len(result['data']) == 1
+        assert result['data'][0]['id'] == 'raspberry-1'
+
+    def test_filter_by_nonempty_object(self):
+        self.validated['querystring'] = {'attributes': {'ibu': 25, 'seen_on': '2017-06-01'}}
+        result = self.resource.collection_get()
+        assert len(result['data']) == 1
+        assert result['data'][0]['id'] == 'strawberry'
+
+    def test_filter_by_null(self):
+        self.validated['querystring'] = {'author': None}
+        result = self.resource.collection_get()
+        assert len(result['data']) == 1
+        assert result['data'][0]['id'] == 'strawberry'

--- a/tests/test_views_collections.py
+++ b/tests/test_views_collections.py
@@ -91,7 +91,7 @@ class CollectionViewTest(BaseWebTest, unittest.TestCase):
         self.app.put_json('/buckets/beers/collections/moderator',
                           collection,
                           headers=self.headers)
-        resp = self.app.get('/buckets/beers/collections?min_size=2',
+        resp = self.app.get('/buckets/beers/collections?has_size=true&min_size=2',
                             headers=self.headers)
         data = resp.json['data']
         self.assertEqual(len(data), 1)

--- a/tests/test_views_groups.py
+++ b/tests/test_views_groups.py
@@ -84,7 +84,7 @@ class GroupViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
         self.app.put_json('/buckets/beers/groups/moderator',
                           group,
                           headers=self.headers)
-        resp = self.app.get('/buckets/beers/groups?min_size=2',
+        resp = self.app.get('/buckets/beers/groups?has_size=true&min_size=2',
                             headers=self.headers)
         data = resp.json['data']
         self.assertEqual(len(data), 1)


### PR DESCRIPTION
Fixes #1215, #1216, #1257, and possibly others.

Instead of coercing all values to strings when doing comparisons in Postgres, let Postgres use its own JSONB type comparison. This gets us 90% of the way to supporting JSON comparisons, including comparisons against null. The remaining part is about handling "missing" fields. I've made the executive decision that a "missing" value is not equal to any value of any type, including the JSON null. (Fortunately, this is easy in Postgres.) We handle these explicitly by adding `field IS NOT NULL AND` or `field IS NULL OR` as needed.

Because we already support sorting on a field with mixed-type values and/or missing values, we already implicitly have an ordering defined for comparisons like LT, GT, MAX, MIN, etc. This ordering puts missing values as "bigger" than other values. While we're messing around with comparisons involving NULL, fix this too.

We don't appear to have any clear recommendation about our ordering in the memory backend. To some extent, the tests assume that the ordering is the same. However, I am skeptical that we can always harmonize on the Postgres ordering. I think a more sensible approach is to allow each backend to define its own sort order, as long as it's consistent. For this reason, I didn't struggle with making the memory backend comparison function exactly the same as the Postgres one does.

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @leplatrem, @Natim 

I'm pretty confident in the approach, but I'm not sure whether this qualifies as a major version and/or API version.
