### PR TITLE
Fix missing principals from user info in root URL when default bucket  plugin is enabled (fixes #1495)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 8.1.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix missing principals from user info in root URL when default bucket plugin is enabled (fixes #1495)
 
 
 8.1.5 (2018-02-09)

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -133,6 +133,14 @@ class JsonLogFormatter(dockerflow_logging.JsonLogFormatter):
         self.logger_name = logger_name
 
 
+def get_user_info(request):
+    # Default user info (shown in hello view for example).
+    return {
+        'id': request.prefixed_userid,
+        'principals': request.prefixed_principals
+    }
+
+
 def includeme(config):
     settings = config.get_settings()
 
@@ -186,10 +194,7 @@ def includeme(config):
     config.add_request_method(follow_subrequest)
     config.add_request_method(prefixed_userid, property=True)
     config.add_request_method(prefixed_principals, reify=True)
-    config.add_request_method(lambda r: {
-        'id': r.prefixed_userid,
-        'principals': r.prefixed_principals},
-        name='get_user_info')
+    config.add_request_method(get_user_info, name='get_user_info')
     config.add_request_method(current_resource_name, reify=True)
     config.add_request_method(current_service, reify=True)
     config.commit()

--- a/kinto/plugins/default_bucket/__init__.py
+++ b/kinto/plugins/default_bucket/__init__.py
@@ -4,6 +4,7 @@ from pyramid import httpexceptions
 from pyramid.settings import asbool
 from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
+from kinto.core import get_user_info as core_get_user_info
 from kinto.core.errors import raise_invalid
 from kinto.core.events import ACTIONS
 from kinto.core.storage.exceptions import UnicityError
@@ -183,8 +184,8 @@ def default_bucket_id(request):
 
 def get_user_info(request):
     user_info = {
-        'id': request.prefixed_userid,
-        'bucket': request.default_bucket_id
+        **core_get_user_info(request),
+        'bucket': request.default_bucket_id,
     }
     return user_info
 

--- a/tests/plugins/test_default_bucket.py
+++ b/tests/plugins/test_default_bucket.py
@@ -259,8 +259,11 @@ class HelloViewTest(DefaultBucketWebTest):
 
     def test_returns_bucket_id_and_url_if_authenticated(self):
         response = self.app.get('/', headers=self.headers)
-        self.assertEqual(response.json['user']['bucket'],
-                         'ddaf8694-fa9e-2949-ed0e-77198a7907fb')
+        userinfo = response.json['user']
+        self.assertIn('id', userinfo)
+        self.assertIn('principals', userinfo)
+        self.assertIn('bucket', userinfo)
+        self.assertEqual(userinfo['bucket'], 'ddaf8694-fa9e-2949-ed0e-77198a7907fb')
 
     def test_flush_capability_if_enabled(self):
         resp = self.app.get('/')


### PR DESCRIPTION
Fixes #1495
