### PR TITLE
Don't purge_deleted

### DIFF
--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -35,7 +35,7 @@ def on_buckets_deleted(event):
                                collection_id=None,
                                with_deleted=False)
             # Remove remaining tombstones too.
-            storage.purge_deleted(parent_id=pattern,
-                                  collection_id=None)
+            # storage.purge_deleted(parent_id=pattern,
+            #                       collection_id=None)
             # Remove related permissions
             permission.delete_object_permissions(pattern)

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -35,7 +35,10 @@ def on_buckets_deleted(event):
                                collection_id=None,
                                with_deleted=False)
             # Remove remaining tombstones too.
-            # storage.purge_deleted(parent_id=pattern,
-            #                       collection_id=None)
+            settings = event.request.registry.settings
+            disable_purge_deleted = settings.get('experimental_disable_purge_deleted', False)
+            if not disable_purge_deleted:
+                storage.purge_deleted(parent_id=pattern,
+                                      collection_id=None)
             # Remove related permissions
             permission.delete_object_permissions(pattern)


### PR DESCRIPTION
Perhaps the reason we're seeing increased CPU load is because the
purge_deleted call, which used to do a table scan over a relatively
small table, is now over the entire records table. This probably
doubles the amount of table scans we perform.

Let's disable this purge_deleted for a while. Tombstones will stay
tombstones for now. This won't be a problem for kintowe because
kintowe never actually generates tombstones (even deleted records are
encrypted as "live" records).
