### PR TITLE
Openid connect support (fixes #939)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 8.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- Add Openid connect support (#939, #1425). See `demo <https://github.com/leplatrem/kinto-oidc-demo>`_
 
 
 8.1.4 (2018-01-31)
@@ -16,6 +18,7 @@ This document describes changes between each past release.
 
 - Allow inherited resources to set a custom model instance before instantiating (fixes #1472)
 - Fix collection timestamp retrieval when the stack is configured as readonly (fixes #1474)
+
 
 8.1.3 (2018-01-26)
 ------------------

--- a/docs/api/1.x/authentication.rst
+++ b/docs/api/1.x/authentication.rst
@@ -229,8 +229,6 @@ You can also read our :ref:`tutorial about how to plug the Github authorisation 
 OpenID Connect
 ==============
 
-Kinto supports :ref:`OpenID <settings-openid>`.
-
 OpenID relies on *OAuth2 bearer tokens*, so basically authentication shall be done using this header:
 
 ::
@@ -245,10 +243,10 @@ OpenID relies on *OAuth2 bearer tokens*, so basically authentication shall be do
 Login and obtain access token
 -----------------------------
 
-Once configured, the OpenID configuration details are provided in the capabilities object at the :ref:`root URL <hello-endpoint>`.
+:ref:`Once configured <settings-openid>`, the OpenID configuration details are provided in the capabilities object at the :ref:`root URL <api-utilities-hello>`:
 
-.. code-block:: HTTP
-    :emphasize-lines: 12-17
+.. code-block:: http
+    :emphasize-lines: 11-16
 
     HTTP/1.1 200 OK
     Content-Length: 638
@@ -271,12 +269,12 @@ Once configured, the OpenID configuration details are provided in the capabiliti
                 "url": "http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html"
             }
         }
-        ...
+    }
 
 In order to initiate the login and its browser redirections (aka. «dance»), just reach the URL specified in the ``auth_path``
 for the configured provider ``name``.
 
-.. code-block:: HTTP
+::
 
     GET /openid/{name}/login?callback={URI}&scope={scope}
 
@@ -288,12 +286,13 @@ for the configured provider ``name``.
 JavaScript example
 ------------------
 
-Let's go through a simple OpenID login example using the :github:`JavaScript kinto client <Kinto/kinto-http.js`.
+Let's go through a simple OpenID login example using the :github:`JavaScript kinto client <Kinto/kinto-http.js>`.
 
 When the user clicks a login button, it initiate the login process by redirecting the browser to the
 Identity Provider, which itself redirects it to the application page once successful.
 
 .. code-block:: JavaScript
+    :emphasize-lines: 12,15,19-25
 
     const KINTO_URL = 'http://localhost:8888/v1';
 
@@ -342,14 +341,18 @@ The ``login()`` function is straightforward:
 
 The ``parseToken()`` function scans the location hash to read the Identity Provider response:
 
+.. code-block:: JavaScript
+
     function parseToken() {
       const hash = decodeURIComponent(window.location.hash);
       const tokensExtract = /tokens=([.\s\S]*)/.exec(hash);
-      if (tokensExtract) {
-        const tokens = tokensExtract[1];
-        const parsed = JSON.parse(tokens);
-        return parsed;
+      if (!tokensExtract) {
+        // No token in URL bar.
+        return null;
       }
-      // Else, no token in URL bar, do nothing.
-      return null;
+      const tokens = tokensExtract[1];
+      const parsed = JSON.parse(tokens);
+      return parsed;
     }
+
+Check out the :github:`full demo source code <leplatrem/kinto-oidc-demo>`.

--- a/docs/api/1.x/authentication.rst
+++ b/docs/api/1.x/authentication.rst
@@ -224,26 +224,132 @@ Some possible strategies:
 You can also read our :ref:`tutorial about how to plug the Github authorisation backend <tutorial-github>`.
 
 
-OAuth Bearer token
-==================
+.. _authentication-openid:
 
-If the configured authentication policy uses *OAuth2 bearer tokens*, authentication
-shall be done using this header:
+OpenID Connect
+==============
+
+Kinto supports :ref:`OpenID <settings-openid>`.
+
+OpenID relies on *OAuth2 bearer tokens*, so basically authentication shall be done using this header:
 
 ::
 
-    Authorization: Bearer <oauth_token>
-
-
-The policy will verify the provided *OAuth2 bearer token* on a remote server.
+    Authorization: Bearer <access_token>
 
 :notes:
 
     If the token is not valid, this will result in a |status-401| error response.
 
 
-Firefox Accounts
-----------------
+Login and obtain access token
+-----------------------------
 
-In order to enable authentication with :term:`Firefox Accounts`, install and
-configure :github:`mozilla-services/kinto-fxa`.
+Once configured, the OpenID configuration details are provided in the capabilities object at the :ref:`root URL <hello-endpoint>`.
+
+.. code-block:: HTTP
+    :emphasize-lines: 12-17
+
+    HTTP/1.1 200 OK
+    Content-Length: 638
+    Content-Type: application/json
+
+    {
+        "capabilities": {
+            "openid": {
+                "description": "OpenID connect support.",
+                "providers": [
+                    {
+                        "name": "google",
+                        "auth_path": "/openid/google/login",
+                        "client_id": "XXXXX.apps.googleusercontent.com",
+                        "header_type": "Bearer",
+                        "issuer": "https://accounts.google.com",
+                        "userinfo_endpoint": "https://www.googleapis.com/oauth2/v3/userinfo"
+                    }
+                ],
+                "url": "http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html"
+            }
+        }
+        ...
+
+In order to initiate the login and its browser redirections (aka. «dance»), just reach the URL specified in the ``auth_path``
+for the configured provider ``name``.
+
+.. code-block:: HTTP
+
+    GET /openid/{name}/login?callback={URI}&scope={scope}
+
+- ``callback`` which is the URI the browser will be redirected to after the login (eg. ``http://dashboard.myapp.com/#tokens=``).
+  It will be suffixed with the JSON response from the :term:`Identity Provider`, which will either be the access and ID tokens or an error.
+- ``scope`` which should at least be ``openid`` (but usually ``openid email``) (see the Identity Provider documentation)
+
+
+JavaScript example
+------------------
+
+Let's go through a simple OpenID login example using the :github:`JavaScript kinto client <Kinto/kinto-http.js`.
+
+When the user clicks a login button, it initiate the login process by redirecting the browser to the
+Identity Provider, which itself redirects it to the application page once successful.
+
+.. code-block:: JavaScript
+
+    const KINTO_URL = 'http://localhost:8888/v1';
+
+    const SCOPES = 'openid email';
+
+    // Redirect to the same page using the location hash.
+    const CALLBACK_URL = window.location.href + '#tokens=';
+
+    const kintoClient = new KintoClient(KINTO_URL);
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      // Initiate login on some button click
+      loginBtn.addEventListener('click', login);
+
+      // Check if the location contains the tokens (after being redirected)
+      const authResult = parseToken();
+      if (authResult) {
+        const {access_token, token_type} = authResult;
+        if (access_token) {
+          // Set access token for requests to Kinto.
+          kintoClient.setHeaders({
+            'Authorization': `${token_type} ${access_token}`,
+          });
+          // Show if Kinto authenticates me:
+          const {user} = await kintoClient.fetchServerInfo();
+          alert("You are " + (user ? user.id : "unknown"));
+        }
+        else {
+          console.error('Authentication error', authResult);
+        }
+
+      }
+    });
+
+The ``login()`` function is straightforward:
+
+.. code-block:: JavaScript
+
+    function login() {
+      const {capabilities: {openid: {providers}}} = await kintoClient.fetchServerInfo();
+      const {auth_path} = providers[0];
+      // Redirect the browser to the authentication page.
+      const callback = encodeURIComponent(CALLBACK_URL);
+      window.location = `${KINTO_URL}${auth_path}?callback=${callback}&scope=${SCOPES}`;
+    }
+
+The ``parseToken()`` function scans the location hash to read the Identity Provider response:
+
+    function parseToken() {
+      const hash = decodeURIComponent(window.location.hash);
+      const tokensExtract = /tokens=([.\s\S]*)/.exec(hash);
+      if (tokensExtract) {
+        const tokens = tokensExtract[1];
+        const parsed = JSON.parse(tokens);
+        return parsed;
+      }
+      // Else, no token in URL bar, do nothing.
+      return null;
+    }

--- a/docs/api/1.x/utilities.rst
+++ b/docs/api/1.x/utilities.rst
@@ -3,6 +3,8 @@
 Utility endpoints for OPS and Devs
 ##################################
 
+.. _api-utilities-hello:
+
 GET /
 =====
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -479,13 +479,14 @@ In order to replace it by another one:
     multiauth.policies = basicauth
     multiauth.policy.basicauth.use = myproject.authn.BasicAuthPolicy
 
+.. _settings-openid:
 
 OpenID Connect
 ::::::::::::::
 
-First of all, you must find an Identity Provider. Google Identity Platform for example, but it may also be Auth0, Microsoft, Yahoo, Paypal, Bitbucket, Ebay, Salesforce, ... or which ever platform that publishes its discovery metadata as JSON.
+First of all, you must find an Identity Provider. Google Identity Platform for example, but it may also be Auth0, Microsoft, Yahoo, Paypal, Bitbucket, Ebay, Salesforce, ... or whichever platform that publishes its discovery metadata as JSON.
 
-Enable the OpenID authentication policy in Kinto settings like below. The ``oidc`` is arbitrary but will become the user ID prefix (e.g. ``google:someuser@gmail.com``)
+Enable the OpenID authentication policy in Kinto settings like below. The ``google`` name is arbitrary but will become the user ID prefix (e.g. ``google:someuser@gmail.com``)
 
 .. code-block:: ini
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -509,13 +509,13 @@ At this point, Kinto should be able to start and OpenID Authentication should wo
 .. code-block:: ini
 
     # User ID field name (Default: `sub`)
-    multiauth.policy.oidc.userid_field = email
+    multiauth.policy.google.userid_field = email
     # Authorization header prefix (Default: `Bearer`)
-    multiauth.policy.oidc.header_type = Bearer+OIDC
+    multiauth.policy.google.header_type = Bearer+OIDC
     # User information cache expiration (Default: 1 day)
-    multiauth.policy.oidc.verification_ttl_seconds = 86400
+    multiauth.policy.google.verification_ttl_seconds = 86400
     # Authentication state cache duration (Default: 1 hour)
-    multiauth.policy.oidc.state_ttl_seconds = 3600
+    multiauth.policy.google.state_ttl_seconds = 3600
 
 
 Custom Authentication

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -480,6 +480,44 @@ In order to replace it by another one:
     multiauth.policy.basicauth.use = myproject.authn.BasicAuthPolicy
 
 
+OpenID Connect
+::::::::::::::
+
+First of all, you must find an Identity Provider. Google Identity Platform for example, but it may also be Auth0, Microsoft, Yahoo, Paypal, Bitbucket, Ebay, Salesforce, ... or which ever platform that publishes its discovery metadata as JSON.
+
+Enable the OpenID authentication policy in Kinto settings like below. The ``oidc`` is arbitrary but will become the user ID prefix (e.g. ``google:someuser@gmail.com``)
+
+.. code-block:: ini
+
+    kinto.includes = kinto.plugins.openid
+
+    multiauth.policies = google
+    multiauth.policy.google.use = kinto.plugins.openid.OpenIDConnectPolicy
+
+Based on the information provided by the Identity Provider configure the ``issuer`` and ``client_id``. Potentially you may have a ``client_secret`` depending on how the application was setup. For example, Auth0 has a *Frontend app* option that does not require any client secret.
+
+.. code-block:: ini
+
+    multiauth.policy.google.issuer = https://accounts.google.com
+    multiauth.policy.google.client_id = 42XXXX365001.apps.googleusercontent.com
+    multiauth.policy.google.client_secret = UAlL-054uyh5in4b6u8jhg5o3hnj
+
+At this point, Kinto should be able to start and OpenID Authentication should work as described in the :ref:`API docs <authentication-openid>`.
+
+**Advanced settings**
+
+.. code-block:: ini
+
+    # User ID field name (Default: `sub`)
+    multiauth.policy.oidc.userid_field = email
+    # Authorization header prefix (Default: `Bearer`)
+    multiauth.policy.oidc.header_type = Bearer+OIDC
+    # User information cache expiration (Default: 1 day)
+    multiauth.policy.oidc.verification_ttl_seconds = 86400
+    # Authentication state cache duration (Default: 1 hour)
+    multiauth.policy.oidc.state_ttl_seconds = 3600
+
+
 Custom Authentication
 :::::::::::::::::::::
 

--- a/docs/core/glossary.rst
+++ b/docs/core/glossary.rst
@@ -20,7 +20,12 @@ Glossary
         lines of code. It differs from «:term:`pluggable`».
 
     Firefox Accounts
-        Account account system run by Mozilla (https://accounts.firefox.com).
+        :term:`Identity Provider` run by Mozilla (https://accounts.firefox.com).
+
+    Identity Provider
+        An identity provider (abbreviated IdP) is a service in charge of managing
+        identity information, and providing authentication endpoints (login forms,
+        tokens manipulation etc.)
 
     HTTP API
         Multiple publicly exposed endpoints that accept HTTP requests and

--- a/kinto/core/authentication.py
+++ b/kinto/core/authentication.py
@@ -1,7 +1,14 @@
+from jose import jwt
 from pyramid import authentication as base_auth
+from pyramid.interfaces import IAuthenticationPolicy
+from zope.interface import implementer
+
+import requests
 
 from kinto.core import utils
 from kinto.core.openapi import OpenAPI
+
+from kinto.core import logger
 
 
 class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
@@ -35,6 +42,93 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
             credentials = '{}:{}'.format(*credentials)
             userid = utils.hmac_digest(hmac_secret, credentials)
             return userid
+
+
+@implementer(IAuthenticationPolicy)
+class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
+    def __init__(self, realm='Realm'):
+        self.realm = realm
+        self._cache = None
+
+        self._jwt_keys = None
+
+    def unauthenticated_userid(self, request):
+        """Return the FxA userid or ``None`` if token could not be verified.
+        """
+        authorization = request.headers.get('Authorization', '')
+        try:
+            authmeth, payload = authorization.split(' ', 1)
+        except ValueError:
+            return None
+
+        if authmeth.lower() != 'bearer+oidc':
+            return None
+
+        try:
+            # Bearer+OIDC id_token=jwt, access_token=bearer
+            parts = payload.split(',')
+            credentials = {k: v for k, v in [p.strip().split("=") for p in parts]}
+            id_token = credentials["id_token"]
+            access_token = credentials["access_token"]
+        except (ValueError, KeyError):
+            # Bearer+OIDC jwt
+            id_token = payload
+            access_token = None
+
+        return self._verify_token(request, id_token, access_token)
+
+    def forget(self, request):
+        """A no-op. Credentials are sent on every request.
+        Return WWW-Authenticate Realm header for Bearer token.
+        """
+        return [('WWW-Authenticate', 'Bearer+OIDC realm="%s"' % self.realm)]
+
+    def _verify_token(self, request, id_token, access_token):
+        # Verify signature
+        audience = request.registry.settings["oidc.audience"]
+        issuer = request.registry.settings["oidc.issuer_url"]
+
+        if self._jwt_keys is None:
+            resp = requests.get(issuer.rstrip("/") + "/.well-known/openid-configuration")
+            jwks_uri = resp.json()["jwks_uri"]
+            resp = requests.get(jwks_uri)
+            self._jwt_keys = resp.json()["keys"]
+
+        try:
+            unverified_header = jwt.get_unverified_header(id_token)
+        except jwt.JWTError:
+            logger.debug("Invalid header. Use an RS256 signed JWT Access Token")
+            return None
+
+        if unverified_header["alg"] != "RS256":
+            logger.debug("Invalid header. Use an RS256 signed JWT Access Token")
+            return None
+
+        rsa_key = {}
+        for key in self._jwt_keys:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = utils.dict_subset(key, ("kty", "kid", "use", "n", "e"))
+                break
+        if not rsa_key:
+            logger.debug("Unable to find appropriate key")
+            return None
+        try:
+            options = None
+            if access_token is None:
+                options = {"verify_at_hash": False}
+
+            payload = jwt.decode(id_token, rsa_key, algorithms=["RS256"],
+                                 audience=audience, issuer=issuer,
+                                 options=options, access_token=access_token)
+            return payload["sub"]
+
+        except jwt.ExpiredSignatureError as e:
+            logger.debug("Token is expired: %s" % e)
+        except jwt.JWTClaimsError as e:
+            logger.debug("Incorrect claims, please check the audience and issuer: %s" % e)
+        except Exception as e:
+            logger.exception("Unable to parse token")
+        return None
 
 
 def includeme(config):

--- a/kinto/core/authentication.py
+++ b/kinto/core/authentication.py
@@ -1,14 +1,7 @@
-from jose import jwt
 from pyramid import authentication as base_auth
-from pyramid.interfaces import IAuthenticationPolicy
-from zope.interface import implementer
-
-import requests
 
 from kinto.core import utils
 from kinto.core.openapi import OpenAPI
-
-from kinto.core import logger
 
 
 class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
@@ -42,93 +35,6 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
             credentials = '{}:{}'.format(*credentials)
             userid = utils.hmac_digest(hmac_secret, credentials)
             return userid
-
-
-@implementer(IAuthenticationPolicy)
-class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
-    def __init__(self, realm='Realm'):
-        self.realm = realm
-        self._cache = None
-
-        self._jwt_keys = None
-
-    def unauthenticated_userid(self, request):
-        """Return the FxA userid or ``None`` if token could not be verified.
-        """
-        authorization = request.headers.get('Authorization', '')
-        try:
-            authmeth, payload = authorization.split(' ', 1)
-        except ValueError:
-            return None
-
-        if authmeth.lower() != 'bearer+oidc':
-            return None
-
-        try:
-            # Bearer+OIDC id_token=jwt, access_token=bearer
-            parts = payload.split(',')
-            credentials = {k: v for k, v in [p.strip().split("=") for p in parts]}
-            id_token = credentials["id_token"]
-            access_token = credentials["access_token"]
-        except (ValueError, KeyError):
-            # Bearer+OIDC jwt
-            id_token = payload
-            access_token = None
-
-        return self._verify_token(request, id_token, access_token)
-
-    def forget(self, request):
-        """A no-op. Credentials are sent on every request.
-        Return WWW-Authenticate Realm header for Bearer token.
-        """
-        return [('WWW-Authenticate', 'Bearer+OIDC realm="%s"' % self.realm)]
-
-    def _verify_token(self, request, id_token, access_token):
-        # Verify signature
-        audience = request.registry.settings["oidc.audience"]
-        issuer = request.registry.settings["oidc.issuer_url"]
-
-        if self._jwt_keys is None:
-            resp = requests.get(issuer.rstrip("/") + "/.well-known/openid-configuration")
-            jwks_uri = resp.json()["jwks_uri"]
-            resp = requests.get(jwks_uri)
-            self._jwt_keys = resp.json()["keys"]
-
-        try:
-            unverified_header = jwt.get_unverified_header(id_token)
-        except jwt.JWTError:
-            logger.debug("Invalid header. Use an RS256 signed JWT Access Token")
-            return None
-
-        if unverified_header["alg"] != "RS256":
-            logger.debug("Invalid header. Use an RS256 signed JWT Access Token")
-            return None
-
-        rsa_key = {}
-        for key in self._jwt_keys:
-            if key["kid"] == unverified_header["kid"]:
-                rsa_key = utils.dict_subset(key, ("kty", "kid", "use", "n", "e"))
-                break
-        if not rsa_key:
-            logger.debug("Unable to find appropriate key")
-            return None
-        try:
-            options = None
-            if access_token is None:
-                options = {"verify_at_hash": False}
-
-            payload = jwt.decode(id_token, rsa_key, algorithms=["RS256"],
-                                 audience=audience, issuer=issuer,
-                                 options=options, access_token=access_token)
-            return payload["sub"]
-
-        except jwt.ExpiredSignatureError as e:
-            logger.debug("Token is expired: %s" % e)
-        except jwt.JWTClaimsError as e:
-            logger.debug("Incorrect claims, please check the audience and issuer: %s" % e)
-        except Exception as e:
-            logger.exception("Unable to parse token")
-        return None
 
 
 def includeme(config):

--- a/kinto/core/openapi.py
+++ b/kinto/core/openapi.py
@@ -28,7 +28,10 @@ class OpenAPI(CorniceSwagger):
         """Allow security extensions to expose authentication methods on the
         OpenAPI documentation. The definition field should correspond to a
         valid OpenAPI security definition. Refer the OpenAPI 2.0 specification
-        for more information. Below are some examples for BasicAuth and OAuth2::
+        for more information.
+        https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
+
+        Below are some examples for BasicAuth and OAuth2::
 
             {
                 "type": "basic",

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -92,7 +92,7 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
                 resp.raise_for_status()
                 userprofile = resp.json()
                 return userprofile
-            except (requests.exceptions.HTTPError, KeyError) as e:
+            except (requests.exceptions.HTTPError, ValueError, KeyError) as e:
                 logger.debug("Unable to fetch user profile from %s with %s" % (uri, access_token))
                 return None
 

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -81,7 +81,7 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
                 userprofile = resp.json()
                 return userprofile["sub"]
             except (requests.exceptions.HTTPError, KeyError) as e:
-                logger.debug("Unable to fetch user profile from %s with %s" (uri, access_token))
+                logger.debug("Unable to fetch user profile from %s with %s" % (uri, access_token))
                 return None
 
         # JWT token is provided.

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -1,0 +1,150 @@
+from jose import jwt
+from pyramid import authentication as base_auth
+from pyramid.interfaces import IAuthenticationPolicy
+from zope.interface import implementer
+
+import requests
+
+from kinto.core import utils
+from kinto.core.openapi import OpenAPI
+
+from kinto.core import logger
+
+
+def fetch_openid_config(issuer):
+    resp = requests.get(issuer.rstrip("/") + "/.well-known/openid-configuration")
+    return resp.json()
+
+
+@implementer(IAuthenticationPolicy)
+class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
+    def __init__(self, realm='Realm', prefix='bearer+oidc'):
+        self.realm = realm
+        self.prefix = prefix
+
+        self._openid_config = None
+        self._jwt_keys = None
+
+    def unauthenticated_userid(self, request):
+        """Return the userid or ``None`` if token could not be verified.
+        """
+        audience = request.registry.settings["oidc.audience"]
+        issuer = request.registry.settings["oidc.issuer_url"]
+
+        authorization = request.headers.get('Authorization', '')
+        try:
+            authmeth, payload = authorization.split(' ', 1)
+        except ValueError:
+            return None
+
+        if authmeth.lower() != self.prefix.lower():
+            return None
+
+        try:
+            # Bearer+OIDC id_token=jwt, access_token=bearer
+            parts = payload.split(',')
+            credentials = {k: v for k, v in [p.strip().split("=") for p in parts]}
+            id_token = credentials["id_token"]
+            access_token = credentials["access_token"]
+        except (ValueError, KeyError):
+            parts = payload.split('.')
+            if len(parts) == 3:
+                # Bearer+OIDC JWT ID ?
+                id_token = payload
+                access_token = None
+            else:
+                # Bearer+OIDC accesstoken
+                id_token = None
+                access_token = payload
+
+            # XXX JWT Access token
+            # https://auth0.com/docs/tokens/access-token#access-token-format
+
+        return self._verify_token(issuer, audience, id_token, access_token)
+
+    def forget(self, request):
+        """A no-op. Credentials are sent on every request.
+        Return WWW-Authenticate Realm header for Bearer token.
+        """
+        return [('WWW-Authenticate', '%s realm="%s"' % (self.prefix, self.realm))]
+
+    def _verify_token(self, issuer, audience, id_token, access_token):
+        if self._openid_config is None:
+            self._openid_config = fetch_openid_config(issuer)
+
+        if id_token is None:
+            uri = self._openid_config["userinfo_endpoint"]
+            # Opaque access token string. Fetch user info from profile.
+            try:
+                resp = requests.get(uri, headers={"Authorization": "Bearer " + access_token})
+                resp.raise_for_status()
+                userprofile = resp.json()
+                return userprofile["sub"]
+            except (requests.exceptions.HTTPError, KeyError) as e:
+                logger.debug("Unable to fetch user profile from %s with %s" (uri, access_token))
+                return None
+
+        # JWT token is provided.
+        # Verify signature
+        if self._jwt_keys is None:
+            jwks_uri = self._openid_config["jwks_uri"]
+            resp = requests.get(jwks_uri)
+            self._jwt_keys = resp.json()["keys"]
+
+        try:
+            unverified_header = jwt.get_unverified_header(id_token)
+        except jwt.JWTError:
+            logger.debug("Invalid header. Use an RS256 signed JWT Access Token")
+            return None
+
+        if unverified_header["alg"] != "RS256":
+            logger.debug("Invalid header. Use an RS256 signed JWT Access Token")
+            return None
+
+        rsa_key = {}
+        for key in self._jwt_keys:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = utils.dict_subset(key, ("kty", "kid", "use", "n", "e"))
+                break
+        if not rsa_key:
+            logger.debug("Unable to find appropriate key")
+            return None
+        try:
+            options = None
+            if access_token is None:
+                options = {"verify_at_hash": False}
+
+            payload = jwt.decode(id_token, rsa_key, algorithms=["RS256"],
+                                 audience=audience, issuer=issuer,
+                                 options=options, access_token=access_token)
+            return payload["sub"]
+
+        except jwt.ExpiredSignatureError as e:
+            logger.debug("Token is expired: %s" % e)
+        except jwt.JWTClaimsError as e:
+            logger.debug("Incorrect claims, please check the audience and issuer: %s" % e)
+        except Exception as e:
+            logger.exception("Unable to parse token")
+        return None
+
+
+def includeme(config):
+    issuer = config.registry.settings['oidc.issuer_url']
+    openid_config = fetch_openid_config(issuer)
+
+    config.add_api_capability(
+        'openid',
+        description='OpenID connect support.',
+        url='http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html',
+        **openid_config
+    )
+
+    OpenAPI.expose_authentication_method('openid', {
+        "type": "oauth2",
+        "authorizationUrl": openid_config['authorization_endpoint'],
+        # "flow": "implicit",
+        # "scopes": {
+        #   "write:pets": "modify pets in your account",
+        #   "read:pets": "read your pets"
+        # }
+    })

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -170,12 +170,14 @@ def includeme(config):
         openid_config = fetch_openid_config(issuer)
 
         client_id = settings['multiauth.policy.%s.client_id' % name]
+        header_type = settings.get('multiauth.policy.%s.header_type', 'Bearer')
 
         providers_infos.append({
             'name': name,
             'issuer': openid_config['issuer'],
             'auth_path': '/openid/%s/login' % name,
             'client_id': client_id,
+            'header_type': header_type,
             'userinfo_endpoint': openid_config['userinfo_endpoint'],
         })
 

--- a/kinto/plugins/openid/utils.py
+++ b/kinto/plugins/openid/utils.py
@@ -3,6 +3,7 @@ import requests
 
 _configs = {}
 
+
 def fetch_openid_config(issuer):
     global _configs
 

--- a/kinto/plugins/openid/utils.py
+++ b/kinto/plugins/openid/utils.py
@@ -8,7 +8,7 @@ def fetch_openid_config(issuer):
     global _configs
 
     if issuer not in _configs:
-        resp = requests.get(issuer.rstrip("/") + "/.well-known/openid-configuration")
+        resp = requests.get(issuer.rstrip('/') + '/.well-known/openid-configuration')
         _configs[issuer] = resp.json()
 
     return _configs[issuer]

--- a/kinto/plugins/openid/utils.py
+++ b/kinto/plugins/openid/utils.py
@@ -1,0 +1,13 @@
+import requests
+
+
+_configs = {}
+
+def fetch_openid_config(issuer):
+    global _configs
+
+    if issuer not in _configs:
+        resp = requests.get(issuer.rstrip("/") + "/.well-known/openid-configuration")
+        _configs[issuer] = resp.json()
+
+    return _configs[issuer]

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -93,7 +93,7 @@ def get_token(request):
         error_details = {
             'name': 'state',
             'description': 'Invalid state',
-            'errno': ERRORS.INVALID_AUTH_TOKEN,
+            'errno': ERRORS.INVALID_AUTH_TOKEN.value,
         }
         raise_invalid(request, **error_details)
 

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -1,0 +1,57 @@
+import hashlib
+import urllib.parse
+import os
+
+import requests
+from pyramid import httpexceptions
+
+from kinto.core import Service
+
+
+state = Service(name='openid_state',
+                path='/openid/state',
+                description='')
+@state.get()
+def get_state(request):
+    state = hashlib.sha256(os.urandom(1024)).hexdigest()
+    callback = request.GET.get("callback")
+    request.registry.cache.set("openid:state:" + state, callback, ttl=3600)
+    return {
+        'state': state
+    }
+
+
+code = Service(name='openid_token',
+               path='/openid/token',
+               description='')
+
+@code.get()
+def get_code(request):
+    code = request.GET.get("code")
+    state = request.GET.get("state")
+
+    callback = request.registry.cache.get("openid:state:" + state)
+    if callback is None:
+        # XXX: invalid state: raise 400
+        return {}
+
+    request.registry.cache.delete("openid:state:" + state)
+
+    client_id = request.registry.settings["oidc.client_id"]
+    client_secret = request.registry.settings["oidc.client_secret"]
+
+    data = {
+        'code': code,
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'redirect_uri': request.route_url('openid_token') + '?',
+        'grant_type': 'authorization_code'
+    }
+
+    resp = requests.post("https://www.googleapis.com/oauth2/v4/token", data=data)
+    if resp.status_code != 200:
+        # XXX: redirect with #&error=<message for ui>
+        return resp.json()
+
+    redirect = callback + urllib.parse.quote(resp.text)
+    raise httpexceptions.HTTPTemporaryRedirect(redirect)

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -6,52 +6,86 @@ import requests
 from pyramid import httpexceptions
 
 from kinto.core import Service
+from kinto.core.errors import raise_invalid, ERRORS
+from kinto.core.utils import random_bytes_hex
+
+from .utils import fetch_openid_config
 
 
-state = Service(name='openid_state',
-                path='/openid/state',
-                description='')
-@state.get()
-def get_state(request):
-    state = hashlib.sha256(os.urandom(1024)).hexdigest()
-    callback = request.GET.get("callback")
-    request.registry.cache.set("openid:state:" + state, callback, ttl=3600)
-    return {
-        'state': state
-    }
+DEFAULT_STATE_TTL_SECONDS = 3600
 
 
-code = Service(name='openid_token',
+login = Service(name='openid_login',
+                path='/openid/login',
+                description='Initiate the OAuth2 login')
+@login.get()
+def get_login(request):
+    # Settings.
+    issuer = request.registry.settings["oidc.issuer_url"]
+    client_id = request.registry.settings["oidc.client_id"]
+    state_ttl = int(request.registry.settings.get("oidc.state_ttl_seconds",
+                                                  DEFAULT_STATE_TTL_SECONDS))
+
+    # Read OpenID configuration (cached by issuer)
+    oid_config = fetch_openid_config(issuer)
+    auth_endpoint = oid_config["authorization_endpoint"]
+
+    scope = request.GET['scope']
+    callback = request.GET['callback']
+
+    # Generate a random string as state.
+    # And save it until code is traded.
+    state = random_bytes_hex(256)
+    request.registry.cache.set("openid:state:" + state, callback, ttl=state_ttl)
+
+    # Redirect the client to the Identity Provider that will eventually redirect
+    # to the OpenID token endpoint.
+    token_uri = request.route_url('openid_token') + '?'
+    params = dict(client_id=client_id, response_type="code", scope=scope,
+                  redirect_uri=token_uri, state=state)
+    redirect = "{}?{}".format(auth_endpoint, urllib.parse.urlencode(params))
+    raise httpexceptions.HTTPTemporaryRedirect(redirect)
+
+
+token = Service(name='openid_token',
                path='/openid/token',
                description='')
 
-@code.get()
-def get_code(request):
-    code = request.GET.get("code")
-    state = request.GET.get("state")
-
-    callback = request.registry.cache.get("openid:state:" + state)
-    if callback is None:
-        # XXX: invalid state: raise 400
-        return {}
-
-    request.registry.cache.delete("openid:state:" + state)
-
+@token.get()
+def get_token(request):
+    # Settings.
+    issuer = request.registry.settings["oidc.issuer_url"]
     client_id = request.registry.settings["oidc.client_id"]
     client_secret = request.registry.settings["oidc.client_secret"]
 
+    # Read OpenID configuration (cached by issuer)
+    oid_config = fetch_openid_config(issuer)
+    token_endpoint = oid_config["token_endpoint"]
+
+    code = request.GET["code"]
+    state = request.GET["state"]
+
+    # State can be used only once.
+    callback = request.registry.cache.delete("openid:state:" + state)
+    if callback is None:
+        error_details = {
+            'name': 'state',
+            'description': 'Invalid state',
+            'errno': ERRORS.INVALID_AUTH_TOKEN,
+        }
+        raise_invalid(request, **error_details)
+
+    # Trade the code for tokens on the Identity Provider.
     data = {
         'code': code,
         'client_id': client_id,
         'client_secret': client_secret,
-        'redirect_uri': request.route_url('openid_token') + '?',
+        'redirect_uri': request.route_url('openid_token') + '?', # required by Google Identity
         'grant_type': 'authorization_code'
     }
+    resp = requests.post(token_endpoint, data=data)
 
-    resp = requests.post("https://www.googleapis.com/oauth2/v4/token", data=data)
-    if resp.status_code != 200:
-        # XXX: redirect with #&error=<message for ui>
-        return resp.json()
-
+    # The IdP response is forwarded to the client in the querystring/location hash.
+    # (eg. callback=`http://localhost:3000/#tokens=`)
     redirect = callback + urllib.parse.quote(resp.text)
     raise httpexceptions.HTTPTemporaryRedirect(redirect)

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -1,6 +1,4 @@
-import hashlib
 import urllib.parse
-import os
 
 import requests
 from pyramid import httpexceptions
@@ -18,6 +16,8 @@ DEFAULT_STATE_TTL_SECONDS = 3600
 login = Service(name='openid_login',
                 path='/openid/login',
                 description='Initiate the OAuth2 login')
+
+
 @login.get()
 def get_login(request):
     # Settings.
@@ -48,8 +48,9 @@ def get_login(request):
 
 
 token = Service(name='openid_token',
-               path='/openid/token',
-               description='')
+                path='/openid/token',
+                description='')
+
 
 @token.get()
 def get_token(request):
@@ -80,7 +81,7 @@ def get_token(request):
         'code': code,
         'client_id': client_id,
         'client_secret': client_secret,
-        'redirect_uri': request.route_url('openid_token') + '?', # required by Google Identity
+        'redirect_uri': request.route_url('openid_token') + '?',  # required by Google Identity
         'grant_type': 'authorization_code'
     }
     resp = requests.post(token_endpoint, data=data)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ REQUIREMENTS = [
     'cornice',
     'cornice_swagger >= 0.5.1',
     'dockerflow',
-    'python-jose',
     'jsonschema',
     'jsonpatch',
     'logging-color-formatter >= 1.0.1',  # Message interpolations.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
 REQUIREMENTS = [
     'bcrypt',
     'colander >= 1.4.0',
-    'cornice >= 2.4',
+    'cornice >= 3.1',  # querystring validator.
     'cornice_swagger >= 0.5.1',
     'dockerflow',
     'python-jose',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
 REQUIREMENTS = [
     'bcrypt',
     'colander >= 1.4.0',
-    'cornice >= 3.1',  # querystring validator.
+    'cornice',
     'cornice_swagger >= 0.5.1',
     'dockerflow',
     'python-jose',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ REQUIREMENTS = [
     'cornice >= 2.4',
     'cornice_swagger >= 0.5.1',
     'dockerflow',
+    'python-jose',
     'jsonschema',
     'jsonpatch',
     'logging-color-formatter >= 1.0.1',  # Message interpolations.

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -25,6 +25,7 @@ class OpenIDWebTest(support.BaseWebTest, unittest.TestCase):
         settings['multiauth.policy.google.issuer'] = 'https://accounts.google.com'
         settings['multiauth.policy.google.client_id'] = '123'
         settings["multiauth.policy.google.client_secret"] = '789'
+        settings["multiauth.policy.google.userid_field"] = 'email'
         return settings
 
 
@@ -264,6 +265,15 @@ class LoginViewTest(OpenIDWebTest):
 
     def test_returns_400_if_provider_is_unknown(self):
         self.app.get('/openid/fxa/login', status=400)
+
+    def test_returns_400_if_email_is_not_in_scope_when_userid_field_is_email(self):
+        scope = 'openid'
+        cb = 'http://ui'
+        self.app.get('/openid/auth0/login', params={'callback': cb, 'scope': scope},
+                     status=307)
+        # See config above (email is userid field)
+        self.app.get('/openid/google/login', params={'callback': cb, 'scope': scope},
+                     status=400)
 
     def test_redirects_to_the_identity_provider(self):
         params = {'callback': 'http://ui', 'scope': 'openid'}

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -96,20 +96,10 @@ class PolicyTest(unittest.TestCase):
         self.request.headers['Authorization'] = 'Basic avrbnnbrbr'
         assert self.policy.unauthenticated_userid(self.request) is None
 
-    def test_can_specify_both_id_and_access_token(self):
-        self.request.headers['Authorization'] = 'Bearer id_token=jwt, access_token=bearer'
-        assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with('jwt', 'bearer')
-
-    def test_can_specify_jwt_token(self):
-        self.request.headers['Authorization'] = 'Bearer j.w.t'
-        assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with('j.w.t', None)
-
     def test_can_specify_only_opaque_access_token(self):
         self.request.headers['Authorization'] = 'Bearer xyz'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with(None, 'xyz')
+        self.verify.assert_called_with('xyz')
 
     def test_returns_none_if_no_cache_and_invalid_access_token(self):
         self.request.headers['Authorization'] = 'Bearer xyz'
@@ -144,115 +134,19 @@ class VerifyTokenTest(unittest.TestCase):
         self.mocked_get = mocked.start()
         self.addCleanup(mocked.stop)
 
-        mocked = mock.patch('kinto.plugins.openid.jwt')
-        self.mocked_jwt = mocked.start()
-        self.addCleanup(mocked.stop)
-
         self.policy = OpenIDConnectPolicy(issuer='https://fxa', client_id='abc')
 
     def test_fetches_userinfo_if_id_token_is_none(self):
         self.mocked_get.return_value.json.side_effect = [
             {"sub": "me"},
         ]
-        payload = self.policy._verify_token(id_token=None, access_token='abc')
+        payload = self.policy._verify_token(access_token='abc')
         assert payload["sub"] == "me"
 
     def test_returns_none_if_fetching_userinfo_fails(self):
         self.mocked_get.return_value.raise_for_status.side_effect = ValueError
-        payload = self.policy._verify_token(id_token=None, access_token='abc')
+        payload = self.policy._verify_token(access_token='abc')
         assert payload is None
-
-    def test_verifies_jwt_headers(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": []},
-        ]
-        self.policy._verify_token(id_token='a.b.c', access_token=None)
-        self.mocked_jwt.get_unverified_header.assert_called_with('a.b.c')
-
-    def test_jwt_keys_are_cached(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": []},
-        ]
-        self.policy._verify_token(id_token='a.b.c', access_token=None)
-        self.policy._verify_token(id_token='a.b.c', access_token=None)
-        calls = [c for c in self.mocked_get.call_args_list
-                 if 'jwks' in c[0][0]]
-        assert len(calls) == 1
-
-    def test_fails_if_signature_verification_fails(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": []},
-        ]
-        self.mocked_jwt.get_unverified_header.side_effect = self.mocked_jwt.JWTError = ValueError
-        payload = self.policy._verify_token(id_token='a.b.c', access_token=None)
-        assert payload is None
-
-    def test_verifies_algo_header(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": []},
-        ]
-        self.mocked_jwt.get_unverified_header.return_value = {'alg': 'unknown'}
-        payload = self.policy._verify_token(id_token='a.b.c', access_token=None)
-        assert payload is None
-
-    def test_fails_if_key_is_not_found(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": [{
-                "kid": 2,
-            }]},
-        ]
-        self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
-        payload = self.policy._verify_token(id_token='a.b.c', access_token=None)
-        assert payload is None
-
-    def test_decodes_jwt_payload(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": [{
-                "kid": 1,
-            }]},
-        ]
-        self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
-        self.mocked_jwt.decode.return_value = {'sub': 'me'}
-        payload = self.policy._verify_token(id_token='a.b.c', access_token='at')
-        assert payload['sub'] == 'me'
-
-    def test_disables_at_hash_verification(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": [{
-                "kid": 1,
-            }]},
-        ]
-        self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
-        self.mocked_jwt.decode.return_value = {'sub': 'me'}
-
-        self.policy._verify_token(id_token='a.b.c', access_token=None)
-
-        self.mocked_jwt.decode.assert_called_with('a.b.c', {'kid': 1}, algorithms=["RS256"],
-                                                  audience='abc', issuer='https://fxa',
-                                                  options={"verify_at_hash": False},
-                                                  access_token=None)
-
-    def test_returns_none_if_jwt_verification_fails(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"keys": [{
-                "kid": 1,
-            }]},
-        ]
-        self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
-        self.mocked_jwt.ExpiredSignatureError = KeyError
-        self.mocked_jwt.JWTClaimsError = ValueError
-
-        self.mocked_jwt.decode.side_effect = ValueError("Claims error")
-        payload = self.policy._verify_token(id_token='a.b.c', access_token='at')
-        assert payload is None
-
-        self.mocked_jwt.decode.side_effect = KeyError("Claims error")
-        payload = self.policy._verify_token(id_token='a.b.c', access_token='at')
-        assert payload is None
-
-        self.mocked_jwt.decode.side_effect = IOError("will catch all")
-        uid = self.policy._verify_token(id_token='a.b.c', access_token='at')
-        assert uid is None
 
 
 class LoginViewTest(OpenIDWebTest):

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -3,6 +3,7 @@ import mock
 
 from kinto.core.testing import DummyRequest
 from kinto.plugins.openid import OpenIDConnectPolicy
