### PR TITLE
Get rid of basicauth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,10 @@ This document describes changes between each past release.
   rather than a list.
 
 
+**Breaking changes**
+
+- The ``basicauth`` policy is not used by default anymore
+
 **New features**
 
 - Include Python 3.7 support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     apt-get install -y nodejs; \
     cd kinto/plugins/admin; npm install; npm run build; \
     pip3 install -e /app[postgresql,memcached,monitoring] -c /app/requirements.txt; \
-    pip3 install kinto-pusher kinto-attachment kinto-emailer kinto-elasticsearch; \
+    pip3 install kinto-attachment kinto-emailer kinto-elasticsearch kinto-portier kinto-redis; \
     kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory; \
     apt-get purge -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs; \
     apt-get autoremove -y -qq; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     apt-get install -y nodejs; \
     cd kinto/plugins/admin; npm install; npm run build; \
     pip3 install -e /app[postgresql,memcached,monitoring] -c /app/requirements.txt; \
-    pip3 install kinto-pusher kinto-attachment ; \
+    pip3 install kinto-pusher kinto-attachment kinto-emailer kinto-elasticsearch; \
     kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory; \
     apt-get purge -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs; \
     apt-get autoremove -y -qq; \

--- a/docs/api/1.x/accounts.rst
+++ b/docs/api/1.x/accounts.rst
@@ -14,38 +14,10 @@ Administrators configured in settings can manage users accounts.
 Setup
 =====
 
-Add the following settings to the ``.ini`` file:
+Details about accounts configuration are given in :ref:`the settings section <settings-accounts>`.
 
-.. code-block:: ini
+Basically, you can check if the ``accounts`` feature is enabled if it is mentioned in the ``"capabilities"`` field on the :ref:`root URL <api-utilities-hello>`.
 
-    # Enable built-in plugin.
-    kinto.includes = kinto.plugins.accounts
-
-    # Enable authenticated policy.
-    multiauth.policies = account
-    multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
-
-    # Allow anyone to create accounts.
-    kinto.account_create_principals = system.Everyone
-
-    # Set the session time to live in seconds
-    kinto.account_cache_ttl_seconds = 30
-
-
-You can use the ``create-user`` command to create an admin:
-
-.. code-block:: bash
-
-    kinto create-user --ini /etc/kinto.ini --username admin --password ThisIsN0tASecurePassword
-
-You can then use it in your config:
-
-.. code-block:: ini
-
-    # Allow anyone to create accounts.
-    kinto.account_create_principals = system.Everyone
-    # But also allow the admin to delete etc.
-    kinto.account_write_principals = account:admin
 
 .. _accounts-auth:
 
@@ -54,8 +26,8 @@ Authentication
 
 Accounts are defined using a username and a password, and uses *Basic Authentication*.
 
-For example, once the ``bob`` account has been created, you can check if authentication
-works using the :ref:`Hello view <api-utilities>`.
+For example, once the ``bob`` account has been created (see below), you can check if authentication
+works using the :ref:`root URL <api-utilities-hello>`.
 
 .. sourcecode:: bash
 
@@ -177,10 +149,10 @@ Alternatively, accounts can be created using POST.  Supply the user id and passw
 
         $ echo '{"data": {"id": "bob", password": "azerty123"}}' | http POST http://localhost:8888/v1/accounts --verbose
 
+.. note::
 
-By default, users can only create their own accounts. "Administrators", meaning anyone who matches ``account_write_principals``, can create accounts for other users as well.
+    Depending on the :ref:`configuration <settings-accounts>`, you may not be allowed to create accounts.
 
-You can set ``account_create_principals`` if you want to limit account creation to certain users. The most common situation is when you want to have a small number of administrators, who are responsible for creating accounts for other users. In this case, you should add the administrators to both ``account_create_principals`` and ``account_write_principals``.
 
 .. _accounts-udpate:
 
@@ -197,7 +169,7 @@ Change password
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"password": "azerty123"}}' | http PUT http://localhost:8888/v1/accounts/bob --verbose --auth 'bob:azerty123'
+        $ echo '{"data": {"password": "qwerty123"}}' | http PUT http://localhost:8888/v1/accounts/bob --verbose --auth 'bob:azerty123'
 
     .. sourcecode:: http
 
@@ -213,7 +185,7 @@ Change password
 
         {
             "data": {
-                "password": "azerty123"
+                "password": "qwerty123"
             }
         }
 
@@ -302,24 +274,23 @@ Manage accounts
 ===============
 
 It is possible to configure administrators in settings. They will be able to manage
-others users accounts via the API.
+others users accounts.
 
-First create the actual accounts:
+For example, create somebody else account:
 
 ::
 
-    $ echo '{"data": {"password": "azerty123"}}' | http PUT http://localhost:8888/v1/accounts/admin
+    $ echo '{"data": {"id": "sam-body", password": "else"}}' | http POST http://localhost:8888/v1/accounts --auth admin:s3cr3t
 
-Then mention the created accounts via the following settings in the ``.ini`` file.
-For example to account IDs ``admin`` and members of the ``admin`` groups in the ``bid`` bucket:
+List accounts:
 
-.. code-block:: ini
+::
 
-    # Give read/write access to all accounts to ``account:admin``.
-    kinto.account_write_principals = account:admin /buckets/bid/groups/admin
-    kinto.account_read_principals = account:admin /buckets/bid/groups/admin
+    $ http GET http://localhost:8888/v1/accounts --auth admin:s3cr3t
 
-.. note::
 
-    It is not very convenient to require a server restart for configuring administrators.
-    But we thought it was acceptable as a first iteration.
+Or delete some account:
+
+::
+
+    $ http DELETE http://localhost:8888/v1/accounts/sam-body --auth admin:s3cr3t

--- a/docs/api/1.x/authentication.rst
+++ b/docs/api/1.x/authentication.rst
@@ -14,8 +14,6 @@ But the main methods you are most likely to encounter will read the ``Authorizat
 * :ref:`Kinto Accounts <api-accounts>` expects a valid username and password as *Basic Auth*
 * :ref:`OpenID Connect <api-openid>` will validate a *Bearer Access Token* against an :term:`Identity Provider`
 
-If the authentication fails, the server will return a |status-401| error response. It can also return a |status-403| error response, which would mean that the operation performed on the resource is not allowed to unauthenticated users :)
-
 
 Getting started
 ---------------
@@ -58,6 +56,17 @@ The currently authenticated *user ID* can be obtained on the :ref:`root URL <api
         }
         ...
     }
+
+
+Error responses
+---------------
+
+As shown in the above section, the easiest way to check your authentication credentials is to use the :ref:`root URL <api-utilities-hello>`.
+
+When authentication fails when interacting with API, you can have two kinds of error responses:
+
+* a |status-401| error response, which means that no authentication method succeeded
+* a |status-403| error response, which could mean that the operation performed on the resource is not allowed for you :) If you didn't authenticate, this could also mean that the operation is not allowed to anonymous users.
 
 
 Available methods

--- a/docs/api/1.x/authentication.rst
+++ b/docs/api/1.x/authentication.rst
@@ -4,385 +4,121 @@ Authentication
 
 .. _authentication:
 
-A word about users
-==================
+Kinto is an API, and uses the request headers to authenticate the current user.
 
-First of all, Kinto **doesn't provide users management**. There is no such thing
-as user sign-up, password modification, etc.
+Based on the authentication enabled in configuration, Kinto will authenticate the user and assign a :term:`user identifier` to the request (eg. ``ldap:alice@corp``).
 
-However, since Kinto handles permissions on objects, users are uniquely
-identified.
+Since authentication is entirely pluggable in Kinto (see :ref:`configuration <configuration-authentication>`), the HTTP method used to authenticate requests may vary.
+But the main methods you are most likely to encounter will read the ``Authorization`` header. For example:
 
-How is that possible?
----------------------
+* :ref:`Kinto Accounts <api-accounts>` expects a valid username and password as *Basic Auth*
+* :ref:`OpenID Connect <api-openid>` will validate a *Bearer Access Token* against an :term:`Identity Provider`
 
-Kinto uses the request headers to authenticate the current user.
-
-Depending on the authentication methods enabled in configuration,
-the HTTP method to authenticate requests may differ.
-
-Kinto can rely on a third-party called «`Identity provider <https://en.wikipedia.org/wiki/Identity_provider>`_»
-to authenticate the request and assign a :term:`user id`.
-
-There are many identity providers solutions in the wild. The most common are OAuth,
-JWT, SAML, x509, Hawk sessions...
-
-A policy based on *OAuth2 bearer tokens* is recommended, but not mandatory.
-
-Low tech included
------------------
-
-Kinto has no third-party policy included (yet!), and only provides a policy based on
-Basic Authentication.
-
-Depending on your use case, you may want to plug GitHub, Facebook, Google, or your
-company identity provider. It is rather easy, :ref:`follow our tutorial <tutorial-github>`!
-
-.. note::
-
-    If you believe that Kinto must provide some third parties providers by default,
-    please come reach us!
-
-    There are many tools in the Python/Pyramid ecosystem, it is probably just
-    a matter of documenting their setup.
+If the authentication fails, the server will return a |status-401| error response. It can also return a |status-403| error response, which would mean that the operation performed on the resource is not allowed to unauthenticated users :)
 
 
-Multiple policies
------------------
+Getting started
+---------------
 
-It is possible to enable several authentication methods.
-See :ref:`configuration <configuration-authentication>`.
+If you are familiar with OpenID Connect, then jump to the :ref:`dedicated section <api-openid>`.
 
-In the current implementation, when multiple policies are configured,
-the first one in the list that succeeds is picked.
-
-:term:`User identifiers` are prefixed with the policy name being used.
-
-
-Basic Auth
-==========
-
-In most examples in this documentation we use the built-in Basic Authentication,
-which computes a user id based on the token provided in the request.
-
-.. warning::
-
-    This method has many limitations but has the advantage of not needing
-    specific setup or third-party services before you get started.
-
-When using arbitrary tokens make sure that:
-
- - each user has a different one;
- - a user always uses the same token.
-
-You can check if Basic Auth is enabled on the server side by checking
-the ``basicauth`` capability.
-
-
-How to Authenticate with Basic Auth?
-------------------------------------
-
-Depending on configuration (*enabled by default*), using a *Basic Auth* token
-will associate a unique :term:`user identifier` to any username/password combination.
+Otherwise, the easiest way to get started with Kinto is probably to use :ref:`internal Kinto accounts <api-accounts>` which work the usual way: users sign-up with username and password. In this case, authentication is as simple as:
 
 ::
 
