### PR TITLE
Add collations to the timestamps table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,11 @@ This document describes changes between each past release.
 8.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Operational concerns**
+
+- *The schema for the Postgres storage backend has changed.* This
+  changes some more ID columns to use the "C" collation, which fixes a
+  bug where the ``bump_timestamps`` trigger was very slow.
 
 
 8.1.0 (2018-01-09)

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -69,7 +69,7 @@ class Storage(StorageBase):
 
     """  # NOQA
 
-    schema_version = 19
+    schema_version = 20
 
     def __init__(self, client, max_fetch_size, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/kinto/core/storage/postgresql/migrations/migration_019_020.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_019_020.sql
@@ -1,0 +1,7 @@
+-- Alter collation to C to improve LIKE-prefix queries in delete_all.
+ALTER TABLE timestamps
+    ALTER COLUMN parent_id TYPE TEXT COLLATE "C",
+    ALTER COLUMN collection_id TYPE TEXT COLLATE "C";
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '20');

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -131,4 +131,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``kinto.core.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '19');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '20');

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -50,8 +50,8 @@ CREATE INDEX IF NOT EXISTS idx_records_last_modified_epoch
 
 
 CREATE TABLE IF NOT EXISTS timestamps (
-  parent_id TEXT NOT NULL,
-  collection_id TEXT NOT NULL,
+  parent_id TEXT NOT NULL COLLATE "C",
+  collection_id TEXT NOT NULL COLLATE "C",
   last_modified TIMESTAMP NOT NULL,
   PRIMARY KEY (parent_id, collection_id)
 );


### PR DESCRIPTION
The trigger bump_timestamp does a query against the timestamps table
using the parent_id and collection_id from the records table (which
are now collation C). If the timestamps columns are not of collation
C, the primary key indices could potentially include different
sequences of letters that should be considered equal, or equal
sequences of bytes which are considered different by the collation, so
Postgres does not use the index. This makes all queries against the
timestamps table perform a table scan, which performs very
badly. Because every request of a default_bucket does at least one
create(), this makes every single HTTP request very expensive.

If we update the collation of the columns in the timestamp table to
match the records table, the queries should return to their previous speed.

- (n/a) Add documentation.
- (n/a) Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
