### PR TITLE
Fix schema validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fix missing ``collection_count`` field in the rebuild-quotas script.
+- Fix bug causing validation to always succeed if no required fields are present.
 
 **Internal changes**
 

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -59,6 +59,9 @@ class Record(resource.ShareableResource):
                            self.schema_field,
                            self.model.permissions_field)
         required_fields = [f for f in schema.get('required', []) if f not in internal_fields]
+        # jsonschema doesn't accept 'required': [] yet.
+        # See https://github.com/Julian/jsonschema/issues/337.
+        # In the meantime, strip out 'required' if no other fields are required.
         if required_fields:
             schema = {**schema, 'required': required_fields}
         else:

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -62,7 +62,7 @@ class Record(resource.ShareableResource):
         if required_fields:
             schema = {**schema, 'required': required_fields}
         else:
-            schema = {f: v for f, v in new.items() if f != 'required'}
+            schema = {f: v for f, v in schema.items() if f != 'required'}
         data = {f: v for f, v in new.items() if f not in internal_fields}
 
         # Validate or fail with 400.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIREMENTS = [
     'jsonpatch',
     'logging-color-formatter >= 1.0.1',  # Message interpolations.
     'python-dateutil',
-    'pyramid > 1.8',
+    'pyramid > 1.8, < 1.9b1',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'transaction',
     # pyramid_tm changed the location of their tween in 2.x and one of

--- a/tests/test_views_collections_schema.py
+++ b/tests/test_views_collections_schema.py
@@ -290,3 +290,10 @@ class InternalRequiredProperties(BaseWebTestWithSchema, unittest.TestCase):
         self.app.post_json(RECORDS_URL,
                            {'data': {'id': 'abc', 'last_modified': 1234}},
                            headers=self.headers)
+
+    def test_record_validation_can_reject_records(self):
+        self.app.post_json(RECORDS_URL,
+                           {'data': {'id': 'abc', 'last_modified': 1234,
+                                     'body': 2}},
+                           headers=self.headers,
+                           status=400)


### PR DESCRIPTION
A typo in https://github.com/Kinto/kinto/pull/1259 led to validation succeeding more than it should. This led to failed builds in kinto-attachment.

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

r? @leplatrem