-    Authorization: Basic <basic_token>
+    Authorization: Basic <string>
 
-The token shall be built using this formula ``base64("token:<secret>")``.
-
-Since any string is accepted, here we use ``token`` only by convention.
-Empty secrets are accepted and can be anything (custom, UUID, etc.)
-
-If the header has an invalid format, or if *Basic Auth* is not enabled,
-this will result in a |status-401| error response.
-
-.. warning::
-
-    Since :term:`user id` is derived from the token, there is no way
-    to change the token without "losing" permissions on existing records.
-    See below for more information.
+where ``<string>`` is the result of ``base64("username:password")``.
 
 
-How does Kinto know it is a valid Basic Auth token?
----------------------------------------------------
+Try authentication
+------------------
 
-For each token, Kinto will calculate a unique user ID which is
-related to your Kinto instance. It uses a bit of cryptography and the value of
-the ``user_hmac_secret`` setting.
+The currently authenticated *user ID* can be obtained on the :ref:`root URL <api-utilities-hello>`. If the ``"user"`` field is not returned, this means that the authentication was not successful.
 
-In other words, every string provided in the *Basic Auth* header will be valid,
-and will lead to a unique user ID.
+.. code-block:: bash
 
-.. note::
-
-    Two Kinto instances using the same ``user_hmac_secret`` will
-    generate the same user ID for a given Basic Auth token.
-
-You can obtain the :term:`user ID` generated for your token on the :ref:`Kinto root URL <api-utilities>`:
-
-.. code-block:: shell
-
-    $ http https://kinto.dev.mozaws.net/v1/ --auth "token:my-secret"
+    $ http GET https://kinto.dev.mozaws.net/v1/ --auth admin:s3cr3t
 
 .. code-block:: http
-    :emphasize-lines: 24
+    :emphasize-lines: 6
 
     HTTP/1.1 200 OK
-    Access-Control-Expose-Headers: Retry-After, Content-Length, Alert, Backoff
-    Connection: keep-alive
-    Content-Length: 498
-    Content-Type: application/json; charset=UTF-8
-    Date: Fri, 29 Jan 2016 09:13:33 GMT
-    Server: nginx
 
     {
-        "http_api_version": "1.0",
-        "project_docs": "https://kinto.readthedocs.io/",
-        "project_name": "kinto",
-        "project_version": "1.10.0",
-        "settings": {
-            "attachment.base_url": "https://kinto.dev.mozaws.net/attachments/",
-            "batch_max_requests": 25,
-            "readonly": false
-        },
         "url": "https://kinto.dev.mozaws.net/v1/",
         "user": {
-            "bucket": "e777874f-2936-11a1-3269-68a6c1648a92",
-            "id": "basicauth:c635be9375673027e9b2f357a3955a0a46b58aeface61930838b61e946008ab0"
+            "bucket": "4399ed6c-802e-3278-5d01-44f261f0bab4",
+            "id": "account:admin",
+            "principals": [
+                "account:admin",
+                "system.Everyone",
+                "system.Authenticated"
+            ]
         }
+        ...
     }
 
-As soon as this user ID is used to give permission on an object
-(buckets, groups, collections, records), the user will be granted that
-permission when using this token.
 
+Available methods
+-----------------
 
-How can we generate strong unique tokens?
------------------------------------------
-
-For certain use cases, tokens can be public and shared publicly. For others, they must
-be kept secret.
-
-For the latter, we recommend using at least a 16 random bytes strings, such as UUIDs:
-
-Using the ``uuidgen`` CLI tool:
+In order to know which authentication methods are supported by a *Kinto* server, you can query the :ref:`root URL <api-utilities-hello>` and check the ``"capabilities"`` field.
 
 .. code-block:: shell
 
-    $ uuidgen
-    3a96294b-4e75-4e32-958d-fea44f2fe5aa
-
-Using Python:
-
-.. code-block:: pycon
-
-    >>> from uuid import uuid4
-    >>> print(uuid4())
-    6f8dfa43-668c-4e5c-89bc-eaabcb866342
-
-Using Node:
-
-.. code-block:: js
-
-    > var uuid = require('node-uuid');
-    > console.log(uuid.v4());
-    0a859a0e-4e6e-4014-896a-aa85d9587c48
-
-Then the string obtained can be used as it is:
-
-.. code-block:: shell
-
-    $ http GET https://kinto.dev.mozaws.net/v1/ \
-        --auth "token:6f8dfa43-668c-4e5c-89bc-eaabcb866342"
-
-And observe the user ID in the response.
-
-
-How can I change the token for a given user?
---------------------------------------------
-
-Asking yourself this question is a first sign that you should not be
-using the Basic Auth authentication method for your use case.
-
-Because the user ID is computed from the token, changing the token
-will change the user ID.
-
-Some possible strategies:
-
-- You can generate new tokens and give the ``write`` permission to their
-  respective user id.
-
-- You can also create a group per « user » whose members are the different
-  user IDs obtained from tokens. And then use this group in permission
-  definitions on objects.
-
-- Most likely, you would use an identity provider which will be in
-  charge of user and token management (generate, refresh, validate, ...).
-  `See this example with Django <https://django-oauth-toolkit.readthedocs.io/en/latest/tutorial/tutorial_01.html>`_.
-
-You can also read our :ref:`tutorial about how to plug the GitHub authorisation backend <tutorial-github>`.
-
-
-.. _authentication-openid:
-
-OpenID Connect
-==============
-
-OpenID relies on *OAuth2 bearer tokens*, so basically authentication shall be done using this header:
-
-::
-
-    Authorization: Bearer <access_token>
-
-:notes:
-
-    If the token is not valid, this will result in a |status-401| error response.
-
-
-Login and obtain access token
------------------------------
-
-:ref:`Once configured <settings-openid>`, the OpenID configuration details are provided in the capabilities object at the :ref:`root URL <api-utilities-hello>`:
+    $ http https://kinto.dev.mozaws.net/v1/
 
 .. code-block:: http
-    :emphasize-lines: 11-16
 
     HTTP/1.1 200 OK
-    Content-Length: 638
+    Access-Control-Expose-Headers: Backoff, Retry-After, Content-Length, Alert
+    Connection: keep-alive
+    Content-Length: 2561
     Content-Type: application/json
+    Date: Mon, 24 Sep 2018 15:12:51 GMT
+    Server: nginx
+    X-Content-Type-Options: nosniff
 
     {
         "capabilities": {
+            "accounts": {
+                "description": "Manage user accounts.",
+                "url": "https://kinto.readthedocs.io/en/latest/api/1.x/accounts.html"
+            },
+            "basicauth": {
+                "description": "Very basic authentication sessions. Not for production use.",
+                "url": "http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html"
+            },
             "openid": {
                 "description": "OpenID connect support.",
                 "providers": [
                     {
-                        "name": "google",
-                        "auth_path": "/openid/google/login",
-                        "client_id": "XXXXX.apps.googleusercontent.com",
+                        "auth_path": "/openid/auth0/login",
+                        "client_id": "XNmXEZhGfNaYltbCKustGunTbH0r8Gkp",
                         "header_type": "Bearer",
-                        "issuer": "https://accounts.google.com",
-                        "userinfo_endpoint": "https://www.googleapis.com/oauth2/v3/userinfo"
+                        "issuer": "https://auth.mozilla.auth0.com/",
+                        "name": "auth0",
+                        "userinfo_endpoint": "https://auth.mozilla.auth0.com/userinfo"
                     }
                 ],
                 "url": "http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html"
+            },
+            "portier": {
+                "description": "Authenticate users using Portier.",
+                "url": "https://github.com/Kinto/kinto-portier",
+                "version": "0.2.0"
             }
         }
     }
 
-In order to initiate the login and its browser redirections (aka. «dance»), just reach the URL specified in the ``auth_path``
-for the configured provider ``name``.
 
