### PR TITLE
Remove kinto-http.js pin in kinto-admin

### DIFF
--- a/kinto/plugins/admin/package.json
+++ b/kinto/plugins/admin/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",
-    "kinto-http": "4.3.4",
     "kinto-admin": "1.14.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"


### PR DESCRIPTION
This should be OK now that Kinto/kinto-http#260 has been released in
4.4.1.
