### PR TITLE
Test against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
     - python: 3.6
       env:
         - TOX_ENV=py36
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - TOX_ENV=py37
     - env: ENV=functional
       before_install:
         - make install-dev

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,9 @@ This document describes changes between each past release.
 9.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
 
+- Include Python 3.7 support.
 
 9.2.3 (2018-07-05)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-raw,py35,py36,flake8
+envlist = py35-raw,py35,py36,py37,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
## Description
Add a Python 3.7 test environment as a first step to add oficial support to Python 3.7.

Release notes: https://www.python.org/downloads/release/python-370/

Related to https://github.com/travis-ci/travis-ci/issues/9815 (why xenial/sudo are required).