+from kinto.plugins.openid.utils import fetch_openid_config
 
 from .. import support
 
@@ -14,7 +15,7 @@ class OpenIDWebTest(support.BaseWebTest, unittest.TestCase):
         settings = super().get_app_settings(extras)
         settings['includes'] = 'kinto.plugins.openid'
         settings['oidc.issuer_url'] = 'https://auth.mozilla.auth0.com'
-        settings['oidc.audience'] = 'abc'
+        settings['oidc.client_id'] = 'abc'
         return settings
 
 
@@ -24,7 +25,8 @@ class HelloViewTest(OpenIDWebTest):
         resp = self.app.get('/')
         capabilities = resp.json['capabilities']
         self.assertIn('openid', capabilities)
-        self.assertIn('authorization_endpoint', capabilities['openid'])
+        self.assertIn('userinfo_endpoint', capabilities['openid'])
+        self.assertIn('auth_uri', capabilities['openid'])
 
     def test_openid_in_openapi(self):
         pass
@@ -35,18 +37,26 @@ class PolicyTest(unittest.TestCase):
         self.policy = OpenIDConnectPolicy()
         self.request = DummyRequest()
         self.request.registry.settings["oidc.issuer_url"] = 'https://idp'
-        self.request.registry.settings["oidc.audience"] = 'abc'
+        self.request.registry.settings["oidc.client_id"] = 'abc'
+
+        self.request.registry.cache.get.return_value = None
+
         mocked = mock.patch.object(self.policy, '_verify_token')
         self.verify = mocked.start()
         self.addCleanup(mocked.stop)
