### PR TITLE
Change collation of ID columns in permission backend to speed up delete_object_permissions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,25 @@ This document describes changes between each past release.
 8.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Flushing a server no longer breaks migration of the storage backend
+  (#1460). If you have ever flushed a server in the past, migration
+  may be broken. This version of Kinto tries to guess what version of
+  the schema you're running, but may guess wrong. See
+  https://github.com/Kinto/kinto/wiki/Schema-versions for some
+  additional information.
+
+**Internal changes**
+
+- We now allow migration of the permission backend's schema.
+
+**Operational concerns**
+
+- *The schema for the Postgres permission backend has changed.* This
+  changes another ID column to use the "C" collation, which should
+  speed up the `delete_object_permissions` query when deleting a
+  bucket.
 
 
 8.1.1 (2018-01-18)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,8 @@
 import os
 import sys
 
+# abspath because this could be __main__, in which case it may not
+# have an absolute __file__
 __HERE__ = os.path.dirname(os.path.abspath(__file__))
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -29,7 +31,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath(os.path.join('..')))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -10,7 +10,7 @@ from kinto import __version__
 
 logger = logging.getLogger(__name__)
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = os.path.dirname(__file__)
 
 
 def render_template(template, destination, **kwargs):

--- a/kinto/core/cache/postgresql/__init__.py
+++ b/kinto/core/cache/postgresql/__init__.py
@@ -80,7 +80,7 @@ class Cache(CacheBase):
                 return
 
         # Create schema
-        here = os.path.abspath(os.path.dirname(__file__))
+        here = os.path.dirname(__file__)
         sql_file = os.path.join(here, 'schema.sql')
 
         if dry_run:

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -79,7 +79,7 @@ class Permission(PermissionBase, MigratorMixin):
     def initialize_schema(self, dry_run=False):
         return self.create_or_migrate_schema(dry_run)
 
-    def _get_installed_version(self):
+    def get_installed_version(self):
         """Return current version of schema or None if not any found.
 
         Migrations were only added to the permission backend in

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -10,7 +10,7 @@ from kinto.core.storage.postgresql.migrator import Migrator
 
 logger = logging.getLogger(__name__)
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = os.path.dirname(__file__)
 
 
 class Permission(PermissionBase, Migrator):

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -89,8 +89,8 @@ class Permission(PermissionBase, MigratorMixin):
         table/permission_schema_version is therefore version 1.
 
         In version 8.1.2, the permission backend added a ``metadata``
-        table. If the permission and storage backends share
-        credentials, this will be the same table created by the
+        table. If the permission and storage backends point to the
+        same database, this will be the same table created by the
         storage backend. This means either backend could create the
         table without the knowledge of the other one. For this reason,
         be careful to handle the case where the metadata table exists

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -5,12 +5,15 @@ from collections import OrderedDict
 
 from kinto.core.permission import PermissionBase
 from kinto.core.storage.postgresql.client import create_from_config
+from kinto.core.storage.postgresql.migrator import Migrator
 
 
 logger = logging.getLogger(__name__)
 
+HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Permission(PermissionBase):
+
+class Permission(PermissionBase, Migrator):
     """Permission backend using PostgreSQL.
 
     Enable in configuration::
