### PR TITLE
Check content-type on batch endpoint (fixes #1529)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ This document describes changes between each past release.
   storage backend which should make it faster for result sets that
   have a lot of records (#1622). This is the first change meant to
   address #1507, though more can still be done.
+- Fix a bug where the batch route accepted all content-types (fixes #1529)
 
 **Internal changes**
 

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -9,6 +9,7 @@ from kinto.core import errors
 from kinto.core import Service
 from kinto.core.errors import ErrorSchema
 from kinto.core.utils import merge_dicts, build_request, build_response
+from kinto.core.resource.viewset import CONTENT_TYPES
 
 
 subrequest_logger = logging.getLogger('subrequest.summary')
@@ -112,6 +113,7 @@ batch = Service(name='batch', path='/batch',
 
 @batch.post(schema=BatchRequest,
             validators=(colander_validator,),
+            content_type=CONTENT_TYPES,
             permission=NO_PERMISSION_REQUIRED,
             tags=['Batch'], operation_id='batch',
             response_schemas=batch_responses)

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -105,6 +105,11 @@ class BatchViewTest(BaseWebTest, unittest.TestCase):
                              headers={'Content-Type': 'application/json'})
         self.assertIn('Invalid JSON', resp.json['message'])
 
+    def test_batch_should_reject_unaccepted_request_content_type(self):
+        request = {'requests': [{'path': '/v0/mushrooms'}]}
+        self.app.post('/batch', request, status=415,
+                      headers={'Content-Type': 'text/plain'})
+
     def test_responses_are_resolved_with_api_with_prefix(self):
         request = {'path': '/'}
         body = {'requests': [request]}


### PR DESCRIPTION
Fixes #1529 

This bug was caused by the request body being in binary form when `Content-Type` was set to anything other than `application/json`, thus it was failing once it started processing `BatchPayloadSchema`. 