-::
-
-    GET /openid/{name}/login?callback={URI}&scope={scope}
-
-- ``callback`` which is the URI the browser will be redirected to after the login (eg. ``http://dashboard.myapp.com/#tokens=``).
-  It will be suffixed with the JSON response from the :term:`Identity Provider`, which will either be the access and ID tokens or an error.
-- ``scope`` which should at least be ``openid`` (but usually ``openid email``) (see your Identity Provider documentation)
-- ``prompt`` (optional) if set has to be the word ``none``. Generally used for Silent Authentication.
-
-.. note::
-
-    Because multiple OpenID providers can be enabled on the server, the ``auth_path`` URI contains the provider name with which the login process is initiated (eg. client initiates login by redirecting to ``/openid/auth0/login?...`` or ``/openid/google/login?...`` etc.)
-
-.. note::
-
-    The effect of adding ``&prompt=none`` tells the Identity Provider to not present a ``200 OK`` response. Only redirects.
-
-JavaScript example
-------------------
-
-Let's go through a simple OpenID login example using the :github:`JavaScript kinto client <Kinto/kinto-http.js>`.
-
-When the user clicks a login button, it initiates the login process by redirecting the browser to the
-Identity Provider, which itself redirects it to the application page once successful.
-
-.. code-block:: JavaScript
-    :emphasize-lines: 12,15,19-25
-
-    const KINTO_URL = 'http://localhost:8888/v1';
-
-    const SCOPES = 'openid email';
-
-    // Redirect to the same page using the location hash.
-    const CALLBACK_URL = window.location.href + '#tokens=';
-
-    const kintoClient = new KintoClient(KINTO_URL);
-
-    document.addEventListener('DOMContentLoaded', async () => {
-      // Initiate login on some button click
-      loginBtn.addEventListener('click', login);
-
-      // Check if the location contains the tokens (after being redirected)
-      const authResult = parseToken();
-      if (authResult) {
-        const {access_token, token_type} = authResult;
-        if (access_token) {
-          // Set access token for requests to Kinto.
-          kintoClient.setHeaders({
-            'Authorization': `${token_type} ${access_token}`,
-          });
-          // Show if Kinto authenticates me:
-          const {user} = await kintoClient.fetchServerInfo();
-          alert("You are " + (user ? user.id : "unknown"));
-        }
-        else {
-          console.error('Authentication error', authResult);
-        }
-
-      }
-    });
-
-The ``login()`` function is straightforward:
-
-.. code-block:: JavaScript
-
-    function login() {
-      const {capabilities: {openid: {providers}}} = await kintoClient.fetchServerInfo();
-      // Use the first configured provider
-      const {auth_path} = providers[0];
-      // Redirect the browser to the authentication page.
-      const callback = encodeURIComponent(CALLBACK_URL);
-      window.location = `${KINTO_URL}${auth_path}?callback=${callback}&scope=${SCOPES}`;
-    }
-
-The ``parseToken()`` function scans the location hash to read the Identity Provider response:
-
-.. code-block:: JavaScript
-
-    function parseToken() {
-      const hash = decodeURIComponent(window.location.hash);
-      const tokensExtract = /tokens=([.\s\S]*)/.exec(hash);
-      if (!tokensExtract) {
-        // No token in URL bar.
-        return null;
-      }
-      const tokens = tokensExtract[1];
-      const parsed = JSON.parse(tokens);
-      return parsed;
-    }
-
-Check out the :github:`full demo source code <leplatrem/kinto-oidc-demo>`.
+For example, :github:`Kinto Admin <Kinto/kinto-admin>` inspects that list in order to dynamically offer several authentication options in its login form.
 
 
-Example of login redirections
------------------------------
+Permissions
+-----------
 
-Let's assume the JavaScript app is accessible on http://localhost:3000 and the Kinto server running on http://localhost:8888.
+In order to control which users are allowed to create or modify objects, we mention their user IDs in permissions or groups members.
 
-When the user clicks the login button, the browser will follow a sequence of redirections similar to this one:
-
-#. User clicks on the ``auth0`` login button
-#. JavaScript redirects to `<http://localhost:8888/v1/openid/auth0/login?scope=openid email&callback=http://localhost:3000/#provider=auth0&tokens=>`_
-#. Kinto generates and stores a *state* string
-#. Kinto redirects to Auth0 that will show the login form `<https://minimal-demo-iam.auth0.com/authorize?client_id=BXqGVgl2meRsdVK0dEZPTk516JUhje2M&response_type=code&scope=openid+email&redirect_uri=http://localhost:8888/v1/openid/auth0/token?&state=3a309f5baba>`_
-#. User enters credentials and authenticates
-#. Auth0 redirects to Kinto with the *state* and a *code* `<http://localhost:8888/v1/openid/auth0/token?code=lWpsu9VoHLJEVyy1&state=3a309f5baba>`_
-#. Kinto checks that the *state* matches
-#. Kinto trades the *code* against the ID and Access tokens
-#. Kinto redirects back to the Single Page App appending the JSON encoded ID and Access tokens to the callback URL provided at step 2 `<http://localhost:3000/#provider=auth0&tokens={"access_token":"tY6um989...jfcer","id_token":"eyJ0eXAiOiJ...KV1QiL.ojkhgwRVH...UG8JGRENNF.Es8...DK10","expires_in":86400,"token_type":"Bearer"}>`_
-#. JavaScript code parses the location hash and reads the ID and Access tokens
-
-The JavaScript app can now use the Access token to make authenticated calls to the Kinto server, and read the user info from the ID token fields. See :github:`demo <leplatrem/kinto-oidc-demo>`.
+For more details, check :ref:`the permissions section of the documention <api-principals>`.

--- a/docs/api/1.x/buckets.rst
+++ b/docs/api/1.x/buckets.rst
@@ -28,7 +28,7 @@ Creating a bucket
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"id": "blog"}}' | http POST http://localhost:8888/v1/buckets --auth="token:bob-token" --verbose
+        $ echo '{"data": {"id": "blog"}}' | http POST http://localhost:8888/v1/buckets --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -67,7 +67,7 @@ Creating a bucket
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -98,7 +98,7 @@ Replacing a bucket
 
     .. sourcecode:: bash
 
-        $ http put http://localhost:8888/v1/buckets/blog --auth="token:bob-token"
+        $ http put http://localhost:8888/v1/buckets/blog --auth="bob:p4ssw0rd"
 
     .. sourcecode:: http
 
@@ -129,7 +129,7 @@ Replacing a bucket
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -154,7 +154,7 @@ Retrieve an existing bucket
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/blog --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets/blog --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -188,7 +188,7 @@ Retrieve an existing bucket
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -229,7 +229,7 @@ Deleting a bucket
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -281,7 +281,7 @@ Retrieving all buckets
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -336,7 +336,7 @@ Delete all buckets
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -396,7 +396,7 @@ bucket implicitly creates the collections objects on their first use.
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/default -v --auth='token:bob-token'
+        $ http get http://localhost:8888/v1/buckets/default -v --auth='bob:p4ssw0rd'
 
     .. sourcecode:: http
 
@@ -429,7 +429,7 @@ bucket implicitly creates the collections objects on their first use.
             },
             "permissions": {
                 "write": [
-                    "basicauth:62e79bedacd2508c7da3dfb16e9724501fb4bdf9a830de7f8abcc8f7f1496c35"
+                    "account:bob"
                 ]
             }
         }
@@ -447,7 +447,7 @@ For convenience, the actual default bucket id is provided in the root URL of *Ki
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/ -v --follow --auth='token:bob-token'
+        $ http get http://localhost:8888/v1/ -v --follow --auth='bob:p4ssw0rd'
 
     **Example Response**
 
@@ -470,7 +470,7 @@ For convenience, the actual default bucket id is provided in the root URL of *Ki
                 "batch_max_requests": 25,
             },
             "user": {
-                "id": "basicauth:62e79bedacd2508c7da3dfb16e9724501fb4bdf9a830de7f8abcc8f7f1496c35",
+                "id": "account:bob",
                 "bucket": "b8f3fa97-3e0a-00ae-7f07-ce8ce05ce0e5",
             }
         }

--- a/docs/api/1.x/collections.rst
+++ b/docs/api/1.x/collections.rst
@@ -50,7 +50,7 @@ List bucket collections
 
    .. sourcecode:: bash
 
-      $ http GET http://localhost:8888/v1/buckets/blog/collections --auth="token:bob-token" --verbose
+      $ http GET http://localhost:8888/v1/buckets/blog/collections --auth="bob:p4ssw0rd" --verbose
 
    .. sourcecode:: http
 
@@ -112,7 +112,7 @@ Delete bucket collections
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog/collections --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog/collections --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -176,7 +176,7 @@ Creating a collection
 
    .. sourcecode:: bash
 
-      $ echo '{"data": {"id": "articles"}}' | http POST http://localhost:8888/v1/buckets/blog/collections --auth="token:bob-token" --verbose
+      $ echo '{"data": {"id": "articles"}}' | http POST http://localhost:8888/v1/buckets/blog/collections --auth="bob:p4ssw0rd" --verbose
 
    .. sourcecode:: http
 
@@ -212,7 +212,7 @@ Creating a collection
           },
           "permissions": {
               "write": [
-                  "basicauth:797df8e4abfb8426cccaeba3b69109c9e8d09fcdfe264d5bba1eb2a239bcf832"
+                  "account:bob"
               ]
           }
       }
@@ -240,7 +240,7 @@ Replacing a collection
 
     .. sourcecode:: bash
 
-        $ http put http://localhost:8888/v1/buckets/blog/collections/articles --auth="token:bob-token" --verbose
+        $ http put http://localhost:8888/v1/buckets/blog/collections/articles --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -269,7 +269,7 @@ Replacing a collection
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -298,7 +298,7 @@ Updating a collection
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"fingerprint": "9cae1b2d0f2b7d09bcf5c1bf51544274"}}' | http patch http://localhost:8888/v1/buckets/blog/collections/articles --auth="token:bob-token" --verbose
+        $ echo '{"data": {"fingerprint": "9cae1b2d0f2b7d09bcf5c1bf51544274"}}' | http patch http://localhost:8888/v1/buckets/blog/collections/articles --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -335,7 +335,7 @@ Updating a collection
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -360,7 +360,7 @@ Retrieving an existing collection
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/blog/collections/articles --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets/blog/collections/articles --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -393,7 +393,7 @@ Retrieving an existing collection
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -418,7 +418,7 @@ Deleting a collection
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog/collections/articles --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog/collections/articles --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -498,7 +498,7 @@ Just modify the ``schema`` attribute of the collection object:
           "required": ["title"]
         }
       }
-    }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth token:admin-token --verbose
+    }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth bob:p4ssw0rd --verbose
 
 .. code-block:: http
 
@@ -567,7 +567,7 @@ Just modify the ``schema`` attribute of the collection object:
         },
         "permissions": {
             "write": [
-                "basicauth:780f1ecd9f57b01bef79608b45916d3bddd17f83461ac6240402e0ffff3596c5"
+                "account:bob"
             ]
         }
     }
@@ -583,7 +583,7 @@ Once a schema has been defined, the posted records must match it:
 
     $ echo '{"data": {
         "body": "Fails if no title"
-    }}' | http POST http://localhost:8888/v1/buckets/blog/collections/articles/records --auth "token:admin-token"
+    }}' | http POST http://localhost:8888/v1/buckets/blog/collections/articles/records --auth "bob:p4ssw0rd"
 
 .. code-block:: http
 
@@ -637,7 +637,7 @@ to an empty mapping.
 
 .. code-block:: bash
 
-    echo '{"data": {"schema": {}} }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth token:admin-token --verbose
+    echo '{"data": {"schema": {}} }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth bob:p4ssw0rd --verbose
 
 .. code-block:: http
 
@@ -678,7 +678,7 @@ to an empty mapping.
         },
         "permissions": {
             "write": [
-                "basicauth:780f1ecd9f57b01bef79608b45916d3bddd17f83461ac6240402e0ffff3596c5"
+                "account:bob"
             ]
         }
     }
@@ -748,7 +748,7 @@ To achieve that, just modify the ``collection:schema`` attribute of the parent b
           }
         }
       }
-    }' | http PATCH "http://localhost:8888/v1/buckets/blog" --auth token:admin-token --verbose
+    }' | http PATCH "http://localhost:8888/v1/buckets/blog" --auth bob:p4ssw0rd --verbose
 
 
 .. _collection-caching:
@@ -765,13 +765,13 @@ For example, set it to ``3600`` (1 hour):
 
 .. code-block:: bash
 
-    echo '{"data": {"cache_expires": 3600} }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth token:admin-token
+    echo '{"data": {"cache_expires": 3600} }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth bob:p4ssw0rd
 
 From now on, the cache control headers are set for the `GET` requests:
 
 .. code-block:: bash
 
-    http  "http://localhost:8888/v1/buckets/blog/collections/articles/records" --auth token:admin-token
+    http  "http://localhost:8888/v1/buckets/blog/collections/articles/records" --auth bob:p4ssw0rd
 
 .. code-block:: http
     :emphasize-lines: 3,8