@@ -63,12 +66,68 @@ class Permission(PermissionBase):
 
     :noindex:
     """  # NOQA
+
+    name = 'permission'
+    schema_version = 2
+    schema_file = os.path.join(HERE, 'schema.sql')
+    migrations_directory = os.path.join(HERE, 'migrations')
+
     def __init__(self, client, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = client
 
     def initialize_schema(self, dry_run=False):
-        # Check if user_principals table exists.
+        return self.create_or_migrate_schema(dry_run)
+
+    def _get_installed_version(self):
+        """Return current version of schema or None if not any found.
+
+        Migrations were only added to the permission backend in
+        8.1.2. Before this, the permission backend was only the two
+        tables ``user_principals`` and ``access_control_entries``. The
+        presence of these two tables and absence of a metadata
+        table/permission_schema_version is therefore version 1.
+
+        In version 8.1.2, the permission backend added a ``metadata``
+        table. If the permission and storage backends share
+        credentials, this will be the same table created by the
+        storage backend. This means either backend could create the
+        table without the knowledge of the other one. For this reason,
+        be careful to handle the case where the metadata table exists
+        but no version exists.
+
+        """
+        query = "SELECT tablename FROM pg_tables WHERE tablename = 'metadata';"
+        with self.client.connect() as conn:
+            result = conn.execute(query)
+            table_exists = result.rowcount > 0
+
+        if table_exists:
+            query = """
+            SELECT value AS version
+              FROM metadata
+             WHERE name = 'permission_schema_version'
+             ORDER BY LPAD(value, 3, '0') DESC
+             LIMIT 1;
+            """
+            with self.client.connect() as conn:
+                result = conn.execute(query)
+                if result.rowcount > 0:
+                    return int(result.fetchone()['version'])
+
+        # Either the metadata table doesn't exist, or it doesn't have
+        # a permission_schema_version row. Many possiblities exist:
+        #
+        # - Maybe we are migrating from <8.1.2 and the permission
+        # backend doesn't have a metadata table.
+        #
+        # - Maybe we are on a new install and don't have any tables.
+        #
+        # - Maybe we are on a new install and the storage backend has
+        # created the metadata table but we haven't initialized yet.
+        #
+        # Check if user_principals table exists. If it does, we are
+        # migrating from pre-8.1.2 and we are version 1.
         query = """
         SELECT 1
           FROM information_schema.tables
@@ -77,23 +136,12 @@ class Permission(PermissionBase):
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query)
             if result.rowcount > 0:
-                logger.info('PostgreSQL permission schema is up-to-date.')
-                return
+                return 1
 
-        # Create schema
-        here = os.path.abspath(os.path.dirname(__file__))
-        sql_file = os.path.join(here, 'schema.sql')
-
-        if dry_run:
-            logger.info("Create permission schema from '{}'".format(sql_file))
-            return
-
-        # Since called outside request, force commit.
-        with open(sql_file) as f:
-            schema = f.read()
-        with self.client.connect(force_commit=True) as conn:
-            conn.execute(schema)
-        logger.info('Created PostgreSQL permission tables')
+        # Metadata table missing or has no
+        # permission_schema_version, and no user_principals table. We
+        # need to initialize.
+        return None
 
     def flush(self):
         query = """

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from kinto.core.permission import PermissionBase
 from kinto.core.storage.postgresql.client import create_from_config
-from kinto.core.storage.postgresql.migrator import Migrator
+from kinto.core.storage.postgresql.migrator import MigratorMixin
 
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 HERE = os.path.dirname(__file__)
 
 
-class Permission(PermissionBase, Migrator):
+class Permission(PermissionBase, MigratorMixin):
     """Permission backend using PostgreSQL.
 
     Enable in configuration::

--- a/kinto/core/permission/postgresql/migrations/migration_001_002.sql
+++ b/kinto/core/permission/postgresql/migrations/migration_001_002.sql
@@ -6,6 +6,9 @@ CREATE TABLE IF NOT EXISTS metadata (
     value VARCHAR(512) NOT NULL
 );
 
+-- IDs are not really human language text, so set them to be COLLATE
+-- "C" rather than the DB default collation. This also speeds up
+-- prefix-match queries (object_id LIKE '/bucket/abc/%').
 ALTER TABLE user_principals
     ALTER COLUMN user_id TYPE TEXT COLLATE "C";
 

--- a/kinto/core/permission/postgresql/migrations/migration_001_002.sql
+++ b/kinto/core/permission/postgresql/migrations/migration_001_002.sql
@@ -6,4 +6,10 @@ CREATE TABLE IF NOT EXISTS metadata (
     value VARCHAR(512) NOT NULL
 );
 
+ALTER TABLE user_principals
+    ALTER COLUMN user_id TYPE TEXT COLLATE "C";
+
+ALTER TABLE access_control_entries
+    ALTER COLUMN object_id TYPE TEXT COLLATE "C";
+
 INSERT INTO metadata VALUES ('permission_schema_version', '2');

--- a/kinto/core/permission/postgresql/migrations/migration_001_002.sql
+++ b/kinto/core/permission/postgresql/migrations/migration_001_002.sql
@@ -1,0 +1,9 @@
+-- Same table as exists in the storage backend, but used to track
+-- migration status for both. Only one schema actually has to create
+-- it.
+CREATE TABLE IF NOT EXISTS metadata (
+    name VARCHAR(128) NOT NULL,
+    value VARCHAR(512) NOT NULL
+);
+
+INSERT INTO metadata VALUES ('permission_schema_version', '2');

