### PR TITLE
HAWK request authentication plugin.  Relies on the account plugin for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(PYTHON):
 build-requirements:
 	$(VIRTUALENV) $(TEMPDIR)
 	$(TEMPDIR)/bin/pip install -U pip
-	$(TEMPDIR)/bin/pip install -Ue ".[monitoring,postgresql,memcached]"
+	$(TEMPDIR)/bin/pip install -Ue ".[monitoring,postgresql,memcached,hawk]"
 	$(TEMPDIR)/bin/pip freeze | grep -v -- '-e' > requirements.txt
 
 build-kinto-admin: need-npm

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -519,6 +519,28 @@ At this point, Kinto should be able to start and OpenID Authentication should wo
     multiauth.policy.google.state_ttl_seconds = 3600
 
 
+Mohawk request Auth
+:::::::::::::::::::
+
+`Mohawk <https://mohawk.readthedocs.io/en/latest/index.html>`_ implements the 
+`Hawk authorization scheme <https://github.com/hueniverse/hawk>`_, which 
+allows you to authenticate messages from your application backend to Kinto.
+In order to prevent replay attacks, nonce checking is enforced.  
+See `here <https://github.com/hueniverse/hawk#implementations>` for 
+some implementations of Hawk in different programming languages.
+
+Mohawk auth is enabled by turning on ``kinto.hawk.enabled`` and providing 
+credential values for ``kinto.hawk.id``, ``kinto.hawk.secret``, and
+``kinto.hawk.algo``.  
+
+.. code-block:: ini
+
+    kinto.hawk.enabled = true
+    kinto.hawk.id = 'some client id'
+    kinto.hawk.secret = 'some secret key'
+    kinto.hawk.algo = 'sha256'
+
+
 Custom Authentication
 :::::::::::::::::::::
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -519,26 +519,25 @@ At this point, Kinto should be able to start and OpenID Authentication should wo
     multiauth.policy.google.state_ttl_seconds = 3600
 
 
-Mohawk request Auth
-:::::::::::::::::::
+Hawk request Auth
+:::::::::::::::::
 
 `Mohawk <https://mohawk.readthedocs.io/en/latest/index.html>`_ implements the 
-`Hawk authorization scheme <https://github.com/hueniverse/hawk>`_, which 
-allows you to authenticate messages from your application backend to Kinto.
-In order to prevent replay attacks, nonce checking is enforced.  
-See `here <https://github.com/hueniverse/hawk#implementations>` for 
-some implementations of Hawk in different programming languages.
+`Hawk authorization scheme <https://github.com/hueniverse/hawk>`_, which
+allows you to authenticate requests. In order to prevent replay
+attacks, nonce checking is enforced.
+See `here <https://github.com/hueniverse/hawk#implementations>` for some
+implementations of Hawk in different programming languages.
 
-Mohawk auth is enabled by turning on ``kinto.hawk.enabled`` and providing 
-credential values for ``kinto.hawk.id``, ``kinto.hawk.secret``, and
-``kinto.hawk.algo``.  
+Hawk authentication can be enabled by turning on
+``kinto.hawk.enabled``. By default Hawk will use the ``sha256`` algorithm.
+
+But you can change this behaviour by setting ``kinto.hawk.algorithm`` value.
 
 .. code-block:: ini
 
     kinto.hawk.enabled = true
-    kinto.hawk.id = 'some client id'
-    kinto.hawk.secret = 'some secret key'
-    kinto.hawk.algo = 'sha256'
+    kinto.hawk.algorithm = sha256
 
 
 Custom Authentication

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -8,7 +8,7 @@ import random
 from pyramid.events import NewRequest, NewResponse
 from pyramid.exceptions import ConfigurationError
 from pyramid.httpexceptions import (HTTPTemporaryRedirect, HTTPGone,
-                                    HTTPBadRequest)
+                                    HTTPBadRequest, HTTPUnauthorized)
 from pyramid.renderers import JSON as JSONRenderer
 from pyramid.response import Response
 from pyramid.security import NO_PERMISSION_REQUIRED

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -7,8 +7,7 @@ import random
 
 from pyramid.events import NewRequest, NewResponse
 from pyramid.exceptions import ConfigurationError
-from pyramid.httpexceptions import (HTTPTemporaryRedirect, HTTPGone,
-                                    HTTPBadRequest, HTTPUnauthorized)
+from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPGone, HTTPBadRequest
 from pyramid.renderers import JSON as JSONRenderer
 from pyramid.response import Response
 from pyramid.security import NO_PERMISSION_REQUIRED

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -3,7 +3,7 @@ from time import time
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
 from kinto.plugins.hawk.hawkauth import HawkAuthenticator
 from kinto.core.storage import exceptions as storage_exceptions