-        self.verify.return_value = 'userid'
+        self.verify.return_value = {'sub': 'userid'}
 
     def test_returns_none_if_no_authorization(self):
         assert self.policy.unauthenticated_userid(self.request) is None
 
-    def test_returns_prefix_in_forget(self):
+    def test_returns_header_type_in_forget(self):
         h = self.policy.forget(self.request)
-        assert self.policy.prefix in h[0][1]
+        assert 'bearer ' in h[0][1]
+
+    def test_header_type_can_be_configured(self):
+        self.request.registry.settings["oidc.header_type"] = 'bearer+oidc'
+        h = self.policy.forget(self.request)
+        assert 'bearer+oidc ' in h[0][1]
 
     def test_returns_none_if_no_authorization_prefix(self):
         self.request.headers['Authorization'] = 'avrbnnbrbr'
@@ -57,22 +67,31 @@ class PolicyTest(unittest.TestCase):
         assert self.policy.unauthenticated_userid(self.request) is None
 
     def test_can_specify_both_id_and_access_token(self):
-        self.request.headers['Authorization'] = 'Bearer+OIDC id_token=jwt, access_token=bearer'
+        self.request.headers['Authorization'] = 'Bearer id_token=jwt, access_token=bearer'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
         self.verify.assert_called_with('https://idp', 'abc', 'jwt', 'bearer')
 
     def test_can_specify_jwt_token(self):