--- a/kinto/core/permission/postgresql/migrations/migration_001_002.sql
+++ b/kinto/core/permission/postgresql/migrations/migration_001_002.sql
@@ -12,4 +12,4 @@ ALTER TABLE user_principals
 ALTER TABLE access_control_entries
     ALTER COLUMN object_id TYPE TEXT COLLATE "C";
 
-INSERT INTO metadata VALUES ('permission_schema_version', '2');
+INSERT INTO metadata (name, value) VALUES ('permission_schema_version', '2');

--- a/kinto/core/permission/postgresql/schema.sql
+++ b/kinto/core/permission/postgresql/schema.sql
@@ -4,6 +4,10 @@
 SET client_min_messages TO ERROR;
 
 CREATE TABLE IF NOT EXISTS user_principals (
+    -- IDs are not really human language text, so set them to be
+    -- COLLATE "C" rather than the DB default collation. This also
+    -- speeds up prefix-match queries (object_id LIKE
+    -- '/bucket/abc/%').
     user_id TEXT COLLATE "C",
     principal TEXT,
 
@@ -11,6 +15,8 @@ CREATE TABLE IF NOT EXISTS user_principals (
 );
 
 CREATE TABLE IF NOT EXISTS access_control_entries (
+    -- Use COLLATE "C" as above because object IDs are really URLs,
+    -- not human text.
     object_id TEXT COLLATE "C",
     permission TEXT,
     principal TEXT,

--- a/kinto/core/permission/postgresql/schema.sql
+++ b/kinto/core/permission/postgresql/schema.sql
@@ -4,14 +4,14 @@
 SET client_min_messages TO ERROR;
 
 CREATE TABLE IF NOT EXISTS user_principals (
-    user_id TEXT,
+    user_id TEXT COLLATE "C",
     principal TEXT,
 
     PRIMARY KEY (user_id, principal)
 );
 
 CREATE TABLE IF NOT EXISTS access_control_entries (
-    object_id TEXT,
+    object_id TEXT COLLATE "C",
     permission TEXT,
     principal TEXT,
 

--- a/kinto/core/permission/postgresql/schema.sql
+++ b/kinto/core/permission/postgresql/schema.sql
@@ -23,3 +23,13 @@ CREATE INDEX IF NOT EXISTS idx_access_control_entries_permission
   ON access_control_entries(permission);
 CREATE INDEX IF NOT EXISTS idx_access_control_entries_principal
   ON access_control_entries(principal);
+
+-- Same table as exists in the storage backend, but used to track
+-- migration status for both. Only one schema actually has to create
+-- it.
+CREATE TABLE IF NOT EXISTS metadata (
+    name VARCHAR(128) NOT NULL,
+    value VARCHAR(512) NOT NULL
+);
+
+INSERT INTO metadata VALUES ('permission_schema_version', '2');

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -140,33 +140,33 @@ class Storage(StorageBase, Migrator):
             result = conn.execute(query)
             if result.rowcount > 0:
                 return int(result.fetchone()['version'])
-            else:
-                # No storage_schema_version row.
-                # Perhaps it got flush()ed by a pre-8.1.2 Kinto (which
-                # would wipe the metadata table).
-                # Alternately, maybe we are working from a very early
-                # Cliquet version which never had a migration.
-                # Check for a created_at row. If this is gone, it's
-                # probably been flushed at some point.
-                query = "SELECT COUNT(*) FROM metadata WHERE name = 'created_at';"
-                result = conn.execute(query)
-                was_flushed = int(result.fetchone()[0]) == 0
-                if not was_flushed:
-                    error_msg = 'No schema history; assuming migration from Cliquet (version 1).'
-                    logger.warning(error_msg)
-                    return 1
 
-                # We have no idea what the schema is here. Migration
-                # is completely broken.
-                # Log an obsequious error message to the user and try
-                # to recover by assuming the last version where we had
-                # this bug.
-                logger.warning(UNKNOWN_SCHEMA_VERSION_MESSAGE)
+            # No storage_schema_version row.
+            # Perhaps it got flush()ed by a pre-8.1.2 Kinto (which
+            # would wipe the metadata table).
+            # Alternately, maybe we are working from a very early
+            # Cliquet version which never had a migration.
+            # Check for a created_at row. If this is gone, it's
+            # probably been flushed at some point.
+            query = "SELECT COUNT(*) FROM metadata WHERE name = 'created_at';"
+            result = conn.execute(query)
+            was_flushed = int(result.fetchone()[0]) == 0
+            if not was_flushed:
+                error_msg = 'No schema history; assuming migration from Cliquet (version 1).'
+                logger.warning(error_msg)
+                return 1
 
-                # This is the last schema version where flushing the
-                # server would delete the schema version.
-                MAX_FLUSHABLE_SCHEMA_VERSION = 20
-                return MAX_FLUSHABLE_SCHEMA_VERSION
+            # We have no idea what the schema is here. Migration
+            # is completely broken.
+            # Log an obsequious error message to the user and try
+            # to recover by assuming the last version where we had
+            # this bug.
+            logger.warning(UNKNOWN_SCHEMA_VERSION_MESSAGE)
+
+            # This is the last schema version where flushing the
+            # server would delete the schema version.
+            MAX_FLUSHABLE_SCHEMA_VERSION = 20
+            return MAX_FLUSHABLE_SCHEMA_VERSION
 
     def flush(self, auth=None):
         """Delete records from tables without destroying schema.

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -118,7 +118,7 @@ class Storage(StorageBase, MigratorMixin):
         if encoding != 'utf8':  # pragma: no cover
             raise AssertionError('Unexpected database encoding {}'.format(encoding))
 
-    def _get_installed_version(self):
+    def get_installed_version(self):
         """Return current version of schema or None if not any found.
         """
         # Check for records table, which definitely indicates a new

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -13,7 +13,7 @@ from kinto.core.utils import COMPARISON
 
 
 logger = logging.getLogger(__name__)
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = os.path.dirname(__file__)
 
 
 class Storage(StorageBase, Migrator):

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -8,7 +8,7 @@ from kinto.core.storage import (
     DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD,
     MISSING)
 from kinto.core.storage.postgresql.client import create_from_config
-from kinto.core.storage.postgresql.migrator import Migrator
+from kinto.core.storage.postgresql.migrator import MigratorMixin
 from kinto.core.utils import COMPARISON
 
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 HERE = os.path.dirname(__file__)
 
 
-class Storage(StorageBase, Migrator):
+class Storage(StorageBase, MigratorMixin):
     """Storage backend using PostgreSQL.
 
     Recommended in production (*requires PostgreSQL 9.4 or higher*).
@@ -71,7 +71,7 @@ class Storage(StorageBase, Migrator):
 
     """  # NOQA
 
-    # Migrator attributes.
+    # MigratorMixin attributes.
     name = 'storage'
     schema_version = 20
     schema_file = os.path.join(HERE, 'schema.sql')

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -120,12 +120,14 @@ class Storage(StorageBase, Migrator):
     def _get_installed_version(self):
         """Return current version of schema or None if not any found.
         """
-        query = "SELECT tablename FROM pg_tables WHERE tablename = 'metadata';"
+        # Check for records table, which definitely indicates a new
+        # DB. (metadata can exist if the permission schema ran first.)
+        query = "SELECT table_name FROM information_schema.tables WHERE table_name = 'records';"
         with self.client.connect() as conn:
             result = conn.execute(query)
-            tables_exist = result.rowcount > 0
+            records_table_exists = result.rowcount > 0
 
-        if not tables_exist:
+        if not records_table_exists:
             return
 
         query = """

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -192,13 +192,13 @@ class Storage(StorageBase):
                 return 1
 
     def flush(self, auth=None):
-        """Delete records from tables without destroying schema. Mainly used
-        in tests suites.
+        """Delete records from tables without destroying schema.
+
+        This is used in test suites as well as in the flush plugin.
         """
         query = """
         DELETE FROM records;
         DELETE FROM timestamps;
-        DELETE FROM metadata;
         """
         with self.client.connect(force_commit=True) as conn:
             conn.execute(query)

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -15,6 +15,7 @@ from kinto.core.utils import COMPARISON
 logger = logging.getLogger(__name__)
 HERE = os.path.abspath(os.path.dirname(__file__))
 
+
 class Storage(StorageBase, Migrator):
     """Storage backend using PostgreSQL.
 

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -1,0 +1,91 @@
+"""
+A helper class to run migrations using a series of SQL files.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class Migrator(object):
+    """Mixin to allow the running of migrations."""
+
+    """Name of this migrator (e.g. "storage"). Override this."""
+    name = None
+
+    """The current "newest" schema version. Override this."""
+    schema_version = None
+
+    """The file to find the current "newest" schema in. Override this."""
+    schema_file = None
+
+    """The directory to find migration files in.
+
+    Migrations should each be a file named migration_nnn_mmm.sql, where mmm = nnn + 1.
+    """
+    migrations_directory = None
+
+    def _get_installed_version(self):
+        """Return current version of schema or None if none found.
+
+        Override this.
+
+        This may be called several times during a single migration.
+        """
+        pass
+
+    def create_or_migrate_schema(self, dry_run=False):
+        """Either create or migrate the schema, as needed."""
+        version = self._get_installed_version()
+        if not version:
+            self.create_schema(dry_run)
+            return
+
+        logger.info('Detected PostgreSQL {} schema version {}.'.format(self.name, version))
+        if version == self.schema_version:
+            logger.info('PostgreSQL {} schema is up-to-date.'.format(self.name))
+            return
+
+        self.migrate_schema(version, dry_run)
+        return
+
+    def create_schema(self, dry_run):
+        """Actually create the schema from scratch using self.schema_file.
+
+        You can override this if you want to add additional sanity checks.
+        """
+        logger.info('Create PostgreSQL {} schema at version {} from {}'.format(
+            self.name, self.schema_version, self.schema_file))
+        if not dry_run:
+            self._execute_sql_file(self.schema_file)
+            logger.info('Created PostgreSQL {} schema (version {}).'.format(
+                self.name, self.schema_version))
+
+    def migrate_schema(self, start_version, dry_run):
+        migrations = [(v, v + 1) for v in range(start_version, self.schema_version)]
+        for migration in migrations:
+            expected = migration[0]
+            current = self._get_installed_version()
+            error_msg = 'PostgreSQL {} schema: Expected version {}. Found version {}.'
+            if not dry_run and expected != current:
+                raise AssertionError(error_msg.format(self.name, expected, current))
+
+            logger.info('Migrate PostgreSQL {} schema from version {} to {}.'.format(
+                self.name, *migration))
+            filename = 'migration_{0:03d}_{1:03d}.sql'.format(*migration)
+            filepath = os.path.join(self.migrations_directory, filename)
+            logger.info('Execute PostgreSQL {} migration from {}'.format(self.name, filepath))
+            if not dry_run:
+                self._execute_sql_file(filepath)
+        logger.info('PostgreSQL {} schema migration {}'.format(
+            self.name,
+            'simulated.' if dry_run else 'done.'))
+
+    def _execute_sql_file(self, filepath):
+        """Helper method to execute the SQL in a file."""
+        with open(filepath) as f:
+            schema = f.read()
+        # Since called outside request, force commit.
+        with self.client.connect(force_commit=True) as conn:
+            conn.execute(schema)

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -52,7 +52,6 @@ class MigratorMixin():
             return
 
         self.migrate_schema(version, dry_run)
-        return
 
     def create_schema(self, dry_run):
         """Actually create the schema from scratch using self.schema_file.

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -82,9 +82,9 @@ class Migrator(object):
             logger.info('Execute PostgreSQL {} migration from {}'.format(self.name, filepath))
             if not dry_run:
                 self._execute_sql_file(filepath)
-        logger.info('PostgreSQL {} schema migration {}'.format(
+        logger.info('PostgreSQL {} schema migration {}.'.format(
             self.name,
-            'simulated.' if dry_run else 'done.'))
+            'simulated' if dry_run else 'done'))
 
     def _execute_sql_file(self, filepath):
         """Helper method to execute the SQL in a file."""

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -37,7 +37,7 @@ class MigratorMixin():
 
         This may be called several times during a single migration.
         """
-        raise NotImplementedError("method not overridden")
+        raise NotImplementedError("method not overridden")  # pragma: no cover
 
     def create_or_migrate_schema(self, dry_run=False):
         """Either create or migrate the schema, as needed."""

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -37,7 +37,7 @@ class MigratorMixin():
 
         This may be called several times during a single migration.
         """
-        pass
+        raise NotImplementedError("method not overridden")
 
     def create_or_migrate_schema(self, dry_run=False):
         """Either create or migrate the schema, as needed."""

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -8,7 +8,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class Migrator(object):
+class MigratorMixin():
     """Mixin to allow the running of migrations.
 
     Your class must provide a `client` attribute (a PostgreSQLClient),

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -30,7 +30,7 @@ class MigratorMixin():
     """
     migrations_directory = None
 
-    def _get_installed_version(self):
+    def get_installed_version(self):
         """Return current version of schema or None if none found.
 
         Override this.
@@ -41,7 +41,7 @@ class MigratorMixin():
 
     def create_or_migrate_schema(self, dry_run=False):
         """Either create or migrate the schema, as needed."""
-        version = self._get_installed_version()
+        version = self.get_installed_version()
         if not version:
             self.create_schema(dry_run)
             return
@@ -70,7 +70,7 @@ class MigratorMixin():
         migrations = [(v, v + 1) for v in range(start_version, self.schema_version)]
         for migration in migrations:
             expected = migration[0]
-            current = self._get_installed_version()
+            current = self.get_installed_version()
             error_msg = 'PostgreSQL {} schema: Expected version {}. Found version {}.'
             if not dry_run and expected != current:
                 raise AssertionError(error_msg.format(self.name, expected, current))

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -9,7 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 class Migrator(object):
-    """Mixin to allow the running of migrations."""
+    """Mixin to allow the running of migrations.
+
+    Your class must provide a `client` attribute (a PostgreSQLClient),
+    as well as override some class attributes.
+    """
 
     """Name of this migrator (e.g. "storage"). Override this."""
     name = None

--- a/kinto/core/views/version.py
+++ b/kinto/core/views/version.py
@@ -6,8 +6,8 @@ from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED
 from kinto.core import Service
 
-HERE = os.path.dirname(os.path.abspath(__file__))
-ORIGIN = os.path.dirname(os.path.dirname(HERE))
+HERE = os.path.dirname(__file__)
+ORIGIN = os.path.dirname(HERE)
 
 
 class VersionResponseSchema(colander.MappingSchema):
@@ -38,9 +38,8 @@ def version_view(request):
         os.path.join(HERE, 'version.json')  # Relative to this file.
     ]
     for version_file in files:
-        file_path = os.path.abspath(version_file)
-        if os.path.exists(file_path):
-            with open(file_path) as f:
+        if os.path.exists(version_file):
+            with open(version_file) as f:
                 version_view.__json__ = json.load(f)
                 return version_view.__json__  # First one wins.
 

--- a/kinto/plugins/admin/views.py
+++ b/kinto/plugins/admin/views.py
@@ -5,7 +5,7 @@ from pyramid.settings import aslist
 
 from kinto.core.decorators import cache_forever
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = os.path.dirname(__file__)
 
 
 # Configured home page

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import codecs
 import os
 from setuptools import setup, find_packages
 
+# abspath here because setup.py may be __main__, in which case
+# __file__ is not guaranteed to be absolute
 here = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/tests/core/schema/postgresql-permission-1.sql
+++ b/tests/core/schema/postgresql-permission-1.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS user_principals (
+    user_id TEXT,
+    principal TEXT,
+
+    PRIMARY KEY (user_id, principal)
+);
+
+CREATE TABLE IF NOT EXISTS access_control_entries (
+    object_id TEXT,
+    permission TEXT,
+    principal TEXT,
+
+    PRIMARY KEY (object_id, permission, principal)
+);
+CREATE INDEX IF NOT EXISTS idx_access_control_entries_object_id
+    ON access_control_entries(object_id);
+CREATE INDEX IF NOT EXISTS idx_access_control_entries_permission
+  ON access_control_entries(permission);
+CREATE INDEX IF NOT EXISTS idx_access_control_entries_principal
+  ON access_control_entries(principal);

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -174,16 +174,20 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
 
     def test_connection_is_rolledback_if_error_occurs(self):
         with self.storage.client.connect() as conn:
-            query = "DELETE FROM metadata WHERE name = 'roll';"
+            query = "DELETE FROM records WHERE collection_id = 'genre';"
             conn.execute(query)
 
         try:
             with self.storage.client.connect() as conn:
-                query = "INSERT INTO metadata VALUES ('roll', 'back');"
+                query = """
+                INSERT INTO records VALUES ('rock-and-roll', 'music', 'genre', NOW(), '{}', FALSE);
+                """
                 conn.execute(query)
                 conn.commit()
 
-                query = "INSERT INTO metadata VALUES ('roll', 'rock');"
+                query = """
+                INSERT INTO records VALUES ('jazz', 'music', 'genre', NOW(), '{}', FALSE);
+                """
                 conn.execute(query)
 
                 raise sqlalchemy.exc.TimeoutError()
@@ -191,7 +195,7 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
             pass
 
         with self.storage.client.connect() as conn:
-            query = "SELECT COUNT(*) FROM metadata WHERE name = 'roll';"
+            query = "SELECT COUNT(*) FROM records WHERE collection_id = 'genre';"
             result = conn.execute(query)
             self.assertEqual(result.fetchone()[0], 1)
 
@@ -223,8 +227,11 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
                                                with_transaction=False)
         with self.assertRaises(exceptions.IntegrityError):
             with client.connect() as conn:
-                # Make some change in metadata.
-                conn.execute("INSERT INTO metadata VALUES ('roll', 'rock');")
+                # Make some change in a table.
+                conn.execute("""
+                INSERT INTO records
+                VALUES ('rock-and-roll', 'music', 'genre', NOW(), '{}', FALSE);
+                """)
                 # Go into a failing integrity constraint.
                 query = "INSERT INTO timestamps VALUES ('a', 'b', NOW());"
                 conn.execute(query)
@@ -232,9 +239,13 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
                 conn.commit()
                 conn.close()
 
-        # Check that change in metadata was rolledback.
+        # Check that change in the above table was rolledback.
         with client.connect() as conn:
-            result = conn.execute("SELECT FROM metadata WHERE name = 'roll';")
+            result = conn.execute("""
+            SELECT FROM records
+             WHERE parent_id = 'music'
+               AND collection_id = 'genre';
+            """)
         self.assertEqual(result.rowcount, 0)
 
 

--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -8,14 +8,14 @@ from pyramid import testing
 from kinto.core.cache import postgresql as postgresql_cache
 from kinto.core.permission import postgresql as postgresql_permission
 from kinto.core.storage import postgresql as postgresql_storage
-from kinto.core.storage.postgresql.migrator import Migrator
+from kinto.core.storage.postgresql.migrator import MigratorMixin
 from kinto.core.testing import skip_if_no_postgresql
 
 
 class MigratorTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.migrator = Migrator()
+        self.migrator = MigratorMixin()
         here = os.path.dirname(__file__)
         migrations_directory = os.path.join(here, 'migrations')
         self.migrator.migrations_directory = migrations_directory

--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -109,7 +109,7 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
         versions = [6, 5, 4, 3, 3]
         self.storage._get_installed_version = lambda: versions.pop()
 
-        with mock.patch('kinto.core.storage.postgresql.logger') as mocked:
+        with mock.patch('kinto.core.storage.postgresql.migrator.logger') as mocked:
             self.storage.initialize_schema(dry_run=True)
 
         output = ''.join([repr(call) for call in mocked.info.call_args_list])

--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -16,7 +16,8 @@ class MigratorTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.migrator = Migrator()
-        migrations_directory = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'migrations')
+        here = os.path.abspath(os.path.dirname(__file__))
+        migrations_directory = os.path.join(here, 'migrations')
         self.migrator.migrations_directory = migrations_directory
 
     def test_schema_is_created_if_no_version(self):
@@ -388,7 +389,7 @@ class PostgresqlPermissionMigrationTest(unittest.TestCase):
               ('sailboat/log', 'read', 'system.Authenticated'),
               ('sailboat/log', 'write', 'admin');
             """
-            result = conn.execute(query)
+            conn.execute(query)
 
         version = self.permission._get_installed_version()
         self.assertEqual(version, 1)
@@ -404,14 +405,19 @@ class PostgresqlPermissionMigrationTest(unittest.TestCase):
         remy_principals = self.permission.get_user_principals('remy')
         self.assertEqual(remy_principals, set(['admin']))
 
-        remy_objects = self.permission.get_accessible_objects(['remy', 'admin', 'system.Authenticated'])
-        self.assertEqual(remy_objects, {'sailboat': set(['write']), 'sailboat/log': set(['read', 'write'])})
+        remy_objects = self.permission.get_accessible_objects(
+            ['remy', 'admin', 'system.Authenticated'])
+        self.assertEqual(remy_objects, {
+            'sailboat': set(['write']),
+            'sailboat/log': set(['read', 'write']),
+        })
 
         # Check that new records can be created
-        r = self.permission.add_user_principal('ethan', 'crew')
+        self.permission.add_user_principal('ethan', 'crew')
 
         # And deleted
         self.permission.remove_principal_from_ace('sailboat/log', 'read', 'system.Authenticated')
+
 
 @skip_if_no_postgresql
 class PostgresqlCacheMigrationTest(unittest.TestCase):

--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -13,8 +13,7 @@ from kinto.core.testing import skip_if_no_postgresql
 
 
 class MigratorTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.migrator = MigratorMixin()
         here = os.path.dirname(__file__)
         migrations_directory = os.path.join(here, 'migrations')

--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -16,7 +16,7 @@ class MigratorTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.migrator = Migrator()
-        here = os.path.abspath(os.path.dirname(__file__))
+        here = os.path.dirname(__file__)
         migrations_directory = os.path.join(here, 'migrations')
         self.migrator.migrations_directory = migrations_directory
 
@@ -113,7 +113,7 @@ class PostgresqlStorageMigrationTest(unittest.TestCase):
 
     def _load_schema(self, filepath):
         with self.storage.client.connect() as conn:
-            here = os.path.abspath(os.path.dirname(__file__))
+            here = os.path.dirname(__file__)
             with open(os.path.join(here, filepath)) as f:
                 old_schema = f.read()
             conn.execute(old_schema)
@@ -309,7 +309,7 @@ class PostgresqlPermissionMigrationTest(unittest.TestCase):
 
     def _load_schema(self, filepath):
         with self.permission.client.connect() as conn:
-            here = os.path.abspath(os.path.dirname(__file__))
+            here = os.path.dirname(__file__)
             with open(os.path.join(here, filepath)) as f:
                 old_schema = f.read()
             conn.execute(old_schema)

--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -23,7 +23,9 @@ class MigratorTest(unittest.TestCase):
     def test_schema_is_created_if_no_version(self):
         self.migrator.schema_version = 6
         with mock.patch.object(self.migrator, 'create_schema') as create_schema:
-            self.migrator.create_or_migrate_schema()
+            with mock.patch.object(self.migrator, 'get_installed_version') as installed_version:
+                installed_version.return_value = None
+                self.migrator.create_or_migrate_schema()
         self.assertTrue(create_schema.called)
 
     def test_schema_is_not_touched_if_already_current(self):

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -9,6 +9,7 @@ import uuid
 import requests
 
 
+# abspath here because __file__ may be relative if it is in __main__
 __HERE__ = os.path.abspath(os.path.dirname(__file__))
 
 SERVER_URL = "http://localhost:8888/v1"

--- a/tests/plugins/test_admin.py
+++ b/tests/plugins/test_admin.py
@@ -5,7 +5,7 @@ from kinto.plugins.admin import views as admin_views
 from ..support import BaseWebTest
 
 
-admin_module = os.path.abspath(os.path.dirname(admin_views.__file__))
+admin_module = os.path.dirname(admin_views.__file__)
 build_folder = os.path.join(admin_module, "build")
 built_index = os.path.join(build_folder, "index.html")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ class ConfigTest(unittest.TestCase):
         with codecs.open(dest, 'r', encoding='utf-8') as d:
             destination_temp = d.read()
 
-        sample_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+        sample_path = os.path.join(os.path.dirname(__file__),
                                    "test_configuration/test.ini")
         with codecs.open(sample_path, 'r', encoding='utf-8') as c:
             sample = c.read()


### PR DESCRIPTION
Fixes #1460.

- [x] Reuse migration mechanism to cover permission backend.
- [x] Actually add a migration for the permission backend adding COLLATE "C" to tables that need it.
- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
