### PR TITLE
Preparing release 9.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 This document describes changes between each past release.
 
 
-9.1.0 (unreleased)
+9.1.0 (2018-05-21)
 ------------------
 
 **API**

--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -177,7 +177,7 @@ adjustments:
 .. note::
 
     For an exhaustive list of available settings and their default values,
-    refer to the *Kinto* :github:`source code <Kinto/kinto/blob/9.0.0/kinto/core/__init__.py#L27-L98>`.
+    refer to the *Kinto* :github:`source code <Kinto/kinto/blob/9.1.0/kinto/core/__init__.py#L27-L98>`.
 
 
 By default, nobody can read buckets list. You can change that using:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='9.1.0.dev0',
+      version='9.1.0',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description='{}\n\n{}\n\n{}'.format(README, CHANGELOG, CONTRIBUTORS),
       license='Apache License (2.0)',


### PR DESCRIPTION
Although no new features have been introduced since 9.0.0, there has been a branch cut (`9.X`) for point releases from 9.0.0, so bump minor. This isn't great but semver says that "It MAY be incremented if substantial new functionality or improvements are introduced within the private code."