### PR TITLE
Kinto-issue1780:Remove assertEquals usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Changelog
 
 This document describes changes between each past release.
 
+10.1.2 (2018-09-28)
+-------------------
+
+**Bug fixes**
+
+- Deprecate assertEquals and use assertEqual (fixes #1780)
+
 
 10.1.2 (unreleased)
 -------------------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -5,6 +5,7 @@ Contributors
 * Adam Chainz <adam@adamj.eu>
 * Aditya Bhasin <conlini@gmail.com>
 * Aiman Parvaiz <aimanparvaiz@gmail.com>
+* Ajey B. Kulkarni <bkajey@gmail.com>
 * Anh <anh.trinhtrung@gmail.com>
 * Alexander Ryabkov <alexryabkov@gmail.com>
 * Alexis Metaireau <alexis@mozilla.com>

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -89,7 +89,7 @@ class CacheTest:
         stored = 'toto'
         self.cache.set('foobar', stored, 42)
         retrieved = self.cache.get('foobar')
-        self.assertEquals(retrieved, stored)
+        self.assertEqual(retrieved, stored)
 
     def test_values_remains_python_dict(self):
         def setget(k, v):

--- a/kinto/core/permission/testing.py
+++ b/kinto/core/permission/testing.py
@@ -92,7 +92,7 @@ class PermissionTest:
         principal = 'bar'
         self.permission.add_user_principal(user_id, principal)
         retrieved = self.permission.get_user_principals(user_id)
-        self.assertEquals(retrieved, {principal})
+        self.assertEqual(retrieved, {principal})
 
     def test_add_twice_a_principal_to_a_user_add_it_once(self):
         user_id = 'foo'
@@ -100,7 +100,7 @@ class PermissionTest:
         self.permission.add_user_principal(user_id, principal)
         self.permission.add_user_principal(user_id, principal)
         retrieved = self.permission.get_user_principals(user_id)
-        self.assertEquals(retrieved, {principal})
+        self.assertEqual(retrieved, {principal})
 
     def test_can_remove_a_principal_for_an_unknown_user(self):
         self.permission.remove_user_principal('foo', 'bar')
@@ -113,7 +113,7 @@ class PermissionTest:
         self.permission.add_user_principal(user_id, principal2)
         self.permission.remove_user_principal(user_id, principal)
         retrieved = self.permission.get_user_principals(user_id)
-        self.assertEquals(retrieved, {principal2})
+        self.assertEqual(retrieved, {principal2})
 
     def test_can_remove_a_unexisting_principal_to_a_user(self):
         user_id = 'foo'
@@ -123,7 +123,7 @@ class PermissionTest:
         self.permission.remove_user_principal(user_id, principal)
         self.permission.remove_user_principal(user_id, principal2)
         retrieved = self.permission.get_user_principals(user_id)
-        self.assertEquals(retrieved, set())
+        self.assertEqual(retrieved, set())
 
     def test_can_remove_principal_from_every_users(self):
         user_id1 = 'foo1'
@@ -137,16 +137,16 @@ class PermissionTest:
         self.permission.remove_principal('unknown')
 
         retrieved = self.permission.get_user_principals(user_id1)
-        self.assertEquals(retrieved, set())
+        self.assertEqual(retrieved, set())
         retrieved = self.permission.get_user_principals(user_id2)
-        self.assertEquals(retrieved, {principal2})
+        self.assertEqual(retrieved, {principal2})
 
     def test_authenticated_is_returned_for_everybody(self):
         user_id = 'foo'
         principal = 'bar'
         self.permission.add_user_principal('system.Authenticated', principal)
         retrieved = self.permission.get_user_principals(user_id)
-        self.assertEquals(retrieved, {principal})
+        self.assertEqual(retrieved, {principal})
 
     #
     # get_object_permission_principals()
@@ -159,7 +159,7 @@ class PermissionTest:
         self.permission.add_principal_to_ace(object_id, permission, principal)
         retrieved = self.permission.get_object_permission_principals(
             object_id, permission)
-        self.assertEquals(retrieved, {principal})
+        self.assertEqual(retrieved, {principal})
 
     def test_add_twice_a_principal_to_an_object_permission_add_it_once(self):
         object_id = 'foo'
@@ -169,7 +169,7 @@ class PermissionTest:
         self.permission.add_principal_to_ace(object_id, permission, principal)
         retrieved = self.permission.get_object_permission_principals(
             object_id, permission)
-        self.assertEquals(retrieved, {principal})
+        self.assertEqual(retrieved, {principal})
 
     def test_can_remove_a_principal_from_an_object_permission(self):
         object_id = 'foo'
@@ -182,7 +182,7 @@ class PermissionTest:
                                                   principal)
         retrieved = self.permission.get_object_permission_principals(
             object_id, permission)
-        self.assertEquals(retrieved, {principal2})
+        self.assertEqual(retrieved, {principal2})
 
     def test_principals_is_empty_if_no_permission(self):
         object_id = 'foo'
@@ -193,7 +193,7 @@ class PermissionTest:
                                                   principal)
         retrieved = self.permission.get_object_permission_principals(
             object_id, permission)
-        self.assertEquals(retrieved, set())
+        self.assertEqual(retrieved, set())
 
     def test_can_remove_an_unexisting_principal_to_an_object_permission(self):
         object_id = 'foo'
@@ -205,7 +205,7 @@ class PermissionTest:
                                                   principal)
         retrieved = self.permission.get_object_permission_principals(
             object_id, permission)
-        self.assertEquals(retrieved, {principal2})
+        self.assertEqual(retrieved, {principal2})
 
     #
     # check_permission()
@@ -266,11 +266,11 @@ class PermissionTest:
         self.permission.add_principal_to_ace(object_id, 'write', user_id)
         principals = self.permission.get_authorized_principals(
             [(object_id, 'write'), (object_id, 'read')])
-        self.assertEquals(principals, {user_id})
+        self.assertEqual(principals, {user_id})
 
     def test_get_authorized_principals_handles_empty_set(self):
         principals = self.permission.get_authorized_principals([])
-        self.assertEquals(principals, set())
+        self.assertEqual(principals, set())
 
     #
     # get_accessible_objects()
@@ -284,14 +284,14 @@ class PermissionTest:
         self.permission.add_principal_to_ace('id3', 'write', 'user2')
         per_object_ids = self.permission.get_accessible_objects(
             ['user1', 'group'])
-        self.assertEquals(sorted(per_object_ids.keys()), ['id1', 'id2'])
-        self.assertEquals(per_object_ids['id1'],
-                          set(['write', 'record:create']))
-        self.assertEquals(per_object_ids['id2'], set(['read']))
+        self.assertEqual(sorted(per_object_ids.keys()), ['id1', 'id2'])
+        self.assertEqual(per_object_ids['id1'],
+                         set(['write', 'record:create']))
+        self.assertEqual(per_object_ids['id2'], set(['read']))
 
     def test_accessible_objects_supports_empty_list(self):
         per_object_ids = self.permission.get_accessible_objects(['user1', 'group'], [])
-        self.assertEquals(per_object_ids, {})
+        self.assertEqual(per_object_ids, {})
 
     def test_accessible_objects_from_permission(self):
         self.permission.add_principal_to_ace('id1', 'write', 'user1')
@@ -304,7 +304,7 @@ class PermissionTest:
         per_object_ids = self.permission.get_accessible_objects(
             ['user1', 'group'],
             [('*', 'read')])
-        self.assertEquals(sorted(per_object_ids.keys()), ['id1', 'id2'])
+        self.assertEqual(sorted(per_object_ids.keys()), ['id1', 'id2'])
 
     def test_accessible_objects_with_pattern(self):
         self.permission.add_principal_to_ace('/url1/id', 'write', 'user1')
