### PR TITLE
Another approach to providing instance_uri_registry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ This document describes changes between each past release.
 - Kinto Admin plugin now supports OpenID Connect
 - Limit network requests to current domain in Kinto Admin using `Content-Security Policies <https://hacks.mozilla.org/2016/02/implementing-content-security-policy/>`_
 - Prompt for cache backend type in ``kinto init`` (#1653)
+- kinto.core.utils now has new features ``route_path_registry`` and
+  ``instance_uri_registry``, suitable for use when you don't
+  necessarily have a ``request`` object around. The existing functions
+  will remain in place.
 
 **Internal changes**
 

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -481,6 +481,17 @@ def instance_uri(request, resource_name, **params):
         '{}-record'.format(resource_name), **params))
 
 
+def instance_uri_registry(registry, resource_name, **params):
+    """Return the URI for the given resource, even if you don't have a request.
+
+    This gins up a request using Request.blank and so does not support
+    any routes with pregenerators.
+    """
+    request = Request.blank(path='')
+    request.registry = registry
+    return instance_uri(request, resource_name, **params)
+
+
 def parse_resource(resource):
     """Extract the bucket_id and collection_id of the given resource (URI)
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -14,6 +14,7 @@ from kinto.core.utils import (
     native_value, strip_whitespace, random_bytes_hex, read_env, hmac_digest,
     current_service, follow_subrequest, build_request, dict_subset, dict_merge,
     parse_resource, prefixed_principals, recursive_update_dict,
+    instance_uri_registry,
     find_nested_value
 )
 from kinto.core.testing import DummyRequest
@@ -349,3 +350,18 @@ class ParseResourceTest(unittest.TestCase):
     def test_resources_must_be_valid_names(self):
         input_arr = ['/buckets/bi+d1/collections/cid', '/buckets/bid1/collections/dci,d']
         self._assert_error(input_arr)
+
+
+class InstanceURIRegistryTest(unittest.TestCase):
+    @mock.patch('kinto.core.utils.instance_uri')
+    def test_instance_uri_registry_calls_instance_uri(self, instance_uri):
+        registry = mock.Mock()
+        instance_uri_registry(registry, 'record', a=1)
+        self.assertEqual(len(instance_uri.call_args_list), 1)
+        (args, kwargs) = instance_uri.call_args_list[0]
+        self.assertEqual(len(args), 2)
+
+        self.assertEqual(args[0].registry, registry)
+        self.assertEqual(args[1], 'record')
+
+        self.assertEqual(kwargs, {'a': 1})


### PR DESCRIPTION
This is another approach to providing #1666. It's simpler to the point that I wonder if it's even worth it.

- (n/a) Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