@@ -797,7 +797,7 @@ If set to ``0``, the collection records become explicitly uncacheable (``no-cach
 
 .. code-block:: bash
 
-    echo '{"data": {"cache_expires": 0} }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth token:admin-token
+    echo '{"data": {"cache_expires": 0} }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/articles" --auth bob:p4ssw0rd
 
 .. code-block:: http
     :emphasize-lines: 3,8,10

--- a/docs/api/1.x/groups.rst
+++ b/docs/api/1.x/groups.rst
@@ -41,7 +41,7 @@ Creating a group
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"members": ["basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"]}}' | http POST http://localhost:8888/v1/buckets/blog/groups --auth="token:bob-token" --verbose
+        $ echo '{"data": {"members": ["account:alice"]}}' | http POST http://localhost:8888/v1/buckets/blog/groups --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -58,7 +58,7 @@ Creating a group
         {
             "data": {
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             }
         }
@@ -79,12 +79,12 @@ Creating a group
                 "id": "wZjuQfpS",
                 "last_modified": 1434644222033,
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             }
         }
@@ -107,7 +107,7 @@ Replacing a group
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"members": ["basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"]}}' | http put http://localhost:8888/v1/buckets/blog/groups/readers --auth="token:bob-token" --verbose
+        $ echo '{"data": {"members": ["account:alice"]}}' | http put http://localhost:8888/v1/buckets/blog/groups/readers --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -124,7 +124,7 @@ Replacing a group
         {
             "data": {
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             }
         }
@@ -145,12 +145,12 @@ Replacing a group
                 "id": "readers",
                 "last_modified": 1434645661227,
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -175,7 +175,7 @@ Modify a group
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"members": ["basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"]}}' | http patch http://localhost:8888/v1/buckets/blog/groups/readers --auth="token:bob-token" --verbose
+        $ echo '{"data": {"members": ["account:alice"]}}' | http patch http://localhost:8888/v1/buckets/blog/groups/readers --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -192,7 +192,7 @@ Modify a group
         {
             "data": {
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             }
         }
@@ -213,12 +213,12 @@ Modify a group
                 "id": "readers",
                 "last_modified": 1434645661227,
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -243,7 +243,7 @@ Retrieving a group
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/blog/groups/readers --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets/blog/groups/readers --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -273,12 +273,12 @@ Retrieving a group
                 "id": "readers",
                 "last_modified": 1434645661227,
                 "members": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:alice"
                 ]
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -303,7 +303,7 @@ Retrieving all groups
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/blog/groups --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets/blog/groups --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -335,7 +335,7 @@ Retrieving all groups
                     "id": "vAQSwSca",
                     "last_modified": 1439468156451,
                     "members": [
-                        "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                        "account:alice"
                     ]
                 }
             ]
@@ -361,7 +361,7 @@ Deleting all groups
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog/groups --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog/groups --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -417,7 +417,7 @@ Deleting a group
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog/groups/readers --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog/groups/readers --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -487,7 +487,7 @@ Just modify the ``group:schema`` attribute of the parent bucket object:
           "required": ["email"]
         }
       }
-    }' | http PATCH "http://localhost:8888/v1/buckets/blog" --auth token:admin-token --verbose
+    }' | http PATCH "http://localhost:8888/v1/buckets/blog" --auth bob:p4ssw0rd --verbose
 
 .. code-block:: http
 
@@ -560,7 +560,7 @@ Just modify the ``group:schema`` attribute of the parent bucket object:
         },
         "permissions": {
             "write": [
-                "basicauth:780f1ecd9f57b01bef79608b45916d3bddd17f83461ac6240402e0ffff3596c5"
+                "account:bob"
             ]
         }
     }

--- a/docs/api/1.x/history.rst
+++ b/docs/api/1.x/history.rst
@@ -37,7 +37,7 @@ Retrieve history
 
     .. sourcecode:: bash
 
-        $ http GET http://localhost:8888/v1/buckets/blog/history --auth="token:bob-token" --verbose
+        $ http GET http://localhost:8888/v1/buckets/blog/history --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -81,13 +81,13 @@ Retrieve history
                         },
                         "permissions": {
                             "write": [
-                                "basicauth:43181ac0ae7581a23288c25a98786ef9db86433c62a04fd6071d11653ee69089"
+                                "account:bob"
                             ]
                         }
                     },
                     "timestamp": 1469006098757,
                     "uri": "/buckets/blog/collections/articles/records/b3b76c56-b6df-4195-8189-d79da4a128e1",
-                    "user_id": "basicauth:43181ac0ae7581a23288c25a98786ef9db86433c62a04fd6071d11653ee69089",
+                    "user_id": "account:bob",
                 }
             ]
         }
@@ -181,7 +181,7 @@ to merge the changes that happened remotely with her local ones.
 
     $ RECORD_URI="buckets/blog/collections/articles/records/xyz"
     $ LOCAL_TIMESTAMP="1469006098757"
-    $ http GET http://localhost:8888/v1/buckets/blog/history?uri=$RECORD_URI&_since=$LOCAL_TIMESTAMP --auth="token:bob-token" --verbose
+    $ http GET http://localhost:8888/v1/buckets/blog/history?uri=$RECORD_URI&_since=$LOCAL_TIMESTAMP --auth="bob:p4ssw0rd" --verbose
 
 Each entries gives the state in which the record was modified. Computing the difference between
 two steps and applying it to the local record is a possible way of solving conflicts automatically.

--- a/docs/api/1.x/index.rst
+++ b/docs/api/1.x/index.rst
@@ -12,6 +12,8 @@ Full detailed API documentation:
    :maxdepth: 1
 
    authentication
+   accounts
+   openid
    buckets
    collections
    records
@@ -23,7 +25,6 @@ Full detailed API documentation:
    selecting_fields
    history
    quotas
-   accounts
    utilities
    batch
    openapi

--- a/docs/api/1.x/openid.rst
+++ b/docs/api/1.x/openid.rst
@@ -1,0 +1,163 @@
+.. _api-openid:
+.. _authentication-openid:
+
+OpenID Connect
+==============
+
+OpenID relies on *OAuth2 bearer tokens*, so basically authentication shall be done using this header:
+
+::
+
+    Authorization: Bearer <access_token>
+
+.. note::
+
+    If the token is not valid, this will result in a |status-401| error response.
+
+
+Login and obtain access token
+-----------------------------
+
+:ref:`Once configured <settings-openid>`, the OpenID configuration details are provided in the capabilities object at the :ref:`root URL <api-utilities-hello>`:
+
+.. code-block:: http
+    :emphasize-lines: 11-16
+
+    HTTP/1.1 200 OK
+    Content-Length: 638
+    Content-Type: application/json
+
+    {
+        "capabilities": {
+            "openid": {
+                "description": "OpenID connect support.",
+                "providers": [
+                    {
+                        "name": "google",
+                        "auth_path": "/openid/google/login",
+                        "client_id": "XXXXX.apps.googleusercontent.com",
+                        "header_type": "Bearer",
+                        "issuer": "https://accounts.google.com",
+                        "userinfo_endpoint": "https://www.googleapis.com/oauth2/v3/userinfo"
+                    }
+                ],
+                "url": "http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html"
+            }
+        }
+    }
+
+In order to initiate the login and its browser redirections (aka. «dance»), just reach the URL specified in the ``auth_path``
+for the configured provider ``name``.
+
+::
+
+    GET /openid/{name}/login?callback={URI}&scope={scope}
+
+- ``callback`` which is the URI the browser will be redirected to after the login (eg. ``http://dashboard.myapp.com/#tokens=``).
+  It will be suffixed with the JSON response from the :term:`Identity Provider`, which will either be the access and ID tokens or an error.
+- ``scope`` which should at least be ``openid`` (but usually ``openid email``) (see your Identity Provider documentation)
+- ``prompt`` (optional) if set has to be the word ``none``. Generally used for Silent Authentication.
+
+.. note::
+
+    Because multiple OpenID providers can be enabled on the server, the ``auth_path`` URI contains the provider name with which the login process is initiated (eg. client initiates login by redirecting to ``/openid/auth0/login?...`` or ``/openid/google/login?...`` etc.)
+
+.. note::
+
+    The effect of adding ``&prompt=none`` tells the Identity Provider to not present a ``200 OK`` response. Only redirects.
+
+JavaScript example
+------------------
+
+Let's go through a simple OpenID login example using the :github:`JavaScript kinto client <Kinto/kinto-http.js>`.
+
+When the user clicks a login button, it initiates the login process by redirecting the browser to the
+Identity Provider, which itself redirects it to the application page once successful.
+
+.. code-block:: JavaScript
+    :emphasize-lines: 12,15,19-25
+
+    const KINTO_URL = 'http://localhost:8888/v1';
+
+    const SCOPES = 'openid email';
+
+    // Redirect to the same page using the location hash.
+    const CALLBACK_URL = window.location.href + '#tokens=';
+
+    const kintoClient = new KintoClient(KINTO_URL);
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      // Initiate login on some button click
+      loginBtn.addEventListener('click', login);
+
+      // Check if the location contains the tokens (after being redirected)
+      const authResult = parseToken();
+      if (authResult) {
+        const {access_token, token_type} = authResult;
+        if (access_token) {
+          // Set access token for requests to Kinto.
+          kintoClient.setHeaders({
+            'Authorization': `${token_type} ${access_token}`,
+          });
+          // Show if Kinto authenticates me:
+          const {user} = await kintoClient.fetchServerInfo();
+          alert("You are " + (user ? user.id : "unknown"));
+        }
+        else {
+          console.error('Authentication error', authResult);
+        }
+
+      }
+    });
+
+The ``login()`` function is straightforward:
+
+.. code-block:: JavaScript
+
+    function login() {
+      const {capabilities: {openid: {providers}}} = await kintoClient.fetchServerInfo();
+      // Use the first configured provider
+      const {auth_path} = providers[0];
+      // Redirect the browser to the authentication page.
+      const callback = encodeURIComponent(CALLBACK_URL);
+      window.location = `${KINTO_URL}${auth_path}?callback=${callback}&scope=${SCOPES}`;
+    }
+
+The ``parseToken()`` function scans the location hash to read the Identity Provider response:
+
+.. code-block:: JavaScript
+
+    function parseToken() {
+      const hash = decodeURIComponent(window.location.hash);
+      const tokensExtract = /tokens=([.\s\S]*)/.exec(hash);
+      if (!tokensExtract) {
+        // No token in URL bar.
+        return null;
+      }
+      const tokens = tokensExtract[1];
+      const parsed = JSON.parse(tokens);
+      return parsed;
+    }
+
+Check out the :github:`full demo source code <leplatrem/kinto-oidc-demo>`.
+
+
+Example of login redirections
+-----------------------------
+
+Let's assume the JavaScript app is accessible on http://localhost:3000 and the Kinto server running on http://localhost:8888.
+
+When the user clicks the login button, the browser will follow a sequence of redirections similar to this one:
+
+#. User clicks on the ``auth0`` login button
+#. JavaScript redirects to `<http://localhost:8888/v1/openid/auth0/login?scope=openid email&callback=http://localhost:3000/#provider=auth0&tokens=>`_
+#. Kinto generates and stores a *state* string
+#. Kinto redirects to Auth0 that will show the login form `<https://minimal-demo-iam.auth0.com/authorize?client_id=BXqGVgl2meRsdVK0dEZPTk516JUhje2M&response_type=code&scope=openid+email&redirect_uri=http://localhost:8888/v1/openid/auth0/token?&state=3a309f5baba>`_
+#. User enters credentials and authenticates
+#. Auth0 redirects to Kinto with the *state* and a *code* `<http://localhost:8888/v1/openid/auth0/token?code=lWpsu9VoHLJEVyy1&state=3a309f5baba>`_
+#. Kinto checks that the *state* matches
+#. Kinto trades the *code* against the ID and Access tokens
+#. Kinto redirects back to the Single Page App appending the JSON encoded ID and Access tokens to the callback URL provided at step 2 `<http://localhost:3000/#provider=auth0&tokens={"access_token":"tY6um989...jfcer","id_token":"eyJ0eXAiOiJ...KV1QiL.ojkhgwRVH...UG8JGRENNF.Es8...DK10","expires_in":86400,"token_type":"Bearer"}>`_
+#. JavaScript code parses the location hash and reads the ID and Access tokens
+
+The JavaScript app can now use the Access token to make authenticated calls to the Kinto server, and read the user info from the ID token fields. See :github:`demo <leplatrem/kinto-oidc-demo>`.