@@ -312,7 +312,7 @@ class PermissionTest:
         per_object_ids = self.permission.get_accessible_objects(
             ['user1'],
             [('*url1*', 'write')])
-        self.assertEquals(sorted(per_object_ids.keys()), ['/url1/id'])
+        self.assertEqual(sorted(per_object_ids.keys()), ['/url1/id'])
 
     def test_accessible_objects_with_pattern_matches_whole_id(self):
         self.permission.add_principal_to_ace('/url1/id', 'write', 'user1')
@@ -322,7 +322,7 @@ class PermissionTest:
             ['user1'],
             [('/url1/*', 'write')],
             with_children=False)
-        self.assertEquals(sorted(per_object_ids.keys()), ['/url1/id'])
+        self.assertEqual(sorted(per_object_ids.keys()), ['/url1/id'])
 
     def test_accessible_objects_several_bound_permissions(self):
         self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
@@ -332,8 +332,8 @@ class PermissionTest:
             ['user1'],
             [('/url/a/id/*', 'read'),
              ('/url/a/id/*', 'write')])
-        self.assertEquals(sorted(per_object_ids.keys()),
-                          ['/url/a/id/1', '/url/a/id/2'])
+        self.assertEqual(sorted(per_object_ids.keys()),
+                         ['/url/a/id/1', '/url/a/id/2'])
 
     def test_accessible_objects_without_match(self):
         self.permission.add_principal_to_ace('/url/a', 'write', 'user1')
@@ -347,8 +347,8 @@ class PermissionTest:
              ('/url/a', 'read'),
              ('/url/a/id/*', 'write'),
              ('/url/a/id/*', 'read')])
-        self.assertEquals(sorted(per_object_ids.keys()),
-                          ['/url/a', '/url/a/id/1', '/url/a/id/2'])
+        self.assertEqual(sorted(per_object_ids.keys()),
+                         ['/url/a', '/url/a/id/1', '/url/a/id/2'])
 
     #
     # get_object_permissions()

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -161,15 +161,15 @@ class BaseTestStorage:
     def test_create_works_as_expected(self):
         stored = self.create_record()
         retrieved = self.storage.get(object_id=stored['id'], **self.storage_kw)
-        self.assertEquals(retrieved, stored)
+        self.assertEqual(retrieved, stored)
 
     def test_create_copies_the_record_before_modifying_it(self):
         self.create_record()
-        self.assertEquals(self.record.get('id'), None)
+        self.assertEqual(self.record.get('id'), None)
 
     def test_create_uses_the_resource_id_generator(self):
         record = self.create_record(id_generator=lambda: RECORD_ID)
-        self.assertEquals(record['id'], RECORD_ID)
+        self.assertEqual(record['id'], RECORD_ID)
 
     def test_create_supports_unicode_for_parent_and_id(self):
         unicode_id = 'Rémy'
@@ -214,7 +214,7 @@ class BaseTestStorage:
                                      **self.storage_kw)
         retrieved = self.storage.get(object_id=RECORD_ID,
                                      **self.storage_kw)
-        self.assertEquals(retrieved, record)
+        self.assertEqual(retrieved, record)
 
     def test_update_overwrites_record_id(self):
         stored = self.create_record()
@@ -223,7 +223,7 @@ class BaseTestStorage:
         self.storage.update(object_id=record_id, record=self.record,
                             **self.storage_kw)
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
-        self.assertEquals(retrieved[self.id_field], record_id)
+        self.assertEqual(retrieved[self.id_field], record_id)
 
     def test_update_generates_a_new_last_modified_field_if_not_present(self):
         stored = self.create_record()
@@ -266,7 +266,7 @@ class BaseTestStorage:
 
         records, count = self.storage.get_all(
             include_deleted=True, **self.storage_kw)
-        self.assertEquals(records[0][self.modified_field], last_modified)
+        self.assertEqual(records[0][self.modified_field], last_modified)
 
     def test_delete_raise_when_unknown(self):
         self.assertRaises(
@@ -284,8 +284,8 @@ class BaseTestStorage:
 
         records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
                                                       include_deleted=True)
-        self.assertEquals(len(records), 2)
-        self.assertEquals(total_records, 1)
+        self.assertEqual(len(records), 2)
+        self.assertEqual(total_records, 1)
 
     def test_get_all_does_proper_parent_id_pattern_matching(self):
         self.create_record(parent_id='abc', collection_id='c')
@@ -294,8 +294,8 @@ class BaseTestStorage:
 
         records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
                                                       include_deleted=True)
-        self.assertEquals(len(records), 1)
-        self.assertEquals(len(records), total_records)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(len(records), total_records)
 
     def test_get_all_parent_id_handles_collisions(self):
         abc1 = self.create_record(parent_id='abc1', collection_id='c',
@@ -304,11 +304,11 @@ class BaseTestStorage:
                                   record={'id': 'abc', 'secret_data': 'abc2'})
         records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
                                                       include_deleted=True)
-        self.assertEquals(len(records), 2)
-        self.assertEquals(len(records), total_records)
+        self.assertEqual(len(records), 2)
+        self.assertEqual(len(records), total_records)
         records.sort(key=lambda record: record['secret_data'])
-        self.assertEquals(records[0], abc1)
-        self.assertEquals(records[1], abc2)
+        self.assertEqual(records[0], abc1)
+        self.assertEqual(records[1], abc2)
 
     def test_get_all_return_all_values(self):
         for x in range(10):
@@ -317,8 +317,8 @@ class BaseTestStorage:
             self.create_record(record)
 
         records, total_records = self.storage.get_all(**self.storage_kw)
-        self.assertEquals(len(records), 10)
-        self.assertEquals(len(records), total_records)
+        self.assertEqual(len(records), 10)
+        self.assertEqual(len(records), total_records)
 
     def test_get_all_handle_limit(self):
         for x in range(10):
@@ -902,11 +902,11 @@ class TimestampsTest:
 
         # Check that the record was assigned the specified timestamp.
         retrieved = self.storage.get(object_id=RECORD_ID, **self.storage_kw)
-        self.assertEquals(retrieved[self.modified_field], last_modified)
+        self.assertEqual(retrieved[self.modified_field], last_modified)
 
         # Collection timestamp is now the same as its only record.
         collection_ts = self.storage.collection_timestamp(**self.storage_kw)
-        self.assertEquals(collection_ts, last_modified)
+        self.assertEqual(collection_ts, last_modified)
 
     def test_create_ignores_specified_last_modified_if_in_the_past(self):
         # Create a first record, and get the timestamp.
@@ -922,13 +922,12 @@ class TimestampsTest:
         # Check that record timestamp is the one specified.
         retrieved = self.storage.get(object_id=RECORD_ID, **self.storage_kw)
         self.assertLess(retrieved[self.modified_field], timestamp_before)
-        self.assertEquals(retrieved[self.modified_field],
-                          record[self.modified_field])
+        self.assertEqual(retrieved[self.modified_field], record[self.modified_field])
 
         # Check that collection timestamp was not changed. Someone importing
         # records in the past must assume the synchronization consequences.
         timestamp = self.storage.collection_timestamp(**self.storage_kw)
-        self.assertEquals(timestamp, timestamp_before)
+        self.assertEqual(timestamp, timestamp_before)
 
     def test_create_ignores_specified_last_modified_if_equal(self):
         # Create a first record, and get the timestamp.
@@ -970,7 +969,7 @@ class TimestampsTest:
         # Check that collection timestamp took the one specified (in future).
         timestamp = self.storage.collection_timestamp(**self.storage_kw)
         self.assertGreater(timestamp, timestamp_before)
-        self.assertEquals(timestamp, retrieved[self.modified_field])
+        self.assertEqual(timestamp, retrieved[self.modified_field])
 
     def test_update_ignores_specified_last_modified_if_in_the_past(self):
         stored = self.create_record()