-        self.request.headers['Authorization'] = 'Bearer+OIDC j.w.t'
+        self.request.headers['Authorization'] = 'Bearer j.w.t'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
         self.verify.assert_called_with('https://idp', 'abc', 'j.w.t', None)
 
     def test_can_specify_only_opaque_access_token(self):
-        self.request.headers['Authorization'] = 'Bearer+OIDC xyz'
+        self.request.headers['Authorization'] = 'Bearer xyz'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
         self.verify.assert_called_with('https://idp', 'abc', None, 'xyz')
 
 
 class VerifyTokenTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # Populate OpenID config cache.
+        with mock.patch('kinto.plugins.openid.utils.requests.get') as m:
+            m.return_value.json.return_value = {'userinfo_endpoint': 'http://uinfo',
+                                                'jwks_uri': 'https://jwks'}
+            fetch_openid_config('https://idp')
+
     def setUp(self):
         self.policy = OpenIDConnectPolicy()
 
@@ -86,36 +105,20 @@ class VerifyTokenTest(unittest.TestCase):
 
         self.verify_kw = dict(issuer='https://idp', audience='abc')
 
-    def test_fetches_openid_config(self):
-        self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
-        self.mocked_get.assert_any_call('https://idp/.well-known/openid-configuration')
-
-    def test_openid_config_is_cached(self):
-        self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
-        self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
-        calls = [c for c in self.mocked_get.call_args_list
-                 if 'openid-configuration' in c[0][0]]
-        assert len(calls) == 1
-
     def test_fetches_userinfo_if_id_token_is_none(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo'},
             {"sub": "me"},
         ]
