### PR TITLE
Show bucket:create permission in permissions endpoint (ref #1510)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ This document describes changes between each past release.
 - Move from importing pip to running it in a subprocess (see https://github.com/pypa/pip/issues/5081).
 - Remove useless print when using the OpenID policy (ref #1509)
 - Try to recover from the race condition where two requests can delete the same record. (Fix #1557; refs #1407.)
+- Add resource permissions defined in settings to permissions endpoint (ref #1510)
 
 
 8.2.0 (2018-03-01)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -66,6 +66,7 @@ Contributors
 * Stanisław Wasiutyński <https://github.com/stanley>
 * Stephen Daves <contact@stephendaves.com>
 * Stephen Donner <stephen.donner@gmail.com>
+* Stephen Martin <lockwood@opperline.com>
 * Shweta Oak <oakshweta11@gmail.com>
 * Sofia Utsch <sofia.utsch@gmail.com>
 * Sumit Sarin <sumitsarinofficial@gmail.com>


### PR DESCRIPTION
Fixes #1510 

For the `kinto/core/utils.py` change, `''` is required for the `resource_name` value in the dictionary lookup in the permissions tree:

https://github.com/Kinto/kinto/blob/6d77dcb2b94f9198fa08db489776440f7df0c275/kinto/views/permissions.py#L123

Since the purpose of the `view_lookup` function is to map a `uri` to a `resource_name`, I thought it best in there.

I was also going under the assumption that the permissions response for the top bucket should not return an id, so there are changes to that effect as well.

Everything else should be pretty straightforward and please let me know if you see any issues or suggestions.

Thanks!
