### PR TITLE
Add cluster property

### DIFF
--- a/docs/tutorials/notifications-websockets.rst
+++ b/docs/tutorials/notifications-websockets.rst
@@ -47,6 +47,7 @@ add these lines to setup a listener, and be notified of record updates per colle
     pusher.app_id = <pusher-app-id>
     pusher.key = <pusher-key>
     pusher.secret = <pusher-secret>
+    pusher.cluster = <pusher-cluster>
 
 And (re)start Kinto with this new configuration.
 


### PR DESCRIPTION
The app will crash if `pusher.cluster` is not set.

Fixes #

- [X] Add documentation.
