### PR TITLE
Pass "command" as part of bootstrap

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,18 @@ Changelog
 This document describes changes between each past release.
 
 
-10.0.1 (unreleased)
+10.1.0 (unreleased)
 -------------------
 
 **Bug fixes**
+
 - Deleting a collection doesn't delete access_control_entrries for its children (fixes #1647)
+
+**New features**
+
+- The registry now has a "command" setting during one-off commands
+  such as ``kinto migrate``. This can be useful for plugins that want
+  to behave differently during a migration, for instance. (#1762)
 
 
 10.0.0 (2018-08-16)

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -41,9 +41,9 @@ DEFAULT_SETTINGS = {
 
 def main(global_config, config=None, **settings):
     if not config:
-        config = Configurator(settings=global_config, root_factory=RouteFactory)
+        config = Configurator(settings=settings, root_factory=RouteFactory)
 
-    config.add_settings(settings)
+    config.registry.command = global_config and global_config.get('command', None)
 
     # Force project name, since it determines settings prefix.
     config.add_settings({'kinto.project_name': 'kinto'})

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -41,7 +41,9 @@ DEFAULT_SETTINGS = {
 
 def main(global_config, config=None, **settings):
     if not config:
-        config = Configurator(settings=settings, root_factory=RouteFactory)
+        config = Configurator(settings=global_config, root_factory=RouteFactory)
+
+    config.add_settings(settings)
 
     # Force project name, since it determines settings prefix.
     config.add_settings({'kinto.project_name': 'kinto'})

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -181,24 +181,24 @@ def main(args=None):
 
     elif which_command == 'migrate':
         dry_run = parsed_args['dry_run']
-        env = bootstrap(config_file)
+        env = bootstrap(config_file, options={'command': 'migrate'})
         scripts.migrate(env, dry_run=dry_run)
 
     elif which_command == 'delete-collection':
-        env = bootstrap(config_file)
+        env = bootstrap(config_file, options={'command': 'delete-collection'})
         return scripts.delete_collection(env,
                                          parsed_args['bucket'],
                                          parsed_args['collection'])
 
     elif which_command == 'rebuild-quotas':
         dry_run = parsed_args['dry_run']
-        env = bootstrap(config_file)
+        env = bootstrap(config_file, options={'command': 'rebuild-quotas'})
         return scripts.rebuild_quotas(env, dry_run=dry_run)
 
     elif which_command == 'create-user':
         username = parsed_args['username']
         password = parsed_args['password']
-        env = bootstrap(config_file)
+        env = bootstrap(config_file, options={'command': 'create-user'})
         return create_user(env, username=username, password=password)
 
     elif which_command == 'start':

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ ENTRY_POINTS = {
 
 
 setup(name='kinto',
-      version='10.0.1.dev0',
+      version='10.1.0.dev0',
       description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
       long_description='{}\n\n{}\n\n{}'.format(README, CHANGELOG, CONTRIBUTORS),
       license='Apache License (2.0)',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,17 @@
+import mock
+import unittest
+
+from kinto import main
+from .support import BaseWebTest
+
+class TestMain(BaseWebTest, unittest.TestCase):
+
+    def test_init_sets_command_on_registry(self):
+        app = main({'command': 'migrate'}, None, **self.get_app_settings())
+
+        self.assertEqual(app.registry.command, 'migrate')
+
+    def test_init_with_no_global_config_doesnt_crash(self):
+        app = main(None, None, **self.get_app_settings())
+
+        self.assertEqual(app.registry.command, None)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,10 @@
-import mock
 import unittest
 
 from kinto import main
 from .support import BaseWebTest
 
-class TestMain(BaseWebTest, unittest.TestCase):
 
+class TestMain(BaseWebTest, unittest.TestCase):
     def test_init_sets_command_on_registry(self):
         app = main({'command': 'migrate'}, None, **self.get_app_settings())
 


### PR DESCRIPTION
This requires storing global_config as part of the settings, but we
may as well do that too.

This lets other parts of the application respond differently during a
migrate command than other commands.

This is one path to fixing https://github.com/Kinto/kinto-changes/issues/43.

- (n/a) Add documentation.
- (n/a?) Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
