### PR TITLE
Fix typo in comment of initialization file.

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -322,7 +322,7 @@ def install_middlewares(app, settings):
 
 def setup_logging(config):
     """Setup structured logging, and emit `request.summary` event on each
-    request, as recommanded by Mozilla Services standard:
+    request, as recommended by Mozilla Services standard:
 
     * https://mana.mozilla.org/wiki/display/CLOUDSERVICES/Logging+Standard
     * http://12factor.net/logs


### PR DESCRIPTION
Fixes #

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