-        uid = self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
-        assert uid == "me"
+        payload = self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
+        assert payload["sub"] == "me"
 
     def test_returns_none_if_fetching_userinfo_fails(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo'},
-            {"some": "invalid json"},
-        ]
-        uid = self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
-        assert uid is None
+        self.mocked_get.return_value.raise_for_status.side_effect = ValueError
+        payload = self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
+        assert payload is None
 
     def test_verifies_jwt_headers(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": []},
         ]
         self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
@@ -123,7 +126,6 @@ class VerifyTokenTest(unittest.TestCase):
 
     def test_jwt_keys_are_cached(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': '', 'jwks_uri': 'http://jwks'},
             {"keys": []},
         ]
         self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
@@ -134,48 +136,43 @@ class VerifyTokenTest(unittest.TestCase):
 
     def test_fails_if_signature_verification_fails(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": []},
         ]
         self.mocked_jwt.get_unverified_header.side_effect = self.mocked_jwt.JWTError = ValueError
-        uid = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
-        assert uid is None
+        payload = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        assert payload is None
 
     def test_verifies_algo_header(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": []},
         ]
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'unknown'}
-        uid = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
-        assert uid is None
+        payload = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        assert payload is None
 
     def test_fails_if_key_is_not_found(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": [{
                 "kid": 2,
             }]},
         ]
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
-        uid = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
-        assert uid is None
+        payload = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        assert payload is None
 
     def test_decodes_jwt_payload(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": [{
                 "kid": 1,
             }]},
         ]
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
         self.mocked_jwt.decode.return_value = {'sub': 'me'}
