### PR TITLE
count deleted by total_records fixes 1170

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ This document describes changes between each past release.
 ------------------
 
 - Batch endpoint now checks for and aborts any parent request if subrequest encounters 409 constraint violation (fixes #1569)
+- Fix a bug where you could not reach the last records via Next-Header when deleting with pagination (fixes #1170)
 
 9.0.0 (2018-04-25)
 ------------------

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -397,8 +397,7 @@ class UserResource:
             self._add_timestamp_header(self.request.response, timestamp=timestamp)
 
             # Add pagination header
-            offset = offset + len(deleted)
-            if limit and len(deleted) == limit and offset < total_records:
+            if limit and len(deleted) == limit and total_records > 1:
                 next_page = self._next_page_url(sorting, limit, lastrecord, offset)
                 self.request.response.headers['Next-Page'] = next_page
         else:

--- a/tests/core/resource/test_pagination.py
+++ b/tests/core/resource/test_pagination.py
@@ -239,6 +239,24 @@ class PaginatedDeleteTest(BasePaginationTest):
         count = headers['Total-Records']
         self.assertEquals(int(count), 20)
 
+    def test_paginated_delete_second_to_last_gets_next_header(self):
+        all_records = self.resource.collection_get()
+        get_all_headers = self.last_response.headers
+        count = int(get_all_headers['Total-Records']) - 1
+
+        self.validated['querystring'] = {'_limit': 1}
+        headers = []
+        for i in range(count):
+            self.resource.collection_delete()
+            headers.append(self.last_response.headers)
+            self._setup_next_page()
+
+        self.resource.collection_delete()
+        headers.append(self.last_response.headers)
+
+        self.assertIn('Next-Page', headers[count - 1])
+        self.assertNotIn('Next-Page', headers[count])
+
     def test_token_cannot_be_reused_twice(self):
         self.resource.request.method = "DELETE"
         self.validated['querystring']['_limit'] = 3

--- a/tests/core/resource/test_pagination.py
+++ b/tests/core/resource/test_pagination.py
@@ -240,7 +240,7 @@ class PaginatedDeleteTest(BasePaginationTest):
         self.assertEquals(int(count), 20)
 
     def test_paginated_delete_second_to_last_gets_next_header(self):
-        all_records = self.resource.collection_get()
+        self.resource.collection_get()
         get_all_headers = self.last_response.headers
         count = int(get_all_headers['Total-Records']) - 1
 


### PR DESCRIPTION
Fixes #1170 

This issue was caused by relying on `offset < total_records` to include the `Next-Page` header.

This Boolean check makes sense when we're getting records since `total_records` does not change and `offset` is incremented. When deleting, however, `offset` is incremented and `total_records` is decremented, so the `Next-Page` header will stop being included when at roughly half of the beginning count of `total_records`.

Also, I understand @glasserc is discussing how to handle `Total-Records` in #1624 and this direct reliance on `Total-Records` might not make sense in the long-term. It still makes sense to me to push this change so you all can close out the original issue, but just thought I'd mention it in case you all have a different opinion on that.