--- a/docs/api/1.x/permissions.rst
+++ b/docs/api/1.x/permissions.rst
@@ -27,7 +27,7 @@ On each kind of object the set of permissions can be:
 
 In the case of a creation, since an object can have several kinds of children, the
 permission is prefixed by the type of child (for instance ``group:create``,
-``collection:create``). When a user is allowed to create a child, she is allowed
+``collection:create`` on buckets). When a user is allowed to create a child, she is allowed
 to read the parent attributes as well as listing accessible objects via the
 plural endpoint.
 
@@ -99,7 +99,7 @@ During the authentication phase, a set of :term:`principals` for the current
 authenticated *user* will be bound to to the request.
 
 The main principal is considered the **user ID** and follows this formalism:
-``{type}:{identifier}`` (e.g. for Firefox Account: ``fxa:32aa95a474c984d41d395e2d0b614aa2``).
+``{policy}:{identifier}`` (e.g. with :ref:`internal accounts <api-accounts>`: ``account:alice``).
 When a user is added to :ref:`a group <groups>`, they receive a principal.
 
 There are two special principals:
@@ -119,17 +119,17 @@ definition is ``read: ["system.Everyone"], write: ["/buckets/pictures/groups/fri
 
 .. _api-current-userid:
 
-Get the current user ID
------------------------
+Get the current user ID and principals
+--------------------------------------
 
 The currently authenticated *user ID* can be obtained on the root URL.
 
 .. code-block:: bash
 
-    $ http GET http://localhost:8888/v1/ --auth token:my-secret
+    $ http GET http://localhost:8888/v1/ --auth bob:my-secret
 
 .. code-block:: http
-    :emphasize-lines: 16
+    :emphasize-lines: 15-23
 
     HTTP/1.1 200 OK
     Access-Control-Expose-Headers: Backoff, Retry-After, Alert, Content-Length
@@ -146,13 +146,19 @@ The currently authenticated *user ID* can be obtained on the root URL.
         },
         "url": "http://localhost:8888/v1/",
         "user": {
-            "id": "basicauth:631c2d625ee5726172cf67c6750de10a3e1a04bcd603bc9ad6d6b196fa8257a6"
-        },
+            "bucket": "4399ed6c-802e-3278-5d01-44f261f0bab4",
+            "id": "account:bob",
+            "principals": [
+                "account:bob",
+                "system.Everyone",
+                "system.Authenticated"
+            ]
+        }
         "version": "1.4.0"
     }
 
 
-In this case the user ID is: ``basicauth:631c2d625ee5726172cf67c6750de10a3e1a04bcd603bc9ad6d6b196fa8257a6``
+In this case the user ID is: ``account:bob``
 
 .. note::
 
@@ -212,7 +218,7 @@ Retrieve objects permissions
 
     .. sourcecode:: bash
 
-        $ http GET http://localhost:8888/v1/buckets/default --auth token:bob-token --verbose
+        $ http GET http://localhost:8888/v1/buckets/default --auth bob:p4ssw0rd --verbose
 
     .. sourcecode:: http
 
@@ -245,7 +251,7 @@ Retrieve objects permissions
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -278,7 +284,7 @@ itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
 
         $ echo '{"permissions": {"read": ["system.Authenticated"]}}' | \
           http PATCH https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks \
-          --auth token:bob-token
+          --auth bob:p4ssw0rd
 
     .. sourcecode:: http
 
@@ -324,7 +330,7 @@ itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
                     "system.Authenticated"
                 ],
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -342,7 +348,7 @@ itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
 
         $ echo '{"permissions": {"write": ["groups:writers"]}}' | \
           http PUT https://kinto.dev.mozaws.net/v1/buckets/default/collections/tasks \
-          --auth token:bob-token
+          --auth bob:p4ssw0rd
 
     .. sourcecode:: http
 
@@ -386,7 +392,7 @@ itself, using the same :ref:`PATCH <record-patch>` and :ref:`PUT
             "permissions": {
                 "write": [
                     "groups:writers",
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -408,7 +414,7 @@ List every permissions
 
     .. sourcecode:: bash
 
-        $ http GET https://kinto.dev.mozaws.net/v1/permissions --auth token:bob-token
+        $ http GET https://kinto.dev.mozaws.net/v1/permissions --auth bob:p4ssw0rd
 
     .. sourcecode:: http
 

--- a/docs/api/1.x/records.rst
+++ b/docs/api/1.x/records.rst
@@ -30,7 +30,7 @@ Uploading a record
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"foo": "bar"}}' | http post http://localhost:8888/v1/buckets/blog/collections/articles/records --auth="token:bob-token" --verbose
+        $ echo '{"data": {"foo": "bar"}}' | http post http://localhost:8888/v1/buckets/blog/collections/articles/records --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -69,7 +69,7 @@ Uploading a record
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -100,7 +100,7 @@ Replacing a record
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"foo": "baz"}}' | http put http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="token:bob-token" --verbose
+        $ echo '{"data": {"foo": "baz"}}' | http put http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -139,7 +139,7 @@ Replacing a record
           },
           "permissions": {
               "write": [
-                  "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                  "account:bob"
               ]
           }
         }
@@ -165,7 +165,7 @@ Updating a record
 
     .. sourcecode:: bash
 
-        $ echo '{"data": {"status": "done"}}' | http patch http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="token:bob-token" --verbose
+        $ echo '{"data": {"status": "done"}}' | http patch http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -205,7 +205,7 @@ Updating a record
           },
           "permissions": {
               "write": [
-                  "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                  "account:bob"
               ]
           }
         }
@@ -230,7 +230,7 @@ Retrieving stored records
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/blog/collections/articles/records --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets/blog/collections/articles/records --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -281,7 +281,7 @@ Retrieving a specific record
 
     .. sourcecode:: bash
 
-        $ http get http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="token:bob-token" --verbose
+        $ http get http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -315,7 +315,7 @@ Retrieving a specific record
             },
             "permissions": {
                 "write": [
-                    "basicauth:206691a25679e4e1135f16aa77ebcf211c767393c4306cfffe6cc228ac0886b6"
+                    "account:bob"
                 ]
             }
         }
@@ -336,7 +336,7 @@ Delete stored records
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog/collections/articles/records --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog/collections/articles/records --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 
@@ -383,7 +383,7 @@ Deleting a single record
 
     .. sourcecode:: bash
 
-        $ http delete http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="token:bob-token" --verbose
+        $ http delete http://localhost:8888/v1/buckets/blog/collections/articles/records/89881454-e4e9-4ef0-99a9-404d95900352 --auth="bob:p4ssw0rd" --verbose
 
     .. sourcecode:: http
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -38,6 +38,7 @@ and the JSON can contain anything.
 A **collection** is a group of records. Records are manipulated as a list
 and can be filtered or sorted. Clients can obtain the list of changes that
 occured on the collection records since a certain revision (e.g. *last synchronisation*).
+A JSON schema can optionally be defined on the collection.
 
 A **bucket** is an abstract notion used to organize collections and their
 permissions.
@@ -70,10 +71,9 @@ to several objects.
 Authentication
 ==============
 
-Kinto doesn't provide users management, like user sign-up, password modification, etc.
-
-Kinto can rely on a third-party called "`Identity provider <https://en.wikipedia.org/wiki/Identity_provider>`_"
-like *Auth0*, *GitHub* or *Google* in order to authenticate the incoming request and assign a :term:`user id`.
+Kinto reads the request headers in order to authenticate the incoming request and assign a :term:`user id`.
+It can rely on a third-party called "`Identity provider <https://en.wikipedia.org/wiki/Identity_provider>`_"
+like *Auth0*, *GitHub* or *Google*.
 
 .. _concepts-permissions:
 

--- a/docs/core/glossary.rst
+++ b/docs/core/glossary.rst
@@ -3,6 +3,10 @@ Glossary
 
 .. glossary::
 
+    authentication policy
+    authentication policies
+        An authentication method enabled in :ref:`configuration <configuration-authentication>`
+
     Kinto-Core HTTP API
         A system of rules that explains the way to interact with the HTTP API
         :term:`endpoints` (utilities, synchronization, headers etc.), and how data
@@ -46,11 +50,9 @@ Glossary
     user id
     user identifier
     user identifiers
-        A string that identifies a user. When using the built-in *Basic Auth*
-        authentication, *Kinto-Core* uses cryptography (HMAC) to generate an
-        identification string.
-
-        See `Pyramid authentication`_.
+        A string that identifies a user. It is prefixed with the authentication
+        policy name (eg. ``account:alice``, ``ldap:bob``, ``google:me@gmail.com``, ...).
+        These identifiers are used to refer to users in :ref:`permissions <concepts-permissions>` or :ref:`groups <concepts-groups>`.
 
     object
     objects
@@ -86,6 +88,3 @@ Glossary
     ACLs
     Access Control List
         A list of Access Control Entities (ACE).
