### PR TITLE
Fix for adding extra OpenId providers (ref #1509)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This document describes changes between each past release.
 10.1.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix for adding extra OpenId providers (fixes #1509)
 
 
 10.1.0 (2018-09-17)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,6 @@ This document describes changes between each past release.
 
 - Fix for adding extra OpenId providers (fixes #1509)
 
-
 10.1.0 (2018-09-17)
 -------------------
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -86,4 +86,5 @@ Contributors
 * Vitor Falcao <vitor.falcaor@gmail.com>
 * Wil Clouser <wclouser@mozilla.com>
 * Yann Klis <yann.klis@gmail.com>
+* Jeff Schobelock <jswhatnot15@gmail.com>
 

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -1,4 +1,3 @@
-import re
 
 import requests
 from pyramid import authentication as base_auth
@@ -96,6 +95,7 @@ def includeme(config):
     if len(openid_policies) == 0:
         # Do not add the capability if no policy is configured.
         return
+    
     providers_infos = []
     for name in openid_policies:
         issuer = settings['multiauth.policy.%s.issuer' % name]

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -95,7 +95,7 @@ def includeme(config):
     if len(openid_policies) == 0:
         # Do not add the capability if no policy is configured.
         return
-    
+
     providers_infos = []
     for name in openid_policies:
         issuer = settings['multiauth.policy.%s.issuer' % name]

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -91,12 +91,11 @@ def includeme(config):
     for policy in aslist(settings['multiauth.policies']):
         v = settings.get('multiauth.policy.%s.use' % policy, '')
         if v.endswith('OpenIDConnectPolicy'):
-            openid_policies.append(v)
+            openid_policies.append(policy)
 
     if len(openid_policies) == 0:
         # Do not add the capability if no policy is configured.
         return
-
     providers_infos = []
     for name in openid_policies:
         issuer = settings['multiauth.policy.%s.issuer' % name]

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -2,6 +2,7 @@ import re
 
 import requests
 from pyramid import authentication as base_auth
+from pyramid.settings import aslist
 from pyramid.interfaces import IAuthenticationPolicy
 from zope.interface import implementer
 
@@ -87,7 +88,7 @@ def includeme(config):
     settings = config.get_settings()
 
     openid_policies = []
-    for policy in settings['multiauth.policies'].split(" "):
+    for policy in aslist(settings['multiauth.policies']):
         v = settings.get('multiauth.policy.%s.use' % policy, '')
         if v.endswith('OpenIDConnectPolicy'):
             openid_policies.append(v)

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -87,11 +87,10 @@ def includeme(config):
     settings = config.get_settings()
 
     openid_policies = []
-    for k, v in settings.items():
-        m = re.match('multiauth\.policy\.(.*)\.use', k)
-        if m:
-            if v.endswith('OpenIDConnectPolicy'):
-                openid_policies.append(m.group(1))
+    for policy in settings['multiauth.policies'].split(" "):
+        v = settings.get('multiauth.policy.%s.use' % policy, '')
+        if v.endswith('OpenIDConnectPolicy'):
+            openid_policies.append(v)
 
     if len(openid_policies) == 0:
         # Do not add the capability if no policy is configured.

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -110,6 +110,7 @@ class HelloViewTest(OpenIDWebTest):
         auth = resp.json['securityDefinitions']['auth0']['authorizationUrl']
         assert auth == 'https://auth.mozilla.auth0.com/authorize'
 
+
 class PolicyTest(unittest.TestCase):
     def setUp(self):
         mocked = mock.patch('kinto.plugins.openid.requests.get')


### PR DESCRIPTION
Filters OpenId policies in settings on multiauth.policies

Fixes #1509
