### PR TITLE
Fix permissions

### DIFF
--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -306,7 +306,7 @@ def extract_record_set(records, filters, sorting,
     paginated = {}
     for rule in pagination_rules or []:
         values = list(apply_filters(filtered, rule))
-        paginated.update(dict(((x.get(id_field), x) for x in values)))
+        paginated.update(dict(((x[id_field], x) for x in values)))
 
     if paginated:
         paginated = paginated.values()

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -306,7 +306,7 @@ def extract_record_set(records, filters, sorting,
     paginated = {}
     for rule in pagination_rules or []:
         values = list(apply_filters(filtered, rule))
-        paginated.update(dict(((x[id_field], x) for x in values)))
+        paginated.update(dict(((x.get(id_field), x) for x in values)))
 
     if paginated:
         paginated = paginated.values()

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -142,6 +142,7 @@ class PermissionsModel:
             entries.append(entry)
 
         return extract_record_set(entries, filters=filters, sorting=sorting,
+                                  id_field='uri',
                                   pagination_rules=pagination_rules,
                                   limit=limit)
 

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -84,20 +84,18 @@ class PermissionsUnauthenticatedViewTest(BaseWebTest, unittest.TestCase):
 
         for order in ['id', '-id', 'uri', '-uri']:
             for limit in range(1, 10):
-                records = []
-                resp = self.app.get('/permissions?_sort={}&_limit={}'.format(order, limit),
-                                    headers=self.everyone_headers)
-                records = records + resp.json['data']
-                while 'Next-Page' in resp.headers:
-                    next_url = resp.headers['Next-Page'][len('http://localhost/v1'):]
-                    resp = self.app.get(next_url, headers=self.everyone_headers)
+                with self.subTest(order=order, limit=limit):
+                    records = []
+                    resp = self.app.get('/permissions?_sort={}&_limit={}'.format(order, limit),
+                                        headers=self.everyone_headers)
                     records = records + resp.json['data']
+                    while 'Next-Page' in resp.headers:
+                        next_url = resp.headers['Next-Page'][len('http://localhost/v1'):]
+                        resp = self.app.get(next_url, headers=self.everyone_headers)
+                        records = records + resp.json['data']
 
-                message = "didn't get same permissions with sort={}, limit={}".format(
-                    order, limit)
-                self.assertEqual(sort_by_uri(real_permissions),
-                                 sort_by_uri(records),
-                                 message)
+                    self.assertEqual(sort_by_uri(real_permissions),
+                                     sort_by_uri(records))
 
     def test_object_details_are_provided(self):
         resp = self.app.get('/permissions', headers=self.everyone_headers)

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -68,11 +68,11 @@ class PermissionsUnauthenticatedViewTest(BaseWebTest, unittest.TestCase):
     def test_bucket_create_permission_exists(self):
         resp = self.app.get('/permissions', headers=self.everyone_headers)
         buckets = resp.json['data']
-        toplevel_bucket = buckets[4]
-        self.assertEqual(toplevel_bucket, {
+        toplevel_bucket = [b for b in buckets if b['uri'] == '/buckets']
+        self.assertEqual(toplevel_bucket, [{
             'permissions': ['bucket:create'],
             'resource_name': 'bucket',
-            'uri': '/buckets'})
+            'uri': '/buckets'}])
 
     def test_permissions_can_be_paginated(self):
         """Verify that pagination doesn't squash same IDs"""

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -61,6 +61,13 @@ class PermissionsUnauthenticatedViewTest(BaseWebTest, unittest.TestCase):
             'resource_name': 'bucket',
             'uri': '/buckets'})
 
+    def test_can_paginate(self):
+        """kinto_http.js uses this sort of request when listing permissions"""
+        resp = self.app.get('/permissions?_sort=id&_limit=1', headers=self.everyone_headers)
+        while 'Next-Page' in resp.headers:
+            next_url = resp.headers['Next-Page'][len('http://localhost/v1'):]
+            resp = self.app.get(next_url, headers=self.everyone_headers)
+
     def test_object_details_are_provided(self):
         resp = self.app.get('/permissions', headers=self.everyone_headers)
         entries = resp.json['data']


### PR DESCRIPTION
kinto-http.js tests started failing because of #1556. This is a quick workaround but I'm not really convinced it's the best solution -- I feel like having entries (in the permissions list, or indeed anywhere) without an ID is asking for trouble. What do you think @leplatrem @stloma ?