### PR TITLE
Fix typo in the Overview section of the documentation

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -48,7 +48,7 @@ Use cases
 - **Offline-first applications**: data can also be stored locally and published later.
 - **Build collaborative applications** with real time updates and fine-grained permissions.
 - **Synchronise application data** between different devices.
-- **Content delivery**: manage remote content or configuracion for your apps via an administration UI
+- **Content delivery**: manage remote content or configuration for your apps via an administration UI
 - **Data collection**: easily collect structured data from surveys, forms, analytics.
 - **Store encrypted data** at a location users can control, ensuring better privacy and security.
 


### PR DESCRIPTION
Changed "configuracion" to "configuration" in the "Content delivery" item in the "Use cases" subsection of the "Overview" section.

- [x] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
