### PR TITLE
Allow inherited resources to set a custom model instance before instantiating (fixes #1472)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,9 @@ This document describes changes between each past release.
 8.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
 
+- Allow inherited resources to set a custom model instance before instantiating (fixes #1472)
 
 8.1.3 (2018-01-26)
 ------------------

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -167,12 +167,13 @@ class UserResource:
         # Authentication to storage is transmitted as is (cf. cloud_storage).
         auth = request.headers.get('Authorization')
 
-        self.model = self.default_model(
-            storage=request.registry.storage,
-            id_generator=self.id_generator,
-            collection_id=classname(self),
-            parent_id=parent_id,
-            auth=auth)
+        if not hasattr(self, 'model'):
+            self.model = self.default_model(
+                storage=request.registry.storage,
+                id_generator=self.id_generator,
+                collection_id=classname(self),
+                parent_id=parent_id,
+                auth=auth)
 
         # Initialize timestamp as soon as possible.
         self.timestamp

--- a/tests/core/resource/test_base.py
+++ b/tests/core/resource/test_base.py
@@ -1,4 +1,5 @@
 import mock
+import unittest
 from pyramid import httpexceptions
 
 from kinto.core.resource import UserResource, ShareableResource
@@ -66,3 +67,16 @@ class ParentIdOverrideResourceTest(BaseTest):
         parent_id = self.resource.get_parent_id(request)
         self.assertEquals(parent_id, 'overrided')
         self.assertEquals(self.resource.model.parent_id, 'overrided')
+
+
+class CustomModelResource(UserResource):
+    def __init__(self, *args, **kwargs):
+        self.model = mock.MagicMock()
+        self.model.name = mock.sentinel.model
+        super().__init__(*args, **kwargs)
+
+
+class CustomModelResourceTets(unittest.TestCase):
+    def test_custom_model_is_not_overriden(self):
+        c = CustomModelResource(request=mock.MagicMock())
+        self.assertEquals(c.model.name, mock.sentinel.model)


### PR DESCRIPTION
Fixes #1472 