-        uid = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
-        assert uid == 'me'
+        payload = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        assert payload['sub'] == 'me'
 
     def test_disables_at_hash_verification(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": [{
                 "kid": 1,
             }]},
@@ -192,7 +189,6 @@ class VerifyTokenTest(unittest.TestCase):
 
     def test_returns_none_if_jwt_verification_fails(self):
         self.mocked_get.return_value.json.side_effect = [
-            {'userinfo_endpoint': 'http://uinfo', 'jwks_uri': ''},
             {"keys": [{
                 "kid": 1,
             }]},
@@ -202,12 +198,12 @@ class VerifyTokenTest(unittest.TestCase):
         self.mocked_jwt.JWTClaimsError = ValueError
 
         self.mocked_jwt.decode.side_effect = ValueError("Claims error")
-        uid = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
-        assert uid is None
+        payload = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        assert payload is None
 
         self.mocked_jwt.decode.side_effect = KeyError("Claims error")
-        uid = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
-        assert uid is None
+        payload = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        assert payload is None
 
         self.mocked_jwt.decode.side_effect = IOError("will catch all")
         uid = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -13,11 +13,33 @@ class OpenIDWebTest(support.BaseWebTest, unittest.TestCase):
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
+        openid_policy = 'kinto.plugins.openid.OpenIDConnectPolicy'
         settings['includes'] = 'kinto.plugins.openid'
-        settings['oidc.issuer_url'] = 'https://auth.mozilla.auth0.com'
-        settings['oidc.client_id'] = 'abc'
-        settings["oidc.client_secret"] = 'xyz'
+        settings['multiauth.policies'] = 'auth0 google'
+        settings['multiauth.policy.auth0.use'] = openid_policy
+        settings['multiauth.policy.auth0.issuer'] = 'https://auth.mozilla.auth0.com'
+        settings['multiauth.policy.auth0.client_id'] = 'abc'
+        settings["multiauth.policy.auth0.client_secret"] = 'xyz'
+
+        settings['multiauth.policy.google.use'] = openid_policy
+        settings['multiauth.policy.google.issuer'] = 'https://accounts.google.com'
+        settings['multiauth.policy.google.client_id'] = '123'
+        settings["multiauth.policy.google.client_secret"] = '789'
         return settings
+
+
+class OpenIDWithoutPolicyTest(support.BaseWebTest, unittest.TestCase):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings['includes'] = 'kinto.plugins.openid'
+        return settings
+
+    def test_openid_capability_is_not_added(self):
+        resp = self.app.get('/')
+        capabilities = resp.json['capabilities']
+        assert 'openid' not in capabilities
 
 
 class HelloViewTest(OpenIDWebTest):
@@ -26,23 +48,26 @@ class HelloViewTest(OpenIDWebTest):
         resp = self.app.get('/')
         capabilities = resp.json['capabilities']
         assert 'openid' in capabilities
-        assert 'userinfo_endpoint' in capabilities['openid']
-        assert 'auth_uri' in capabilities['openid']
+        assert len(capabilities['openid']['providers']) == 2
+        assert 'userinfo_endpoint' in capabilities['openid']['providers'][0]
+        assert 'auth_path' in capabilities['openid']['providers'][0]
 
     def test_openid_in_openapi(self):
         resp = self.app.get('/__api__')
-        assert 'openid' in resp.json['securityDefinitions']
-        auth = resp.json['securityDefinitions']['openid']['authorizationUrl']
+        assert 'auth0' in resp.json['securityDefinitions']
+        auth = resp.json['securityDefinitions']['auth0']['authorizationUrl']
         assert auth == 'https://auth.mozilla.auth0.com/authorize'
 
 
 class PolicyTest(unittest.TestCase):
     def setUp(self):
-        self.policy = OpenIDConnectPolicy()
-        self.request = DummyRequest()
-        self.request.registry.settings["oidc.issuer_url"] = 'https://idp'
-        self.request.registry.settings["oidc.client_id"] = 'abc'
+        mocked = mock.patch('kinto.plugins.openid.requests.get')
+        self.mocked_get = mocked.start()
+        self.addCleanup(mocked.stop)
 
+        self.policy = OpenIDConnectPolicy(issuer='https://idp', client_id='abc')
+
+        self.request = DummyRequest()
         self.request.registry.cache.get.return_value = None
 
         mocked = mock.patch.object(self.policy, '_verify_token')
@@ -55,10 +80,10 @@ class PolicyTest(unittest.TestCase):
 
     def test_returns_header_type_in_forget(self):
         h = self.policy.forget(self.request)
-        assert 'bearer ' in h[0][1]
+        assert 'Bearer ' in h[0][1]
 
     def test_header_type_can_be_configured(self):
-        self.request.registry.settings["oidc.header_type"] = 'bearer+oidc'
+        self.policy.header_type = 'bearer+oidc'
         h = self.policy.forget(self.request)
         assert 'bearer+oidc ' in h[0][1]
 
@@ -73,17 +98,17 @@ class PolicyTest(unittest.TestCase):
     def test_can_specify_both_id_and_access_token(self):
         self.request.headers['Authorization'] = 'Bearer id_token=jwt, access_token=bearer'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with('https://idp', 'abc', 'jwt', 'bearer')
+        self.verify.assert_called_with('jwt', 'bearer')
 
     def test_can_specify_jwt_token(self):
         self.request.headers['Authorization'] = 'Bearer j.w.t'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with('https://idp', 'abc', 'j.w.t', None)
+        self.verify.assert_called_with('j.w.t', None)
 
     def test_can_specify_only_opaque_access_token(self):
         self.request.headers['Authorization'] = 'Bearer xyz'
         assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with('https://idp', 'abc', None, 'xyz')
+        self.verify.assert_called_with(None, 'xyz')
 
     def test_returns_none_if_no_cache_and_invalid_access_token(self):
         self.request.headers['Authorization'] = 'Bearer xyz'
@@ -111,11 +136,9 @@ class VerifyTokenTest(unittest.TestCase):
         with mock.patch('kinto.plugins.openid.utils.requests.get') as m:
             m.return_value.json.return_value = {'userinfo_endpoint': 'http://uinfo',
                                                 'jwks_uri': 'https://jwks'}
-            fetch_openid_config('https://idp')
+            fetch_openid_config('https://fxa')
 
     def setUp(self):
-        self.policy = OpenIDConnectPolicy()
-
         mocked = mock.patch('kinto.plugins.openid.requests.get')
         self.mocked_get = mocked.start()
         self.addCleanup(mocked.stop)
@@ -124,33 +147,33 @@ class VerifyTokenTest(unittest.TestCase):
         self.mocked_jwt = mocked.start()
         self.addCleanup(mocked.stop)
 
-        self.verify_kw = dict(issuer='https://idp', audience='abc')
+        self.policy = OpenIDConnectPolicy(issuer='https://fxa', client_id='abc')
 
     def test_fetches_userinfo_if_id_token_is_none(self):
         self.mocked_get.return_value.json.side_effect = [
             {"sub": "me"},
         ]
-        payload = self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
+        payload = self.policy._verify_token(id_token=None, access_token='abc')
         assert payload["sub"] == "me"
 
     def test_returns_none_if_fetching_userinfo_fails(self):
         self.mocked_get.return_value.raise_for_status.side_effect = ValueError
-        payload = self.policy._verify_token(id_token=None, access_token='abc', **self.verify_kw)
+        payload = self.policy._verify_token(id_token=None, access_token='abc')
         assert payload is None
 
     def test_verifies_jwt_headers(self):
         self.mocked_get.return_value.json.side_effect = [
             {"keys": []},
         ]
-        self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        self.policy._verify_token(id_token='a.b.c', access_token=None)
         self.mocked_jwt.get_unverified_header.assert_called_with('a.b.c')
 
     def test_jwt_keys_are_cached(self):
         self.mocked_get.return_value.json.side_effect = [
             {"keys": []},
         ]
-        self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
-        self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        self.policy._verify_token(id_token='a.b.c', access_token=None)
+        self.policy._verify_token(id_token='a.b.c', access_token=None)
         calls = [c for c in self.mocked_get.call_args_list
                  if 'jwks' in c[0][0]]
         assert len(calls) == 1
@@ -160,7 +183,7 @@ class VerifyTokenTest(unittest.TestCase):
             {"keys": []},
         ]
         self.mocked_jwt.get_unverified_header.side_effect = self.mocked_jwt.JWTError = ValueError
