### PR TITLE
Use index for delete all

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ This document describes changes between each past release.
 
 - Update the Docker compose configuration to use memcache for the cache backend (#1405)
 
+**Operational concerns**
+
+- *The schema for the Postgres ``storage`` backend has changed.* This
+  changes some ID columns to use the "C" collation, which will make
+  delete_all queries faster. This may change the sort order and
+  grouping of record IDs.
+
 **New features**
 
 - New setting ``kinto.backoff_percentage`` to only set the backoff header a portion of the time

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,10 +12,15 @@ This document describes changes between each past release.
 
 **Operational concerns**
 
-- *The schema for the Postgres ``storage`` backend has changed.* This
+- *The schema for the Postgres storage backend has changed.* This
   changes some ID columns to use the "C" collation, which will make
-  delete_all queries faster. This may change the sort order and
-  grouping of record IDs.
+  ``delete_all`` queries faster. (See
+  e.g. https://www.postgresql.org/docs/9.6/static/indexes-opclass.html,
+  which says "If you do use the C locale, you do not need the
+  xxx_pattern_ops operator classes, because an index with the default
+  operator class is usable for pattern-matching queries in the C
+  locale.") This may change the default sort order and grouping of
+  record IDs.
 
 **New features**
 

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -69,7 +69,7 @@ class Storage(StorageBase):
 
     """  # NOQA
 
-    schema_version = 18
+    schema_version = 19
 
     def __init__(self, client, max_fetch_size, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/kinto/core/storage/postgresql/migrations/migration_018_019.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_018_019.sql
@@ -1,0 +1,8 @@
+-- Alter collation to C to improve LIKE-prefix queries in delete_all.
+ALTER TABLE records
+    ALTER COLUMN id TYPE TEXT COLLATE "C",
+    ALTER COLUMN parent_id TYPE TEXT COLLATE "C",
+    ALTER COLUMN collection_id TYPE TEXT COLLATE "C";
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '19');

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -23,6 +23,10 @@ IMMUTABLE;
 -- Actual records
 --
 CREATE TABLE IF NOT EXISTS records (
+    -- These are all IDs stored as text, and not human language.
+    -- Therefore, we store them in the C collation. This lets Postgres
+    -- use the index on parent_id for prefix matching (parent_id LIKE
+    -- '/buckets/abc/%').
     id TEXT COLLATE "C" NOT NULL,
     parent_id TEXT COLLATE "C" NOT NULL,
     collection_id TEXT COLLATE "C" NOT NULL,

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -23,9 +23,9 @@ IMMUTABLE;
 -- Actual records
 --
 CREATE TABLE IF NOT EXISTS records (
-    id TEXT NOT NULL,
-    parent_id TEXT NOT NULL,
-    collection_id TEXT NOT NULL,
+    id TEXT COLLATE "C" NOT NULL,
+    parent_id TEXT COLLATE "C" NOT NULL,
+    collection_id TEXT COLLATE "C" NOT NULL,
 
     -- Timestamp is relevant because adequate semantically.
     -- Since the HTTP API manipulates integers, it could make sense
@@ -127,4 +127,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``kinto.core.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '18');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '19');


### PR DESCRIPTION
This is a potential fix for e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1421999, where delete_all is very slow because it can't use any indices. This approach changes the collation for id, parent_id, and collection_id columns to "C" because they are not meant to be a human language. This allows the existing `idx_records_parent_id_collection_id_last_modified` (which is btree on `parent_id` and then some other stuff) to service queries like `SELECT * FROM records WHERE parent_id LIKE '/buckets/abcd%'`.

Other approaches are possible. If we would rather keep the collation the same, we could add a new index using `text_pattern_ops`. This should be more efficient than that, if we believe this is more technically correct.