### PR TITLE
Cache safer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Changelog
 7.3.2 (unreleased)
 ------------------
 
+**Bug fixes**
+
+- The PostgreSQL cache backend now orders deletes according to keys,
+  which are a well-defined order that never changes. (Fixes #1308.)
+
 **Internal changes**
 
 - Use json instead of ujson in storage in tests (#1255)


### PR DESCRIPTION
Fixes #1308.

- (n/a) Add documentation.
- (n/a) Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
