### PR TITLE
Potential fix for #1308

### DIFF
--- a/kinto/core/cache/postgresql/__init__.py
+++ b/kinto/core/cache/postgresql/__init__.py
@@ -140,8 +140,16 @@ class Cache(CacheBase):
                                      value=value, ttl=ttl))
 
     def get(self, key):
-        purge = "DELETE FROM cache WHERE ttl IS NOT NULL AND now() > ttl;"
-        query = "SELECT value FROM cache WHERE key = :key;"
+        purge = """
+        DELETE FROM cache c
+        USING (
+            SELECT key
+            FROM cache
+            WHERE ttl IS NOT NULL AND now() > ttl
+            ORDER BY ttl ASC FOR UPDATE
+        ) del
+        WHERE del.key = c.key;"""
+        query = "SELECT value FROM cache WHERE key = :key AND now() < ttl;"
         with self.client.connect() as conn:
             conn.execute(purge)
             result = conn.execute(query, dict(key=self.prefix + key))


### PR DESCRIPTION
This is a pretty targeted fix, only intending to cause DELETE queries
to lock rows in the same (deterministic) order. Larger design
questions are outside the scope of this commit.

So far this has run for a little while without crashing, but I won't be confident for another hour or so.

Fixes #1308.

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
