### PR TITLE
Account bugs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,16 @@ This document describes changes between each past release.
 7.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Account plugin now allows account IDs to be email addresses (fixes
+  #1283).
+- Make it illegal for a principal to be present in
+  ``account_create_principals`` without also being in
+  ``account_write_principals``. Restricting creation of accounts to
+  specified users only makes sense if those users are "admins", which
+  means they're in ``account_write_principals``. (Fixes #1281.)
+- Fix a 500 when accounts without an ID are created (fixes #1280).
 
 
 7.2.2 (2017-06-22)

--- a/docs/api/1.x/accounts.rst
+++ b/docs/api/1.x/accounts.rst
@@ -158,6 +158,10 @@ Create account
         }
 
 
+By default, users can only create their own accounts. "Administrators", meaning anyone who matches ``account_write_principals``, can create accounts for other users as well.
+
+You can set ``account_create_principals`` if you want to limit account creation to certain users. The most common situation is when you want to have a small number of administrators, who are responsible for creating accounts for other users. In this case, you should add the administrators to both ``account_create_principals`` and ``account_write_principals``.
+
 .. _accounts-udpate:
 
 Change password

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -1,4 +1,3 @@
-import warnings
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
 from pyramid.exceptions import ConfigurationError
 
@@ -46,4 +45,5 @@ def includeme(config):
                    'If you want these users to be able to create accounts for other users, '
                    'add them to account_write_principals.\n'
                    'Affected users: {}'.format(list(cant_create_anything)))
-        warnings.warn(message)
+
+        raise ConfigurationError(message)

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
 from pyramid.exceptions import ConfigurationError
 
@@ -26,3 +27,23 @@ def includeme(config):
             error_msg = ("'basicauth' should not be mentioned before 'account' "
                          "in 'multiauth.policies' setting.")
             raise ConfigurationError(error_msg)
+
+    # We assume anyone in account_create_principals is to create
+    # accounts for other people.
+    # No one can create accounts for other people unless they are an
+    # "admin", defined as someone matching account_write_principals.
+    # Therefore any account that is in account_create_principals
+    # should be in account_write_principals too.
+    creators = set(settings.get('account_create_principals', '').split())
+    admins = set(settings.get('account_write_principals', '').split())
+    cant_create_anything = creators.difference(admins)
+    # system.Everyone isn't an account.
+    cant_create_anything.discard('system.Everyone')
+    if cant_create_anything:
+        message = ('Configuration has some principals in account_create_principals '
+                   'but not in account_write_principals. These principals will only be '
+                   'able to create their own accounts. This may not be what you want.\n'
+                   'If you want these users to be able to create accounts for other users, '
+                   'add them to account_write_principals.\n'
+                   'Affected users: {}'.format(list(cant_create_anything)))
+        warnings.warn(message)

--- a/kinto/plugins/accounts/views.py
+++ b/kinto/plugins/accounts/views.py
@@ -27,6 +27,12 @@ def _extract_posted_body_id(request):
         raise http_error(httpexceptions.HTTPUnauthorized(), error=error_msg)
 
 
+class AccountIdGenerator(NameGenerator):
+    """Allow @ signs in account IDs."""
+
+    regexp = r'^[a-zA-Z0-9][.@a-zA-Z0-9_-]*$'
+
+
 class AccountSchema(resource.ResourceSchema):
     password = colander.SchemaNode(colander.String())
 
@@ -55,7 +61,7 @@ class Account(resource.ShareableResource):
     @reify
     def id_generator(self):
         # This generator is used for ID validation.
-        return NameGenerator()
+        return AccountIdGenerator()
 
     def get_parent_id(self, request):
         # The whole challenge here is that we want to isolate what

--- a/kinto/plugins/accounts/views.py
+++ b/kinto/plugins/accounts/views.py
@@ -114,6 +114,14 @@ class Account(resource.ShareableResource):
         if self.context.is_administrator or self.context.is_anonymous:
             return new
 
+        # Do not let accounts be created without usernames.
+        if self.model.id_field not in new:
+            error_details = {
+                'name': 'data.id',
+                'description': 'Accounts must have an ID.',
+            }
+            raise_invalid(self.request, **error_details)
+
         # Otherwise, we force the id to match the authenticated username.
         if new[self.model.id_field] != self.request.selected_userid:
             error_details = {

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -287,6 +287,21 @@ class WarnAdminCreateTest(AccountsWebTest):
                    'Affected users: [\'account:admin\']')
         mocked.warn.assert_called_with(message)
 
