### PR TITLE
Travis workaround

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document describes changes between each past release.
 **Internal Changes**
 
 - Now fully rely on Pyup.io (or contributors) to update the versions in the `requirements.txt` file (fixes #1512)
+- Move from importing pip to running it in a subprocess (see https://github.com/pypa/pip/issues/5081).
 
 
 8.2.0 (2018-03-01)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ flake8==3.5.0
 mock==2.0.0
 pytest==3.4.2
 pytest-cache==1.0
-pytest-cover==3.0.0
+pytest-cov==2.5.1
 pytest-sugar==0.9.1
 pytest-watch==4.1.0
 SQLAlchemy==1.2.5

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 import sys
 import logging
 import logging.config
@@ -144,14 +145,14 @@ def main(args=None):
             try:
                 import psycopg2  # NOQA
             except ImportError:
-                import pip
-                pip.main(['install', 'kinto[postgresql]'])
+                subprocess.check_call([sys.executable, '-m', 'pip',
+                                       'install', 'kinto[postgresql]'])
         elif backend == 'redis':
             try:
                 import kinto_redis  # NOQA
             except ImportError:
-                import pip
-                pip.main(['install', 'kinto[redis]'])
+                subprocess.check_call([sys.executable, '-m', 'pip',
+                                       'install', 'kinto[redis]'])
 
     elif which_command == 'migrate':
         dry_run = parsed_args['dry_run']

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -69,7 +69,8 @@ class TestMain(unittest.TestCase):
                 return realimport(name, *args, **kwargs)
 
         with mock.patch('builtins.__import__', side_effect=psycopg2_missing):
-            with mock.patch('pip.main', return_value=None) as mocked_pip:
+            with mock.patch('kinto.__main__.subprocess.check_call',
+                            return_value=None) as mocked_pip:
                 with mock.patch("kinto.__main__.input", create=True, return_value="1"):
                     res = main(['init', '--ini', TEMP_KINTO_INI])
                     assert res == 0
@@ -85,7 +86,8 @@ class TestMain(unittest.TestCase):
                 return realimport(name, *args, **kwargs)
 
         with mock.patch('builtins.__import__', side_effect=redis_missing):
-            with mock.patch('pip.main', return_value=None) as mocked_pip:
+            with mock.patch('kinto.__main__.subprocess.check_call',
+                            return_value=None) as mocked_pip:
                 with mock.patch("kinto.__main__.input", create=True, return_value="2"):
                     res = main(['init', '--ini', TEMP_KINTO_INI])
                     assert res == 0

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = True
 passenv = TRAVIS
 commands =
     python --version
-    py.test --cov-report term-missing --cov-fail-under 100 --cov kinto {posargs}
+    py.test --cov-report term-missing --cov-branch --cov-fail-under 100 --cov kinto {posargs}
 deps =
     -rdev-requirements.txt
     -crequirements.txt


### PR DESCRIPTION
Fixes the recent failing builds which have to do with how we're invoking pip, which never supported what we're doing and (as of 9.0.2) breaks when we even try it.

However (and I have no idea if this is related or not), fixing that causes the reappearance of the coverage "can't combine line data with arc data" error. Try to fix that by changing random things until the errors stop.

- (n/a) Add documentation.
- (n/a) Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
