### PR TITLE
Fix DeprecationWarning for unrecognized backslash escapes

### DIFF
--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -992,8 +992,8 @@ class UserResource:
                 )
                 continue
 
-            allKeywords = '|'.join([i.name.lower() for i in COMPARISON])
-            m = re.match(r'^('+allKeywords+')_([\w\.]+)$', param)
+            all_keywords = '|'.join([i.name.lower() for i in COMPARISON])
+            m = re.match(r'^(' + all_keywords + r')_([\w\.]+)$', param)
             if m:
                 keyword, field = m.groups()
                 operator = getattr(COMPARISON, keyword.upper())

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -300,7 +300,7 @@ class JsonPatchOperationSchema(colander.MappingSchema):
         return colander.OneOf(op_values)
 
     def path_validator():
-        return colander.Regex('(/\w*)+')
+        return colander.Regex('(/\\w*)+')
 
     op = colander.SchemaNode(colander.String(), validator=op_validator())
     path = colander.SchemaNode(colander.String(), validator=path_validator())

--- a/kinto/core/schema.py
+++ b/kinto/core/schema.py
@@ -107,7 +107,7 @@ class HeaderQuotedInteger(HeaderField):
 
     schema_type = colander.String
     error_message = 'The value should be integer between double quotes.'
-    validator = colander.Regex('^"([0-9]+?)"$|\*', msg=error_message)
+    validator = colander.Regex('^"([0-9]+?)"$|\\*', msg=error_message)
 
     def deserialize(self, cstruct=colander.null):
         param = super(HeaderQuotedInteger, self).deserialize(cstruct)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-memcached==1.59
 raven==6.9.0
 repoze.lru==0.7
 requests==2.19.1
-simplejson==3.16.1
+simplejson==3.16.0
 six==1.11.0
 SQLAlchemy==1.2.11
 statsd==3.3.0


### PR DESCRIPTION
This became a warning as of Python 3.6 -- see
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior.
