### PR TITLE
This has been here for a while cleanup.

### DIFF
--- a/kinto/plugins/admin/src/index.js
+++ b/kinto/plugins/admin/src/index.js
@@ -3,9 +3,6 @@ import ReactDOM from "react-dom";
 import KintoAdmin from "kinto-admin";
 import * as signoffPlugin from "kinto-admin/lib/plugins/signoff";
 
-/* Make sure we remove previously saved passwords */
-localStorage.removeItem('kinto-admin-session');
-
 const settings = {
   maxPerPage: 50,
   singleServer: document.location.toString().split('/admin/')[0],


### PR DESCRIPTION
This was from a time where we were storing credentials in local storage.
It has not been the case for [over a year](https://github.com/Kinto/kinto/commit/460e5abe442cf86a30c19175b68f2c47a0cfd3e6#diff-74473360ae11dfe647ca65f4d7f00800R7) (Kinto 6.0).