@@ -985,13 +984,13 @@ class TimestampsTest:
         # Check that record timestamp is the one specified.
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
         self.assertLess(retrieved[self.modified_field], timestamp_before)
-        self.assertEquals(retrieved[self.modified_field],
-                          stored[self.modified_field])
+        self.assertEqual(retrieved[self.modified_field],
+                         stored[self.modified_field])
 
         # Check that collection timestamp was not changed. Someone importing
         # records in the past must assume the synchronization consequences.
         timestamp = self.storage.collection_timestamp(**self.storage_kw)
-        self.assertEquals(timestamp, timestamp_before)
+        self.assertEqual(timestamp, timestamp_before)
 
     def test_update_ignores_specified_last_modified_if_equal(self):
         stored = self.create_record()

--- a/tests/core/resource/test_base.py
+++ b/tests/core/resource/test_base.py
@@ -13,7 +13,7 @@ class ResourceTest(BaseTest):
     def test_get_parent_id_default_to_prefixed_userid(self):
         request = self.get_request()
         parent_id = self.resource.get_parent_id(request)
-        self.assertEquals(parent_id, 'basicauth:bob')
+        self.assertEqual(parent_id, 'basicauth:bob')
 
     def test_raise_if_backend_fails_to_obtain_timestamp(self):
         request = self.get_request()
@@ -50,7 +50,7 @@ class ShareableResourceTest(BaseTest):
     def test_get_parent_id_is_empty(self):
         request = self.get_request()
         parent_id = self.resource.get_parent_id(request)
-        self.assertEquals(parent_id, '')
+        self.assertEqual(parent_id, '')
 
 
 class NewResource(UserResource):
@@ -65,8 +65,8 @@ class ParentIdOverrideResourceTest(BaseTest):
         request = self.get_request()
 
         parent_id = self.resource.get_parent_id(request)
-        self.assertEquals(parent_id, 'overrided')
-        self.assertEquals(self.resource.model.parent_id, 'overrided')
+        self.assertEqual(parent_id, 'overrided')
+        self.assertEqual(self.resource.model.parent_id, 'overrided')
 
 
 class CustomModelResource(UserResource):
@@ -79,4 +79,4 @@ class CustomModelResource(UserResource):
 class CustomModelResourceTets(unittest.TestCase):
     def test_custom_model_is_not_overriden(self):
         c = CustomModelResource(request=mock.MagicMock())
-        self.assertEquals(c.model.name, mock.sentinel.model)
+        self.assertEqual(c.model.name, mock.sentinel.model)

--- a/tests/core/resource/test_model.py
+++ b/tests/core/resource/test_model.py
@@ -79,7 +79,7 @@ class IsolatedModelsTest(BaseTest):
     def test_list_is_filtered_by_user(self):
         resp = self.resource.collection_get()
         records = resp['data']
-        self.assertEquals(len(records), 0)
+        self.assertEqual(len(records), 0)
 
     def test_update_record_of_another_user_will_create_it(self):
         self.resource.request.validated['body'] = {'data': {'some': 'record'}}

--- a/tests/core/resource/test_pagination.py
+++ b/tests/core/resource/test_pagination.py
@@ -67,7 +67,7 @@ class PaginationTest(BasePaginationTest):
         self.resource.collection_get()
         headers = self.last_response.headers
         count = headers['Total-Records']
-        self.assertEquals(int(count), 20)
+        self.assertEqual(int(count), 20)
 
     def test_return_next_page_url_is_given_in_headers(self):
         self.validated['querystring'] = {'_limit': 10}
@@ -237,7 +237,7 @@ class PaginatedDeleteTest(BasePaginationTest):
         self.resource.collection_delete()
         headers = self.last_response.headers
         count = headers['Total-Records']
-        self.assertEquals(int(count), 20)
+        self.assertEqual(int(count), 20)
 
     def test_paginated_delete_second_to_last_gets_next_header(self):
         self.resource.collection_get()

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -238,20 +238,20 @@ class PatchTest(BaseTest):
         self.assertNotEquals(after, before)
 
     def test_patch_record_returns_updated_fields(self):
-        self.assertEquals(self.stored['id'], self.result['id'])
-        self.assertEquals(self.result['position'], 10)
+        self.assertEqual(self.stored['id'], self.result['id'])
+        self.assertEqual(self.result['position'], 10)
 
     def test_record_timestamp_is_not_updated_if_none_for_missing_field(self):
         self.validated['body'] = {'data': {'polo': None}}
         result = self.resource.patch()['data']
-        self.assertEquals(self.result['last_modified'],
-                          result['last_modified'])
+        self.assertEqual(self.result['last_modified'],
+                         result['last_modified'])
 
     def test_record_timestamp_is_not_updated_if_no_field_changed(self):
         self.validated['body'] = {'data': {'position': 10}}
         result = self.resource.patch()['data']
-        self.assertEquals(self.result['last_modified'],
-                          result['last_modified'])
+        self.assertEqual(self.result['last_modified'],
+                         result['last_modified'])
 
     def test_collection_timestamp_is_not_updated_if_no_field_changed(self):
         self.validated['body'] = {'data': {'position': 10}}
@@ -261,15 +261,14 @@ class PatchTest(BaseTest):
         self.resource.request.validated = self.validated
         self.resource.collection_get()['data']
         last_modified = int(self.last_response.headers['ETag'][1:-1])
-        self.assertEquals(self.result['last_modified'], last_modified)
+        self.assertEqual(self.result['last_modified'], last_modified)
 
     def test_timestamp_is_not_updated_if_no_change_after_preprocessed(self):
         with mock.patch.object(self.resource, 'process_record') as mocked:
             mocked.return_value = self.result
             self.validated['body'] = {'data': {'position': 20}}
             result = self.resource.patch()['data']
-            self.assertEquals(self.result['last_modified'],
-                              result['last_modified'])
+            self.assertEqual(self.result['last_modified'], result['last_modified'])
 
     def test_returns_changed_fields_among_provided_if_behaviour_is_diff(self):
         self.validated['body'] = {'data': {'unread': True, 'position': 15}}

--- a/tests/core/resource/test_schema.py
+++ b/tests/core/resource/test_schema.py
@@ -32,7 +32,7 @@ class ResourceSchemaTest(unittest.TestCase):
         schema_instance = PreserveSchema()
         deserialized = schema_instance.deserialize({'foo': 'bar'})
         self.assertIn('foo', deserialized)
-        self.assertEquals(deserialized['foo'], 'bar')
+        self.assertEqual(deserialized['foo'], 'bar')
 
     def test_ignore_unknwon_fields_when_specified(self):
         class PreserveSchema(schema.ResourceSchema):
@@ -117,7 +117,7 @@ class HeaderFieldSchemaTest(unittest.TestCase):
     def test_decode_unicode(self):
         value = '\xe7 is not a c'
         deserialized = self.schema.deserialize(value.encode('utf-8'))
-        self.assertEquals(deserialized, value)
+        self.assertEqual(deserialized, value)
 
     def test_bad_unicode_raises_invalid(self):
         value = b'utf8 \xe9'
@@ -129,7 +129,7 @@ class QueryFieldSchemaTest(unittest.TestCase):
     def test_deserialize_integer_between_quotes(self):
         self.schema = schema.QueryField(colander.Integer())
         deserialized = self.schema.deserialize("123")
-        self.assertEquals(deserialized, 123)
+        self.assertEqual(deserialized, 123)
 
 
 class FieldListSchemaTest(unittest.TestCase):
@@ -140,17 +140,17 @@ class FieldListSchemaTest(unittest.TestCase):
     def test_deserialize_as_list(self):
         value = 'foo,-bar,123'
         deserialized = self.schema.deserialize(value)
