### PR TITLE
Simplify native_value

### DIFF
--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -113,10 +113,7 @@ def native_value(value):
         try:
             value = json.loads(value)
         except ValueError:
-            try:
-                value = json.loads('"{}"'.format(value))
-            except ValueError:
-                return value
+            return value
     return value
 
 


### PR DESCRIPTION
Even if the JSON parse succeeds, we end up with the same string value
we started with.
