### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .coverage
 .tox/
 loadtests/.env.install
+testresults.xml
 docs/_build/
 .cache/
 *.un~

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
   - TOX_ENV=flake8
   - TOX_ENV=docs
 install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
   - pip install tox
 before_script:
   - echo "Pull request ${TRAVIS_PULL_REQUEST}"
@@ -20,7 +23,17 @@ before_script:
   - psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres
   - make version-file
 script:
-  - tox -e $TOX_ENV
+  - if [[ "${TOX_ENV}" =~ ^py ]] ; then
+      tox -e $TOX_ENV -- --junit-xml=testresults.xml;
+    else
+      tox -e $TOX_ENV;
+    fi
+after_script:
+  - if [[ "${TOX_ENV}" =~ ^py ]] ; then
+      testspace [${TOX_ENV}]testresults.xml{tests};
+    elif [[ "${ENV}" = "functional" ]] ; then
+      testspace [${ENV}]testresults.xml{tests};
+    fi
 after_success:
   # Report coverage results to coveralls.io
   - pip install coveralls

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ runkinto: install-dev
 	$(VENV)/bin/kinto start --ini tests/functional.ini
 
 functional: install-dev need-kinto-running
-	$(VENV)/bin/py.test tests/functional.py
+	$(VENV)/bin/py.test tests/functional.py --junit-xml=testresults.xml
 
 clean:
 	find . -name '*.pyc' -delete


### PR DESCRIPTION
Hi, `Kinto` team. We’ve made a few minor changes to demonstrate how you can add a Results Dashboard for Travis CI using [Testspace.com](https://www.testspace.com/).
 
Check out YOUR RESULTS at https://open.testspace.com/projects/TryTestspace:kinto from our fork.

A few of the **benefits** for your Contributors:
 * Move beyond the flat, endless console output. Results in Testspace mirror your matrix jobs, test folders, suites, and cases hierarchy.
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

And for Owners:
 * Monitor the status of all your repositories, their local branches, and pull requests from a single dashboard.
 * View historical tracking of all your important metrics; test case and coverage growth, static analysis issues, custom metrics, etc.

[Read more...](https://blog.testspace.com/testspace-and-open-source/)

----

**Want to Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing. 
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users