### PR TITLE
handle json pointer errors, fixes #1685

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ This document describes changes between each past release.
 9.3.0 (unreleased)
 ------------------
 
+** Bug fixes**
+
+- Fixed bug where unresolved JSON pointers would crash server (fixes #1685)
+
 **Internal changes**
 
 - Update the Dockerfile with the new kinto --cache-backend option. (#1686)

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -5,7 +5,7 @@ from kinto.core import resource, utils
 from kinto.core.errors import raise_invalid
 from kinto.views import object_exists_or_404
 from kinto.schema_validation import (validate_from_bucket_schema_or_400, validate_schema,
-                                     ValidationError)
+                                     ValidationError, RefResolutionError)
 
 
 _parent_path = '/buckets/{{bucket_id}}/collections/{{collection_id}}'
@@ -66,6 +66,8 @@ class Record(resource.ShareableResource):
                 validate_schema(new, schema, ignore_fields=internal_fields)
             except ValidationError as e:
                 raise_invalid(self.request, name=e.field, description=e.message)
+            except RefResolutionError as e:
+                raise_invalid(self.request, name='schema', description=str(e))
 
             # Assign the schema version to the record.
             schema_timestamp = self._collection[self.model.modified_field]

--- a/tests/test_views_schema_collection.py
+++ b/tests/test_views_schema_collection.py
@@ -79,3 +79,24 @@ class CollectionValidationTest(BaseWebTestWithSchema, unittest.TestCase):
                           {'data': {'displayFields': 42}},
                           headers=self.headers,
                           status=400)
+
+
+SCHEMA_UNRESOLVABLE = {
+    'properties': {
+        'displayFields': {'$ref': '#/definitions/displayFields'}
+    },
+}
+
+
+class CollectionUnresolvableTest(BaseWebTestWithSchema, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        resp = self.app.put_json(BUCKET_URL,
+                                 {'data': {'collection:schema': SCHEMA_UNRESOLVABLE}},
+                                 headers=self.headers)
+        self.collection = resp.json['data']
+
+    def test_unresolvable_errors_handled(self):
+        self.app.put_json(COLLECTION_URL,
+                          {'data': {'displayFields': 42}},
+                          headers=self.headers, status=400)

--- a/tests/test_views_schema_group.py
+++ b/tests/test_views_schema_group.py
@@ -79,3 +79,24 @@ class CollectionValidationTest(BaseWebTestWithSchema, unittest.TestCase):
                           {'data': {'phone': 42}},
                           headers=self.headers,
                           status=400)
+
+
+SCHEMA_UNRESOLVABLE = {
+    'properties': {
+        'phone': {'$ref': '#/definitions/phone'}
+    },
+}
+
+
+class CollectionUnresolvableTest(BaseWebTestWithSchema, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        resp = self.app.put_json(BUCKET_URL,
+                                 {'data': {'group:schema': SCHEMA_UNRESOLVABLE}},
+                                 headers=self.headers)
+        self.collection = resp.json['data']
+
+    def test_unresolvable_errors_handled(self):
+        self.app.put_json(GROUP_URL,
+                          {'data': {'phone': 42}},
+                          headers=self.headers, status=400)

--- a/tests/test_views_schema_record.py
+++ b/tests/test_views_schema_record.py
@@ -368,3 +368,39 @@ class BothBucketAndCollectionSchemas(BaseWebTestWithSchema, unittest.TestCase):
                            {'data': {'filters': 42, **VALID_RECORD}},
                            headers=self.headers,
                            status=400)
+
+
+SCHEMA_UNRESOLVABLE = {
+    'properties': {
+        'title': {'$ref': '#/definitions/title'}
+    },
+}
+
+
+class RecordsUnresolvableTest(BaseWebTestWithSchema, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        resp = self.app.put_json(COLLECTION_URL,
+                                 {'data': {'schema': SCHEMA_UNRESOLVABLE}},
+                                 headers=self.headers)
+        self.collection = resp.json['data']
+
+    def test_unresolvable_errors_handled(self):
+        self.app.post_json(RECORDS_URL,
+                           {'data': {'title': 'b'}},
+                           headers=self.headers,
+                           status=400)
+
+
+class BucketUnresolvableRecordSchema(BaseWebTestWithSchema, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.app.put_json(BUCKET_URL,
+                          {'data': {'record:schema': SCHEMA_UNRESOLVABLE}},
+                          headers=self.headers)
+
+    def test_records_are_valid_if_match_schema(self):
+        self.app.post_json(RECORDS_URL,
+                           {'data': {'title': 'b'}},
+                           headers=self.headers,
+                           status=400)


### PR DESCRIPTION
Fixes #1685 

This fixes unhandled errors when evaluating data against schema with pointers.

I originally proposed that a possible way to handle this was to, upon initial creation of the schema, verify whether it fully resolves or not and reject it if it does not.

Unfortunately, there was no good way that I found to do this. According to `jsonschema`, this lazy lookup for `$ref` is intended behavior for now (though there is discussion to include this check as default behavior in v2).

This leaves the option to either write an independent implementation in Kinto, or add a library on top of `jsonschema` to do this lookup when creating schema.

My initial thought is I'm not a big fan of either of those, particularly when there is discussion of adding the functionality to `jsonschema` in the future.

My solution was to follow the `jsonschema` thought process and lazy lookup `$ref` references. So, accept any schema and provide a meaningful error if a reference fails when a JSON document is evaluated against it.

If there is a desire to add functionality to fail upon creation of the schema, I can give more options as well, but I think this is a good solution everything considered.
