### PR TITLE
Fix resource names for account:create and bucket:create permission in permissions endpoint

### DIFF
--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -24,7 +24,7 @@ from kinto.core import authorization as core_authorization
 # automatically provides it
 # Ex: bucket:read is granted by both bucket:write and bucket:read
 PERMISSIONS_INHERITANCE_TREE = {
-    '': {  # Granted via settings only.
+    'root': {  # Granted via settings only.
         'bucket:create': {},
         'write': {},
         'read': {},

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -12,7 +12,7 @@ def includeme(config):
 
     config.scan('kinto.plugins.accounts.views')
 
-    PERMISSIONS_INHERITANCE_TREE[''].update({
+    PERMISSIONS_INHERITANCE_TREE['root'].update({
         'account:create': {}
     })
     PERMISSIONS_INHERITANCE_TREE['account'] = {

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -42,7 +42,10 @@ def allowed_from_settings(settings, principals):
             resource_name = {  # resource parents.
                 'collection': 'bucket',
                 'group': 'bucket',
-                'record': 'collection'}.get(resource_name, '')
+                'record': 'collection',
+                'bucket': 'root',
+                'account': 'root',
+            }.get(resource_name, '')
         # Store them in a convenient way.
         from_settings.setdefault(resource_name, set()).add(permission)
     return from_settings
@@ -83,10 +86,10 @@ class PermissionsModel:
         from_settings = allowed_from_settings(self.request.registry.settings, principals)
 
         # Add additional resources and permissions defined in settings/plugins
-        for root_perm in from_settings.get('', []):
+        for root_perm in from_settings.get('root', []):
             resource_name, _ = root_perm.split(':')
             perms_by_object_uri.setdefault('/', set()).add(root_perm)
-            perms_descending_tree.setdefault('', {}).update({root_perm: {'': {root_perm}}})
+            perms_descending_tree.setdefault('root', {}).update({root_perm: {'root': {root_perm}}})
 
         # Expand permissions obtained from backend with the object URIs that
         # correspond to permissions allowed from settings.
@@ -128,7 +131,7 @@ class PermissionsModel:
             # The imaginary "root" resource gets mapped to the hello
             # view. Handle it explicitly.
             if resource_name == 'hello':
-                resource_name = ''
+                resource_name = 'root'
 
             # Expand implicit permissions using descending tree.
             permissions = set(perms)
@@ -137,10 +140,6 @@ class PermissionsModel:
                 # Related to same resource only and not every sub-objects.
                 # (e.g "bucket:write" gives "bucket:read" but not "group:read")
                 permissions |= obtained[resource_name]
-
-            # Expose this resource with a nicer name.
-            if resource_name == '':
-                resource_name = 'root'
 
             entry = dict(uri=object_uri,
                          resource_name=resource_name,

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -253,26 +253,26 @@ class PermissionsEndpointTest(AccountsWebTest):
         assert uris == ['/buckets/a/collections/b/records/c',
                         '/buckets/a/collections/b',
                         '/buckets/a',
-                        '/buckets',
                         '/accounts/alice',
-                        '/accounts']
+                        '/']
 
     def test_account_create_read_write_permissions_(self):
         resp = self.app.get('/permissions', headers=self.headers)
         buckets = resp.json['data']
-        accounts = buckets[4]
-        account = buckets[5]
-        accounts['permissions'].sort()
-        self.assertEqual(accounts, {
+        account = buckets[3]
+        account['permissions'].sort()
+        root = buckets[4]
+        root['permissions'].sort()
+        self.assertEqual(account, {
             'account_id': 'alice',
             'id': 'alice',
             'permissions': ['read', 'write'],
             'resource_name': 'account',
             'uri': '/accounts/alice'})
-        self.assertEqual(account, {
-            'permissions': ['account:create'],
-            'resource_name': 'account',
-            'uri': '/accounts'})
+        self.assertEqual(root, {
+            'permissions': ['account:create', 'bucket:create'],
+            'resource_name': 'root',
+            'uri': '/'})
 
 
 class PermissionsEndpointTestUnauthenticatedCreatePermission(AccountsWebTest):
@@ -290,16 +290,12 @@ class PermissionsEndpointTestUnauthenticatedCreatePermission(AccountsWebTest):
     def test_permissions_endpoint_is_compatible_with_accounts_plugin(self):
         resp = self.app.get('/permissions', headers=self.everyone_headers)
         buckets = resp.json['data']
-        bucket_create = buckets[0]
-        account_create = buckets[1]
-        self.assertEqual(bucket_create, {
-            'permissions': ['bucket:create'],
-            'resource_name': 'bucket',
-            'uri': '/buckets'})
-        self.assertEqual(account_create, {
-            'permissions': ['account:create'],
-            'resource_name': 'account',
-            'uri': '/accounts'})
+        root = buckets[0]
+        root['permissions'] = set(root['permissions'])
+        self.assertEqual(root, {
+            'permissions': {'account:create', 'bucket:create'},
+            'resource_name': 'root',
+            'uri': '/'})
 
 
 class AdminTest(AccountsWebTest):

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -291,9 +291,9 @@ class PermissionsEndpointTestUnauthenticatedCreatePermission(AccountsWebTest):
         resp = self.app.get('/permissions', headers=self.everyone_headers)
         buckets = resp.json['data']
         root = buckets[0]
-        root['permissions'] = set(root['permissions'])
+        root['permissions'].sort()
         self.assertEqual(root, {
-            'permissions': {'account:create', 'bucket:create'},
+            'permissions': ['account:create', 'bucket:create'],
             'resource_name': 'root',
             'uri': '/'})
 

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -57,7 +57,7 @@ class PermissionsUnauthenticatedViewTest(BaseWebTest, unittest.TestCase):
 
         uris = [bucket['uri'] for bucket in buckets]
         self.assertEqual(sorted(uris), [
-            '/buckets',
+            '/',
             '/buckets/beers',
             '/buckets/beers/collections/barley',
             '/buckets/beers/collections/barley/records/{}'.format(RECORD_ID),
@@ -68,11 +68,11 @@ class PermissionsUnauthenticatedViewTest(BaseWebTest, unittest.TestCase):
     def test_bucket_create_permission_exists(self):
         resp = self.app.get('/permissions', headers=self.everyone_headers)
         buckets = resp.json['data']
-        toplevel_bucket = [b for b in buckets if b['uri'] == '/buckets']
+        toplevel_bucket = [b for b in buckets if b['resource_name'] == 'root']
         self.assertEqual(toplevel_bucket, [{
             'permissions': ['bucket:create'],
-            'resource_name': 'bucket',
-            'uri': '/buckets'}])
+            'resource_name': 'root',
+            'uri': '/'}])
 
     def test_permissions_can_be_paginated(self):
         """Verify that pagination doesn't squash same IDs"""
@@ -257,8 +257,8 @@ class GroupsPermissionTest(PermissionsViewTest):
     def test_permissions_inherited_are_not_listed(self):
         resp = self.app.get('/permissions', headers=self.admin_headers)
         collections = [e for e in resp.json['data']
-                       # top level '/buckets' does not have an id
-                       if e['uri'] != '/buckets'
+                       # top level '/' does not have an id
+                       if e['uri'] != '/'
                        if e['bucket_id'] == 'beers' and e['resource_name'] == 'collection']
         self.assertEqual(len(collections), 0)
 

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -166,7 +166,7 @@ class EntriesTest(PermissionsViewTest):
         resp = self.app.get('/permissions?in_resource_name=bucket,collection',
                             headers=self.headers)
         permissions = resp.json['data']
-        self.assertEqual(len(permissions), 3)
+        self.assertEqual(len(permissions), 2)
 
     def test_filtering_with_unknown_field_is_not_supported(self):
         self.app.get('/permissions?movie=bourne',


### PR DESCRIPTION
Refs #1576. At first I thought this was part of the same issue and was going to fix it in the same PR, but thinking about it more, I decided it was better to split it off. The basic inconsistency here is that `/buckets/foo` is `resource_name` `bucket`, with `permissions` such as `collection:create` and `group:create`, but the `bucket:create` permission is on `/buckets` and not `/`. This would be OK if the `collection:create` permission were on `/buckets/foo/collections`, but it isn't, and I'd argue it shouldn't be.

The third commit gets a bit more strident about reorganizing the codebase. Up until now, we have this mysterious empty string resource name representing the root of the hierarchy, but things can be a little simpler if we just call it `root`, since that's what it is. It's possible that you don't approve of this change -- the empty string is symmetric with the empty-string `parent_id` that we use as the parents for e.g. buckets. I consider these two things different -- things in the inheritance tree are really resource names, and things in parent_id are really URLs -- but I don't feel strongly about it and will unwind the change if you prefer.