### PR TITLE
Expose bump_timestamp and bump_and_store_timestamp as part as the MemoryBasedStorage class.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 
 - Introduce ``contains`` and ``contains_any`` filter operators (fixes #343).
 
+**Internal changes**
+
+- Expose the manage_timestamp storage method so that memory based storage can use it.
+
 **Documentation**
 
 - Version number is taken from package in order to ease release process

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,22 +4,22 @@ Changelog
 This document describes changes between each past release.
 
 
-8.4.0 (unreleased)
+9.0.0 (unreleased)
 ------------------
 
 **Protocol**
 
 - Introduce ``contains`` and ``contains_any`` filter operators (fixes #343).
 
-**Internal changes**
+**Breaking changes**
 
-- Expose the manage_timestamp storage method so that memory based storage can use it.
+- Expose the ``bump_timestamp`` and ``bump_and_store_timestamp`` methods
+  so that memory based storage can use them. (#1596)
 
 **Documentation**
 
-- Version number is taken from package in order to ease release process
-- Copyright year is now dynamic
-
+- Version number is taken from package in order to ease release process (#1594)
+- Copyright year is now dynamic (#1595)
 
 
 8.3.0 (2018-04-06)

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -46,9 +46,9 @@ class MemoryBasedStorage(StorageBase):
     def set_record_timestamp(self, collection_id, parent_id, record,
                              modified_field=DEFAULT_MODIFIED_FIELD,
                              last_modified=None):
-        timestamp = self._bump_and_store_timestamp(collection_id, parent_id, record,
-                                                   modified_field,
-                                                   last_modified=last_modified)
+        timestamp = self.bump_and_store_timestamp(collection_id, parent_id, record,
+                                                  modified_field,
+                                                  last_modified=last_modified)
         record[modified_field] = timestamp
         return record
 
@@ -105,6 +105,12 @@ class MemoryBasedStorage(StorageBase):
             collection_timestamp = current
         return current, collection_timestamp
 
+    def bump_and_store_timestamp(self, collection_id, parent_id, record=None,
+                                 modified_field=None, last_modified=None):
+        """Use the bump_timestamp to get its next value and store the collection_timestamp.
+        """
+        raise NotImplementedError
+
 
 class Storage(MemoryBasedStorage):
     """Storage backend implementation in memory.
@@ -139,10 +145,10 @@ class Storage(MemoryBasedStorage):
         if self.readonly:
             error_msg = 'Cannot initialize empty collection timestamp when running in readonly.'
             raise exceptions.BackendError(message=error_msg)
-        return self._bump_and_store_timestamp(collection_id, parent_id)
+        return self.bump_and_store_timestamp(collection_id, parent_id)
 
-    def _bump_and_store_timestamp(self, collection_id, parent_id, record=None,
-                                  modified_field=None, last_modified=None):
+    def bump_and_store_timestamp(self, collection_id, parent_id, record=None,
+                                 modified_field=None, last_modified=None):
         """Use the bump_timestamp to get its next value and store the collection_timestamp.
         """
         current_collection_timestamp = self._timestamps[parent_id].get(collection_id, 0)

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -46,9 +46,9 @@ class MemoryBasedStorage(StorageBase):
     def set_record_timestamp(self, collection_id, parent_id, record,
                              modified_field=DEFAULT_MODIFIED_FIELD,
                              last_modified=None):
-        timestamp = self._bump_timestamp(collection_id, parent_id, record,
-                                         modified_field,
-                                         last_modified=last_modified)
+        timestamp = self._bump_and_store_timestamp(collection_id, parent_id, record,
+                                                   modified_field,
+                                                   last_modified=last_modified)
         record[modified_field] = timestamp
         return record
 
@@ -67,8 +67,16 @@ class MemoryBasedStorage(StorageBase):
                                   pagination_rules=pagination_rules,
                                   limit=limit)
 
-    def _manage_collection_timestamp(self, collection_timestamp,
-                                     record, modified_field, last_modified):
+    def bump_timestamp(self, collection_timestamp,
+                       record, modified_field, last_modified):
+        """Timestamp are base on current millisecond.
+
+        .. note ::
+
+            Here it is assumed that if requests from the same user burst in,
+            the time will slide into the future. It is not problematic since
+            the timestamp notion is opaque, and behaves like a revision number.
+        """
         is_specified = (record is not None and
                         modified_field in record or
                         last_modified is not None)
@@ -131,21 +139,15 @@ class Storage(MemoryBasedStorage):
         if self.readonly:
             error_msg = 'Cannot initialize empty collection timestamp when running in readonly.'
             raise exceptions.BackendError(message=error_msg)
-        return self._bump_timestamp(collection_id, parent_id)
+        return self._bump_and_store_timestamp(collection_id, parent_id)
 
-    def _bump_timestamp(self, collection_id, parent_id, record=None,
-                        modified_field=None, last_modified=None):
-        """Timestamp are base on current millisecond.
-
-        .. note ::
-
-            Here it is assumed that if requests from the same user burst in,
-            the time will slide into the future. It is not problematic since
-            the timestamp notion is opaque, and behaves like a revision number.
+    def _bump_and_store_timestamp(self, collection_id, parent_id, record=None,
+                                  modified_field=None, last_modified=None):
+        """Use the bump_timestamp to get its next value and store the collection_timestamp.
         """
         current_collection_timestamp = self._timestamps[parent_id].get(collection_id, 0)
 
-        current, collection_timestamp = self._manage_collection_timestamp(
+        current, collection_timestamp = self.bump_timestamp(
             current_collection_timestamp,
             record, modified_field,
             last_modified)

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='8.4.0.dev0',
+      version='9.0.0.dev0',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description='{}\n\n{}\n\n{}'.format(README, CHANGELOG, CONTRIBUTORS),
       license='Apache License (2.0)',

--- a/tests/core/resource/test_sync.py
+++ b/tests/core/resource/test_sync.py
@@ -14,7 +14,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
         self.validated['body'] = {'data': {}}
 
         with mock.patch.object(self.model.storage,
-                               '_bump_and_store_timestamp') as msec_mocked:
+                               'bump_and_store_timestamp') as msec_mocked:
             for i in range(6):
                 msec_mocked.return_value = i
                 self.resource.collection_post()

--- a/tests/core/resource/test_sync.py
+++ b/tests/core/resource/test_sync.py
@@ -14,7 +14,7 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
         self.validated['body'] = {'data': {}}
 
         with mock.patch.object(self.model.storage,
-                               '_bump_timestamp') as msec_mocked:
+                               '_bump_and_store_timestamp') as msec_mocked:
             for i in range(6):
                 msec_mocked.return_value = i
                 self.resource.collection_post()

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -84,7 +84,7 @@ class MemoryStorageTest(StorageTest, unittest.TestCase):
         super().setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage,
-            '_bump_timestamp',
+            '_bump_and_store_timestamp',
             side_effect=exceptions.BackendError("Segmentation fault."))
 
     def test_backend_error_provides_original_exception(self):

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -84,7 +84,7 @@ class MemoryStorageTest(StorageTest, unittest.TestCase):
         super().setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage,
-            '_bump_and_store_timestamp',
+            'bump_and_store_timestamp',
             side_effect=exceptions.BackendError("Segmentation fault."))
 
     def test_backend_error_provides_original_exception(self):

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 
 from kinto.core.utils import COMPARISON, sqlalchemy
 from kinto.core.storage import generators, memory, postgresql, exceptions, StorageBase
@@ -72,6 +73,13 @@ class StorageBaseTest(unittest.TestCase):
     def test_backenderror_message_default_to_original_exception_message(self):
         error = exceptions.BackendError(ValueError("Pool Error"))
         self.assertEqual(str(error), "ValueError: Pool Error")
+
+
+class MemoryBasedStorageTest(unittest.TestCase):
+    def test_backend_raise_not_implemented_error(self):
+        storage = memory.MemoryBasedStorage()
+        with pytest.raises(NotImplementedError):
+            storage.bump_and_store_timestamp("record", "/buckets/foo/collections/bar")
 
 
 class MemoryStorageTest(StorageTest, unittest.TestCase):


### PR DESCRIPTION
Fix [a XXX](https://github.com/Kinto/kinto/pull/1596/files#diff-73e8dd09932ff9ff7ea1678c7a44fc39L116) in the code.