### PR TITLE
Extract instance_uri_registry too

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 
 - Kinto Admin plugin now supports OpenID Connect
 - Limit network requests to current domain in Kinto Admin using `Content-Security Policies <https://hacks.mozilla.org/2016/02/implementing-content-security-policy/>`_
+- kinto.core.utils now has new features ``route_path_registry`` and
+  ``instance_uri_registry``, suitable for use when you don't
+  necessarily have a ``request`` object around. The existing functions
+  will remain in place.
 
 **Internal changes**
 

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -477,8 +477,31 @@ def view_lookup_registry(registry, uri):
 
 def instance_uri(request, resource_name, **params):
     """Return the URI for the given resource."""
-    return strip_uri_prefix(request.route_path(
+    return instance_uri_registry(request.registry, resource_name, **params)
+
+
+def instance_uri_registry(registry, resource_name, **params):
+    """Return the URI for the given resource, given only a registry."""
+    return strip_uri_prefix(route_path_registry(
+        registry,
         '{}-record'.format(resource_name), **params))
+
+
+def route_path_registry(registry, route_name, **params):
+    """Generate the path for a given route_name.
+
+    This is adapted from URLMethodsMixin.route_url, but with some
+    simplifications due to how we use it in Kinto.
+    """
+    mapper = registry.getUtility(IRoutesMapper)
+    route = mapper.get_route(route_name)
+
+    if route is None:
+        raise KeyError('No such route named %s' % route_name)
+
+    # No pregenerator support here. Hopefully we don't need to support
+    # this feature.
+    return route.generate(params)  # raises KeyError if generate fails
 
 
 def parse_resource(resource):


### PR DESCRIPTION
This is slightly less theoretically correct in the
instance_uri_registry case:

- request.route_path handles certain "special" params such as
  _script_url, _scheme, _host, _port, _query, and _anchor. However, we
  never use these in calls to instance_uri.

- request.route_path calls route.pregenerator, which allows Pyramid
  plugins to do fancy things like customize the routes generated
  according to the request. This is apparently used by e.g. Pylons
  subdomain support. However, we don't appear to use this either.

- (n/a) Add documentation.
- (n/a) Add tests.
- (n/a) Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