-        payload = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        payload = self.policy._verify_token(id_token='a.b.c', access_token=None)
         assert payload is None
 
     def test_verifies_algo_header(self):
@@ -168,7 +191,7 @@ class VerifyTokenTest(unittest.TestCase):
             {"keys": []},
         ]
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'unknown'}
-        payload = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        payload = self.policy._verify_token(id_token='a.b.c', access_token=None)
         assert payload is None
 
     def test_fails_if_key_is_not_found(self):
@@ -178,7 +201,7 @@ class VerifyTokenTest(unittest.TestCase):
             }]},
         ]
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
-        payload = self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        payload = self.policy._verify_token(id_token='a.b.c', access_token=None)
         assert payload is None
 
     def test_decodes_jwt_payload(self):
@@ -189,7 +212,7 @@ class VerifyTokenTest(unittest.TestCase):
         ]
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
         self.mocked_jwt.decode.return_value = {'sub': 'me'}
-        payload = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        payload = self.policy._verify_token(id_token='a.b.c', access_token='at')
         assert payload['sub'] == 'me'
 
     def test_disables_at_hash_verification(self):
@@ -201,10 +224,10 @@ class VerifyTokenTest(unittest.TestCase):
         self.mocked_jwt.get_unverified_header.return_value = {'alg': 'RS256', 'kid': 1}
         self.mocked_jwt.decode.return_value = {'sub': 'me'}
 
-        self.policy._verify_token(id_token='a.b.c', access_token=None, **self.verify_kw)
+        self.policy._verify_token(id_token='a.b.c', access_token=None)
 
         self.mocked_jwt.decode.assert_called_with('a.b.c', {'kid': 1}, algorithms=["RS256"],
-                                                  audience='abc', issuer='https://idp',
+                                                  audience='abc', issuer='https://fxa',
                                                   options={"verify_at_hash": False},
                                                   access_token=None)
 
@@ -219,31 +242,35 @@ class VerifyTokenTest(unittest.TestCase):
         self.mocked_jwt.JWTClaimsError = ValueError
 
         self.mocked_jwt.decode.side_effect = ValueError("Claims error")
-        payload = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        payload = self.policy._verify_token(id_token='a.b.c', access_token='at')
         assert payload is None
 
         self.mocked_jwt.decode.side_effect = KeyError("Claims error")
-        payload = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        payload = self.policy._verify_token(id_token='a.b.c', access_token='at')
         assert payload is None
 
         self.mocked_jwt.decode.side_effect = IOError("will catch all")
-        uid = self.policy._verify_token(id_token='a.b.c', access_token='at', **self.verify_kw)
+        uid = self.policy._verify_token(id_token='a.b.c', access_token='at')
         assert uid is None
 
 
 class LoginViewTest(OpenIDWebTest):
 
     def test_returns_400_if_parameters_are_missing_or_bad(self):
-        self.app.get('/openid/login', status=400)
-        self.app.get('/openid/login', params={'callback': 'http://no-scope'}, status=400)
-        self.app.get('/openid/login', params={'callback': 'bad', 'scope': 'openid'}, status=400)
+        self.app.get('/openid/auth0/login', status=400)
+        self.app.get('/openid/auth0/login', params={'callback': 'http://no-scope'}, status=400)
+        self.app.get('/openid/auth0/login', params={'callback': 'bad', 'scope': 'openid'},
+                     status=400)
+
+    def test_returns_400_if_provider_is_unknown(self):
+        self.app.get('/openid/fxa/login', status=400)
 
     def test_redirects_to_the_identity_provider(self):
         params = {'callback': 'http://ui', 'scope': 'openid'}