-from kinto.core.errors import (http_error, raise_invalid, 
+from kinto.core.errors import (http_error, raise_invalid,
                                send_alert, ERRORS, request_GET)
 
 import requests
@@ -23,16 +23,16 @@ def clear_all_hawk_sessions(request, account):
 
     ACCOUNT_CACHE_KEY = 'accounts:{}:verified'
 
-    request.registry.storage.update(collection_id='account', 
+    request.registry.storage.update(collection_id='account',
                                    parent_id=account['id'],
-                                   object_id=account['id'], 
+                                   object_id=account['id'],
                                    record=account)
 
 def add_hawk_session(request, account, token):
     """Add a hawk session to the account using `token` as the session token.
-    
+
     Sessions are stored at the cache layer, with the client ID as the key.
-    This allows for fast lookups by HAWK client ID, which is found in the auth 
+    This allows for fast lookups by HAWK client ID, which is found in the auth
     header of the request.
     """
     hawk_auth = HawkAuth(hawk_session=token)
@@ -41,7 +41,7 @@ def add_hawk_session(request, account, token):
 
     hawk_auth.credentials.update({
         'session': token,
-        'id': hawk_auth.credentials['id'].decode(), 
+        'id': hawk_auth.credentials['id'].decode(),
         'key': hawk_auth.credentials['key'].decode(),
         'expires': expire_time,
         'account_user_id': account['id']
@@ -51,9 +51,9 @@ def add_hawk_session(request, account, token):
     client_id = hawk_auth.credentials['id']
     # The client ID is the dict key into the session credentials.
     account['hawk-sessions'].append(client_id)
-    request.registry.storage.update(collection_id='account', 
+    request.registry.storage.update(collection_id='account',
                                    parent_id=account['id'],
-                                   object_id=account['id'], 
+                                   object_id=account['id'],
                                    record=account)
 
     request.registry.cache.set(client_id, hawk_auth.credentials, expire_time)
@@ -98,7 +98,7 @@ def includeme(config):
     config.add_view(hawk_sessions_current,
                    route_name='hawk_sessions_current')
     config.add_route('hawk_sessions', '/accounts/{userid:.*}/hawk-sessions')
-    config.add_route('hawk_sessions_current', 
+    config.add_route('hawk_sessions_current',
                      '/accounts/{userid:.*}/hawk-sessions/current')
 
     config.add_api_capability(

--- a/kinto/plugins/accounts/views.py
+++ b/kinto/plugins/accounts/views.py
@@ -5,6 +5,8 @@ from pyramid.security import Authenticated, Everyone
 from pyramid.settings import aslist
 from pyramid.events import subscriber
 
+from ..hawk.hawkauth import HawkAuth
+
 from kinto.views import NameGenerator
 from kinto.core import resource, utils
 from kinto.core.errors import raise_invalid, http_error
@@ -106,8 +108,9 @@ class Account(resource.ShareableResource):
 
     def process_record(self, new, old=None):
         new = super(Account, self).process_record(new, old)
-
         new['password'] = hash_password(new['password'])
+        # Generate HAWK client secret for use with the Kinto hawk plugin
+        new['hawk_secret'] = HawkAuth.generate_secret()
 
         # Administrators can reach other accounts and anonymous have no
         # selected_userid. So do not try to enforce.

--- a/kinto/plugins/hawk/__init__.py
+++ b/kinto/plugins/hawk/__init__.py
@@ -1,0 +1,6 @@
+def includeme(config):
+    config.add_api_capability(
+        'hawk',
+        description='Hawk request authentication',
+        url='https://kinto.readthedocs.io/en/latest/\
+        configuration/settings.html#plugins')

--- a/kinto/plugins/hawk/authentication.py
+++ b/kinto/plugins/hawk/authentication.py
@@ -16,7 +16,7 @@ class HawkAuthenticationPolicy(CallbackAuthenticationPolicy):
 
     def forget(self, request):
         return [('WWW-Authenticate', 'Hawk')]
-        
+
     def _test_credentials(self, request):
         """Test credentials in request against account HAWK credentials"""
         account_creds = self._get_account_hawk_creds(request)
@@ -27,7 +27,7 @@ class HawkAuthenticationPolicy(CallbackAuthenticationPolicy):
 
     def _get_account_hawk_creds(self, request):
         """Check storage for the request account HAWK credentials.
-        
+
         The accounts plugin is a depency of this plugin, so we can rely
         on Basic Auth credentials to get the account and its HAWK creds.
         """

--- a/kinto/plugins/hawk/authentication.py
+++ b/kinto/plugins/hawk/authentication.py
@@ -1,0 +1,50 @@
+from pyramid.interfaces import IAuthenticationPolicy
+from pyramid.authentication import CallbackAuthenticationPolicy
+from pyramid.authentication import extract_http_basic_credentials
+
+from zope.interface import implementer
+
+from kinto.core.storage import exceptions as storage_exceptions
+
+from .hawkauth import HawkAuth
+
+@implementer(IAuthenticationPolicy)
+class HawkAuthenticationPolicy(CallbackAuthenticationPolicy):
+    def unauthenticated_userid(self, request):
+        user_id = self._test_credentials(request)
+        return user_id
+
+    def forget(self, request):
+        return [('WWW-Authenticate', 'Hawk')]
+        
+    def _test_credentials(self, request):
+        """Test credentials in request against account HAWK credentials"""
+        account_creds = self._get_account_hawk_creds(request)
+        try:
+            return account_creds['id']
+        except:
+            return None
+
+    def _get_account_hawk_creds(self, request):
+        """Check storage for the request account HAWK credentials.
+        
+        The accounts plugin is a depency of this plugin, so we can rely
+        on Basic Auth credentials to get the account and its HAWK creds.
+        """
+        print('check hawk')
+        basic_creds = extract_http_basic_credentials(request)
+        if basic_creds:
+            username, password = basic_creds
+            try:
+                account = request.registry.storage.get(parent_id=username,
+                                                       collection_id='account',
+                                                       object_id=username)
+            except storage_exceptions.RecordNotFoundError:
+                return None
+
+            cache = request.registry.cache
+            authenticator = HawkAuth(account['id'],
+                                     account['hawk_secret'],
+                                     cache)
+            if authenticator.authenticate(request):
+                return account

--- a/kinto/plugins/hawk/hawkauth.py
+++ b/kinto/plugins/hawk/hawkauth.py
@@ -1,0 +1,107 @@
+import logging
+import os
+
+from pyramid.exceptions import ConfigurationError
+from mohawk import Receiver
+
+from kinto.core import errors
+
+logger = logging.getLogger(__name__)
+
+SHA256_ALGO_NAME = 'sha256'
+# Currently only support sha256
+algorithms = set([SHA256_ALGO_NAME])
+
+class HawkAuth():
+    """Class reponsible for performing hawk authentication.
+
+    Relies on Mohawk library to check signature and nonce.
+    """
+    def __init__(self, client_id, secret, settings):
+        """initialize instance variables with hawk credentials.
+
+        :param client_id: Client ID used by kinto server to check signature
+        :param secret: Client Secret assoicated with the Client ID
+        :param settings: pyramid.registry.settings object.
+        """
+        self._client_id = client_id
+        self._secret = secret
+        self._algo = settings.get('kinto.hawk_algo') or SHA256_ALGO_NAME
+        self._nonce_lifespan = settings.get('kinto.hawk_nonce_lifespan') or 60
+
+        self._validate_config()
+
+    def _validate_config(self):
+        """Validate the hawk settings"""
+        if self._algo not in algorithms:
+            raise ConfigurationError(
+                'Hawk authorization algorithm is invalid in configuration \
+                settings: "{}" is not a valid algorithm.'.format(self._algo))
+        elif type(self._nonce_lifespan) != int:
+            raise ConfigurationError(
+                '`kinto.hawk_nonce_lifespan` must be an integer.')
+
+    @staticmethod
+    def generate_session_token():
+        """Utility method for generating random HAWK session token
+        
+        :returns: hex string, 32 bytes
+        """
+        return os.urandom(32).hex()
+        
+    @staticmethod
+    def get_credentials_from_session(token):
+        """Utility function to derive HAWK credentials from session token"""
+        pass
+
+    def authenticate(self, request):
+        """Perform hawk authorization on the request.  
+
+        The sender(client) credentials are checked against our receiver(server)
+        credentials.  The timestamp of the request must match the server time
+        (within 60 seconds by default) and the nonce sent by the client must be new.
+
+        :param request: Pyramid request object
+        :returns: ``True`` if authentication is successful, ``False`` otherwise
+        """
+        cache = request.registry.cache
+        # HAWK credentials lookup function
+        def get_credentials(client_id):
+            if client_id == self._client_id:
+                return {'id': self._client_id, 'key': self._secret, 
+                        'algorithm': self._algo}
+            raise LookupError('Client ID not found.')
+
+        # define a function for nonce checking
+        def seen_nonce(sender_id, nonce, timestamp):
+            key = '{id}:{nonce}:{ts}'.format(id=sender_id, nonce=nonce,
+                                             ts=timestamp)
+            if cache.get(key):
+                return True
+            else:
+                # Messages expire after 60 seconds, and we only need to 
+                # store the nonce for as long as messages are valid.
+                # Users can set their own nonce lifetime in settings.
+                cache.set(
+                    key, True, 
+                    self._nonce_lifespan)
+                return False
+
+        # Receiver constructor will raise exception if auth fails.
+        try:
+            receiver = Receiver(get_credentials,
+                                request.headers['Authorization'],
+                                request.url,
+                                request.method,
+                                content = request.body,
+                                content_type = request.headers['Content-Type'],
+                                seen_nonce = seen_nonce)
+        except:
+            return False
+
+        return True
+
+
+
+
+

--- a/kinto/plugins/hawk/hawkauth.py
+++ b/kinto/plugins/hawk/hawkauth.py
@@ -44,18 +44,18 @@ class HawkAuth():
     @staticmethod
     def generate_session_token():
         """Utility method for generating random HAWK session token
-        
+
         :returns: hex string, 32 bytes
         """
         return os.urandom(32).hex()
-        
+
     @staticmethod
     def get_credentials_from_session(token):
         """Utility function to derive HAWK credentials from session token"""
         pass
 
     def authenticate(self, request):
-        """Perform hawk authorization on the request.  
+        """Perform hawk authorization on the request.
 
         The sender(client) credentials are checked against our receiver(server)
         credentials.  The timestamp of the request must match the server time
@@ -68,7 +68,7 @@ class HawkAuth():
         # HAWK credentials lookup function
         def get_credentials(client_id):
             if client_id == self._client_id:
-                return {'id': self._client_id, 'key': self._secret, 
+                return {'id': self._client_id, 'key': self._secret,
                         'algorithm': self._algo}
             raise LookupError('Client ID not found.')
 
@@ -79,11 +79,11 @@ class HawkAuth():
             if cache.get(key):
                 return True
             else:
-                # Messages expire after 60 seconds, and we only need to 
+                # Messages expire after 60 seconds, and we only need to
                 # store the nonce for as long as messages are valid.
                 # Users can set their own nonce lifetime in settings.
                 cache.set(
-                    key, True, 
+                    key, True,
                     self._nonce_lifespan)
                 return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ jsonpointer==2.0
 jsonschema==2.6.0
 logging-color-formatter==1.0.2
 newrelic==2.106.0.87
+mohawk==0.3.4
 PasteDeploy==1.5.2
 plaster==1.0
 plaster-pastedeploy==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ jsonschema==2.6.0
 logging-color-formatter==1.0.2
 newrelic==2.106.0.87
 mohawk==0.3.4
+requests-hawk==1.0.0
 PasteDeploy==1.5.2
 plaster==1.0
 plaster-pastedeploy==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,9 @@ MEMCACHED_REQUIRES = [
     'python-memcached'
 ]
 
-MOHAWK_REQUIRES = [
-    'mohawk'
+HAWK_REQUIRES = [
+    'mohawk',
+    'requests-hawk'
 ]
 
 SETUP_REQUIRES = [
@@ -117,7 +118,7 @@ setup(name='kinto',
           'memcached': MEMCACHED_REQUIRES,
           'postgresql': POSTGRESQL_REQUIRES,
           'monitoring': MONITORING_REQUIRES,
-          'mohawk': MOHAWK_REQUIRES
+          'hawk': HAWK_REQUIRES
       },
       test_suite='tests',
       dependency_links=DEPENDENCY_LINKS,

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,10 @@ MEMCACHED_REQUIRES = [
     'python-memcached'
 ]
 
+MOHAWK_REQUIRES = [
+    'mohawk'
+]
+
 SETUP_REQUIRES = [
     'pytest-runner'
 ]
@@ -113,6 +117,7 @@ setup(name='kinto',
           'memcached': MEMCACHED_REQUIRES,
           'postgresql': POSTGRESQL_REQUIRES,
           'monitoring': MONITORING_REQUIRES,
+          'mohawk': MOHAWK_REQUIRES
       },
       test_suite='tests',
       dependency_links=DEPENDENCY_LINKS,

--- a/tests/core/test_hawk_authorization.py
+++ b/tests/core/test_hawk_authorization.py
@@ -1,0 +1,97 @@
+import mock
+import uuid
+
+from pyramid.config import Configurator
+from pyramid.exceptions import ConfigurationError
+
+from kinto.core import DEFAULT_SETTINGS
+from kinto.core.hawkauth import HawkAuth
+from kinto.core import authentication
+from kinto.core import utils
+from kinto.core.testing import DummyRequest, unittest
+
+from .support import BaseWebTest
+
+# settings names
+SETTING_NAME_MOHAWK_POWER_SWITCH = 'kinto.hawk.enabled'
+SETTING_NAME_MOHAWK_CLIENT = 'kinto.hawk.id'
+SETTING_NAME_MOHAWK_SECRET = 'kinto.hawk.secret'
+SETTING_NAME_MOHAWK_ALGORITHM = 'kinto.hawk.algo'
+
+# test credentials
+TEST_CLIENT_ID = 'test_client'
+TEST_SECRET = '8a6ebaf9-94fe-4c43-9d58-fb0aed2b24c7'
+TEST_ALGORITHM = 'sha256'
+
+
+hawk_settings = {
+    SETTING_NAME_MOHAWK_POWER_SWITCH: False,
+    SETTING_NAME_MOHAWK_CLIENT: TEST_CLIENT_ID,
+    SETTING_NAME_MOHAWK_SECRET: TEST_SECRET,
+    SETTING_NAME_MOHAWK_ALGORITHM: TEST_ALGORITHM
+}
+
+# Test configuration settings without sending credentials in request
+class HawkRequestAuthorizationSettingsTest(BaseWebTest, unittest.TestCase):
+    def setUp(self):
+        self.policy = authentication.BasicAuthAuthenticationPolicy()
+        self.request = DummyRequest()
+        self.request.headers['Authorization'] = 'Basic bWF0Og=='
+
+    def test_hawk_auth_is_ignored_if_disabled_in_settings(self):
+        app = self.make_app(hawk_settings)
+        app.get(self.collection_url, headers=self.headers, status=200)
+
+    def test_hawk_auth_request_is_forbidden_if_settings_are_valid(self):
+        # settings are valid but the request fails to send the correct signature
+        enabled_hawk_settings = hawk_settings.copy()
+        enabled_hawk_settings.update({
+            SETTING_NAME_MOHAWK_POWER_SWITCH: True})
+        app = self.make_app(enabled_hawk_settings)
+        app.get(self.collection_url, headers=self.headers, status=401)
+    
+    def test_hawk_auth_raises_if_empty_client_id_or_secret_in_settings(self):
+        settings = {**DEFAULT_SETTINGS}
+        config = Configurator(settings=settings)
+        config.registry.cache = {}
+
+        invalid_hawk_settings = hawk_settings.copy()
+        invalid_hawk_settings.update({
+            SETTING_NAME_MOHAWK_POWER_SWITCH: True,
+            SETTING_NAME_MOHAWK_CLIENT: ''})
+
+        # empty client ID raises ConfigurationError
+        with self.assertRaises(ConfigurationError):
+            authenticator = HawkAuth(
+                invalid_hawk_settings[SETTING_NAME_MOHAWK_CLIENT],
+                invalid_hawk_settings[SETTING_NAME_MOHAWK_SECRET],
+                invalid_hawk_settings[SETTING_NAME_MOHAWK_ALGORITHM],
+                config)
+        # empty secret raises ConfigurationError
+        with self.assertRaises(ConfigurationError):
+            authenticator = HawkAuth(
+                TEST_CLIENT_ID,
+                '',
+                invalid_hawk_settings[SETTING_NAME_MOHAWK_ALGORITHM],
+                config)
+
+    def test_hawk_auth_raises_if_invalid_algorithm_in_settings(self):
+        pass
+        
+# Mock request with HAWK credentials and test authentication
+class HawkRequestAuthorizationTest(BaseWebTest, unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_hawk_auth_fails_if_secret_is_incorrect(self):
+        pass
+
+    def test_hawk_auth_fails_if_nonce_has_already_been_used(self):
+        pass
+
+    def test_hawk_auth_fails_when_timestamps_mismatch(self):
+        pass
+
+    def test_hawk_auth_succeeds_with_good_credentials(self):
+        pass
+


### PR DESCRIPTION
storing secret, and the account user ID is used as the client ID.
Account creation triggers a secret to be generated and exposed to the
user.

Fixes #

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