-        self.assertEquals(deserialized, ['foo', '-bar', '123'])
+        self.assertEqual(deserialized, ['foo', '-bar', '123'])
 
     def test_handle_drop(self):
         value = colander.null
         deserialized = self.schema.deserialize(value)
-        self.assertEquals(deserialized, colander.drop)
+        self.assertEqual(deserialized, colander.drop)
 
     def test_handle_empty(self):
         value = ''
         deserialized = self.schema.deserialize(value)
-        self.assertEquals(deserialized, [])
+        self.assertEqual(deserialized, [])
 
     def test_raises_invalid_if_not_string(self):
         value = 123
@@ -167,12 +167,12 @@ class HeaderQuotedIntegerSchemaTest(unittest.TestCase):
     def test_deserialize_as_integer(self):
         value = '"123"'
         deserialized = self.schema.deserialize(value)
-        self.assertEquals(deserialized, 123)
+        self.assertEqual(deserialized, 123)
 
     def test_deserialize_any(self):
         value = '*'
         deserialized = self.schema.deserialize(value)
-        self.assertEquals(deserialized, '*')
+        self.assertEqual(deserialized, '*')
 
     def test_unquoted_raises_invalid(self):
         value = '123'
@@ -208,14 +208,14 @@ class RecordSchemaTest(unittest.TestCase):
         bound = self.schema.bind(data=schema.ResourceSchema())
         value = {'data': {'foo': 'bar'}}
         deserialized = bound.deserialize(value)
-        self.assertEquals(deserialized, value)
+        self.assertEqual(deserialized, value)
 
     def test_binds_permissions(self):
         permissions = schema.PermissionsSchema(permissions=('sleep', ))
         bound = self.schema.bind(permissions=permissions)
         value = {'permissions': {'sleep': []}}
         deserialized = bound.deserialize(value)
-        self.assertEquals(deserialized, value)
+        self.assertEqual(deserialized, value)
 
     def test_allow_binding_perms_after_data(self):
         bound = self.schema.bind(data=schema.ResourceSchema())
@@ -223,7 +223,7 @@ class RecordSchemaTest(unittest.TestCase):
         bound = bound.bind(permissions=permissions)
         value = {'data': {'foo': 'bar'}, 'permissions': {'sleep': []}}
         deserialized = bound.deserialize(value)
-        self.assertEquals(deserialized, value)
+        self.assertEqual(deserialized, value)
 
     def test_doesnt_allow_permissions_unless_bound(self):
         bound = self.schema.bind(data=schema.ResourceSchema())
@@ -240,35 +240,35 @@ class RequestSchemaTest(unittest.TestCase):
         header = colander.MappingSchema(missing={'foo': 'bar'})
         bound = self.schema.bind(header=header)
         deserialized = bound.deserialize({})
-        self.assertEquals(deserialized['header'], {'foo': 'bar'})
+        self.assertEqual(deserialized['header'], {'foo': 'bar'})
 
     def test_querystring_supports_binding(self):
         querystring = colander.MappingSchema(missing={'foo': 'bar'})
         bound = self.schema.bind(querystring=querystring)
         deserialized = bound.deserialize({})
-        self.assertEquals(deserialized['querystring'], {'foo': 'bar'})
+        self.assertEqual(deserialized['querystring'], {'foo': 'bar'})
 
     def test_default_header_if_not_bound(self):
         bound = self.schema.bind()
-        self.assertEquals(type(bound['header']), schema.HeaderSchema)
+        self.assertEqual(type(bound['header']), schema.HeaderSchema)
 
     def test_default_querystring_if_not_bound(self):
         bound = self.schema.bind()
-        self.assertEquals(type(bound['querystring']), schema.QuerySchema)
+        self.assertEqual(type(bound['querystring']), schema.QuerySchema)
 
     def test_header_preserve_unknown_fields(self):
         value = {'header': {'foo': 'bar'}}
         deserialized = self.schema.bind().deserialize(value)
-        self.assertEquals(deserialized, value)
+        self.assertEqual(deserialized, value)
 
     def test_querystring_preserve_unknown_fields(self):
         value = {'querystring': {'foo': 'bar'}}
         deserialized = self.schema.bind().deserialize(value)
-        self.assertEquals(deserialized, value)
+        self.assertEqual(deserialized, value)
 
     def test_drops(self):
         deserialized = self.schema.bind().deserialize({})
-        self.assertEquals(deserialized, {})
+        self.assertEqual(deserialized, {})
 
 
 class PayloadRequestSchemaTest(unittest.TestCase):
@@ -280,7 +280,7 @@ class PayloadRequestSchemaTest(unittest.TestCase):
         body = colander.MappingSchema(missing={'foo': 'bar'})
         bound = self.schema.bind(body=body)
         deserialized = bound.deserialize({})
-        self.assertEquals(deserialized['body'], {'foo': 'bar'})
+        self.assertEqual(deserialized['body'], {'foo': 'bar'})
 
     def test_body_supports_binding_after_other_binds(self):
         querystring = colander.MappingSchema(missing={'foo': 'bar'})
@@ -288,8 +288,8 @@ class PayloadRequestSchemaTest(unittest.TestCase):
         body = colander.MappingSchema(missing={'foo': 'beer'})
         bound = bound.bind(body=body)
         deserialized = bound.deserialize({})
-        self.assertEquals(deserialized['querystring'], {'foo': 'bar'})
-        self.assertEquals(deserialized['body'], {'foo': 'beer'})
+        self.assertEqual(deserialized['querystring'], {'foo': 'bar'})
+        self.assertEqual(deserialized['body'], {'foo': 'beer'})
 
 
 class CollectionQuerySchemaTest(unittest.TestCase):
@@ -318,7 +318,7 @@ class CollectionQuerySchemaTest(unittest.TestCase):
     def test_decode_valid_querystring(self):
         self.maxDiff = None
         deserialized = self.schema.deserialize(self.querystring)
