### PR TITLE
Commit the transaction at the end of the create-user script.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
-7.6.0 (unreleased)
+7.5.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix `create-user` command for PostgreSQL backend (#1340)
 
 
 7.5.0 (2017-09-27)

--- a/kinto/plugins/accounts/scripts.py
+++ b/kinto/plugins/accounts/scripts.py
@@ -1,5 +1,7 @@
 import logging
 import getpass
+
+import transaction as current_transaction
 from pyramid.settings import asbool
 
 from .utils import hash_password
@@ -55,5 +57,7 @@ def create_user(env, username=None, password=None):
     registry.permission.add_principal_to_ace('/accounts/{}'.format(username),
                                              'write',
                                              'account:{}'.format(username))
+
+    current_transaction.commit()
 
     return 0


### PR DESCRIPTION
Fixes #1336

- [x] Add tests.
- [x] Add a changelog entry.
