### PR TITLE
Enforce pyramid_tm > 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'pyramid > 1.8',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'transaction',
-    'pyramid_tm',
+    'pyramid_tm >= 2.1',
     'requests',
     'waitress',
     'ujson >= 1.35'

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ REQUIREMENTS = [
     'pyramid > 1.8',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'transaction',
+    # pyramid_tm changed the location of their tween in 2.x and one of
+    # our tests fails on 2.0.
     'pyramid_tm >= 2.1',
     'requests',
     'waitress',


### PR DESCRIPTION
The tests *almost* all pass with pyramid_tm 2.0, but the quota ones
fail on pyramid_tm 1.1.1. Let's just enforce 2.1 to be sure.

Follow-up to #1263.

- [x] Add documentation (as part of the previous PR).
- (n/a) Add tests.
- (n/a) Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @leplatrem 
