### PR TITLE
Don't restart pagination if we don't match any objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ This document describes changes between each past release.
 - Move from importing pip to running it in a subprocess (see https://github.com/pypa/pip/issues/5081).
 - Remove useless print when using the OpenID policy (ref #1509)
 - Try to recover from the race condition where two requests can delete the same record. (Fix #1557; refs #1407.)
+- Fix a bug in the memory backend where paginating past the end of a list would restart pagination. (Refs #1584.)
 
 
 8.2.2 (2018-03-28)

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -307,7 +307,7 @@ def extract_record_set(records, filters, sorting,
         paginated = {}
         for rule in pagination_rules:
             values = apply_filters(filtered, rule)
-            paginated.update(dict(((x[id_field], x) for x in values)))
+            paginated.update(((x[id_field], x) for x in values))
         paginated = paginated.values()
     else:
         paginated = filtered

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -303,12 +303,11 @@ def extract_record_set(records, filters, sorting,
     filtered = list(apply_filters(records, filters or []))
     total_records = len(filtered)
 
-    paginated = {}
-    for rule in pagination_rules or []:
-        values = list(apply_filters(filtered, rule))
-        paginated.update(dict(((x[id_field], x) for x in values)))
-
-    if paginated:
+    if pagination_rules:
+        paginated = {}
+        for rule in pagination_rules:
+            values = apply_filters(filtered, rule)
+            paginated.update(dict(((x[id_field], x) for x in values)))
         paginated = paginated.values()
     else:
         paginated = filtered

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -1364,6 +1364,17 @@ class DeletedRecordsTest:
         self.assertIn('deleted', records[0])
         self.assertNotIn('deleted', records[1])
 
+    def test_pagination_can_skip_everything(self):
+        for i in range(5):
+            self.create_record({'i': i})
+
+        pagination = [[Filter('i', 7, utils.COMPARISON.GT)]]
+        records, count = self.storage.get_all(pagination_rules=pagination,
+                                              limit=5,
+                                              include_deleted=True,
+                                              **self.storage_kw)
+        self.assertEqual(len(records), 0)
+
     def test_get_all_handle_a_pagination_rules(self):
         for x in range(10):
             record = dict(self.record)


### PR DESCRIPTION
An attempt to answer #1584 empirically (using the test suite).