### PR TITLE
Use timestamp to communicate collection_timestamp of the parent

### DIFF
--- a/docs/core/notifications.rst
+++ b/docs/core/notifications.rst
@@ -110,7 +110,8 @@ Payload
 The :class:`kinto.core.events.ResourceChanged` and :class:`kinto.core.events.AfterResourceChanged`
 events contain a ``payload`` attribute with the following information:
 
-- **timestamp**: the time of the event
+- **timestamp**: the collection timestamp of the ``(parent_id, resource_name)`` pair for
+  which this event was sent
 - **action**: what happened. 'create', 'update' or 'delete'
 - **uri**: the uri of the impacted resource
 - **user_id**: the authenticated user id

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -738,7 +738,7 @@ class UserResource:
 
         parent_id = self.get_parent_id(self.request)
         self.request.notify_resource_event(parent_id=parent_id,
-                                           timestamp=self.timestamp,
+                                           timestamp=self.model.timestamp(),
                                            data=result,
                                            action=action,
                                            old=old)


### PR DESCRIPTION
Don't re-use old self.timestamp when notifying of event. Instead,
re-compute it fresh.

Fixes #1769.

- [x] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
