### PR TITLE
Cleanup Postgres get_all

### DIFF
--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -319,11 +319,10 @@ def extract_record_set(records, filters, sorting,
     total_records = len(filtered)
 
     if pagination_rules:
-        paginated = {}
+        paginated = []
         for rule in pagination_rules:
             values = apply_filters(filtered, rule)
-            paginated.update((id(x), x) for x in values)
-        paginated = paginated.values()
+            paginated.extend(values)
     else:
         paginated = filtered
 

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -322,7 +322,7 @@ def extract_record_set(records, filters, sorting,
         paginated = {}
         for rule in pagination_rules:
             values = apply_filters(filtered, rule)
-            paginated.update(((x[id_field], x) for x in values))
+            paginated.update((id(x), x) for x in values)
         paginated = paginated.values()
     else:
         paginated = filtered

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -600,16 +600,12 @@ class Storage(StorageBase, MigratorMixin):
             SELECT COUNT(id) AS count_total
               FROM collection_filtered
              WHERE NOT deleted
-        ),
-        paginated_records AS (
-            SELECT DISTINCT id
-              FROM collection_filtered
-              {pagination_rules}
         )
          SELECT count_total,
                a.id, as_epoch(a.last_modified) AS last_modified, a.data
-          FROM paginated_records AS p JOIN collection_filtered AS a ON (a.id = p.id),
+          FROM collection_filtered AS a,
                total_filtered
+          {pagination_rules}
           {sorting}
          LIMIT :pagination_limit;
         """

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -595,6 +595,7 @@ class Storage(StorageBase, MigratorMixin):
                AND collection_id = :collection_id
                {conditions_deleted}
                {conditions_filter}
+             {sorting}
         ),
         total_filtered AS (
             SELECT COUNT(id) AS count_total
@@ -606,7 +607,6 @@ class Storage(StorageBase, MigratorMixin):
           FROM collection_filtered AS a,
                total_filtered
           {pagination_rules}
-          {sorting}
          LIMIT :pagination_limit;
         """
 

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -297,6 +297,19 @@ class BaseTestStorage:
         self.assertEquals(len(records), 1)
         self.assertEquals(len(records), total_records)
 
+    def test_get_all_parent_id_handles_collisions(self):
+        abc1 = self.create_record(parent_id='abc1', collection_id='c',
+                                  record={'id': 'abc', 'secret_data': 'abc1'})
+        abc2 = self.create_record(parent_id='abc2', collection_id='c',
+                                  record={'id': 'abc', 'secret_data': 'abc2'})
+        records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
+                                                      include_deleted=True)
+        self.assertEquals(len(records), 2)
+        self.assertEquals(len(records), total_records)
+        records.sort(key=lambda record: record['secret_data'])
+        self.assertEquals(records[0], abc1)
+        self.assertEquals(records[1], abc2)
+
     def test_get_all_return_all_values(self):
         for x in range(10):
             record = dict(self.record)


### PR DESCRIPTION
This is a more conservative approach towards addressing #1507. In particular, it doesn't introduce any race conditions, and probably reduces query times by much less.

The existing query's performance comes down to three factors:

1. It matches every record in the database that matches the queries, and outputs them in any random order.
2. It then sorts those records according to the order given in the sort order.
3. It does a distinct/join as part of paginating.

The performance characteristics of these steps varies depending on how many records the filters match and how many they don't match, as well as what proportion of the database is under the given parent_id.

1. If most of the database is under this parent, then doing a sequential scan is the fastest way to do this. Otherwise, you want to use an index scan to narrow it down as much as possible before applying filters.
2. Sorting is O(n log n), so if a lot of records match the filters, doing a sort afterwards is expensive. In those cases, you generally want to do an index scan to produce the records in the right order to begin with.
3. Doing a distinct/join is probably O(n log n), so it becomes more expensive the more records match.

Per our discussion in #1616, there are a couple of subtle bugs in the use of wildcard `parent_id`, which I used as the crowbar to try to pry open this query. First, introduce some tests to firm up the behavior we expect for wildcard `parent_ids`. It turns out that the third step above introduces a bug in pagination of results when doing a wildcard `parent_id` match, so just delete it.

Doing the sorting at the end seems wasteful to me; you need to sort anyhow in order to do the pagination, so why not generate records in the right order to begin with? I moved the 2nd step into the first step. This encourages Postgres to use indexes when called for. However, it seems that the benefit to the second step of using an index is outweighed by the cost to the first step of doing an index scan when very few records match, so in a Kinto instance with all records under one parent, doing a query with filters that match comparatively few records, this query is slower than the previous one.

I tested this by filling a Kinto instance with about 10m records, all in the same collection, each of the form `{"id": "id-XXXXXX", "my_data": XXXXXX}`, and then PATCHing one record to add a `"foo": true` field to it. I then measured the time of `http GET  'localhost:8888/v1/buckets/a/collections/b/records?_limit=10'`, `http GET  'localhost:8888/v1/buckets/a/collections/b/records?_limit=10&has_foo=true'`, and `http GET  'localhost:8888/v1/buckets/a/collections/b/records?_limit=10&has_foo=false'`. The first and last requests tend to perform the same, because both match the vast majority of the records in the database; on these, the new query takes about 60s (to the old query's ~90s, so about 33% faster). The second query is a little slower than the previous one (4.52s to 2.65s, or about 80% slower).

Perhaps it's possible to get the benefit of both queries by using heuristics to choose the sequential scan or the index scan, but then we're in the situation of trying to beat the Postgres query planner and I'm not sanguine about our chances. On the other hand, note that the Postgres query planner is hamstrung by the lack of indexing on the `data` column.

My conclusions are:

- It isn't really clear what the scalability characteristics of Kinto are or should be. Is Kinto meant to store 10m records? I would say probably not. What about 1m records, but all in one collection? I'm not certain.
- It isn't really clear (to me, at least) what queries Kinto should support as "first-class" and which are "gravy", i.e. added bonuses that we threw in because they were easy to implement but are not as well-loved, performant etc. as others. Naïvely I would say syncing collections is more important than supporting arbitrary filters, but then again, if that's what you want, CouchDB is available and may be a better fit for you.
- It isn't really clear to me what the relative priorities are in the Kinto ecosystem. As an example, in order to produce a `Total-Records` header, we have to add a `COUNT` to our queries, which means enumerating all the matching records rather than just the ones that we're going to render in the response. In other distributed systems, you might just paginate until you get an empty page. Is the ease-of-use/sanity checking provided by the `Total-Records` header worth the performance cost?

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
