### PR TITLE
OpenID payload cache uses the wrong cache key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ This document describes changes between each past release.
 - Kinto Admin plugin now supports OpenID Connect
 - Limit network requests to current domain in Kinto Admin using `Content-Security Policies <https://hacks.mozilla.org/2016/02/implementing-content-security-policy/>`_
 
+**Bug fixes**
+
+- OpenID plugin used the same cache key for every access-token (fixes #1660)
+
 **Internal changes**
 
 - Upgrade to kinto-admin v1.18.0

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -57,6 +57,7 @@ Contributors
 * Oron Gola <oron.golar@gmail.com>
 * Palash Nigam <npalash25@gmail.com>
 * PeriGK <per.gkolias@gmail.com>
+* Peter Bengtsson <mail@peterbe.com>
 * realsumit <sumitsarinofficial@gmail.com>
 * Rektide <rektide@voodoowarez.com>
 * Rémy Hubscher <rhubscher@mozilla.com>

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -49,7 +49,6 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
         # Check cache if these tokens were already verified.
         hmac_tokens = core_utils.hmac_digest(hmac_secret, access_token)
         cache_key = 'openid:verify:{}'.format(hmac_tokens)
-        raise Exception
         payload = request.registry.cache.get(cache_key)
         if payload is None:
             # This can take some time.

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -48,7 +48,7 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
 
         # Check cache if these tokens were already verified.
         hmac_tokens = core_utils.hmac_digest(hmac_secret, access_token)
-        cache_key = 'openid:verify:%s'.format(hmac_tokens)
+        cache_key = 'openid:verify:{}'.format(hmac_tokens)
         payload = request.registry.cache.get(cache_key)
         if payload is None:
             # This can take some time.

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -49,6 +49,7 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
         # Check cache if these tokens were already verified.
         hmac_tokens = core_utils.hmac_digest(hmac_secret, access_token)
         cache_key = 'openid:verify:{}'.format(hmac_tokens)
+        raise Exception
         payload = request.registry.cache.get(cache_key)
         if payload is None:
             # This can take some time.


### PR DESCRIPTION
Fixes #1660

- [ ] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