-        resp = self.app.get('/openid/login', params=params, status=307)
+        resp = self.app.get('/openid/auth0/login', params=params, status=307)
         location = resp.headers['Location']
         assert 'auth0.com/authorize?' in location
-        assert '%2Fv1%2Fopenid%2Ftoken' in location
+        assert '%2Fv1%2Fopenid%2Fauth0%2Ftoken' in location
         assert 'scope=openid' in location
         assert 'client_id=abc' in location
 
@@ -251,7 +278,7 @@ class LoginViewTest(OpenIDWebTest):
         params = {'callback': 'http://ui', 'scope': 'openid'}
         with mock.patch('kinto.plugins.openid.views.random_bytes_hex') as m:
             m.return_value = 'key'
-            self.app.get('/openid/login', params=params, status=307)
+            self.app.get('/openid/auth0/login', params=params, status=307)
 
         cached = self.app.app.registry.cache.get('openid:state:key')
         assert cached == 'http://ui'
@@ -260,39 +287,42 @@ class LoginViewTest(OpenIDWebTest):
 class TokenViewTest(OpenIDWebTest):
 
     def test_returns_400_if_parameters_are_missing_or_bad(self):
-        self.app.get('/openid/token', status=400)
-        self.app.get('/openid/token', params={'code': 'abc'}, status=400)
-        self.app.get('/openid/token', params={'state': 'abc'}, status=400)
+        self.app.get('/openid/auth0/token', status=400)
+        self.app.get('/openid/auth0/token', params={'code': 'abc'}, status=400)
+        self.app.get('/openid/auth0/token', params={'state': 'abc'}, status=400)
+
+    def test_returns_400_if_provider_is_unknown(self):
+        self.app.get('/openid/fxa/token', status=400)
 
     def test_returns_400_if_state_is_invalid(self):
-        self.app.get('/openid/token', params={'code': 'abc', 'state': 'abc'}, status=400)
+        self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'abc'}, status=400)
 
     def test_code_is_traded_using_client_secret(self):
         self.app.app.registry.cache.set('openid:state:key', 'http://ui', ttl=100)
         with mock.patch('kinto.plugins.openid.views.requests.post') as m:
             m.return_value.text = '{"access_token": "token"}'
-            self.app.get('/openid/token', params={'code': 'abc', 'state': 'key'})
+            self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'})
             m.assert_called_with(
                 'https://auth.mozilla.auth0.com/oauth/token',
                 data={
                     'code': 'abc',
                     'client_id': 'abc',
                     'client_secret': 'xyz',
-                    'redirect_uri': 'http://localhost/v1/openid/token?',
+                    'redirect_uri': 'http://localhost/v1/openid/auth0/token?',
                     'grant_type': 'authorization_code'})
 
     def test_state_cannot_be_reused(self):
         self.app.app.registry.cache.set('openid:state:key', 'http://ui', ttl=100)
         with mock.patch('kinto.plugins.openid.views.requests.post') as m:
             m.return_value.text = '{"access_token": "token"}'
-            self.app.get('/openid/token', params={'code': 'abc', 'state': 'key'})
-            self.app.get('/openid/token', params={'code': 'abc', 'state': 'key'}, status=400)
+            self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'})
+            self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'}, status=400)
 
     def test_redirects_to_callback_using_authorization_response(self):
         self.app.app.registry.cache.set('openid:state:key', 'http://ui/#token=', ttl=100)
         with mock.patch('kinto.plugins.openid.views.requests.post') as m:
             m.return_value.text = '{"access_token": "token"}'
-            resp = self.app.get('/openid/token', params={'code': 'abc', 'state': 'key'},
+            resp = self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'},
                                 status=307)
         location = resp.headers['Location']
         assert location == 'http://ui/#token=%7B%22access_token%22%3A%20%22token%22%7D'

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -1,0 +1,115 @@
+import json
+import re
+import unittest
+import mock
+
+from kinto.core.testing import DummyRequest
+from kinto.plugins.openid import OpenIDConnectPolicy
+
+from .. import support
+
+
+class OpenIDWebTest(support.BaseWebTest, unittest.TestCase):
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings['includes'] = 'kinto.plugins.openid'
+        settings['oidc.issuer_url'] = 'https://auth.mozilla.auth0.com'
+        settings['oidc.audience'] = 'abc'
+        return settings
+
+
+class HelloViewTest(OpenIDWebTest):
+
+    def test_openid_capability_if_enabled(self):
+        resp = self.app.get('/')
+        capabilities = resp.json['capabilities']
+        self.assertIn('openid', capabilities)
+        self.assertIn('authorization_endpoint', capabilities['openid'])
+
+    def test_openid_in_openapi(self):
+        pass
+
+
+class PolicyTest(unittest.TestCase):
+    def setUp(self):
+        self.policy = OpenIDConnectPolicy()
+        self.request = DummyRequest()
+        self.request.registry.settings["oidc.issuer_url"] = 'https://idp'
+        self.request.registry.settings["oidc.audience"] = 'abc'
+        mocked = mock.patch.object(self.policy, '_verify_token')
+        self.verify = mocked.start()
+        self.addCleanup(mocked.stop)
+        self.verify.return_value = 'userid'
+
+    def test_returns_none_if_no_authorization(self):
+        assert self.policy.unauthenticated_userid(self.request) is None
+
+    def test_returns_none_if_no_authorization_prefix(self):
+        self.request.headers['Authorization'] = 'avrbnnbrbr'
+        assert self.policy.unauthenticated_userid(self.request) is None
+
+    def test_returns_none_if_bad_prefix(self):
+        self.request.headers['Authorization'] = 'Basic avrbnnbrbr'
+        assert self.policy.unauthenticated_userid(self.request) is None
+
+    def test_can_specify_both_id_and_access_token(self):
+        self.request.headers['Authorization'] = 'Bearer+OIDC id_token=jwt, access_token=bearer'
+        assert self.policy.unauthenticated_userid(self.request) == 'userid'
+        self.verify.assert_called_with('https://idp', 'abc', 'jwt', 'bearer')
+
+    def test_can_specify_jwt_token(self):
+        self.request.headers['Authorization'] = 'Bearer+OIDC j.w.t'
+        assert self.policy.unauthenticated_userid(self.request) == 'userid'
+        self.verify.assert_called_with('https://idp', 'abc', 'j.w.t', None)
+
+    def test_can_specify_only_opaque_access_token(self):
+        self.request.headers['Authorization'] = 'Bearer+OIDC xyz'
+        assert self.policy.unauthenticated_userid(self.request) == 'userid'
+        self.verify.assert_called_with('https://idp', 'abc', None, 'xyz')
+
+
+class VerifyTokenTest(unittest.TestCase):
+    def setUp(self):
+        self.policy = OpenIDConnectPolicy()
+
+        mocked = mock.patch('kinto.plugins.openid.requests.get')
+        self.mocked_get = mocked.start()
+        self.addCleanup(mocked.stop)
+
+        mocked = mock.patch('kinto.plugins.openid.jwt')
+        self.jwt_requests = mocked.start()
+        self.addCleanup(mocked.stop)
+
+    def test_fetches_openid_config(self):
+        self.policy._verify_token(issuer='https://idp', audience='abc',
+                                  id_token=None, access_token='abc')
+        self.mocked_get.assert_any_call('https://idp/.well-known/openid-configuration')
+
+    def test_fetches_userinfo_if_id_token_is_none(self):
+        self.mocked_get().json().side_effects = [
+            {"userinfo_endpoint": "https://userinfo"},
+            {"sub": "me"},
+        ]
+        uid = self.policy._verify_token(issuer='https://idp', audience='abc',
+                                        id_token=None, access_token='abc')
+        assert uid == "me"
+
+    def test_verifies_jwt_headers(self):
+        pass
+
+    def test_verifies_algo_header(self):
+        pass
+
+    def test_fails_if_key_is_not_found(self):
+        pass
+
+    def test_decodes_jwt_payload(self):
+        pass
+
+    def test_disables_at_hash_verification(self):
+        pass
+
+    def test_returns_none_if_jwt_verification_fails(self):
+        pass


### PR DESCRIPTION
Fixes #939 

- [x] Add docs
- [x] Move to plugins folder
- [x] Choose appropriate settings name
- [x] Add tests
- [x] Publish demo somewhere?
- [x] Create issue for kinto-admin support 
- [ ] Add mention in Github tutorial ? ref #508   
- [x] Polish OpenAPI spec
- [x] Reject scope that does not contain `email` if the configured userid_field is email
- [ ] Implement the scope filtering as we did for kinto-fxa

We could make this piece of code work with both Auth0 and Firefox Accounts \o/  

@rfk f?