-
-
-.. _Pyramid authentication: http://docs.pylonsproject.org/docs/pyramid/en/latest/narr/security.html

--- a/docs/core/permission.rst
+++ b/docs/core/permission.rst
@@ -140,22 +140,6 @@ That means that a user is always able to replace or delete the records she creat
     current behaviour instead of always granting ``write`` on current user!
 
 
-BasicAuth trickery
-------------------
-
-Like for user resources, if *Basic Auth* authentication is enabled, the predictable
-user id can be used to define semi-private or public if the ``user:pass`` is
-known and shared (for example ``public:`` is a valid user:pass combination).
-
-For example, get the user id obtained in the hello :ref:`root view <api-utilities>` with a
-user:pass combination and use it in the permissions JSON payloads, or settings:
-
-::
-
-    kinto.{collection}_read_principals = basicauth:631c2d625ee5726172cf67c6750de10a3e1a04bcd603bc9ad6d6b196fa8257a6
-
-
-
 Related/Inherited permissions
 -----------------------------
 
@@ -250,7 +234,7 @@ Or during application init (or scripts):
         kinto.core.initialize(config, __version__)
         # ...
 
-        some_user_id = 'basicauth:ut082jghnrgnjnj'
+        some_user_id = 'ldap:alice@corp.com'
         permission_object_id = '/articles'
         permission = 'create'
         config.registry.permission.add_principal_to_ace(permission_object_id,

--- a/docs/tutorials/authentication-github.rst
+++ b/docs/tutorials/authentication-github.rst
@@ -8,6 +8,10 @@ In this tutorial, we will authenticate users using GitHub.
 Users obtain a Bearer token from GitHub and use it in an ``Authenticatìon`` header.
 Leveraging Kinto pluggability, a custom authentication policy is specified in settings in order to validate it.
 
+.. important::
+
+    This is a tutorial that demonstrates the authentication pluggability of Kinto
+
 Custom authentication
 ---------------------
 
@@ -72,7 +76,7 @@ enable a new policy pointing to your Python class:
 
 .. code-block:: ini
 
-    multiauth.policies = github basicauth
+    multiauth.policies = github
 
     multiauth.policy.github.use = kinto_github.GitHubAuthenticationPolicy
 
@@ -82,33 +86,13 @@ Kinto should start without errors.
 Test it
 '''''''
 
-Since we left ``basicauth`` in settings, it should still be accepted:
-
+Let's try with a random string, that obviously will fail to authenticate:
 ::
 
-    $ http GET http://localhost:8888/v1/ --auth token:alice-token
-
-.. code-block:: javascript
-
-    {
-        "http_api_version": "1.2",
-        "project_docs": "https://kinto.readthedocs.io/",
-        "project_name": "kinto",
-        "project_version": "1.11.0.dev0",
-        "settings": {
-            "attachment.base_url": "http://localhost:7777",
-            "batch_max_requests": 25,
-            "readonly": false
-        },
-        "url": "http://localhost:8888/v1/",
-        "user": {
-            "bucket": "71aefbc6-d333-832b-8e39-18da76d11bae",
-            "id": "basicauth:63279e82e351f8f318eea09ae5e3bcfc3b9e3eee06e9befacbf17102e0595dad"
-        }
-    }
+    $ http GET http://localhost:8888/v1/ "Authorization: blabla"
 
 
-And since the ``github`` authentication is also enabled (*but does nothing yet*), you
+Since our ``github`` authentication is enabled (*but does nothing yet*), you
 should see its output in the console when a request comes in.
 
 .. code-block:: shell
@@ -117,7 +101,7 @@ should see its output in the console when a request comes in.
     Starting server in PID 8079.
     serving on http://0.0.0.0:8888
     Check GitHub
-    2016-01-26 11:59:04,918 INFO  [kinto.core.initialization][waitress] "GET   /v1/" 200 (1 ms) request.summary lang=None; uid=63279e82e351f8f318eea09ae5e3bcfc3b9e3eee06e9befacbf17102e0595dad; errno=None; agent=HTTPie/0.9.2; authn_type=BasicAuth; time=2016-01-26T11:59:04
+    2016-01-26 11:59:04,918 INFO  [kinto.core.initialization][waitress] "GET   /v1/" 200 (1 ms) request.summary lang=None; uid=None; errno=None; agent=HTTPie/0.9.2; authn_type=BasicAuth; time=2016-01-26T11:59:04
 
 
 GitHub token validation
@@ -332,12 +316,13 @@ Use it in permissions
 '''''''''''''''''''''
 
 The user id ``github:<username>`` can now be used in permissions definitions.
-It is much more convenient than Basic Auth identifiers!
+
+For example, give @Natim the permission to read the bucket I create:
 
 ::
 
-    $ echo '{"permissions": {"read": ["github:leplatrem"]}}' | \
-        http PUT http://localhost:8888/v0/buckets/test  --auth='token:another-user-token'
+    $ echo '{"permissions": {"read": ["github:Natim"]}}' | \
+        http PUT http://localhost:8888/v0/buckets/test "Authorization:github+Bearer 7f7f911969279d8b16a12f44b8bc6e2d216dc51e"
 
 
 Cache the token validation

--- a/docs/tutorials/custom-id-generator.rst
+++ b/docs/tutorials/custom-id-generator.rst
@@ -87,7 +87,7 @@ well done!
         },
         "permissions": {
             "write": [
-                "basicauth:2025f72e6967625e3e878288b55d8946839e51968d11991b8a7dd0f040d4b6f0"
+                "account:user"
             ]
         }
     }

--- a/docs/tutorials/install.rst
+++ b/docs/tutorials/install.rst
@@ -68,6 +68,18 @@ If you have `Docker <https://docker.com/>`_, *Kinto* can be started locally with
 The server should now be running on http://localhost:8888
 
 
+Create the admin account
+------------------------
+
+The accounts feature is enabled in the default configuration. You have to create an ``admin`` account with a custom password:
+
+.. code-block:: shell
+
+    curl -X PUT http://localhost:8888/v1/accounts/admin \
+         -d '{"data": {"password": "s3cr3t"}}' \
+         -H 'Content-Type:application/json'
+
+
 Environment variables
 ---------------------
 
@@ -229,6 +241,18 @@ Then install the package using the default configuration:
     kinto start
 
 The server should now be running on http://localhost:8888
+
+
+Create the admin account
+------------------------
+
+The accounts feature is enabled in the default configuration. You have to create an ``admin`` account with a custom password:
+
+.. code-block:: shell
+
+    curl -X PUT http://localhost:8888/v1/accounts/admin \
+         -d '{"data": {"password": "s3cr3t"}}' \
+         -H 'Content-Type:application/json'
 
 
 .. _run-kinto-from-source:

--- a/docs/tutorials/notifications-custom.rst
+++ b/docs/tutorials/notifications-custom.rst
@@ -148,15 +148,15 @@ Create a bucket (using `HTTPie <http://httpie.org>`_):
 
 .. code-block:: shell
 
-    $ http --auth token:alice-token --verbose PUT http://localhost:8888/v1/buckets/bid1
-    $ http --auth token:alice-token --verbose PUT http://localhost:8888/v1/buckets/bid2
+    $ http --auth alice:s3cr3t --verbose PUT http://localhost:8888/v1/buckets/bid1
+    $ http --auth alice:s3cr3t --verbose PUT http://localhost:8888/v1/buckets/bid2
 
 Now, every response has a ``Buckets-Created`` header:
 
 .. code-block:: shell
     :emphasize-lines: 6
 
-    $ http --auth token:alice-token --verbose GET http://localhost:8888/v1/
+    $ http --auth alice:s3cr3t --verbose GET http://localhost:8888/v1/
 
     HTTP/1.1 200 OK
     Content-Length: 66
@@ -256,7 +256,7 @@ Create a record (using `HTTPie <http://httpie.org>`_):
 .. code-block:: shell
 
     $ echo '{"data": {"note": "kinto"}}' | \
-        http --auth token:alice-token --verbose POST http://localhost:8888/v1/buckets/default/collections/notes/records
+        http --auth alice:s3cr3t --verbose POST http://localhost:8888/v1/buckets/default/collections/notes/records
 
 The server response is returned immediately.
 
@@ -264,6 +264,6 @@ But 2 seconds later, look at the worker output:
 
 ::
 
-    {'resource_name': 'record', 'user_id': 'basicauth:fea1e21d339299506d89e60f048cefd5b424ea641ba48267c35a4ce921439fa4', 'timestamp': 1453459942672, 'uri': '/buckets/c8c94a74-5bf6-9fb0-5b72-b0777da6718e/collections/assets/records', 'bucket_id': 'c8c94a74-5bf6-9fb0-5b72-b0777da6718e', 'action': 'create', 'collection_id': 'assets'}
+    {'resource_name': 'record', 'user_id': 'account:alice', 'timestamp': 1453459942672, 'uri': '/buckets/c8c94a74-5bf6-9fb0-5b72-b0777da6718e/collections/assets/records', 'bucket_id': 'c8c94a74-5bf6-9fb0-5b72-b0777da6718e', 'action': 'create', 'collection_id': 'assets'}
 
 It worked!

--- a/docs/tutorials/notifications-websockets.rst
+++ b/docs/tutorials/notifications-websockets.rst
@@ -58,12 +58,17 @@ Test Pusher events
 Now that *Kinto* runs locally and is configured to send events to *Pusher*, you
 should be able to see them in the *Debug Console* of your *Pusher dashboard*.
 
-For example, create an arbitrary record with `httpie <http://httpie.org>`_
+For example, with `httpie <http://httpie.org>`_, create an :ref:`account <api-accounts>` and create an arbitrary record in the :ref:`default bucket <buckets-default-id>`:
+
+.. code-block:: shell
+
+    $ echo '{"data":{"password":"s3cr3t"}}' | \
+        http POST http://localhost:8888/v1/accounts/alice
 
 .. code-block:: shell
 
     $ echo '{"data":{"name":"bob"}}' | \
-        http POST http://localhost:8888/v1/buckets/default/collections/tasks/records --auth token:alice-token
+        http POST http://localhost:8888/v1/buckets/default/collections/tasks/records --auth alice:s3cr3t
 
 This created a record, and you should see the generated event in the dashboard.
 

--- a/docs/tutorials/permission-setups.rst
+++ b/docs/tutorials/permission-setups.rst
@@ -36,8 +36,8 @@ The following objects are created:
 +---------------------------------+-------------+----------------------------------------------------+
 | Object                          | Permissions | Principals                                         |
 +=================================+=============+====================================================+
-| Bucket ``servicedenuages_blog`` | ``write``   | ``fxaoauth:<alexis id>``                           |
-|                                 |             | ``fxaoauth:<mathieu id>``                          |
+| Bucket ``servicedenuages_blog`` | ``write``   | ``account:<alexis id>``                            |
+|                                 |             | ``account:<mathieu id>``                           |
 +---------------------------------+-------------+----------------------------------------------------+
 | Collection ``article``          | ``write``   | ``/bucket/servicedenuages_blog/groups/moderators`` |
 |                                 +-------------+----------------------------------------------------+
@@ -56,15 +56,15 @@ The following objects are created:
 - A ``wiki`` bucket, where new groups can be created by authenticated users;
 - An ``article`` collection is created.
 
-+-------------------------+---------------------+---------------------------------+
-| Object                  | Permissions         | Principals                      |
-+=========================+=====================+=================================+
-| Bucket ``wiki``         | ``write``           | ``fxa:<wiki administrator id>`` |
-+-------------------------+---------------------+---------------------------------+
-| Collection ``articles`` | ``write``           | ``system.Authenticated``        |
-|                         +---------------------+---------------------------------+
-|                         | ``read``            | ``system.Everyone``             |
-+-------------------------+---------------------+---------------------------------+
++-------------------------+---------------------+-------------------------------------+
+| Object                  | Permissions         | Principals                          |
++=========================+=====================+=====================================+
+| Bucket ``wiki``         | ``write``           | ``account:<wiki administrator id>`` |
++-------------------------+---------------------+-------------------------------------+
+| Collection ``articles`` | ``write``           | ``system.Authenticated``            |
+|                         +---------------------+-------------------------------------+
+|                         | ``read``            | ``system.Everyone``                 |
++-------------------------+---------------------+-------------------------------------+
 
 
 A Company Wiki
@@ -83,7 +83,7 @@ The following objects are created:
 +--------------------------+--------------+-------------------------------------------+
 | Object                   | Permissions  | Principals                                |
 +==========================+==============+===========================================+
-| Bucket ``companywiki``   | ``write``    | ``fxa:<wiki administrator id>``           |
+| Bucket ``companywiki``   | ``write``    | ``account:<wiki administrator id>``       |
 +--------------------------+--------------+-------------------------------------------+
 | Group ``employees``      | ``write``    | ``/buckets/companywiki/groups/managers``  |
 +--------------------------+--------------+-------------------------------------------+
@@ -114,23 +114,23 @@ The following objects are created:
 +------------------------------------------+---------------------+------------------------------------------------+
 | Object                                   | Permissions         | Principals                                     |
 +==========================================+=====================+================================================+
-| Bucket ``microblog``                     | ``write``           | ``fxa:<microblog administrator id>``           |
+| Bucket ``microblog``                     | ``write``           | ``account:<microblog administrator id>``       |
 |                                          +---------------------+------------------------------------------------+
 |                                          | ``group:create``    | ``system.Authenticated``                       |
 +------------------------------------------+---------------------+------------------------------------------------+
 | Collection ``articles``                  | ``record:create``   | ``system.Authenticated``                       |
 +------------------------------------------+---------------------+------------------------------------------------+
-| Group ``alexis_buddies``                 | ``write``           | ``fxa:<alexis id>``                            |
+| Group ``alexis_buddies``                 | ``write``           | ``account:<alexis id>``                        |
 +------------------------------------------+---------------------+------------------------------------------------+
-| A public message                         | ``write``           | ``fxa:<alexis id>``                            |
+| A public message                         | ``write``           | ``account:<alexis id>``                        |
 |                                          +---------------------+------------------------------------------------+
 |                                          | ``read``            | ``system.Everyone``                            |
 +------------------------------------------+---------------------+------------------------------------------------+
-| A direct message for a user              | ``write``           | ``fxa:<alexis id>``                            |
+| A direct message for a user              | ``write``           | ``account:<alexis id>``                        |
 |                                          +---------------------+------------------------------------------------+
-|                                          | ``read``            | ``fxa:<tarek id>``                             |
+|                                          | ``read``            | ``account:<tarek id>``                         |
 +------------------------------------------+---------------------+------------------------------------------------+
-| A private message for a group            | ``write``           | ``fxa:<alexis id>``                            |
+| A private message for a group            | ``write``           | ``account:<alexis id>``                        |
 |                                          +---------------------+------------------------------------------------+
 |                                          | ``read``            | ``/buckets/microblog/groups/alexis_following`` |
 +------------------------------------------+---------------------+------------------------------------------------+
@@ -170,7 +170,7 @@ The following objects are created:
 | Bucket ``payments``  | ``write``   | ``hawk:<payment app>``  |
 +----------------------+-------------+-------------------------+
 | On every record      | ``read``    | ``hawk:<selling app>``  |
-|                      |             | ``fxa:<buyer id>``      |
+|                      |             | ``account:<buyer id>``  |
 +----------------------+-------------+-------------------------+
 
 This ensures every app can list the receipts of every buyer, and that each

--- a/docs/tutorials/write-plugin.rst
+++ b/docs/tutorials/write-plugin.rst
@@ -353,20 +353,20 @@ Create a bucket and collection:
 
 ::
 
-    $ http --auth token:alice-token --verbose PUT http://localhost:8888/v1/buckets/example
-    $ http --auth token:alice-token --verbose PUT http://localhost:8888/v1/buckets/example/collections/notes
+    $ http --auth alice:s3cr3t --verbose PUT http://localhost:8888/v1/buckets/example
+    $ http --auth alice:s3cr3t --verbose PUT http://localhost:8888/v1/buckets/example/collections/notes
 
 Add a new record:
 
 ::
 
-    $ echo '{"data": {"note": "kinto"}}' | http --auth token:alice-token --verbose POST http://localhost:8888/v1/buckets/example/collections/notes/records
+    $ echo '{"data": {"note": "kinto"}}' | http --auth alice:s3cr3t --verbose POST http://localhost:8888/v1/buckets/example/collections/notes/records
 
 It should now be possible to search for it:
 
 ::
 
-    $ http --auth token:alice-token --verbose POST http://localhost:8888/v1/buckets/default/collections/assets/search
+    $ http --auth alice:s3cr3t --verbose POST http://localhost:8888/v1/buckets/default/collections/assets/search
 
 .. code-block:: http
     :emphasize-lines: 20-24

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -92,7 +92,7 @@ multiauth.policies = account
 # Set `kinto.includes` to `kinto.plugins.accounts`
 # Enable authenticated policy.
 # Set `multiauth.policies` to `account`
-multiauth.policy.account.use = kinto.plugins.account.AccountsPolicy
+multiauth.policy.account.use = kinto.plugins.accounts.AccountsPolicy
 # Allow anyone to create accounts.
 kinto.account_create_principals = system.Everyone
 # Set user 'account:admin' as the administrator.

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -32,8 +32,8 @@ use = egg:kinto
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#plugins
 # https://github.com/uralbash/awesome-pyramid
 kinto.includes = kinto.plugins.default_bucket
-#                kinto.plugins.admin
-#                kinto.plugins.accounts
+                 kinto.plugins.admin
+                 kinto.plugins.accounts
 #                kinto.plugins.history
 #                kinto.plugins.quotas
 
@@ -82,7 +82,7 @@ kinto.permission_url = {permission_url}
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
 #
 kinto.userid_hmac_secret = {secret}
-multiauth.policies = basicauth
+multiauth.policies = account
 # Any pyramid multiauth setting can be specified for custom authentication
 # https://github.com/uralbash/awesome-pyramid#authentication
 #
@@ -92,12 +92,13 @@ multiauth.policies = basicauth
 # Set `kinto.includes` to `kinto.plugins.accounts`
 # Enable authenticated policy.
 # Set `multiauth.policies` to `account`
-# multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
 # Allow anyone to create accounts.
-# kinto.account_create_principals = system.Everyone
+kinto.account_create_principals = system.Everyone
 # Set user 'account:admin' as the administrator.
-# kinto.account_write_principals = account:admin
-# kinto.account_read_principals = account:admin
+kinto.account_write_principals = account:admin
+# Allow administrators to create buckets
+kinto.bucket_create_principals = account:admin
 #
 # Kinto-portier authentication
 # https://github.com/Kinto/kinto-portier

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -92,7 +92,7 @@ multiauth.policies = account
 # Set `kinto.includes` to `kinto.plugins.accounts`
 # Enable authenticated policy.
 # Set `multiauth.policies` to `account`
-multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+multiauth.policy.account.use = kinto.plugins.account.AccountsPolicy
 # Allow anyone to create accounts.
 kinto.account_create_principals = system.Everyone
 # Set user 'account:admin' as the administrator.

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -99,15 +99,6 @@ kinto.account_create_principals = system.Everyone
 kinto.account_write_principals = account:admin
 # Allow administrators to create buckets
 kinto.bucket_create_principals = account:admin
-#
-# Kinto-portier authentication
-# https://github.com/Kinto/kinto-portier
-# Set `multiauth.policies` to `portier`
-# multiauth.policy.portier.use = kinto_portier.authentication.PortierOAuthAuthenticationPolicy
-# kinto.portier.broker_url = https://broker.portier.io
-# kinto.portier.webapp.authorized_domains = *.github.io
-# kinto.portier.cache_ttl_seconds = 300
-# kinto.portier.state.ttl_seconds = 3600
 
 # Notifications
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#notifications

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -90,9 +90,6 @@ DEFAULT_SETTINGS = {
     'version_prefix_redirect_enabled': True,
     'trailing_slash_redirect_enabled': True,
     'multiauth.groupfinder': 'kinto.core.authorization.groupfinder',
-    'multiauth.policies': 'basicauth',
-    'multiauth.policy.basicauth.use': ('kinto.core.authentication.'
-                                       'BasicAuthAuthenticationPolicy'),
     'multiauth.authorization_policy': ('kinto.core.authorization.'
                                        'AuthorizationPolicy'),
 }

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -90,6 +90,9 @@ DEFAULT_SETTINGS = {
     'version_prefix_redirect_enabled': True,
     'trailing_slash_redirect_enabled': True,
     'multiauth.groupfinder': 'kinto.core.authorization.groupfinder',
+    'multiauth.policies': '',
+    'multiauth.policy.basicauth.use': ('kinto.core.authentication.'
+                                       'BasicAuthAuthenticationPolicy'),
     'multiauth.authorization_policy': ('kinto.core.authorization.'
                                        'AuthorizationPolicy'),
 }

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -3,6 +3,9 @@ import re
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
 from pyramid.exceptions import ConfigurationError
 
+from authentication import AccountsAuthenticationPolicy as AccountsPolicy
+
+
 ACCOUNT_CACHE_KEY = 'accounts:{}:verified'
 ACCOUNT_POLICY_NAME = 'account'
 
@@ -28,12 +31,12 @@ def includeme(config):
     settings = config.get_settings()
 
     # Check that the account policy is mentioned in config if included.
-    accountClass = 'AccountsAuthenticationPolicy'
+    accountClass = 'AccountsPolicy'
     policy = None
     for k, v in settings.items():
         m = re.match('multiauth\.policy\.(.*)\.use', k)
         if m:
-            if v.endswith(accountClass):
+            if v.endswith(accountClass) or v.endswith("AccountsAuthenticationPolicy"):
                 policy = m.group(1)
 
     if not policy:

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -3,11 +3,11 @@ import re
 from kinto.authorization import PERMISSIONS_INHERITANCE_TREE
 from pyramid.exceptions import ConfigurationError
 
-from authentication import AccountsAuthenticationPolicy as AccountsPolicy
+from .authentication import AccountsAuthenticationPolicy as AccountsPolicy
+from .utils import ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
 
 
-ACCOUNT_CACHE_KEY = 'accounts:{}:verified'
-ACCOUNT_POLICY_NAME = 'account'
+__all__ = ['ACCOUNT_CACHE_KEY', 'ACCOUNT_POLICY_NAME', 'AccountsPolicy']
 
 DOCS_URL = "https://kinto.readthedocs.io/en/stable/api/1.x/accounts.html"
 

--- a/kinto/plugins/accounts/authentication.py
+++ b/kinto/plugins/accounts/authentication.py
@@ -4,7 +4,7 @@ from pyramid import authentication as base_auth
 from kinto.core import utils
 from kinto.core.storage import exceptions as storage_exceptions
 
-from . import ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
+from .utils import ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
 
 
 def account_check(username, password, request):

--- a/kinto/plugins/accounts/utils.py
+++ b/kinto/plugins/accounts/utils.py
@@ -1,6 +1,10 @@
 import bcrypt
 
 
+ACCOUNT_CACHE_KEY = 'accounts:{}:verified'
+ACCOUNT_POLICY_NAME = 'account'
+
+
 def hash_password(password):
     # Store password safely in database as str
     # (bcrypt.hashpw returns base64 bytes).

--- a/kinto/plugins/accounts/views.py
+++ b/kinto/plugins/accounts/views.py
@@ -10,8 +10,7 @@ from kinto.core import resource, utils
 from kinto.core.errors import raise_invalid, http_error
 from kinto.core.events import ResourceChanged, ACTIONS
 
-from . import ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
-from .utils import hash_password
+from .utils import hash_password, ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
 
 
 def _extract_posted_body_id(request):

--- a/tests/core/support.py
+++ b/tests/core/support.py
@@ -42,6 +42,7 @@ class BaseWebTest(testing.BaseWebTest):
         extras.setdefault('project_version', '0.0.1')
         extras.setdefault('http_api_version', '0.1')
         extras.setdefault('project_docs', 'https://kinto.readthedocs.io/')
+        extras.setdefault('multiauth.policies', 'basicauth')
         extras.setdefault('multiauth.authorization_policy',
                           cls.authorization_policy)
         return super().get_app_settings(extras)

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -254,7 +254,11 @@ class ApplicationWrapperTest(unittest.TestCase):
 
 class StatsDConfigurationTest(unittest.TestCase):
     def setUp(self):
-        settings = {**kinto.core.DEFAULT_SETTINGS, 'statsd_url': 'udp://host:8080'}
+        settings = {
+            **kinto.core.DEFAULT_SETTINGS,
+            'statsd_url': 'udp://host:8080',
+            'multiauth.policies': 'basicauth',
+        }
         self.config = Configurator(settings=settings)
         self.config.registry.storage = {}
         self.config.registry.cache = {}
@@ -434,7 +438,8 @@ class PluginsTest(unittest.TestCase):
         config = Configurator(settings={**kinto.core.DEFAULT_SETTINGS})
         config.add_settings({
             'permission_backend': 'kinto.core.permission.memory',
-            'includes': 'tests.core.testplugin'
+            'includes': 'tests.core.testplugin',
+            'multiauth.policies': 'basicauth',
         })
         kinto.core.initialize(config, '0.0.1', 'name')
         return webtest.TestApp(config.make_wsgi_app())

--- a/tests/functional.ini
+++ b/tests/functional.ini
@@ -26,13 +26,16 @@ kinto.permission_url = postgres://postgres:postgres@localhost/testdb
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
 #
 kinto.userid_hmac_secret = b6626ff6d28b02367127d80e2e9b596034af6c49c23eb02995dc8a76049f7b65
-multiauth.policies = basicauth
+multiauth.policies = account
+multiauth.policy.account.use = kinto.plugins.accounts.AccountsPolicy
+kinto.account_create_principals = system.Everyone
 
 #
 # Plugins
 #
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.admin
+                 kinto.plugins.accounts
                  kinto.plugins.flush
 
 #

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -35,6 +35,17 @@ class FunctionalTest(unittest.TestCase):
         self.session = requests.Session()
         self.session.auth = DEFAULT_AUTH
 
+    def setUp(self):
+        # Create accounts used in the different tests.
+        requests.post(urljoin(self.server_url, '/accounts'),
+                      json={"data": {"id": "user", "password": "p4ssw0rd"}})
+        requests.post(urljoin(self.server_url, '/accounts'),
+                      json={"data": {"id": "bob", "password": "s3cr3t"}})
+        requests.post(urljoin(self.server_url, '/accounts'),
+                      json={"data": {"id": "alice", "password": "wh1sp3r"}})
+        requests.post(urljoin(self.server_url, '/accounts'),
+                      json={"data": {"id": "mary", "password": "s4f3"}})
+
     def tearDown(self):
         # Delete all the created objects
         flush_url = urljoin(self.server_url, '/__flush__')
@@ -170,7 +181,7 @@ class FunctionalTest(unittest.TestCase):
                       collection['permissions']['record:create'])
 
         # Create a new tasks for Alice
-        alice_auth = ('token', 'alice-secret-%s' % uuid.uuid4())
+        alice_auth = ('alice', 'wh1sp3r')
         alice_task = build_task()
         resp = self.session.post(
             collection_url,
@@ -181,7 +192,7 @@ class FunctionalTest(unittest.TestCase):
         self.assertIn('write', collection['permissions'])
         alice_task_id = collection['data']['id']
 
-        bob_auth = ('token', 'bob-secret-%s' % uuid.uuid4())
+        bob_auth = ('bob', 's3cr3t')
 
         # Bob has no task yet.
         resp = self.session.get(collection_url, auth=bob_auth)
@@ -223,7 +234,7 @@ class FunctionalTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         # Get mary's userid
-        mary_auth = ('token', 'mary-secret-%s' % uuid.uuid4())
+        mary_auth = ('mary', 's4f3')
         resp = self.session.get('{}/'.format(self.server_url), auth=mary_auth)
         self.assertEqual(resp.status_code, 200)
         hello = resp.json()

--- a/tests/support.py
+++ b/tests/support.py
@@ -25,7 +25,10 @@ class BaseWebTest(testing.BaseWebTest):
 
     @classmethod
     def get_app_settings(cls, extras=None):
-        settings = {**DEFAULT_SETTINGS}
+        settings = {
+            **DEFAULT_SETTINGS,
+            'multiauth.policies': 'basicauth',
+        }
         if extras is not None:
             settings.update(extras)
         settings = super().get_app_settings(extras=settings)

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -92,7 +92,7 @@ multiauth.policies = account
 # Set `kinto.includes` to `kinto.plugins.accounts`
 # Enable authenticated policy.
 # Set `multiauth.policies` to `account`
-multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+multiauth.policy.account.use = kinto.plugins.accounts.AccountsPolicy
 # Allow anyone to create accounts.
 kinto.account_create_principals = system.Everyone
 # Set user 'account:admin' as the administrator.

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -99,15 +99,6 @@ kinto.account_create_principals = system.Everyone
 kinto.account_write_principals = account:admin
 # Allow administrators to create buckets
 kinto.bucket_create_principals = account:admin
-#
-# Kinto-portier authentication
-# https://github.com/Kinto/kinto-portier
-# Set `multiauth.policies` to `portier`
-# multiauth.policy.portier.use = kinto_portier.authentication.PortierOAuthAuthenticationPolicy
-# kinto.portier.broker_url = https://broker.portier.io
-# kinto.portier.webapp.authorized_domains = *.github.io
-# kinto.portier.cache_ttl_seconds = 300
-# kinto.portier.state.ttl_seconds = 3600
 
 # Notifications
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#notifications

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -32,8 +32,8 @@ use = egg:kinto
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#plugins
 # https://github.com/uralbash/awesome-pyramid
 kinto.includes = kinto.plugins.default_bucket
-#                kinto.plugins.admin
-#                kinto.plugins.accounts
+                 kinto.plugins.admin
+                 kinto.plugins.accounts
 #                kinto.plugins.history
 #                kinto.plugins.quotas
 
@@ -82,7 +82,7 @@ kinto.permission_url = permission_url
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
 #
 kinto.userid_hmac_secret = secret
-multiauth.policies = basicauth
+multiauth.policies = account
 # Any pyramid multiauth setting can be specified for custom authentication
 # https://github.com/uralbash/awesome-pyramid#authentication
 #
@@ -92,12 +92,13 @@ multiauth.policies = basicauth
 # Set `kinto.includes` to `kinto.plugins.accounts`
 # Enable authenticated policy.
 # Set `multiauth.policies` to `account`
-# multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
 # Allow anyone to create accounts.
-# kinto.account_create_principals = system.Everyone
+kinto.account_create_principals = system.Everyone
 # Set user 'account:admin' as the administrator.
-# kinto.account_write_principals = account:admin
-# kinto.account_read_principals = account:admin
+kinto.account_write_principals = account:admin
+# Allow administrators to create buckets
+kinto.bucket_create_principals = account:admin
 #
 # Kinto-portier authentication
 # https://github.com/Kinto/kinto-portier


### PR DESCRIPTION
Alright, let's do this.

Ref #1733 #1494 

The `basicauth` authentication policy is one the most confusing feature of Kinto. And it's used by default. 
Let's switch everything to `accounts` by default. 

* [x] Remove default value for policies
* [x] Rewrite tutorials
* [ ] Remove basicauth for tests (use specific *always true* policy)
* [x] Rewrite functional tests
* [x] Get green tests