### PR TITLE
Raises 400 invalid request when field parameters contain a NUL character

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,14 +9,8 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Set schema to an instance instead of class (fixes #1781)
-
-
-10.1.2 (2018-09-28)
--------------------
-
-**Bug fixes**
-
 - Deprecate assertEquals and use assertEqual (fixes #1780)
+- Fix for invalid filter parameters (see #1787)
 
 
 10.1.2 (unreleased)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -60,6 +60,7 @@ Contributors
 * Niraj <https://github.com/niraj8>
 * Oron Gola <oron.golar@gmail.com>
 * Palash Nigam <npalash25@gmail.com>
+* Pascal Roessner <roessner.pascal@gmail.com>
 * PeriGK <per.gkolias@gmail.com>
 * Peter Bengtsson <mail@peterbe.com>
 * realsumit <sumitsarinofficial@gmail.com>

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -1022,6 +1022,9 @@ class UserResource:
                 if has_invalid_value:
                     raise_invalid(self.request, **error_details)
 
+            if '\x00' in field:
+                raise_invalid(self.request, **error_details)
+
             if field == self.model.modified_field and value == '':
                 raise_invalid(self.request, **error_details)
 

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -1022,7 +1022,7 @@ class UserResource:
                 if has_invalid_value:
                     raise_invalid(self.request, **error_details)
 
-            if '\x00' in field:
+            if '\x00' in field or '\x00' in str(value):
                 raise_invalid(self.request, **error_details)
 
             if field == self.model.modified_field and value == '':

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -7,7 +7,7 @@ from kinto.core.errors import ERRORS, http_error
 from kinto.core.testing import FormattedErrorMixin
 from kinto.core.storage import exceptions as storage_exceptions
 
-from .support import BaseWebTest, authorize
+from .support import BaseWebTest, authorize, PostgreSQLTest
 
 
 class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
@@ -195,6 +195,14 @@ class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
                 self.app.get(self.sample_url, headers=self.headers, status=500)
         self.assertTrue(mocked_logger.error.called)
         self.assertEqual(mocked_logger.error.call_args[1]['exc_info'], custom_error)
+
+
+class ErrorPostgresViewTest(FormattedErrorMixin, PostgreSQLTest, unittest.TestCase):
+    sample_url = "/mushrooms"
+
+    def test_400_with_invalid_query_field(self):
+        response = self.app.get(self.sample_url + '?field\x00="2"', headers=self.headers, status=400)
+        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS, "Invalid parameters", "Invalid value for")
 
 
 class RedirectViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -7,7 +7,7 @@ from kinto.core.errors import ERRORS, http_error
 from kinto.core.testing import FormattedErrorMixin
 from kinto.core.storage import exceptions as storage_exceptions
 
-from .support import BaseWebTest, authorize, PostgreSQLTest
+from .support import BaseWebTest, authorize
 
 
 class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -201,8 +201,10 @@ class ErrorPostgresViewTest(FormattedErrorMixin, PostgreSQLTest, unittest.TestCa
     sample_url = "/mushrooms"
 
     def test_400_with_invalid_query_field(self):
-        response = self.app.get(self.sample_url + '?field\x00="2"', headers=self.headers, status=400)
-        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS, "Invalid parameters", "Invalid value for")
+        response = self.app.get(self.sample_url + '?field\x00="2"',
+                                headers=self.headers, status=400)
+        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS,
+                                  "Invalid parameters", "Invalid value for")
 
 
 class RedirectViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -201,7 +201,14 @@ class ErrorPostgresViewTest(FormattedErrorMixin, PostgreSQLTest, unittest.TestCa
     sample_url = "/mushrooms"
 
     def test_400_with_invalid_query_field(self):
+        # test null in field name
         response = self.app.get(self.sample_url + '?field\x00="2"',
+                                headers=self.headers, status=400)
+        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS,
+                                  "Invalid parameters", "Invalid value for")
+
+        # test null in value
+        response = self.app.get(self.sample_url + '?field="\x00"',
                                 headers=self.headers, status=400)
         self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS,
                                   "Invalid parameters", "Invalid value for")


### PR DESCRIPTION
Fixes #1704 

- [x] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.

As suggested I discussed I implemented a fix for the null char.

I did however not include this in the 

``` native_value() ``` 
function as this function is never called on the query parameters, and including some exception to catch null bytes would break the tests for the function.

I am open to some better way of fixing the issue.

For the testing I did not use the already existing 400 test as the failure only shows when using the postgres backend. 

