### PR TITLE
503 error when expected 409 constraint violation to batch endpoint fixes 1569

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,7 @@ This document describes changes between each past release.
 9.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Batch endpoint now checks for and aborts any parent request if subrequest encounters 409 constraint violation (fixes #1569)
 
 9.0.0 (2018-04-25)
 ------------------

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -145,8 +145,10 @@ def post_batch(request):
                                                          use_tweens=False)
         except httpexceptions.HTTPException as e:
             # Since some request in the batch failed, we need to stop the parent request
-            # through Pyramid's transaction manager.
-            if e.status_code == 409 or e.status_code >= 500:
+            # through Pyramid's transaction manager. 5XX errors are already caught by
+            # pyramid_tm's commit_veto
+            # https://github.com/Kinto/kinto/issues/624
+            if e.status_code == 409:
                 request.tm.abort()
 
             if e.content_type == 'application/json':

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -146,6 +146,11 @@ def post_batch(request):
         except httpexceptions.HTTPException as e:
             if e.content_type == 'application/json':
                 resp = e
+                # Since some request in the batch failed, we need to "doom" the parent process
+                # through Pyramid's transaction manager.
+                transaction_manager = request.tm
+                transaction_manager.begin()
+                transaction_manager.doom()
             else:
                 # JSONify raw Pyramid errors.
                 resp = errors.http_error(e)

--- a/tests/core/test_views_transaction.py
+++ b/tests/core/test_views_transaction.py
@@ -86,9 +86,8 @@ class TransactionTest(PostgreSQLTest, unittest.TestCase):
         resp = self.app.post_json('/batch', body, headers=self.headers)
         response = resp.json['responses'][1]
         self.assertEqual(response['status'], 409)
-        resp = self.app.get('/buckets/mushrooms', headers=self.headers)
+        resp = self.app.get('/mushrooms', headers=self.headers)
         self.assertEqual(len(resp.json['data']), 0)
-
 
     def test_modifications_are_rolled_back_on_error_accross_backends(self):
         self.run_failing_post()

--- a/tests/core/test_views_transaction.py
+++ b/tests/core/test_views_transaction.py
@@ -56,7 +56,7 @@ class TransactionTest(PostgreSQLTest, unittest.TestCase):
         resp = self.app.get('/mushrooms', headers=self.headers)
         self.assertEqual(len(resp.json['data']), 0)
 
-    def test_modifications_are_not_rolled_back_on_4XX_error(self):
+    def test_modifications_are_not_rolled_back_on_401_error(self):
         request_create = {
             'method': 'POST',
             'path': '/mushrooms',
@@ -70,6 +70,25 @@ class TransactionTest(PostgreSQLTest, unittest.TestCase):
         resp = self.app.post_json('/batch', body, headers=self.headers)
         resp = self.app.get('/mushrooms', headers=self.headers)
         self.assertEqual(len(resp.json['data']), 1)
+
+    def test_modifications_are_rolled_back_on_409_error(self):
+        bucket_create = {
+            'method': 'POST',
+            'path': '/mushrooms',
+            'body': {'data': {'name': 'Vesse de loup', 'last_modified': 123}}
+        }
+        bucket_ccreate = {
+            'method': 'POST',
+            'path': '/mushrooms',
+            'body': {'data': {'name': 'Vesse de loup', 'last_modified': 123}}
+        }
+        body = {'requests': [bucket_create, bucket_ccreate]}
+        resp = self.app.post_json('/batch', body, headers=self.headers)
+        response = resp.json['responses'][1]
+        self.assertEqual(response['status'], 409)
+        resp = self.app.get('/buckets/mushrooms', headers=self.headers)
+        self.assertEqual(len(resp.json['data']), 0)
+
 
     def test_modifications_are_rolled_back_on_error_accross_backends(self):
         self.run_failing_post()


### PR DESCRIPTION
Fixes #1569 

I believe this is the best way to fix this error. If agreed, I'll write the tests.

The issue was caused when Kinto processed a batch request. If one of the requests failed, e.g., a contraint violation, the `parent` process would not know and continue on into event notifications, e.g., `ResourceChanged`, after its child failed.

This wasn't triggering any noticable errors until the history plugin was turned on. In this case, `history/listener.py` was triggered from a change event and would try to query the database while `psycopg2` was in the following error state from the constraint violation: `current transaction is aborted, commands ignored until end of transaction block and can’t do anything else!` It was this condition that caused Kinto to return `503: Service temporary unavailable due to overloading or maintenance, please retry later.`

The solution I came up with was to use Pyramid's builtin transaction manager to `doom` the `parent` process so it would not continue on into triggering event notifications.