-        self.assertEquals(deserialized, {
+        self.assertEqual(deserialized, {
             '_limit': 2,
             '_sort': ['toto', 'tata'],
             '_token': 'abc',
@@ -400,15 +400,14 @@ class ResourceReponsesTest(unittest.TestCase):
         responses = self.handler.get_and_bind('record', 'get',
                                               record=self.record)
         ok_response = responses['200']
-        self.assertEquals(self.record['data'], ok_response['body']['data'])
+        self.assertEqual(self.record['data'], ok_response['body']['data'])
 
     def test_get_and_bind_assign_resource_schema_to_collections(self):
         responses = self.handler.get_and_bind('collection', 'get',
                                               record=self.record)
         ok_response = responses['200']
         # XXX: Data is repeated because it's a colander sequence type index
-        self.assertEquals(self.record['data'],
-                          ok_response['body']['data']['data'])
+        self.assertEqual(self.record['data'], ok_response['body']['data']['data'])
 
     def test_responses_doesnt_have_permissions_if_not_bound(self):
         responses = self.handler.get_and_bind('record', 'get',
@@ -437,5 +436,5 @@ class ShareableResourceReponsesTest(unittest.TestCase):
         responses = self.handler.get_and_bind('record', 'get',
                                               record=self.record)
         ok_response = responses['200']
-        self.assertEquals(self.record['permissions'],
-                          ok_response['body']['permissions'])
+        self.assertEqual(self.record['permissions'],
+                         ok_response['body']['permissions'])

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -480,7 +480,7 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
             "]")
         for message in messages:
             self.assertIn(message, resp.json['message'])
-        self.assertEquals(len("".join(messages)), len(resp.json['message']))
+        self.assertEqual(len("".join(messages)), len(resp.json['message']))
 
 
 class IgnoredFieldsTest(BaseWebTest, unittest.TestCase):

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -49,8 +49,8 @@ class ViewSetTest(unittest.TestCase):
 
     def test_arguments_are_merged_on_initialization(self):
         viewset = ViewSet(collection_path=mock.sentinel.collection_path)
-        self.assertEquals(viewset.collection_path,
-                          mock.sentinel.collection_path)
+        self.assertEqual(viewset.collection_path,
+                         mock.sentinel.collection_path)
 
     def test_default_arguments_are_copied_before_being_returned(self):
         original_arguments = {}
@@ -58,14 +58,14 @@ class ViewSetTest(unittest.TestCase):
             collection_get_arguments=original_arguments)
         viewset.responses = mock.MagicMock()
         arguments = viewset.collection_arguments(mock.MagicMock(), 'GET')
-        self.assertEquals(original_arguments, {})
+        self.assertEqual(original_arguments, {})
         self.assertNotEquals(original_arguments, arguments)
 
     def test_permission_private_is_set_by_default(self):
         viewset = ViewSet()
         viewset.responses = mock.MagicMock()
         args = viewset.collection_arguments(mock.MagicMock(), 'GET')
-        self.assertEquals(args['permission'], 'private')
+        self.assertEqual(args['permission'], 'private')
 
     def test_schema_is_added_when_method_matches(self):
         viewset = ViewSet()
@@ -247,24 +247,22 @@ class ViewSetTest(unittest.TestCase):
 
     def test_get_service_name_returns_the_viewset_name_if_defined(self):
         viewset = ViewSet(name='fakename')
-        self.assertEquals(
-            viewset.get_service_name('record', mock.MagicMock),
-            'fakename-record')
+        self.assertEqual(viewset.get_service_name('record', mock.MagicMock),
+                         'fakename-record')
 
     def test_get_service_name_returns_resource_att_if_not_callable(self):
         viewset = ViewSet()
         resource = mock.MagicMock()
         resource.name = 'fakename'
-        self.assertEquals(
-            viewset.get_service_name('record', resource),
-            'fakename-record')
+        self.assertEqual(viewset.get_service_name('record', resource),
+                         'fakename-record')
 
     def test_get_service_name_doesnt_use_callable_as_a_name(self):
         viewset = ViewSet()
         resource = mock.MagicMock()
         resource.name = lambda x: 'should not be called'
         resource.__name__ = "FakeName"
-        self.assertEquals(
+        self.assertEqual(
             viewset.get_service_name('record', resource),
             'fakename-record')
 
@@ -391,7 +389,7 @@ class TestViewsetBindedSchemas(unittest.TestCase):
         value = {'querystring': {'_sort': 'foo,-bar'}}
         deserialized = schema.deserialize(value)
         expected = {'querystring': {'_sort': ['foo', '-bar']}}
-        self.assertEquals(deserialized, expected)
+        self.assertEqual(deserialized, expected)
 
     def test_get_collection_deserialize_fields(self):
         arguments = self.viewset.collection_arguments(self.resource, 'GET')
@@ -399,7 +397,7 @@ class TestViewsetBindedSchemas(unittest.TestCase):
         value = {'querystring': {'_fields': 'foo,bar'}}
         deserialized = schema.deserialize(value)
         expected = {'querystring': {'_fields': ['foo', 'bar']}}
-        self.assertEquals(deserialized, expected)
+        self.assertEqual(deserialized, expected)
 
     def test_get_record_deserialize_fields(self):
         arguments = self.viewset.record_arguments(self.resource, 'GET')
@@ -407,7 +405,7 @@ class TestViewsetBindedSchemas(unittest.TestCase):
         value = {'querystring': {'_fields': 'foo,bar'}}
         deserialized = schema.deserialize(value)
         expected = {'querystring': {'_fields': ['foo', 'bar']}}
-        self.assertEquals(deserialized, expected)
+        self.assertEqual(deserialized, expected)
 
     def test_patch_record_validate_response_behavior(self):
         arguments = self.viewset.collection_arguments(self.resource, 'PATCH')
@@ -421,7 +419,7 @@ class TestViewsetSchemasTest(unittest.TestCase):
     def test_partial_schema_ignores_unknown(self):
         schema = PartialSchema()
         result = schema.deserialize({'foo': 'bar'})
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
     def test_strict_schema_raise_on_unknown(self):
         schema = StrictSchema()
@@ -435,7 +433,7 @@ class ShareableViewSetTest(unittest.TestCase):
         viewset.responses = mock.MagicMock()
         resource = mock.MagicMock()
         args = viewset.collection_arguments(resource, 'GET')
-        self.assertEquals(args['permission'], 'dynamic')
+        self.assertEqual(args['permission'], 'dynamic')
 
     def test_get_service_arguments_has_default_factory(self):
         viewset = ShareableViewSet()
@@ -535,7 +533,7 @@ class RegisterTest(unittest.TestCase):
         # Only the collection views should have been added.
         # 3 calls: two registering the service classes,
         # one for the collection_get
-        self.assertEquals(len(service_cls.mock_calls), 3)
+        self.assertEqual(len(service_cls.mock_calls), 3)
         service_cls.assert_any_call('fake-collection', '/fake', depth=1,
                                     **self.viewset.get_service_arguments())
         service_cls().add_view.assert_any_call(
@@ -556,7 +554,7 @@ class RegisterTest(unittest.TestCase):
         # Only the collection views should have been added.
         # 3 calls: two registering the service classes,
         # one for the collection_get
-        self.assertEquals(len(service_class.mock_calls), 3)
+        self.assertEqual(len(service_class.mock_calls), 3)
         service_class.assert_any_call('fake-record', '/fake/{id}', depth=1,
                                       **self.viewset.get_service_arguments())
         service_class().add_view.assert_any_call(

--- a/tests/core/test_authorization.py
+++ b/tests/core/test_authorization.py
@@ -34,7 +34,7 @@ class RouteFactoryTest(unittest.TestCase):
             request.upath_info = uri
             context = RouteFactory(request)
 
-            self.assertEquals(context.required_permission, permission)
+            self.assertEqual(context.required_permission, permission)
 
     def test_http_unknown_does_not_raise_a_500(self):
         self.assert_request_resolves_to("unknown", None)
@@ -63,7 +63,7 @@ class RouteFactoryTest(unittest.TestCase):
             request.matchdict = {'bucket_id': 'abc'}
             context = RouteFactory(request)
 
-            self.assertEquals(context.required_permission, 'create')
+            self.assertEqual(context.required_permission, 'create')
 
     def test_http_put_existing_record_resolves_in_a_write_permission(self):
         self.assert_request_resolves_to("put", "write")
@@ -78,7 +78,7 @@ class RouteFactoryTest(unittest.TestCase):
             # Do the actual call.
             request = DummyRequest(method='put')
             context = RouteFactory(request)
-            self.assertEquals(context.current_record, mock.sentinel.record)
+            self.assertEqual(context.current_record, mock.sentinel.record)
 
     def test_http_patch_resolves_in_a_write_permission(self):
         self.assert_request_resolves_to("patch", "write")
@@ -152,7 +152,7 @@ class RouteFactoryTest(unittest.TestCase):
             '/obj/3': ['obj:create']
         }
         context.fetch_shared_records('read', ['userid'], None)
-        self.assertEquals(sorted(context.shared_ids), ['1', '3'])
+        self.assertEqual(sorted(context.shared_ids), ['1', '3'])
 
     def test_fetch_shared_records_sets_shared_ids_if_empty(self):
         request = DummyRequest()
@@ -302,12 +302,12 @@ class GuestAuthorizationPolicyTest(unittest.TestCase):
         self.request.path = '/comments'
         self.context.resource_name = 'comment'
         obj_id = self.context.get_permission_object_id(self.request, '*')
-        self.assertEquals(obj_id, '/comments/sub/*')
+        self.assertEqual(obj_id, '/comments/sub/*')
 
         self.request.path = '/articles'
         self.context.resource_name = 'article'
         obj_id = self.context.get_permission_object_id(self.request, '*')
-        self.assertEquals(obj_id, '/articles/*')
+        self.assertEqual(obj_id, '/articles/*')
 
 
 class GroupFinderTest(unittest.TestCase):

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -194,7 +194,7 @@ class ApplicationWrapperTest(unittest.TestCase):
         mocked_newrelic.WSGIApplicationWrapper.return_value = 'wrappedApp'
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
         mocked_newrelic.initialize.assert_called_with('/foo/bar.ini', 'test')
-        self.assertEquals(app, 'wrappedApp')
+        self.assertEqual(app, 'wrappedApp')
 
     @unittest.skipIf(initialization.newrelic is None,
                      "newrelic is not installed.")
@@ -203,14 +203,14 @@ class ApplicationWrapperTest(unittest.TestCase):
         settings = {'newrelic_config': False}
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
         mocked_newrelic.initialize.assert_not_called()
-        self.assertEquals(app, mock.sentinel.app)
+        self.assertEqual(app, mock.sentinel.app)
 
     @mock.patch('kinto.core.initialization.ProfilerMiddleware')
     def test_profiler_is_not_installed_if_set_to_false(self, mocked_profiler):
         settings = {'profiler_enabled': False}
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
         mocked_profiler.initialize.assert_not_called()
-        self.assertEquals(app, mock.sentinel.app)
+        self.assertEqual(app, mock.sentinel.app)
 
     @mock.patch('kinto.core.initialization.ProfilerMiddleware')
     def test_profiler_is_installed_if_set_to_true(self, mocked_profiler):
@@ -226,7 +226,7 @@ class ApplicationWrapperTest(unittest.TestCase):
             restrictions='*kinto.core*',
             profile_dir='/tmp/path')
 
-        self.assertEquals(app, 'wrappedApp')
+        self.assertEqual(app, 'wrappedApp')
 
     def test_load_default_settings_handle_prefix_attributes(self):
         config = mock.MagicMock()

--- a/tests/core/test_openapi.py
+++ b/tests/core/test_openapi.py
@@ -17,12 +17,12 @@ class OpenAPITest(BaseWebTest, unittest.TestCase):
         self.api_doc = self.generator.generate()
 
     def test_assign_base_path(self):
-        self.assertEquals(self.api_doc['basePath'], "/{}".format(self.api_prefix))
+        self.assertEqual(self.api_doc['basePath'], "/{}".format(self.api_prefix))
 
     def test_default_security_generator(self):
-        self.assertEquals(self.api_doc['paths']['/']['get']['security'], [])
-        self.assertEquals(self.api_doc['paths']['/mushrooms']['get']['security'],
-                          [{'basicauth': []}])
+        self.assertEqual(self.api_doc['paths']['/']['get']['security'], [])
+        self.assertEqual(self.api_doc['paths']['/mushrooms']['get']['security'],
+                         [{'basicauth': []}])
 
     def test_security_extensions(self):
         method = {
@@ -35,18 +35,18 @@ class OpenAPITest(BaseWebTest, unittest.TestCase):
         self.generator.expose_authentication_method("fxa", method)
         api_doc = self.generator.generate()
 
-        self.assertEquals(api_doc['securityDefinitions']['fxa'], method)
+        self.assertEqual(api_doc['securityDefinitions']['fxa'], method)
         self.assertCountEqual(api_doc['paths']['/mushrooms']['get']['security'],
                               [{'basicauth': []}, {'fxa': ['kinto']}])
 
     def test_default_tags(self):
-        self.assertEquals(self.api_doc['paths']['/mushrooms']['get']['tags'],
-                          ['Mushrooms'])
-        self.assertEquals(self.api_doc['paths']['/mushrooms/{id}']['get']['tags'],
-                          ['Mushrooms'])
+        self.assertEqual(self.api_doc['paths']['/mushrooms']['get']['tags'],
+                         ['Mushrooms'])
+        self.assertEqual(self.api_doc['paths']['/mushrooms/{id}']['get']['tags'],
+                         ['Mushrooms'])
 
     def test_default_operation_ids(self):
-        self.assertEquals(self.api_doc['paths']['/mushrooms']['get']['operationId'],
-                          'get_mushrooms')
-        self.assertEquals(self.api_doc['paths']['/mushrooms/{id}']['get']['operationId'],
-                          'get_mushroom')
+        self.assertEqual(self.api_doc['paths']['/mushrooms']['get']['operationId'],
+                         'get_mushrooms')
+        self.assertEqual(self.api_doc['paths']['/mushrooms/{id}']['get']['operationId'],
+                         'get_mushroom')

--- a/tests/core/test_storage_pool.py
+++ b/tests/core/test_storage_pool.py
@@ -43,8 +43,8 @@ class QueuePoolWithMaxBacklogTest(unittest.TestCase):
         # The pool allows an overflow of 1, so we can
         # take another, ephemeral connection without any error.
         self.take_connection()
-        self.assertEquals(len(self.connections), 3)
-        self.assertEquals(len(self.errors), 0)
+        self.assertEqual(len(self.connections), 3)
+        self.assertEqual(len(self.errors), 0)
 
     def test_max_backlog_fails_when_reached(self):
         self.exhaust_pool()
@@ -55,14 +55,14 @@ class QueuePoolWithMaxBacklogTest(unittest.TestCase):
         thread1.start()
         thread2 = threading.Thread(target=self.take_connection)
         thread2.start()
-        self.assertEquals(len(self.connections), 3)
-        self.assertEquals(len(self.errors), 0)
+        self.assertEqual(len(self.connections), 3)
+        self.assertEqual(len(self.errors), 0)
         # The pool is now exhausted and at maximum backlog.
         # Trying to take another connection fails immediately.
         t1 = time.time()
         self.take_connection()
         t2 = time.time()
-        self.assertEquals(len(self.connections), 3)
+        self.assertEqual(len(self.connections), 3)
         # This checks that it failed immediately rather than timing out.
         self.assertTrue(t2 - t1 < 1.1)
         self.assertTrue(len(self.errors) >= 1)
@@ -70,8 +70,8 @@ class QueuePoolWithMaxBacklogTest(unittest.TestCase):
         # And eventually, the blocked threads will time out.
         thread1.join()
         thread2.join()
-        self.assertEquals(len(self.connections), 3)
-        self.assertEquals(len(self.errors), 3)
+        self.assertEqual(len(self.connections), 3)
+        self.assertEqual(len(self.errors), 3)
 
     def test_recreates_reinstantiate_with_same_pool_class(self):
         from kinto.core.storage.postgresql.pool import QueuePoolWithMaxBacklog

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -333,7 +333,7 @@ class ParseResourceTest(unittest.TestCase):
         for input in input_arr:
             with pytest.raises(ValueError) as excinfo:
                 parse_resource(input)
-            self.assertEquals(str(excinfo.value), self.error_msg)
+            self.assertEqual(str(excinfo.value), self.error_msg)
 
     def test_malformed_url_raises_an_exception(self):
         input_arr = ['foo', '/', '/bar', 'baz/', '/fo/o', '/buckets/sbid/scid']

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -22,7 +22,7 @@ class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
         with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10)]):
             response = self.app.get(self.sample_url, headers=self.headers, status=200)
         self.assertIn('Backoff', response.headers)
-        self.assertEquals(response.headers['Backoff'], '10')
+        self.assertEqual(response.headers['Backoff'], '10')
 
     def test_backoff_headers_is_present_if_less_than_percentage(self):
         with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10),
@@ -30,7 +30,7 @@ class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
             with mock.patch('kinto.core.initialization.random.random', return_value=0.4):
                 response = self.app.get(self.sample_url, headers=self.headers, status=200)
         self.assertIn('Backoff', response.headers)
-        self.assertEquals(response.headers['Backoff'], '10')
+        self.assertEqual(response.headers['Backoff'], '10')
 
     def test_backoff_headers_is_not_present_if_greater_than_percentage(self):
         with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10),

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -62,11 +62,11 @@ class FunctionalTest(unittest.TestCase):
         # 201 created with data and permission.write
         resp = self.session.post(collection_url, json={"data": task})
         resp.raise_for_status()
