### PR TITLE
Use single quotes everywhere

### DIFF
--- a/kinto/core/cache/memcached.py
+++ b/kinto/core/cache/memcached.py
@@ -67,7 +67,7 @@ class Cache(CacheBase):
         if not value:
             return None, 0
         data = json.loads(value)
-        return data["value"], data["ttl"]
+        return data['value'], data['ttl']
 
     def ttl(self, key):
         _, ttl = self._get(key)
@@ -91,7 +91,7 @@ class Cache(CacheBase):
     def set(self, key, value, ttl):
         if isinstance(value, bytes):
             raise TypeError("a string-like object is required, not 'bytes'")
-        value = json.dumps({"value": value, "ttl": ceil(time() + ttl)})
+        value = json.dumps({'value': value, 'ttl': ceil(time() + ttl)})
         self._client.set(self.prefix + key, value, int(ttl))
 
     @wrap_memcached_error

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -99,7 +99,7 @@ class Storage(MemoryBasedStorage):
         if ts is not None:
             return ts
         if self.readonly:
-            error_msg = "Cannot initialize empty collection timestamp when running in readonly."
+            error_msg = 'Cannot initialize empty collection timestamp when running in readonly.'
             raise exceptions.BackendError(message=error_msg)
         return self._bump_timestamp(collection_id, parent_id)
 

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -228,8 +228,8 @@ class Storage(StorageBase, MigratorMixin):
             # If the backend is readonly, we should not try to create the timestamp.
             if self.readonly:
                 if existing_ts is None:
-                    error_msg = ("Cannot initialize empty collection timestamp "
-                                 "when running in readonly.")
+                    error_msg = ('Cannot initialize empty collection timestamp '
+                                 'when running in readonly.')
                     raise exceptions.BackendError(message=error_msg)
                 record = row
             else:

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -37,7 +37,7 @@ class MigratorMixin():
 
         This may be called several times during a single migration.
         """
-        raise NotImplementedError("method not overridden")  # pragma: no cover
+        raise NotImplementedError('method not overridden')  # pragma: no cover
 
     def create_or_migrate_schema(self, dry_run=False):
         """Either create or migrate the schema, as needed."""

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -997,8 +997,8 @@ class DeletedRecordsTest:
                                               include_deleted=True,
                                               **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertTrue(records[0]["deleted"])
-        self.assertTrue(records[0]["id"], r["id"])
+        self.assertTrue(records[0]['deleted'])
+        self.assertTrue(records[0]['id'], r['id'])
         self.assertEqual(count, 0)
 
     def test_delete_can_delete_without_tombstones(self):


### PR DESCRIPTION
    $ pip install unify
    $ find kinto -name "*.py" | xargs unify --in-place