+
+class CreateOtherUserTest(AccountsWebTest):
+    def setUp(self):
+        self.app.put_json('/accounts/bob', {'data': {'password': '123456'}}, status=201)
+        self.bob_headers = get_user_headers('bob', '123456')
+
+    def test_create_other_id_is_still_required(self):
+        self.app.post_json('/accounts', {'data': {'password': 'azerty'}}, status=400,
+                           headers=self.bob_headers)
+
+    def test_create_other_forbidden_without_write(self):
+        self.app.put_json('/accounts/alice', {'data': {'password': 'azerty'}}, status=400,
+                          headers=self.bob_headers)
+
+
 class WithBasicAuthTest(AccountsWebTest):
 
     @classmethod

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import unittest
 
+import mock
 from kinto.core.testing import get_user_headers
 from pyramid.exceptions import ConfigurationError
 
@@ -272,6 +273,19 @@ class AdminTest(AccountsWebTest):
 
         self.app.delete('/accounts/alice', headers=get_user_headers('alice', 'bouh'))
 
+
+class WarnAdminCreateTest(AccountsWebTest):
+    def test_raise_if_create_but_no_write(self):
+        with mock.patch('kinto.plugins.accounts.warnings') as mocked:
+            self.make_app({'account_create_principals': 'account:admin'})
+
+        message = ('Configuration has some principals in account_create_principals '
+                   'but not in account_write_principals. These principals will only be '
+                   'able to create their own accounts. This may not be what you want.\n'
+                   'If you want these users to be able to create accounts for other users, '
+                   'add them to account_write_principals.\n'
+                   'Affected users: [\'account:admin\']')
+        mocked.warn.assert_called_with(message)
 
 class WithBasicAuthTest(AccountsWebTest):
 

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-import mock
 from kinto.core.testing import get_user_headers
 from pyramid.exceptions import ConfigurationError
 
@@ -274,18 +273,10 @@ class AdminTest(AccountsWebTest):
         self.app.delete('/accounts/alice', headers=get_user_headers('alice', 'bouh'))
 
 
-class WarnAdminCreateTest(AccountsWebTest):
+class CheckAdminCreateTest(AccountsWebTest):
     def test_raise_if_create_but_no_write(self):
-        with mock.patch('kinto.plugins.accounts.warnings') as mocked:
+        with self.assertRaises(ConfigurationError):
             self.make_app({'account_create_principals': 'account:admin'})
-
-        message = ('Configuration has some principals in account_create_principals '
-                   'but not in account_write_principals. These principals will only be '
-                   'able to create their own accounts. This may not be what you want.\n'
-                   'If you want these users to be able to create accounts for other users, '
-                   'add them to account_write_principals.\n'
-                   'Affected users: [\'account:admin\']')
-        mocked.warn.assert_called_with(message)
 
 
 class CreateOtherUserTest(AccountsWebTest):

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -60,6 +60,10 @@ class AccountCreationTest(AccountsWebTest):
     def test_id_field_is_mandatory(self):
         self.app.post_json('/accounts', {'data': {'password': 'pass'}}, status=400)
 
+    def test_id_can_be_email(self):
+        self.app.put_json('/accounts/alice@example.com', {'data': {'password': '123456'}},
+                          status=201)
+
     def test_account_can_have_metadata(self):
         resp = self.app.post_json('/accounts',
                                   {'data': {'id': 'me', 'password': 'bouh', 'age': 42}},


### PR DESCRIPTION
Fix a few minor bugs in the accounts plugin to try to make it more production-ready.

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)

Of specific interest is #1281, where a user is in `account_create_principals` but not `account_write_principals`. The current interpretation of this configuration is that users cannot create accounts, except for the specified user, who is allowed to only create their own account. This seems nonsensical, since there's no way to authenticate the given user, so whichever user is first to create that account ID gets it. However, I was hesitant to outlaw this configuration, so I just logged a warning. The alternative would be to throw a ConfigurationError. What do you think?

r? @leplatrem @Natim 