-        self.assertEquals(resp.status_code, 201)
+        self.assertEqual(resp.status_code, 201)
         record = resp.json()
 
-        self.assertEquals(record['data']['description'], task['description'])
-        self.assertEquals(record['data']['status'], task['status'])
+        self.assertEqual(record['data']['description'], task['description'])
+        self.assertEqual(record['data']['status'], task['status'])
         self.assertIn('write', record['permissions'])
 
         # Create a new one with PUT and If-None-Match: "*"
@@ -78,11 +78,11 @@ class FunctionalTest(unittest.TestCase):
                                 headers={'If-None-Match': '*'})
         resp.raise_for_status()
         resp.raise_for_status()
-        self.assertEquals(resp.status_code, 201)
+        self.assertEqual(resp.status_code, 201)
         record = resp.json()
 
-        self.assertEquals(record['data']['description'], task['description'])
-        self.assertEquals(record['data']['status'], task['status'])
+        self.assertEqual(record['data']['description'], task['description'])
+        self.assertEqual(record['data']['status'], task['status'])
         self.assertIn('write', record['permissions'])
 
         # Fetch the collection list and see the tasks (save the etag)

--- a/tests/plugins/test_default_bucket.py
+++ b/tests/plugins/test_default_bucket.py
@@ -69,8 +69,8 @@ class DefaultBucketViewTest(FormattedErrorMixin, DefaultBucketWebTest):
 
     def test_unauthenticated_bucket_access_raises_json_401(self):
         resp = self.app.get(self.bucket_url, status=401)
