### PR TITLE
Fix jsonschema errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ API is now at version **1.17**. See `API changelog`_.
   with #1252, this should fix #1215, #1216, #1217 and #1257, as well as
   possibly some others.
 - Fix requests output when running with make serve (fixes #1242)
+- Restore error format for JSON schema validation errors (which was
+  changed in #1245).
 
 **Internal changes**
 

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -65,7 +65,9 @@ class Record(resource.ShareableResource):
             stripped.pop(self.schema_field, None)
             jsonschema.validate(stripped, schema)
         except jsonschema_exceptions.ValidationError as e:
-            if e.validator_value:
+            if e.path:
+                field = e.path[-1]
+            elif e.validator_value:
                 field = e.validator_value[-1]
             else:
                 field = e.schema_path[-1]

--- a/tests/test_views_collections_schema.py
+++ b/tests/test_views_collections_schema.py
@@ -14,6 +14,17 @@ SCHEMA = {
     "properties": {
         "title": {"type": "string"},
         "body": {"type": "string"},
+        "file": {
+            "type": "object",
+            "properties": {
+                "size": {
+                    "type": "number",
+                },
+                "name": {
+                    "type": "string",
+                }
+            },
+        },
     },
     "required": ["title"]
 }
@@ -165,6 +176,19 @@ class RecordsValidationTest(BaseWebTestWithSchema, unittest.TestCase):
                                   status=400)
         self.assertIn("'title' is a required property", resp.json['message'])
         self.assertEqual(resp.json['details'][0]['name'], 'title')
+
+    def test_validation_error_response_provides_details_and_path(self):
+        resp = self.app.post_json(RECORDS_URL,
+                                  {'data': {
+                                      'title': 'Some title',
+                                      'file': {
+                                          'size': "hi!",
+                                      }
+                                  }},
+                                  headers=self.headers,
+                                  status=400)
+        self.assertIn("size in body: 'hi!' is not of type 'number'", resp.json['message'])
+        self.assertEqual(resp.json['details'][0]['name'], 'size')
 
     def test_records_of_other_bucket_are_not_impacted(self):
         self.app.put_json('/buckets/cms', headers=self.headers)


### PR DESCRIPTION
https://github.com/Kinto/kinto/pull/1245 changed the format of the jsonschema error messages. It isn't clear exactly why; the commit message just says "Simplify and fix coverage". https://github.com/Kinto/kinto-attachment has a test that started failing because it relies on the format of the error message. Restore it.

- (n/a) Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @leplatrem 
