### PR TITLE
Drop content of test listener

### DIFF
--- a/tests/core/listeners.py
+++ b/tests/core/listeners.py
@@ -1,23 +1,2 @@
-import json
-import logging
-
-from kinto.core.listeners import ListenerBase
-
-
-logger = logging.getLogger(__name__)
-
-
-class Listener(ListenerBase):
-    """
-    A demo listener that just log received info in the stdout.
-    """
-    def __call__(self, event):
-        try:
-            logger.info(json.dumps(event.payload))
-        except TypeError:
-            logger.error("Unable to dump the payload", exc_info=True)
-            return
-
-
 def load_from_config(config, prefix):
-    return Listener()
+    return ()


### PR DESCRIPTION
No test actually uses this.

I'm not sure if this is meant to be an example or something, but if
so, maybe we should write a test that actually invokes the listener.

- (n/a) Add documentation.
- (n/a) Add tests.
- (n/a) Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
