### PR TITLE
Fix pyramid requirement in setup.py to match #1355

### DIFF
--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -43,10 +43,11 @@ class DummyRequest(mock.MagicMock):
         self.log_context = lambda **kw: kw
         self.matchdict = {}
         self.response = mock.MagicMock(headers={})
+        self.application_url = ''   # used by parse_url_overrides
 
         def route_url(*a, **kw):
             # XXX: refactor DummyRequest to take advantage of `pyramid.testing`
-            parts = parse_url_overrides(kw)
+            parts = parse_url_overrides(self, kw)
             return ''.join([p for p in parts if p])
 
         self.route_url = route_url

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIREMENTS = [
     'jsonpatch',
     'logging-color-formatter >= 1.0.1',  # Message interpolations.
     'python-dateutil',
-    'pyramid > 1.8, < 2.0',
+    'pyramid >= 1.9.1, < 2.0',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'transaction',
     # pyramid_tm changed the location of their tween in 2.x and one of

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIREMENTS = [
     'jsonpatch',
     'logging-color-formatter >= 1.0.1',  # Message interpolations.
     'python-dateutil',
-    'pyramid > 1.8, < 1.9b1',
+    'pyramid > 1.8, < 2.0',
     'pyramid_multiauth >= 0.8',  # User on policy selected event.
     'transaction',
     # pyramid_tm changed the location of their tween in 2.x and one of


### PR DESCRIPTION
I believe this is why kinto.js builds are failing against current master.