-        self.assertEquals(resp.json['message'],
-                          'Please authenticate yourself to use this endpoint.')
+        self.assertEqual(resp.json['message'],
+                         'Please authenticate yourself to use this endpoint.')
 
     def test_bucket_id_is_an_uuid_with_dashes(self):
         bucket = self.app.get(self.bucket_url, headers=self.headers)
@@ -133,7 +133,7 @@ class DefaultBucketViewTest(FormattedErrorMixin, DefaultBucketWebTest):
             self.bucket_url.replace('default', 'default-1234'),
             headers=self.headers, status=201)
         bucket_id = resp.json['data']['id']
-        self.assertEquals(bucket_id, 'default-1234')
+        self.assertEqual(bucket_id, 'default-1234')
 
         # We can then create the collection
         collection_url = '/buckets/default-1234/collections/default'
@@ -143,7 +143,7 @@ class DefaultBucketViewTest(FormattedErrorMixin, DefaultBucketWebTest):
             status=201)
         resp = self.app.get('/buckets/default-1234/collections',
                             headers=self.headers)
-        self.assertEquals(resp.json['data'][0]['id'], 'default')
+        self.assertEqual(resp.json['data'][0]['id'], 'default')
 
     def test_bucket_id_in_body_can_be_default(self):
         self.app.put_json('/buckets/default',

--- a/tests/plugins/test_flush.py
+++ b/tests/plugins/test_flush.py
@@ -93,7 +93,7 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
 
     def test_flush_returns_json(self):
         response = self.app.post('/__flush__', headers=self.headers, status=202)
-        self.assertEquals(response.json, {})
+        self.assertEqual(response.json, {})
 
     def test_flush_capability_if_enabled(self):
         resp = self.app.get('/')

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -87,16 +87,16 @@ class PermissionInheritanceTest(unittest.TestCase):
 
     def test_inherited_permissions_supports_buckets_named_collections(self):
         uri = '/buckets/collections'
-        self.assertEquals(set(_inherited_permissions(uri, 'write')),
-                          set([(uri, 'write')]))
+        self.assertEqual(set(_inherited_permissions(uri, 'write')),
+                         set([(uri, 'write')]))
 
     def test_inherited_permissions_for_bucket_permission(self):
         # write
-        self.assertEquals(
+        self.assertEqual(
             _inherited_permissions(self.bucket_uri, 'write'),
             [(self.bucket_uri, 'write')])
         # read
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(self.bucket_uri, 'read')),
             set([(self.bucket_uri, 'write'),
                  (self.bucket_uri, 'read'),
@@ -105,7 +105,7 @@ class PermissionInheritanceTest(unittest.TestCase):
 
         # group:create
         groups_uri = self.bucket_uri + '/groups'
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(groups_uri, 'group:create')),
             set(
                 [(self.bucket_uri, 'write'),
@@ -114,19 +114,19 @@ class PermissionInheritanceTest(unittest.TestCase):
 
         # collection:create
         collections_uri = self.bucket_uri + '/collections'
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(collections_uri, 'collection:create')),
             set([(self.bucket_uri, 'write'),
                  (self.bucket_uri, 'collection:create')]))
 
     def test_inherited_permissions_for_group_permission(self):
         # write
-        self.assertEquals(
+        self.assertEqual(
             _inherited_permissions(self.group_uri, 'write'),
             [(self.group_uri, 'write'),
              (self.bucket_uri, 'write')])
         # read
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(self.group_uri, 'read')),
             set([(self.bucket_uri, 'write'),
                  (self.bucket_uri, 'read'),
@@ -135,12 +135,12 @@ class PermissionInheritanceTest(unittest.TestCase):
 
     def test_inherited_permissions_for_collection_permission(self):
         # write
-        self.assertEquals(
+        self.assertEqual(
             _inherited_permissions(self.collection_uri, 'write'),
             [(self.collection_uri, 'write'),
              (self.bucket_uri, 'write')])
         # read
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(self.collection_uri, 'read')),
             set([(self.bucket_uri, 'write'),
                  (self.bucket_uri, 'read'),
@@ -149,7 +149,7 @@ class PermissionInheritanceTest(unittest.TestCase):
                  (self.collection_uri, 'record:create')]))
         # records:create
         records_uri = self.collection_uri + '/records'
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(records_uri, 'record:create')),
             set([(self.bucket_uri, 'write'),
                  (self.collection_uri, 'write'),
@@ -157,13 +157,13 @@ class PermissionInheritanceTest(unittest.TestCase):
 
     def test_inherited_permissions_for_record_permission(self):
         # write
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(self.record_uri, 'write')),
             set([(self.bucket_uri, 'write'),
                  (self.collection_uri, 'write'),
                  (self.record_uri, 'write')]))
         # read
-        self.assertEquals(
+        self.assertEqual(
             set(_inherited_permissions(self.record_uri, 'read')),
             set([(self.bucket_uri, 'write'),
                  (self.bucket_uri, 'read'),
@@ -174,12 +174,12 @@ class PermissionInheritanceTest(unittest.TestCase):
 
     def test_inherited_permissions_for_list_of_buckets(self):
         permissions = _inherited_permissions('/buckets', 'read')
-        self.assertEquals(permissions, [])
+        self.assertEqual(permissions, [])
 
     def test_inherited_permissions_for_non_resource_url(self):
         unknown = '/resource/unknown'
         permissions = _inherited_permissions(unknown, 'read')
-        self.assertEquals(permissions, [])
+        self.assertEqual(permissions, [])
 
     def test_inherited_permissions_for_attachment_url(self):
         attachment = '/buckets/bid/collections/cid/records/rid/attachment'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,14 +57,14 @@ class ConfigTest(unittest.TestCase):
     def test_hmac_secret_is_text(self, mocked_render_template):
         config.init('kinto.ini', backend='postgresql', cache_backend='postgresql')
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEquals(type(kwargs['secret']), str)
+        self.assertEqual(type(kwargs['secret']), str)
 
     @mock.patch('kinto.config.render_template')
     def test_init_postgresql_values(self, mocked_render_template):
         config.init('kinto.ini', backend='postgresql', cache_backend='postgresql')
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEquals(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
 
         postgresql_url = "postgres://postgres:postgres@localhost/postgres"
         self.assertDictEqual(kwargs, {
@@ -85,7 +85,7 @@ class ConfigTest(unittest.TestCase):
         config.init('kinto.ini', backend='postgresql', cache_backend='memcached')
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEquals(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
 
         postgresql_url = "postgres://postgres:postgres@localhost/postgres"
         cache_url = '127.0.0.1:11211 127.0.0.2:11211'
@@ -107,7 +107,7 @@ class ConfigTest(unittest.TestCase):
         config.init('kinto.ini', backend='redis', cache_backend='redis')
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEquals(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
 
         redis_url = "redis://localhost:6379"
         self.maxDiff = None  # See the full diff in case of error
@@ -129,7 +129,7 @@ class ConfigTest(unittest.TestCase):
         config.init('kinto.ini', backend='memory', cache_backend='memory')
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEquals(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
 
         self.assertDictEqual(kwargs, {
             'host': '127.0.0.1',

--- a/tests/test_views_groups.py
+++ b/tests/test_views_groups.py
@@ -186,18 +186,18 @@ class GroupManagementTest(BaseWebTest, unittest.TestCase):
         self.app.delete('/buckets/beers/groups', headers=self.headers,
                         status=200)
 
-        self.assertEquals(self.permission.get_user_principals('fxa:me'), set())
-        self.assertEquals(self.permission.get_user_principals('natim'), set())
-        self.assertEquals(self.permission.get_user_principals('alexis'), set())
+        self.assertEqual(self.permission.get_user_principals('fxa:me'), set())
+        self.assertEqual(self.permission.get_user_principals('natim'), set())
+        self.assertEqual(self.permission.get_user_principals('alexis'), set())
 
     def test_group_is_added_to_user_principals_when_added_to_members(self):
         self.create_group('beers', 'moderators', ['natim', 'mat'])
 
         self.app.get('/buckets/beers/groups', headers=self.headers, status=200)
-        self.assertEquals(self.permission.get_user_principals('natim'),
-                          {'/buckets/beers/groups/moderators'})
-        self.assertEquals(self.permission.get_user_principals('mat'),
-                          {'/buckets/beers/groups/moderators'})
+        self.assertEqual(self.permission.get_user_principals('natim'),
+                         {'/buckets/beers/groups/moderators'})
+        self.assertEqual(self.permission.get_user_principals('mat'),
+                         {'/buckets/beers/groups/moderators'})
 
     def test_group_is_added_to_user_principals_on_members_add_with_patch(self):
         self.create_group('beers', 'moderators', ['natim', 'mat'])
@@ -206,12 +206,12 @@ class GroupManagementTest(BaseWebTest, unittest.TestCase):
         self.app.patch_json(group_url, group,
                             headers=self.headers, status=200)
         self.app.get('/buckets/beers/groups', headers=self.headers, status=200)
-        self.assertEquals(self.permission.get_user_principals('natim'),
-                          {group_url})
-        self.assertEquals(self.permission.get_user_principals('mat'),
-                          {group_url})
-        self.assertEquals(self.permission.get_user_principals('alice'),
-                          {group_url})
+        self.assertEqual(self.permission.get_user_principals('natim'),
+                         {group_url})
+        self.assertEqual(self.permission.get_user_principals('mat'),
+                         {group_url})
+        self.assertEqual(self.permission.get_user_principals('alice'),
+                         {group_url})
 
     def test_group_member_removal_updates_user_principals(self):
         self.create_group('beers', 'moderators', ['natim', 'mat'])
@@ -220,25 +220,25 @@ class GroupManagementTest(BaseWebTest, unittest.TestCase):
         self.app.put_json(group_url, group,
                           headers=self.headers, status=200)
         self.app.get('/buckets/beers/groups', headers=self.headers, status=200)
-        self.assertEquals(self.permission.get_user_principals('natim'), set())
-        self.assertEquals(self.permission.get_user_principals('mat'),
-                          {group_url})
+        self.assertEqual(self.permission.get_user_principals('natim'), set())
+        self.assertEqual(self.permission.get_user_principals('mat'),
+                         {group_url})
 
     def test_group_with_authenticated_is_added_to_everbody(self):
         self.create_group('beers', 'reviewers', ['system.Authenticated'])
-        self.assertEquals(self.permission.get_user_principals('natim'),
-                          {'/buckets/beers/groups/reviewers'})
-        self.assertEquals(self.permission.get_user_principals('mat'),
-                          {'/buckets/beers/groups/reviewers'})
+        self.assertEqual(self.permission.get_user_principals('natim'),
+                         {'/buckets/beers/groups/reviewers'})
+        self.assertEqual(self.permission.get_user_principals('mat'),
+                         {'/buckets/beers/groups/reviewers'})
 
     def test_group_member_removal_updates_user_principals_with_patch(self):
         self.create_group('beers', 'moderators', ['natim', 'mat'])
         group_url = '/buckets/beers/groups/moderators'
         group = {'data': {'members': ['mat']}}
         self.app.patch_json(group_url, group, headers=self.headers, status=200)
-        self.assertEquals(self.permission.get_user_principals('natim'), set())
-        self.assertEquals(self.permission.get_user_principals('mat'),
-                          {group_url})
+        self.assertEqual(self.permission.get_user_principals('natim'), set())
+        self.assertEqual(self.permission.get_user_principals('mat'),
+                         {group_url})
 
     def test_groups_can_be_created_after_deletion(self):
         self.create_group('beers', 'moderators')

--- a/tests/test_views_records.py
+++ b/tests/test_views_records.py
@@ -82,7 +82,7 @@ class RecordsViewTest(BaseWebTest, unittest.TestCase):
         record = response.json['data']
         del record['id']
         del record['last_modified']
-        self.assertEquals(record, MINIMALIST_RECORD['data'])
+        self.assertEqual(record, MINIMALIST_RECORD['data'])
 
     def test_records_are_isolated_by_bucket_and_by_collection(self):
         # By collection.
@@ -314,8 +314,8 @@ class RecordsViewMergeTest(BaseWebTest, unittest.TestCase):
                                    json,
                                    headers=headers,
                                    status=200)
-        self.assertEquals(resp.json['data']['grain']['one'], 1)
-        self.assertEquals(resp.json['data']['grain']['two'], 2)
+        self.assertEqual(resp.json['data']['grain']['one'], 1)
+        self.assertEqual(resp.json['data']['grain']['two'], 2)
 
     def test_merge_patch_remove_nones(self):
         headers = {**self.headers, 'Content-Type': 'application/merge-patch+json'}
@@ -428,7 +428,7 @@ class RecordsViewPatchTest(BaseWebTest, unittest.TestCase):
         perms = resp.json['permissions']
         data = resp.json['data']
         self.assertNotIn('alice', perms['read'])
-        self.assertEquals('alice', data['old'])
+        self.assertEqual('alice', data['old'])
 
     def test_patch_raises_400_on_wrong_path(self):
         json = [{'op': 'add', 'path': '/permissions/destroy/me'}]


### PR DESCRIPTION
Fixes # issue 1780

- [x] Add documentation.
- [ ] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
