### PR TITLE
Fix permissions endpoint when using account plugin (fixes #1276)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 7.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix permissions endpoint when using account plugin (fixes #1276)
 
 
 7.2.1 (2017-06-20)

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -40,10 +40,9 @@ def allowed_from_settings(settings, principals):
                 resource_name=resource_name,
                 permission=permission)
             resource_name = {  # resource parents.
-                'bucket': '',
                 'collection': 'bucket',
                 'group': 'bucket',
-                'record': 'collection'}[resource_name]
+                'record': 'collection'}.get(resource_name, '')
         # Store them in a convenient way.
         from_settings.setdefault(resource_name, set()).add(permission)
     return from_settings

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -199,7 +199,10 @@ class PermissionsEndpointTest(AccountsWebTest):
     def test_permissions_endpoint_is_compatible_with_accounts_plugin(self):
         resp = self.app.get('/permissions', headers=self.headers)
         uris = [r["uri"] for r in resp.json["data"]]
-        assert uris == ['/buckets/a/collections/b/records/c', '/buckets/a/collections/b', '/buckets/a', '/accounts/alice']
+        assert uris == ['/buckets/a/collections/b/records/c',
+                        '/buckets/a/collections/b',
+                        '/buckets/a',
+                        '/accounts/alice']
 
 
 class AdminTest(AccountsWebTest):

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -182,6 +182,26 @@ class AccountViewsTest(AccountsWebTest):
                      status=403)
 
 
+class PermissionsEndpointTest(AccountsWebTest):
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings['experimental_permissions_endpoint'] = 'True'
+        return settings
+
+    def setUp(self):
+        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
+        self.headers = get_user_headers('alice', '123456')
+        self.app.put('/buckets/a', headers=self.headers)
+        self.app.put('/buckets/a/collections/b', headers=self.headers)
+        self.app.put('/buckets/a/collections/b/records/c', headers=self.headers)
+
+    def test_permissions_endpoint_is_compatible_with_accounts_plugin(self):
+        resp = self.app.get('/permissions', headers=self.headers)
+        uris = [r["uri"] for r in resp.json["data"]]
+        assert uris == ['/buckets/a/collections/b/records/c', '/buckets/a/collections/b', '/buckets/a', '/accounts/alice']
+
+
 class AdminTest(AccountsWebTest):
 
     @classmethod


### PR DESCRIPTION
Fixes #1276 
