### PR TITLE
Update Docker to use the new --cache-backend kinto option as well as node 10.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This document describes changes between each past release.
 9.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Internal changes**
+
+- Update the Dockerfile with the new kinto --cache-backend option. (#1686)
 
 
 9.2.0 (2018-06-07)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@ ENV PORT 8888
 # dependencies all at once to build a small image.
 RUN \
     apt-get update; \
-    apt-get install -y gcc libpq5 curl libssl-dev libffi-dev libpq-dev; \
-    curl -sL https://deb.nodesource.com/setup_7.x | bash; \
+    apt-get install -y gcc libpq5 curl libssl-dev libffi-dev libpq-dev gnupg2; \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
     apt-get install -y nodejs; \
     cd kinto/plugins/admin; npm install; npm run build; \
     pip3 install -e /app[postgresql,memcached,monitoring] -c /app/requirements.txt; \
     pip3 install kinto-pusher kinto-attachment ; \
-    kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory; \
-    apt-get remove -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs; \
+    kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory; \
+    apt-get purge -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs; \
     apt-get autoremove -y -qq; \
     apt-get clean -y
 

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,6 @@ docs: install-docs
 	$(VENV)/bin/sphinx-build -a -W -n -b html -d $(SPHINX_BUILDDIR)/doctrees docs $(SPHINX_BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(SPHINX_BUILDDIR)/html/index.html"
+
+build:
+	docker build --pull -t kinto/kinto-server:latest .

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import mock
 import unittest
 


### PR DESCRIPTION
Fixes #1686 

- [x] Add a changelog entry.
