### PR TITLE
Move to pytest==3.3.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,8 @@
 bravado_core==4.11.0
 flake8==3.5.0
 mock==2.0.0
-pytest==3.2.5
+pytest==3.3.0
 pytest-cache==1.0
-pytest-capturelog==0.7
 pytest-cover==3.0.0
 pytest-sugar==0.9.0
 SQLAlchemy==1.1.15

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ deps =
     mock
     pytest
     pytest-cache
-    pytest-capturelog
     pytest-cover
     pytest-sugar
     webtest


### PR DESCRIPTION
This breaks compatibility with the (apparently) defunct
pytest-capturelog plugin.

Fixes #1402.

- (n/a) Add documentation.
- (n/a) Add tests.
- (n/a) Add a changelog entry.
- [x] Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
