### PR TITLE
Fix StatsD unparseable metric packets for the unique user counter (fixes #1282)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ This document describes changes between each past release.
   specified users only makes sense if those users are "admins", which
   means they're in ``account_write_principals``. (Fixes #1281.)
 - Fix a 500 when accounts without an ID are created (fixes #1280).
+- Fix StatsD unparseable metric packets for the unique user counter (fixes #1282)
 
 
 7.2.2 (2017-06-22)

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -278,6 +278,8 @@ def setup_statsd(config):
             # Count unique users.
             user_id = request.prefixed_userid
             if user_id:
+                # Get rid of colons in metric packet (see #1282).
+                user_id = user_id.replace(':', '.')
                 client.count('users', unique=user_id)
 
             # Count authentication verifications.

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -328,7 +328,7 @@ class StatsDConfigurationTest(unittest.TestCase):
         app = webtest.TestApp(self.config.make_wsgi_app())
         headers = {'Authorization': 'Basic bWF0Og=='}
         app.get('/v0/', headers=headers)
-        self.mocked().count.assert_any_call('users', unique='basicauth:mat')
+        self.mocked().count.assert_any_call('users', unique='basicauth.mat')
 
     def test_statsd_counts_authentication_types(self):
         kinto.core.initialize(self.config, '0.0.1', 'project_name')


### PR DESCRIPTION
Fixes #1282
