### PR TITLE
Blackify code base

### DIFF
--- a/.therapist.yml
+++ b/.therapist.yml
@@ -1,0 +1,9 @@
+actions:
+  black:
+    run: black --check --diff {files}
+    fix: black {files}
+    include: "*.py"
+
+  flake8:
+    run: flake8 {files}
+    include: "*.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
     - python: 3.6
       env:
         - TOX_ENV=py36
+    - python: 3.6
+      env:
+        - TOX_ENV=lint
     - python: 3.7
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 env:
   - TOX_ENV=py35
   - TOX_ENV=py35-raw
-  - TOX_ENV=flake8
   - TOX_ENV=docs
 install:
   - pip install tox

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -151,7 +151,6 @@ Get started!
 
     therapist install
 
-
 9. Commit your changes and push your branch to GitHub::
 
     git add .

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -139,17 +139,26 @@ Get started!
 
    Now you can make your changes locally.
 
-6. When you're done making changes, check that your changes pass the tests::
+6. When you're done making changes, check that your changes pass linting (requires python >= 3.6)::
+
+    tox -e lint
+
+7. Don't forget to check that your changes pass the tests::
 
     make tests
 
-7. Commit your changes and push your branch to GitHub::
+8. (Optional) Install a git hook::
 
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+    therapist install
 
-8. Submit a pull request through the GitHub website.
+
+9. Commit your changes and push your branch to GitHub::
+
+    git add .
+    git commit -m "Your detailed description of your changes."
+    git push origin name-of-your-bugfix-or-feature
+
+10. Submit a pull request through the GitHub website.
 
 
 Testing methodology

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,11 +19,12 @@ import sys
 # have an absolute __file__
 __HERE__ = os.path.dirname(os.path.abspath(__file__))
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # otherwise, readthedocs.io uses their theme by default, so no need to specify
@@ -32,7 +33,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- General configuration ------------------------------------------------
 
@@ -43,31 +44,29 @@ sys.path.insert(0, os.path.abspath('..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinxcontrib.httpdomain',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.intersphinx',
+    "sphinx.ext.autodoc",
+    "sphinxcontrib.httpdomain",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
-html_additional_pages = {
-    'index': 'indexcontent.html',
-}
+templates_path = ["_templates"]
+html_additional_pages = {"index": "indexcontent.html"}
 
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'Kinto'
-copyright = '2015-%s — Mozilla Services' % datetime.datetime.now().year
+project = "Kinto"
+copyright = "2015-%s — Mozilla Services" % datetime.datetime.now().year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -80,59 +79,59 @@ release = ".".join(version.split(".")[:2])
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Kintodoc'
+htmlhelp_basename = "Kintodoc"
 
 
 # -- Options for autodoc --------------------------------------------------
 
-autodoc_member_order = 'bysource'
+autodoc_member_order = "bysource"
 # Enable nitpicky mode - which ensures that all references in the docs
 # resolve.
 # See: http://stackoverflow.com/a/30624034/186202
 nitpicky = True
 nitpick_ignore = [
-    ('py:class', 'Exception'),
-    ('py:class', 'bool'),
-    ('py:class', 'cornice.Service'),
-    ('py:class', 'dict'),
-    ('py:class', 'float'),
-    ('py:class', 'int'),
-    ('py:class', 'list'),
-    ('py:class', 'str'),
-    ('py:class', 'tuple'),
+    ("py:class", "Exception"),
+    ("py:class", "bool"),
+    ("py:class", "cornice.Service"),
+    ("py:class", "dict"),
+    ("py:class", "float"),
+    ("py:class", "int"),
+    ("py:class", "list"),
+    ("py:class", "str"),
+    ("py:class", "tuple"),
     # Member autodoc fails with those:
     # kinto.core.resource.schema
-    ('py:class', 'Integer'),
-    ('py:class', 'String'),
+    ("py:class", "Integer"),
+    ("py:class", "String"),
     # kinto.core.resource
-    ('py:class', 'Model'),
-    ('py:class', 'ResourceSchema'),
-    ('py:class', 'ShareableModel'),
-    ('py:class', 'ShareableViewSet'),
-    ('py:class', 'ViewSet'),
-    ('py:class', 'Sequence'),
+    ("py:class", "Model"),
+    ("py:class", "ResourceSchema"),
+    ("py:class", "ShareableModel"),
+    ("py:class", "ShareableViewSet"),
+    ("py:class", "ViewSet"),
+    ("py:class", "Sequence"),
     # kinto.core.resource.schema
-    ('py:attr', 'colander.null'),
+    ("py:attr", "colander.null"),
 ]
 
 
 # -- Options of extlinks --------------------------------------------------
 
 extlinks = {
-    'github': ('https://github.com/%s/', ''),
-    'rtd': ('https://%s.readthedocs.io', ''),
-    'blog': ('http://www.servicedenuages.fr/%s', '')
+    "github": ("https://github.com/%s/", ""),
+    "rtd": ("https://%s.readthedocs.io", ""),
+    "blog": ("http://www.servicedenuages.fr/%s", ""),
 }
 
 
@@ -159,16 +158,16 @@ rst_epilog = """
 # --
 def setup(app):
     # path relative to _static
-    app.add_stylesheet('theme_overrides.css')
-    app.add_javascript('piwik.js')
+    app.add_stylesheet("theme_overrides.css")
+    app.add_javascript("piwik.js")
 
 
 # -- Options for intersphinx --------------------------------------------------
 
 intersphinx_mapping = {
-    'colander': ('https://colander.readthedocs.io/en/latest/', None),
-    'cornice': ('https://cornice.readthedocs.io/en/latest/', None),
-    'pyramid': ('https://pyramid.readthedocs.io/en/latest/', None)
+    "colander": ("https://colander.readthedocs.io/en/latest/", None),
+    "cornice": ("https://cornice.readthedocs.io/en/latest/", None),
+    "pyramid": ("https://pyramid.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -179,8 +178,7 @@ latex_elements = {}
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ('index', 'Kinto.tex', 'Kinto Documentation',
-     'Mozilla Services — Da French Team', 'manual'),
+    ("index", "Kinto.tex", "Kinto Documentation", "Mozilla Services — Da French Team", "manual")
 ]
 
 
@@ -188,10 +186,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'kinto', 'Kinto Documentation',
-     ['Mozilla Services — Da French Team'], 1)
-]
+man_pages = [("index", "kinto", "Kinto Documentation", ["Mozilla Services — Da French Team"], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -200,8 +195,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'Kinto', 'Kinto Documentation',
-     'Mozilla Services — Da French Team', 'Kinto',
-     'A remote storage service with syncing and sharing abilities.',
-     'Miscellaneous'),
+    (
+        "index",
+        "Kinto",
+        "Kinto Documentation",
+        "Mozilla Services — Da French Team",
+        "Kinto",
+        "A remote storage service with syncing and sharing abilities.",
+        "Miscellaneous",
+    )
 ]

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -13,30 +13,29 @@ from kinto.authorization import RouteFactory
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # Implemented HTTP API Version
-HTTP_API_VERSION = '1.20'
+HTTP_API_VERSION = "1.20"
 
 # Main kinto logger
 logger = logging.getLogger(__name__)
 
 
 DEFAULT_SETTINGS = {
-    'retry_after_seconds': 3,
-    'cache_backend': 'kinto.core.cache.memory',
-    'permission_backend': 'kinto.core.permission.memory',
-    'storage_backend': 'kinto.core.storage.memory',
-    'project_docs': 'https://kinto.readthedocs.io/',
-    'bucket_create_principals': Authenticated,
-    'permissions_read_principals': Everyone,
-    'multiauth.authorization_policy': (
-        'kinto.authorization.AuthorizationPolicy'),
-    'experimental_collection_schema_validation': False,
-    'experimental_permissions_endpoint': False,
-    'http_api_version': HTTP_API_VERSION,
-    'bucket_id_generator': 'kinto.views.NameGenerator',
-    'collection_id_generator': 'kinto.views.NameGenerator',
-    'group_id_generator': 'kinto.views.NameGenerator',
-    'record_id_generator': 'kinto.views.RelaxedUUID',
-    'project_name': 'kinto',
+    "retry_after_seconds": 3,
+    "cache_backend": "kinto.core.cache.memory",
+    "permission_backend": "kinto.core.permission.memory",
+    "storage_backend": "kinto.core.storage.memory",
+    "project_docs": "https://kinto.readthedocs.io/",
+    "bucket_create_principals": Authenticated,
+    "permissions_read_principals": Everyone,
+    "multiauth.authorization_policy": ("kinto.authorization.AuthorizationPolicy"),
+    "experimental_collection_schema_validation": False,
+    "experimental_permissions_endpoint": False,
+    "http_api_version": HTTP_API_VERSION,
+    "bucket_id_generator": "kinto.views.NameGenerator",
+    "collection_id_generator": "kinto.views.NameGenerator",
+    "group_id_generator": "kinto.views.NameGenerator",
+    "record_id_generator": "kinto.views.RelaxedUUID",
+    "project_name": "kinto",
 }
 
 
@@ -44,47 +43,45 @@ def main(global_config, config=None, **settings):
     if not config:
         config = Configurator(settings=settings, root_factory=RouteFactory)
 
-    config.registry.command = global_config and global_config.get('command', None)
+    config.registry.command = global_config and global_config.get("command", None)
 
     # Force settings prefix.
-    config.add_settings({'kinto.settings_prefix': 'kinto'})
+    config.add_settings({"kinto.settings_prefix": "kinto"})
 
-    kinto.core.initialize(config,
-                          version=__version__,
-                          default_settings=DEFAULT_SETTINGS)
+    kinto.core.initialize(config, version=__version__, default_settings=DEFAULT_SETTINGS)
 
     settings = config.get_settings()
 
     # Expose capability
-    schema_enabled = asbool(
-        settings['experimental_collection_schema_validation']
-    )
+    schema_enabled = asbool(settings["experimental_collection_schema_validation"])
     if schema_enabled:
         config.add_api_capability(
-            'schema',
-            description='Validates collection records with JSON schemas.',
-            url='https://kinto.readthedocs.io/en/latest/api/1.x/'
-                'collections.html#collection-json-schema')
+            "schema",
+            description="Validates collection records with JSON schemas.",
+            url="https://kinto.readthedocs.io/en/latest/api/1.x/"
+            "collections.html#collection-json-schema",
+        )
 
     # Scan Kinto views.
     kwargs = {}
 
     # Permissions endpoint enabled if permission backend is setup.
-    is_admin_enabled = 'kinto.plugins.admin' in settings['includes']
+    is_admin_enabled = "kinto.plugins.admin" in settings["includes"]
     permissions_endpoint_enabled = (
-        (is_admin_enabled or asbool(settings['experimental_permissions_endpoint'])) and
-        hasattr(config.registry, 'permission'))
+        is_admin_enabled or asbool(settings["experimental_permissions_endpoint"])
+    ) and hasattr(config.registry, "permission")
     if permissions_endpoint_enabled:
         config.add_api_capability(
-            'permissions_endpoint',
-            description='The permissions endpoint can be used to list all '
-                        'user objects permissions.',
-            url='https://kinto.readthedocs.io/en/latest/configuration/'
-                'settings.html#activating-the-permissions-endpoint')
+            "permissions_endpoint",
+            description="The permissions endpoint can be used to list all "
+            "user objects permissions.",
+            url="https://kinto.readthedocs.io/en/latest/configuration/"
+            "settings.html#activating-the-permissions-endpoint",
+        )
     else:
-        kwargs.setdefault('ignore', []).append('kinto.views.permissions')
+        kwargs.setdefault("ignore", []).append("kinto.views.permissions")
 
-    config.scan('kinto.views', **kwargs)
+    config.scan("kinto.views", **kwargs)
 
     app = config.make_wsgi_app()
 

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -12,10 +12,10 @@ from pyramid.paster import bootstrap
 from kinto import __version__
 from kinto.config import init
 
-DEFAULT_CONFIG_FILE = os.getenv('KINTO_INI', 'config/kinto.ini')
+DEFAULT_CONFIG_FILE = os.getenv("KINTO_INI", "config/kinto.ini")
 DEFAULT_PORT = 8888
 DEFAULT_LOG_LEVEL = logging.INFO
-DEFAULT_LOG_FORMAT = '%(levelname)-5.5s  %(message)s'
+DEFAULT_LOG_FORMAT = "%(levelname)-5.5s  %(message)s"
 
 
 def main(args=None):
@@ -23,122 +23,151 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
 
-    parser = argparse.ArgumentParser(description='Kinto Command-Line '
-                                                 'Interface')
-    commands = ('init', 'start', 'migrate', 'delete-collection', 'version',
-                'rebuild-quotas', 'create-user')
-    subparsers = parser.add_subparsers(title='subcommands',
-                                       description='Main Kinto CLI commands',
-                                       dest='subcommand',
-                                       help='Choose and run with --help')
+    parser = argparse.ArgumentParser(description="Kinto Command-Line " "Interface")
+    commands = (
+        "init",
+        "start",
+        "migrate",
+        "delete-collection",
+        "version",
+        "rebuild-quotas",
+        "create-user",
+    )
+    subparsers = parser.add_subparsers(
+        title="subcommands",
+        description="Main Kinto CLI commands",
+        dest="subcommand",
+        help="Choose and run with --help",
+    )
     subparsers.required = True
 
     for command in commands:
         subparser = subparsers.add_parser(command)
         subparser.set_defaults(which=command)
 
-        subparser.add_argument('--ini',
-                               help='Application configuration file',
-                               dest='ini_file',
-                               required=False,
-                               default=DEFAULT_CONFIG_FILE)
+        subparser.add_argument(
+            "--ini",
+            help="Application configuration file",
+            dest="ini_file",
+            required=False,
+            default=DEFAULT_CONFIG_FILE,
+        )
 
-        subparser.add_argument('-q', '--quiet', action='store_const',
-                               const=logging.CRITICAL, dest='verbosity',
-                               help='Show only critical errors.')
+        subparser.add_argument(
+            "-q",
+            "--quiet",
+            action="store_const",
+            const=logging.CRITICAL,
+            dest="verbosity",
+            help="Show only critical errors.",
+        )
 
-        subparser.add_argument('-v', '--debug', action='store_const',
-                               const=logging.DEBUG, dest='verbosity',
-                               help='Show all messages, including debug messages.')
+        subparser.add_argument(
+            "-v",
+            "--debug",
+            action="store_const",
+            const=logging.DEBUG,
+            dest="verbosity",
+            help="Show all messages, including debug messages.",
+        )
 
-        if command == 'init':
-            subparser.add_argument('--backend',
-                                   help='{memory,redis,postgresql}',
-                                   dest='backend',
-                                   required=False,
-                                   default=None)
-            subparser.add_argument('--cache-backend',
-                                   help='{memory,redis,postgresql,memcached}',
-                                   dest='cache-backend',
-                                   required=False,
-                                   default=None)
-            subparser.add_argument('--host',
-                                   help='Host to listen() on.',
-                                   dest='host',
-                                   required=False,
-                                   default='127.0.0.1')
-        elif command == 'migrate':
-            subparser.add_argument('--dry-run',
-                                   action='store_true',
-                                   help='Simulate the migration operations '
-                                        'and show information',
-                                   dest='dry_run',
-                                   required=False,
-                                   default=False)
-        elif command == 'delete-collection':
-            subparser.add_argument('--bucket',
-                                   help='The bucket where the collection '
-                                        'belongs to.',
-                                   required=True)
-            subparser.add_argument('--collection',
-                                   help='The collection to remove.',
-                                   required=True)
+        if command == "init":
+            subparser.add_argument(
+                "--backend",
+                help="{memory,redis,postgresql}",
+                dest="backend",
+                required=False,
+                default=None,
+            )
+            subparser.add_argument(
+                "--cache-backend",
+                help="{memory,redis,postgresql,memcached}",
+                dest="cache-backend",
+                required=False,
+                default=None,
+            )
+            subparser.add_argument(
+                "--host",
+                help="Host to listen() on.",
+                dest="host",
+                required=False,
+                default="127.0.0.1",
+            )
+        elif command == "migrate":
+            subparser.add_argument(
+                "--dry-run",
+                action="store_true",
+                help="Simulate the migration operations " "and show information",
+                dest="dry_run",
+                required=False,
+                default=False,
+            )
+        elif command == "delete-collection":
+            subparser.add_argument(
+                "--bucket", help="The bucket where the collection " "belongs to.", required=True
+            )
+            subparser.add_argument("--collection", help="The collection to remove.", required=True)
 
-        elif command == 'rebuild-quotas':
-            subparser.add_argument('--dry-run',
-                                   action='store_true',
-                                   help='Simulate the rebuild operation '
-                                        'and show information',
-                                   dest='dry_run',
-                                   required=False,
-                                   default=False)
+        elif command == "rebuild-quotas":
+            subparser.add_argument(
+                "--dry-run",
+                action="store_true",
+                help="Simulate the rebuild operation " "and show information",
+                dest="dry_run",
+                required=False,
+                default=False,
+            )
 
-        elif command == 'start':
-            subparser.add_argument('--reload',
-                                   action='store_true',
-                                   help='Restart when code or config changes',
-                                   required=False,
-                                   default=False)
-            subparser.add_argument('--port',
-                                   type=int,
-                                   help='Listening port number',
-                                   required=False,
-                                   default=DEFAULT_PORT)
+        elif command == "start":
+            subparser.add_argument(
+                "--reload",
+                action="store_true",
+                help="Restart when code or config changes",
+                required=False,
+                default=False,
+            )
+            subparser.add_argument(
+                "--port",
+                type=int,
+                help="Listening port number",
+                required=False,
+                default=DEFAULT_PORT,
+            )
 
-        elif command == 'create-user':
-            subparser.add_argument('-u', '--username',
-                                   help='Superuser username',
-                                   required=False,
-                                   default=None)
-            subparser.add_argument('-p', '--password',
-                                   help='Superuser password',
-                                   required=False,
-                                   default=None)
+        elif command == "create-user":
+            subparser.add_argument(
+                "-u", "--username", help="Superuser username", required=False, default=None
+            )
+            subparser.add_argument(
+                "-p", "--password", help="Superuser password", required=False, default=None
+            )
 
     # Parse command-line arguments
     parsed_args = vars(parser.parse_args(args))
 
-    config_file = parsed_args['ini_file']
-    which_command = parsed_args['which']
+    config_file = parsed_args["ini_file"]
+    which_command = parsed_args["which"]
 
     # Initialize logging from
-    level = parsed_args.get('verbosity') or DEFAULT_LOG_LEVEL
+    level = parsed_args.get("verbosity") or DEFAULT_LOG_LEVEL
     logging.basicConfig(level=level, format=DEFAULT_LOG_FORMAT)
 
-    if which_command == 'init':
+    if which_command == "init":
         if os.path.exists(config_file):
-            print('{} already exists.'.format(config_file), file=sys.stderr)
+            print("{} already exists.".format(config_file), file=sys.stderr)
             return 1
 
-        backend = parsed_args['backend']
-        cache_backend = parsed_args['cache-backend']
+        backend = parsed_args["backend"]
+        cache_backend = parsed_args["cache-backend"]
         if not backend:
             while True:
-                prompt = ('Select the backend you would like to use: '
-                          '(1 - postgresql, 2 - redis, default - memory) ')
+                prompt = (
+                    "Select the backend you would like to use: "
+                    "(1 - postgresql, 2 - redis, default - memory) "
+                )
                 answer = input(prompt).strip()
                 try:
-                    backends = {'1': 'postgresql', '2': 'redis', '': 'memory'}
+                    backends = {"1": "postgresql", "2": "redis", "": "memory"}
                     backend = backends[answer]
                     break
                 except KeyError:
@@ -146,75 +175,78 @@ def main(args=None):
 
         if not cache_backend:
             while True:
-                prompt = ('Select the cache backend you would like to use: '
-                          '(1 - postgresql, 2 - redis, 3 - memcached, default - memory) ')
+                prompt = (
+                    "Select the cache backend you would like to use: "
+                    "(1 - postgresql, 2 - redis, 3 - memcached, default - memory) "
+                )
                 answer = input(prompt).strip()
                 try:
-                    cache_backends = {'1': 'postgresql', '2': 'redis',
-                                      '3': 'memcached', '': 'memory'}
+                    cache_backends = {
+                        "1": "postgresql",
+                        "2": "redis",
+                        "3": "memcached",
+                        "": "memory",
+                    }
                     cache_backend = cache_backends[answer]
                     break
                 except KeyError:
                     pass
 
-        init(config_file, backend, cache_backend, parsed_args['host'])
+        init(config_file, backend, cache_backend, parsed_args["host"])
 
         # Install postgresql libraries if necessary
-        if backend == 'postgresql' or cache_backend == 'postgresql':
+        if backend == "postgresql" or cache_backend == "postgresql":
             try:
                 import psycopg2  # NOQA
             except ImportError:
-                subprocess.check_call([sys.executable, '-m', 'pip',
-                                       'install', 'kinto[postgresql]'])
-        elif backend == 'redis' or cache_backend == 'redis':
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", "kinto[postgresql]"]
+                )
+        elif backend == "redis" or cache_backend == "redis":
             try:
                 import kinto_redis  # NOQA
             except ImportError:
-                subprocess.check_call([sys.executable, '-m', 'pip',
-                                       'install', 'kinto[redis]'])
-        elif cache_backend == 'memcached':
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "kinto[redis]"])
+        elif cache_backend == "memcached":
             try:
                 import memcache  # NOQA
             except ImportError:
-                subprocess.check_call([sys.executable, '-m', 'pip',
-                                       'install', 'kinto[memcached]'])
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "kinto[memcached]"])
 
-    elif which_command == 'migrate':
-        dry_run = parsed_args['dry_run']
-        env = bootstrap(config_file, options={'command': 'migrate'})
+    elif which_command == "migrate":
+        dry_run = parsed_args["dry_run"]
+        env = bootstrap(config_file, options={"command": "migrate"})
         scripts.migrate(env, dry_run=dry_run)
 
-    elif which_command == 'delete-collection':
-        env = bootstrap(config_file, options={'command': 'delete-collection'})
-        return scripts.delete_collection(env,
-                                         parsed_args['bucket'],
-                                         parsed_args['collection'])
+    elif which_command == "delete-collection":
+        env = bootstrap(config_file, options={"command": "delete-collection"})
+        return scripts.delete_collection(env, parsed_args["bucket"], parsed_args["collection"])
 
-    elif which_command == 'rebuild-quotas':
-        dry_run = parsed_args['dry_run']
-        env = bootstrap(config_file, options={'command': 'rebuild-quotas'})
+    elif which_command == "rebuild-quotas":
+        dry_run = parsed_args["dry_run"]
+        env = bootstrap(config_file, options={"command": "rebuild-quotas"})
         return scripts.rebuild_quotas(env, dry_run=dry_run)
 
-    elif which_command == 'create-user':
-        username = parsed_args['username']
-        password = parsed_args['password']
-        env = bootstrap(config_file, options={'command': 'create-user'})
+    elif which_command == "create-user":
+        username = parsed_args["username"]
+        password = parsed_args["password"]
+        env = bootstrap(config_file, options={"command": "create-user"})
         return create_user(env, username=username, password=password)
 
-    elif which_command == 'start':
-        pserve_argv = ['pserve']
+    elif which_command == "start":
+        pserve_argv = ["pserve"]
 
-        if parsed_args['reload']:
-            pserve_argv.append('--reload')
+        if parsed_args["reload"]:
+            pserve_argv.append("--reload")
 
         if level == logging.DEBUG:
-            pserve_argv.append('-v')
+            pserve_argv.append("-v")
 
         if level == logging.CRITICAL:
-            pserve_argv.append('-q')
+            pserve_argv.append("-q")
 
         pserve_argv.append(config_file)
-        pserve_argv.append('http_port={}'.format(parsed_args['port']))
+        pserve_argv.append("http_port={}".format(parsed_args["port"]))
         pserve.main(argv=pserve_argv)
 
     else:

--- a/kinto/authorization.py
+++ b/kinto/authorization.py
@@ -24,68 +24,35 @@ from kinto.core import authorization as core_authorization
 # automatically provides it
 # Ex: bucket:read is granted by both bucket:write and bucket:read
 PERMISSIONS_INHERITANCE_TREE = {
-    'root': {  # Granted via settings only.
-        'bucket:create': {},
-        'write': {},
-        'read': {},
+    "root": {"bucket:create": {}, "write": {}, "read": {}},  # Granted via settings only.
+    "bucket": {
+        "write": {"bucket": ["write"]},
+        "read": {"bucket": ["write", "read"]},
+        "read:attributes": {"bucket": ["write", "read", "collection:create", "group:create"]},
+        "group:create": {"bucket": ["write", "group:create"]},
+        "collection:create": {"bucket": ["write", "collection:create"]},
     },
-    'bucket': {
-        'write': {
-            'bucket': ['write']
-        },
-        'read': {
-            'bucket': ['write', 'read'],
-        },
-        'read:attributes': {
-            'bucket': ['write', 'read', 'collection:create', 'group:create']
-        },
-        'group:create': {
-            'bucket': ['write', 'group:create']
-        },
-        'collection:create': {
-            'bucket': ['write', 'collection:create']
-        },
+    "group": {
+        "write": {"bucket": ["write"], "group": ["write"]},
+        "read": {"bucket": ["write", "read"], "group": ["write", "read"]},
     },
-    'group': {
-        'write': {
-            'bucket': ['write'],
-            'group': ['write']
+    "collection": {
+        "write": {"bucket": ["write"], "collection": ["write"]},
+        "read": {"bucket": ["write", "read"], "collection": ["write", "read"]},
+        "read:attributes": {
+            "bucket": ["write", "read"],
+            "collection": ["write", "read", "record:create"],
         },
-        'read': {
-            'bucket': ['write', 'read'],
-            'group': ['write', 'read']
+        "record:create": {"bucket": ["write"], "collection": ["write", "record:create"]},
+    },
+    "record": {
+        "write": {"bucket": ["write"], "collection": ["write"], "record": ["write"]},
+        "read": {
+            "bucket": ["write", "read"],
+            "collection": ["write", "read"],
+            "record": ["write", "read"],
         },
     },
-    'collection': {
-        'write': {
-            'bucket': ['write'],
-            'collection': ['write'],
-        },
-        'read': {
-            'bucket': ['write', 'read'],
-            'collection': ['write', 'read'],
-        },
-        'read:attributes': {
-            'bucket': ['write', 'read'],
-            'collection': ['write', 'read', 'record:create'],
-        },
-        'record:create': {
-            'bucket': ['write'],
-            'collection': ['write', 'record:create']
-        },
-    },
-    'record': {
-        'write': {
-            'bucket': ['write'],
-            'collection': ['write'],
-            'record': ['write']
-        },
-        'read': {
-            'bucket': ['write', 'read'],
-            'collection': ['write', 'read'],
-            'record': ['write', 'read']
-        },
-    }
 }
 
 
@@ -94,7 +61,7 @@ def _resource_endpoint(object_uri):
     the specified `object_uri`. Returns `(None, None)` for the root URL plural
     endpoint.
     """
-    obj_parts = object_uri.split('/')
+    obj_parts = object_uri.split("/")
     plural_endpoint = len(obj_parts) % 2 == 0
     if plural_endpoint:
         # /buckets/bid/collections -> /buckets/bid
@@ -102,21 +69,21 @@ def _resource_endpoint(object_uri):
 
     if len(obj_parts) <= 2:
         # Root URL /buckets -> ('', False)
-        return '', False
+        return "", False
 
     # /buckets/bid -> buckets
     resource_name = obj_parts[-2]
     # buckets -> bucket
-    resource_name = resource_name.rstrip('s')
+    resource_name = resource_name.rstrip("s")
     return resource_name, plural_endpoint
 
 
 def _relative_object_uri(resource_name, object_uri):
     """Returns object_uri
     """
-    obj_parts = object_uri.split('/')
+    obj_parts = object_uri.split("/")
     for length in range(len(obj_parts) + 1):
-        parent_uri = '/'.join(obj_parts[:length])
+        parent_uri = "/".join(obj_parts[:length])
         parent_resource_name, _ = _resource_endpoint(parent_uri)
         if resource_name == parent_resource_name:
             return parent_uri
@@ -144,7 +111,7 @@ def _inherited_permissions(object_uri, permission):
 
     # When requesting permissions for a single object, we check if they are any
     # specific inherited permissions for the attributes.
-    attributes_permission = '{}:attributes'.format(permission) if not plural else permission
+    attributes_permission = "{}:attributes".format(permission) if not plural else permission
     inherited_perms = object_perms_tree.get(attributes_permission, object_perms_tree[permission])
 
     granters = set()

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -20,60 +20,60 @@ def render_template(template, destination, **kwargs):
     if folder and not os.path.exists(folder):
         os.makedirs(folder)
 
-    logger.info('Created config {}'.format(os.path.abspath(destination)))
+    logger.info("Created config {}".format(os.path.abspath(destination)))
 
-    with codecs.open(template, 'r', encoding='utf-8') as f:
+    with codecs.open(template, "r", encoding="utf-8") as f:
         raw_template = f.read()
         rendered = raw_template.format_map(kwargs)
-        with codecs.open(destination, 'w+', encoding='utf-8') as output:
+        with codecs.open(destination, "w+", encoding="utf-8") as output:
             output.write(rendered)
 
 
 def get_cache_backend_url(cache_be_value):
-    if cache_be_value == 'kinto.core.cache.postgresql':
-        url = 'postgres://postgres:postgres@localhost/postgres'
-    elif cache_be_value == 'kinto.core.cache.redis':
-        url = 'redis://localhost:6379/2'
-    elif cache_be_value == 'kinto.core.cache.memcached':
-        url = '127.0.0.1:11211 127.0.0.2:11211'
+    if cache_be_value == "kinto.core.cache.postgresql":
+        url = "postgres://postgres:postgres@localhost/postgres"
+    elif cache_be_value == "kinto.core.cache.redis":
+        url = "redis://localhost:6379/2"
+    elif cache_be_value == "kinto.core.cache.memcached":
+        url = "127.0.0.1:11211 127.0.0.2:11211"
     else:
-        url = ''
+        url = ""
     return url
 
 
-def init(config_file, backend, cache_backend, host='127.0.0.1'):
+def init(config_file, backend, cache_backend, host="127.0.0.1"):
     values = {}
 
-    values['host'] = host
-    values['secret'] = core_utils.random_bytes_hex(32)
+    values["host"] = host
+    values["secret"] = core_utils.random_bytes_hex(32)
 
-    values['kinto_version'] = __version__
-    values['config_file_timestamp'] = str(strftime('%a, %d %b %Y %H:%M:%S %z'))
+    values["kinto_version"] = __version__
+    values["config_file_timestamp"] = str(strftime("%a, %d %b %Y %H:%M:%S %z"))
 
-    values['storage_backend'] = 'kinto.core.storage.{}'.format(backend)
-    values['cache_backend'] = 'kinto.core.cache.{}'.format(cache_backend)
-    values['permission_backend'] = 'kinto.core.permission.{}'.format(backend)
-    cache_backend_url = get_cache_backend_url(values['cache_backend'])
+    values["storage_backend"] = "kinto.core.storage.{}".format(backend)
+    values["cache_backend"] = "kinto.core.cache.{}".format(cache_backend)
+    values["permission_backend"] = "kinto.core.permission.{}".format(backend)
+    cache_backend_url = get_cache_backend_url(values["cache_backend"])
 
-    if backend == 'postgresql':
-        postgresql_url = 'postgres://postgres:postgres@localhost/postgres'
-        values['storage_url'] = postgresql_url
-        values['cache_url'] = cache_backend_url
-        values['permission_url'] = postgresql_url
+    if backend == "postgresql":
+        postgresql_url = "postgres://postgres:postgres@localhost/postgres"
+        values["storage_url"] = postgresql_url
+        values["cache_url"] = cache_backend_url
+        values["permission_url"] = postgresql_url
 
-    elif backend == 'redis':
-        redis_url = 'redis://localhost:6379'
-        values['storage_backend'] = 'kinto_redis.storage'
-        values['cache_backend'] = 'kinto_redis.cache'
-        values['permission_backend'] = 'kinto_redis.permission'
+    elif backend == "redis":
+        redis_url = "redis://localhost:6379"
+        values["storage_backend"] = "kinto_redis.storage"
+        values["cache_backend"] = "kinto_redis.cache"
+        values["permission_backend"] = "kinto_redis.permission"
 
-        values['storage_url'] = redis_url + '/1'
-        values['cache_url'] = cache_backend_url
-        values['permission_url'] = redis_url + '/3'
+        values["storage_url"] = redis_url + "/1"
+        values["cache_url"] = cache_backend_url
+        values["permission_url"] = redis_url + "/3"
 
     else:
-        values['storage_url'] = ''
-        values['cache_url'] = ''
-        values['permission_url'] = ''
+        values["storage_url"] = ""
+        values["cache_url"] = ""
+        values["permission_url"] = ""
 
-    render_template('kinto.tpl', config_file, **values)
+    render_template("kinto.tpl", config_file, **values)

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -11,91 +11,98 @@ from pyramid.settings import aslist
 from kinto.core import errors
 from kinto.core import events
 from kinto.core.initialization import (  # NOQA
-    initialize, install_middlewares,
-    load_default_settings)
+    initialize,
+    install_middlewares,
+    load_default_settings,
+)
 from kinto.core.utils import (
-    follow_subrequest, current_service, current_resource_name,
-    prefixed_userid, prefixed_principals, log_context)
+    follow_subrequest,
+    current_service,
+    current_resource_name,
+    prefixed_userid,
+    prefixed_principals,
+    log_context,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
 # Module version, as defined in PEP-0396.
-__version__ = pkg_resources.get_distribution('kinto').version  # FIXME?
+__version__ = pkg_resources.get_distribution("kinto").version  # FIXME?
 
 DEFAULT_SETTINGS = {
-    'backoff': None,
-    'backoff_percentage': None,
-    'batch_max_requests': 25,
-    'cache_backend': '',
-    'cache_hosts': '',
-    'cache_url': '',
-    'cache_pool_size': 25,
-    'cache_prefix': '',
-    'cache_max_size_bytes': 524288,
-    'cors_origins': '*',
-    'cors_max_age_seconds': 3600,
-    'eos': None,
-    'eos_message': None,
-    'eos_url': None,
-    'error_info_link': 'https://github.com/Kinto/kinto/issues/',
-    'http_host': None,
-    'http_scheme': None,
-    'id_generator': 'kinto.core.storage.generators.UUID4',
-    'includes': '',
-    'initialization_sequence': (
-        'kinto.core.initialization.setup_request_bound_data',
-        'kinto.core.initialization.setup_json_serializer',
-        'kinto.core.initialization.setup_logging',
-        'kinto.core.initialization.setup_storage',
-        'kinto.core.initialization.setup_permission',
-        'kinto.core.initialization.setup_cache',
-        'kinto.core.initialization.setup_requests_scheme',
-        'kinto.core.initialization.setup_version_redirection',
-        'kinto.core.initialization.setup_deprecation',
-        'kinto.core.initialization.setup_authentication',
-        'kinto.core.initialization.setup_backoff',
-        'kinto.core.initialization.setup_statsd',
-        'kinto.core.initialization.setup_listeners',
-        'kinto.core.events.setup_transaction_hook',
+    "backoff": None,
+    "backoff_percentage": None,
+    "batch_max_requests": 25,
+    "cache_backend": "",
+    "cache_hosts": "",
+    "cache_url": "",
+    "cache_pool_size": 25,
+    "cache_prefix": "",
+    "cache_max_size_bytes": 524288,
+    "cors_origins": "*",
+    "cors_max_age_seconds": 3600,
+    "eos": None,
+    "eos_message": None,
+    "eos_url": None,
+    "error_info_link": "https://github.com/Kinto/kinto/issues/",
+    "http_host": None,
+    "http_scheme": None,
+    "id_generator": "kinto.core.storage.generators.UUID4",
+    "includes": "",
+    "initialization_sequence": (
+        "kinto.core.initialization.setup_request_bound_data",
+        "kinto.core.initialization.setup_json_serializer",
+        "kinto.core.initialization.setup_logging",
+        "kinto.core.initialization.setup_storage",
+        "kinto.core.initialization.setup_permission",
+        "kinto.core.initialization.setup_cache",
+        "kinto.core.initialization.setup_requests_scheme",
+        "kinto.core.initialization.setup_version_redirection",
+        "kinto.core.initialization.setup_deprecation",
+        "kinto.core.initialization.setup_authentication",
+        "kinto.core.initialization.setup_backoff",
+        "kinto.core.initialization.setup_statsd",
+        "kinto.core.initialization.setup_listeners",
+        "kinto.core.events.setup_transaction_hook",
     ),
-    'event_listeners': '',
-    'heartbeat_timeout_seconds': 10,
-    'newrelic_config': None,
-    'newrelic_env': 'dev',
-    'paginate_by': None,
-    'pagination_token_validity_seconds': 10 * 60,
-    'permission_backend': '',
-    'permission_url': '',
-    'permission_pool_size': 25,
-    'profiler_dir': tempfile.gettempdir(),
-    'profiler_enabled': False,
-    'project_docs': '',
-    'project_name': '',
-    'project_version': '',
-    'readonly': False,
-    'retry_after_seconds': 30,
-    'settings_prefix': '',
-    'statsd_backend': 'kinto.core.statsd',
-    'statsd_prefix': 'kinto.core',
-    'statsd_url': None,
-    'storage_backend': '',
-    'storage_url': '',
-    'storage_max_fetch_size': 10000,
-    'storage_pool_size': 25,
-    'tm.annotate_user': False,  # Do annotate transactions with the user-id.
-    'transaction_per_request': True,
-    'userid_hmac_secret': '',
-    'version_json_path': 'version.json',
-    'version_prefix_redirect_enabled': True,
-    'trailing_slash_redirect_enabled': True,
-    'multiauth.groupfinder': 'kinto.core.authorization.groupfinder',
-    'multiauth.policies': '',
-    'multiauth.policy.basicauth.use': ('kinto.core.authentication.'
-                                       'BasicAuthAuthenticationPolicy'),
-    'multiauth.authorization_policy': ('kinto.core.authorization.'
-                                       'AuthorizationPolicy'),
+    "event_listeners": "",
+    "heartbeat_timeout_seconds": 10,
+    "newrelic_config": None,
+    "newrelic_env": "dev",
+    "paginate_by": None,
+    "pagination_token_validity_seconds": 10 * 60,
+    "permission_backend": "",
+    "permission_url": "",
+    "permission_pool_size": 25,
+    "profiler_dir": tempfile.gettempdir(),
+    "profiler_enabled": False,
+    "project_docs": "",
+    "project_name": "",
+    "project_version": "",
+    "readonly": False,
+    "retry_after_seconds": 30,
+    "settings_prefix": "",
+    "statsd_backend": "kinto.core.statsd",
+    "statsd_prefix": "kinto.core",
+    "statsd_url": None,
+    "storage_backend": "",
+    "storage_url": "",
+    "storage_max_fetch_size": 10000,
+    "storage_pool_size": 25,
+    "tm.annotate_user": False,  # Do annotate transactions with the user-id.
+    "transaction_per_request": True,
+    "userid_hmac_secret": "",
+    "version_json_path": "version.json",
+    "version_prefix_redirect_enabled": True,
+    "trailing_slash_redirect_enabled": True,
+    "multiauth.groupfinder": "kinto.core.authorization.groupfinder",
+    "multiauth.policies": "",
+    "multiauth.policy.basicauth.use": (
+        "kinto.core.authentication." "BasicAuthAuthenticationPolicy"
+    ),
+    "multiauth.authorization_policy": ("kinto.core.authorization." "AuthorizationPolicy"),
 }
 
 
@@ -105,27 +112,27 @@ class Service(CorniceService):
     This is useful in order to attach specific behaviours without monkey
     patching the default cornice service (which would impact other uses of it)
     """
-    default_cors_headers = ('Backoff', 'Retry-After', 'Alert',
-                            'Content-Length')
+
+    default_cors_headers = ("Backoff", "Retry-After", "Alert", "Content-Length")
 
     def error_handler(self, request):
         return errors.json_error_handler(request)
 
     @classmethod
     def init_from_settings(cls, settings):
-        cls.cors_origins = tuple(aslist(settings['cors_origins']))
-        cors_max_age = settings['cors_max_age_seconds']
+        cls.cors_origins = tuple(aslist(settings["cors_origins"]))
+        cors_max_age = settings["cors_max_age_seconds"]
         cls.cors_max_age = int(cors_max_age) if cors_max_age else None
 
 
 class JsonLogFormatter(dockerflow_logging.JsonLogFormatter):
-    logger_name = 'kinto'
+    logger_name = "kinto"
 
     @classmethod
     def init_from_settings(cls, settings):
-        cls.logger_name = settings['project_name']
+        cls.logger_name = settings["project_name"]
 
-    def __init__(self, fmt=None, datefmt=None, style='%'):
+    def __init__(self, fmt=None, datefmt=None, style="%"):
         # Do not let mozilla-cloud-services-logger constructor to improperly
         # use style as the logger_name.
         # See https://github.com/mozilla/mozilla-cloud-services-logger/issues/3
@@ -136,10 +143,7 @@ class JsonLogFormatter(dockerflow_logging.JsonLogFormatter):
 
 def get_user_info(request):
     # Default user info (shown in hello view for example).
-    return {
-        'id': request.prefixed_userid,
-        'principals': request.prefixed_principals
-    }
+    return {"id": request.prefixed_userid, "principals": request.prefixed_principals}
 
 
 def includeme(config):
@@ -149,10 +153,10 @@ def includeme(config):
     config.registry.heartbeats = {}
 
     # Public settings registry.
-    config.registry.public_settings = {'batch_max_requests', 'readonly'}
+    config.registry.public_settings = {"batch_max_requests", "readonly"}
 
     # Directive to declare arbitrary API capabilities.
-    def add_api_capability(config, identifier, description='', url='', **kw):
+    def add_api_capability(config, identifier, description="", url="", **kw):
         existing = config.registry.api_capabilities.get(identifier)
         if existing:
             error_msg = "The '{}' API capability was already registered ({})."
@@ -161,23 +165,21 @@ def includeme(config):
         capability = dict(description=description, url=url, **kw)
         config.registry.api_capabilities[identifier] = capability
 
-    config.add_directive('add_api_capability', add_api_capability)
+    config.add_directive("add_api_capability", add_api_capability)
     config.registry.api_capabilities = {}
 
     # Resource events helpers.
-    config.add_request_method(events.get_resource_events,
-                              name='get_resource_events')
-    config.add_request_method(events.notify_resource_event,
-                              name='notify_resource_event')
+    config.add_request_method(events.get_resource_events, name="get_resource_events")
+    config.add_request_method(events.notify_resource_event, name="notify_resource_event")
 
     # Setup cornice.
-    config.include('cornice')
+    config.include("cornice")
 
     # Setup cornice api documentation
-    config.include('cornice_swagger')
+    config.include("cornice_swagger")
 
     # Per-request transaction.
-    config.include('pyramid_tm')
+    config.include("pyramid_tm")
 
     # Add CORS settings to the base kinto.core Service class.
     Service.init_from_settings(settings)
@@ -186,7 +188,7 @@ def includeme(config):
     JsonLogFormatter.init_from_settings(settings)
 
     # Setup components.
-    for step in aslist(settings['initialization_sequence']):
+    for step in aslist(settings["initialization_sequence"]):
         step_func = config.maybe_dotted(step)
         step_func(config)
 
@@ -195,13 +197,13 @@ def includeme(config):
     config.add_request_method(follow_subrequest)
     config.add_request_method(prefixed_userid, property=True)
     config.add_request_method(prefixed_principals, reify=True)
-    config.add_request_method(get_user_info, name='get_user_info')
+    config.add_request_method(get_user_info, name="get_user_info")
     config.add_request_method(current_resource_name, reify=True)
     config.add_request_method(current_service, reify=True)
     config.commit()
 
     # Include plugins after init, unlike pyramid includes.
-    includes = aslist(settings['includes'])
+    includes = aslist(settings["includes"])
     for app in includes:
         config.include(app)
 
@@ -210,8 +212,8 @@ def includeme(config):
     #     logger.info('Using {} = {}'.format(key, value))
 
     # Scan views.
-    config.scan('kinto.core.views')
+    config.scan("kinto.core.views")
 
     # Give sign of life.
-    msg = 'Running {project_name} {project_version}.'
+    msg = "Running {project_name} {project_version}."
     logger.info(msg.format_map(settings))

--- a/kinto/core/authentication.py
+++ b/kinto/core/authentication.py
@@ -11,9 +11,11 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
     account).
 
     """
+
     def __init__(self, *args, **kwargs):
         def noop_check(*a):
             return []
+
         super().__init__(noop_check, *args, **kwargs)
 
     def effective_principals(self, request):
@@ -31,16 +33,16 @@ class BasicAuthAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
             if not username:
                 return
 
-            hmac_secret = settings['userid_hmac_secret']
-            credentials = '{}:{}'.format(*credentials)
+            hmac_secret = settings["userid_hmac_secret"]
+            credentials = "{}:{}".format(*credentials)
             userid = utils.hmac_digest(hmac_secret, credentials)
             return userid
 
 
 def includeme(config):
     config.add_api_capability(
-        'basicauth',
-        description='Very basic authentication sessions. Not for production use.',
-        url='http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html',
+        "basicauth",
+        description="Very basic authentication sessions. Not for production use.",
+        url="http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html",
     )
-    OpenAPI.expose_authentication_method('basicauth', {'type': 'basic'})
+    OpenAPI.expose_authentication_method("basicauth", {"type": "basic"})

--- a/kinto/core/cache/__init__.py
+++ b/kinto/core/cache/__init__.py
@@ -6,15 +6,14 @@ logger = logging.getLogger(__name__)
 
 
 _HEARTBEAT_DELETE_RATE = 0.5
-_HEARTBEAT_KEY = '__heartbeat__'
+_HEARTBEAT_KEY = "__heartbeat__"
 _HEARTBEAT_TTL_SECONDS = 3600
 
 
 class CacheBase:
-
     def __init__(self, *args, **kwargs):
-        self.prefix = kwargs['cache_prefix']
-        self.max_size_bytes = kwargs.get('cache_max_size_bytes')
+        self.prefix = kwargs["cache_prefix"]
+        self.max_size_bytes = kwargs.get("cache_max_size_bytes")
 
     def initialize_schema(self, dry_run=False):
         """Create every necessary objects (like tables or indices) in the
@@ -88,10 +87,10 @@ def heartbeat(backend):
             if random.SystemRandom().random() < _HEARTBEAT_DELETE_RATE:
                 backend.delete(_HEARTBEAT_KEY)
             else:
-                backend.set(_HEARTBEAT_KEY, 'alive', _HEARTBEAT_TTL_SECONDS)
+                backend.set(_HEARTBEAT_KEY, "alive", _HEARTBEAT_TTL_SECONDS)
             return True
         except Exception:
-            logger.exception('Heartbeat Failure')
+            logger.exception("Heartbeat Failure")
             return False
 
     return ping

--- a/kinto/core/cache/memcached.py
+++ b/kinto/core/cache/memcached.py
@@ -19,18 +19,21 @@ def wrap_memcached_error(func):
             return func(*args, **kwargs)
         except TypeError:
             raise
-        except (memcache.Client.MemcachedKeyError,
-                memcache.Client.MemcachedStringEncodingError) as e:
+        except (
+            memcache.Client.MemcachedKeyError,
+            memcache.Client.MemcachedStringEncodingError,
+        ) as e:
             logger.exception(e)
             raise exceptions.BackendError(original=e)
+
     return wrapped
 
 
-def create_from_config(config, prefix=''):
+def create_from_config(config, prefix=""):
     """Redis client instantiation from settings.
     """
     settings = config.get_settings()
-    hosts = aslist(settings[prefix + 'hosts'])
+    hosts = aslist(settings[prefix + "hosts"])
     return memcache.Client(hosts)
 
 
@@ -67,7 +70,7 @@ class Cache(CacheBase):
         if not value:
             return None, 0
         data = json.loads(value)
-        return data['value'], data['ttl']
+        return data["value"], data["ttl"]
 
     def ttl(self, key):
         _, ttl = self._get(key)
@@ -91,7 +94,7 @@ class Cache(CacheBase):
     def set(self, key, value, ttl):
         if isinstance(value, bytes):
             raise TypeError("a string-like object is required, not 'bytes'")
-        value = json.dumps({'value': value, 'ttl': ceil(time() + ttl)})
+        value = json.dumps({"value": value, "ttl": ceil(time() + ttl)})
         self._client.set(self.prefix + key, value, int(ttl))
 
     @wrap_memcached_error
@@ -103,5 +106,5 @@ class Cache(CacheBase):
 
 def load_from_config(config):
     settings = config.get_settings()
-    client = create_from_config(config, prefix='cache_')
-    return Cache(client, cache_prefix=settings['cache_prefix'])
+    client = create_from_config(config, prefix="cache_")
+    return Cache(client, cache_prefix=settings["cache_prefix"])

--- a/kinto/core/cache/memory.py
+++ b/kinto/core/cache/memory.py
@@ -36,7 +36,7 @@ class Cache(CacheBase):
         current = msec_time()
         expired = [k for k, v in self._ttl.items() if current >= v]
         for expired_item_key in expired:
-            self.delete(expired_item_key[len(self.prefix):])
+            self.delete(expired_item_key[len(self.prefix) :])
 
     def _clean_oversized(self):
         if self._quota < self.max_size_bytes:
@@ -45,7 +45,7 @@ class Cache(CacheBase):
         for key, value in sorted(self._created_at.items(), key=lambda k: k[1]):
             if self._quota < (self.max_size_bytes * 0.8):
                 break
-            self.delete(key[len(self.prefix):])
+            self.delete(key[len(self.prefix) :])
 
     @synchronized
     def ttl(self, key):
@@ -87,8 +87,10 @@ class Cache(CacheBase):
 
 def load_from_config(config):
     settings = config.get_settings()
-    return Cache(cache_prefix=settings['cache_prefix'],
-                 cache_max_size_bytes=settings['cache_max_size_bytes'])
+    return Cache(
+        cache_prefix=settings["cache_prefix"],
+        cache_max_size_bytes=settings["cache_max_size_bytes"],
+    )
 
 
 def size_of(key, value):

--- a/kinto/core/cache/postgresql/__init__.py
+++ b/kinto/core/cache/postgresql/__init__.py
@@ -62,6 +62,7 @@ class Cache(CacheBase):
 
     :noindex:
     """  # NOQA
+
     def __init__(self, client, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = client
@@ -76,12 +77,12 @@ class Cache(CacheBase):
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query)
             if result.rowcount > 0:
-                logger.info('PostgreSQL cache schema is up-to-date.')
+                logger.info("PostgreSQL cache schema is up-to-date.")
                 return
 
         # Create schema
         here = os.path.dirname(__file__)
-        sql_file = os.path.join(here, 'schema.sql')
+        sql_file = os.path.join(here, "schema.sql")
 
         if dry_run:
             logger.info("Create cache schema from '{}'".format(sql_file))
@@ -92,7 +93,7 @@ class Cache(CacheBase):
             schema = f.read()
         with self.client.connect(force_commit=True) as conn:
             conn.execute(schema)
-        logger.info('Created PostgreSQL cache tables')
+        logger.info("Created PostgreSQL cache tables")
 
     def flush(self):
         query = """
@@ -101,7 +102,7 @@ class Cache(CacheBase):
         # Since called outside request (e.g. tests), force commit.
         with self.client.connect(force_commit=True) as conn:
             conn.execute(query)
-        logger.debug('Flushed PostgreSQL cache tables')
+        logger.debug("Flushed PostgreSQL cache tables")
 
     def ttl(self, key):
         query = """
@@ -113,7 +114,7 @@ class Cache(CacheBase):
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query, dict(key=self.prefix + key))
             if result.rowcount > 0:
-                return result.fetchone()['ttl']
+                return result.fetchone()["ttl"]
         return -1
 
     def expire(self, key, ttl):
@@ -136,8 +137,7 @@ class Cache(CacheBase):
         """
         value = json.dumps(value)
         with self.client.connect() as conn:
-            conn.execute(query, dict(key=self.prefix + key,
-                                     value=value, ttl=ttl))
+            conn.execute(query, dict(key=self.prefix + key, value=value, ttl=ttl))
 
     def get(self, key):
         purge = """
@@ -150,25 +150,25 @@ class Cache(CacheBase):
             FOR UPDATE
         ) del
         WHERE del.key = c.key;"""
-        query = 'SELECT value FROM cache WHERE key = :key AND now() < ttl;'
+        query = "SELECT value FROM cache WHERE key = :key AND now() < ttl;"
         with self.client.connect() as conn:
             conn.execute(purge)
             result = conn.execute(query, dict(key=self.prefix + key))
             if result.rowcount > 0:
-                value = result.fetchone()['value']
+                value = result.fetchone()["value"]
                 return json.loads(value)
 
     def delete(self, key):
-        query = 'DELETE FROM cache WHERE key = :key RETURNING value;'
+        query = "DELETE FROM cache WHERE key = :key RETURNING value;"
         with self.client.connect() as conn:
             result = conn.execute(query, dict(key=self.prefix + key))
             if result.rowcount > 0:
-                value = result.fetchone()['value']
+                value = result.fetchone()["value"]
                 return json.loads(value)
         return None
 
 
 def load_from_config(config):
     settings = config.get_settings()
-    client = create_from_config(config, prefix='cache_', with_transaction=False)
-    return Cache(client=client, cache_prefix=settings['cache_prefix'])
+    client = create_from_config(config, prefix="cache_", with_transaction=False)
+    return Cache(client=client, cache_prefix=settings["cache_prefix"])

--- a/kinto/core/cache/testing.py
+++ b/kinto/core/cache/testing.py
@@ -35,7 +35,7 @@ class CacheTest:
 
     def get_backend_prefix(self, prefix):
         settings_prefix = {**self.settings}
-        settings_prefix['cache_prefix'] = prefix
+        settings_prefix["cache_prefix"] = prefix
         config_prefix = self._get_config(settings=settings_prefix)
 
         # initiating cache backend with prefix:
@@ -47,11 +47,11 @@ class CacheTest:
         self.client_error_patcher.start()
         calls = [
             (self.cache.flush,),
-            (self.cache.ttl, ''),
-            (self.cache.expire, '', 0),
-            (self.cache.get, ''),
-            (self.cache.set, '', '', 42),
-            (self.cache.delete, ''),
+            (self.cache.ttl, ""),
+            (self.cache.expire, "", 0),
+            (self.cache.get, ""),
+            (self.cache.set, "", "", 42),
+            (self.cache.delete, ""),
         ]
         for call in calls:
             self.assertRaises(exceptions.BackendError, *call)
@@ -64,31 +64,31 @@ class CacheTest:
         self.client_error_patcher.start()
         ping = heartbeat(self.cache)
         self.assertFalse(ping(self.request))
-        with mock.patch('kinto.core.cache.random.SystemRandom.random', return_value=0.6):
+        with mock.patch("kinto.core.cache.random.SystemRandom.random", return_value=0.6):
             self.assertFalse(ping(self.request))
-        with mock.patch('kinto.core.cache.random.SystemRandom.random', return_value=0.4):
+        with mock.patch("kinto.core.cache.random.SystemRandom.random", return_value=0.4):
             self.assertFalse(ping(self.request))
 
     def test_ping_returns_true_if_available(self):
         ping = heartbeat(self.cache)
-        with mock.patch('kinto.core.cache.random.random', return_value=0.6):
+        with mock.patch("kinto.core.cache.random.random", return_value=0.6):
             self.assertTrue(ping(self.request))
-        with mock.patch('kinto.core.cache.random.random', return_value=0.4):
+        with mock.patch("kinto.core.cache.random.random", return_value=0.4):
             self.assertTrue(ping(self.request))
 
     def test_ping_logs_error_if_unavailable(self):
         self.client_error_patcher.start()
         ping = heartbeat(self.cache)
 
-        with mock.patch('kinto.core.cache.logger.exception') as exc_handler:
+        with mock.patch("kinto.core.cache.logger.exception") as exc_handler:
             self.assertFalse(ping(self.request))
 
         self.assertTrue(exc_handler.called)
 
     def test_set_adds_the_record(self):
-        stored = 'toto'
-        self.cache.set('foobar', stored, 42)
-        retrieved = self.cache.get('foobar')
+        stored = "toto"
+        self.cache.set("foobar", stored, 42)
+        retrieved = self.cache.get("foobar")
         self.assertEqual(retrieved, stored)
 
     def test_values_remains_python_dict(self):
@@ -96,114 +96,114 @@ class CacheTest:
             self.cache.set(k, v, 42)
             return (self.cache.get(k), v)
 
-        self.assertEqual(*setget('foobar', 3))
-        self.assertEqual(*setget('foobar', ['a']))
-        self.assertEqual(*setget('foobar', {'b': [1, 2]}))
-        self.assertEqual(*setget('foobar', 3.14))
+        self.assertEqual(*setget("foobar", 3))
+        self.assertEqual(*setget("foobar", ["a"]))
+        self.assertEqual(*setget("foobar", {"b": [1, 2]}))
+        self.assertEqual(*setget("foobar", 3.14))
 
     def test_bytes_cannot_be_stored_in_the_cache(self):
         with pytest.raises(TypeError):
-            self.cache.set('test', b'foo', 42)
+            self.cache.set("test", b"foo", 42)
 
     def test_delete_removes_the_record(self):
-        self.cache.set('foobar', 'toto', 42)
-        returned = self.cache.delete('foobar')
-        self.assertEqual(returned, 'toto')
-        missing = self.cache.get('foobar')
+        self.cache.set("foobar", "toto", 42)
+        returned = self.cache.delete("foobar")
+        self.assertEqual(returned, "toto")
+        missing = self.cache.get("foobar")
         self.assertIsNone(missing)
 
     def test_delete_does_not_fail_if_record_is_unknown(self):
-        returned = self.cache.delete('foobar')
+        returned = self.cache.delete("foobar")
         self.assertIsNone(returned)
 
     def test_expire_expires_the_value(self):
-        self.cache.set('foobar', 'toto', 42)
-        self.cache.expire('foobar', 0.01)
+        self.cache.set("foobar", "toto", 42)
+        self.cache.expire("foobar", 0.01)
         time.sleep(0.02)
-        retrieved = self.cache.get('foobar')
+        retrieved = self.cache.get("foobar")
         self.assertIsNone(retrieved)
 
     def test_set_with_ttl_expires_the_value(self):
-        self.cache.set('foobar', 'toto', 0.01)
+        self.cache.set("foobar", "toto", 0.01)
         time.sleep(0.02)
-        retrieved = self.cache.get('foobar')
+        retrieved = self.cache.get("foobar")
         self.assertIsNone(retrieved)
 
     def test_ttl_return_the_time_to_live(self):
-        self.cache.set('foobar', 'toto', 42)
-        self.cache.expire('foobar', 10)
-        ttl = self.cache.ttl('foobar')
+        self.cache.set("foobar", "toto", 42)
+        self.cache.expire("foobar", 10)
+        ttl = self.cache.ttl("foobar")
         self.assertGreater(ttl, 0)
         self.assertLessEqual(ttl, 10)
 
     def test_ttl_return_none_if_unknown(self):
-        ttl = self.cache.ttl('unknown')
+        ttl = self.cache.ttl("unknown")
         self.assertTrue(ttl < 0)
 
     def test_cache_prefix_is_set(self):
-        backend_prefix = self.get_backend_prefix(prefix='prefix_')
+        backend_prefix = self.get_backend_prefix(prefix="prefix_")
 
         # Set the value
-        backend_prefix.set('key', 'foo', 42)
+        backend_prefix.set("key", "foo", 42)
 
         # Validate that it was set with the prefix.
-        obtained = self.cache.get('prefix_key')
-        self.assertEqual(obtained, 'foo')
+        obtained = self.cache.get("prefix_key")
+        self.assertEqual(obtained, "foo")
 
     def test_cache_when_prefix_is_not_set(self):
-        backend_prefix = self.get_backend_prefix(prefix='')
+        backend_prefix = self.get_backend_prefix(prefix="")
 
         # Set a value
-        backend_prefix.set('key', 'foo', 42)
+        backend_prefix.set("key", "foo", 42)
 
         # Validate that it was set with no prefix
-        obtained = self.cache.get('key')
-        self.assertEqual(obtained, 'foo')
+        obtained = self.cache.get("key")
+        self.assertEqual(obtained, "foo")
 
     def test_prefix_value_use_to_get_data(self):
-        backend_prefix = self.get_backend_prefix(prefix='prefix_')
+        backend_prefix = self.get_backend_prefix(prefix="prefix_")
 
         # Set the value with the prefix
-        self.cache.set('prefix_key', 'foo', 42)
+        self.cache.set("prefix_key", "foo", 42)
 
         # Validate that the prefix was added
-        obtained = backend_prefix.get('key')
-        self.assertEqual(obtained, 'foo')
+        obtained = backend_prefix.get("key")
+        self.assertEqual(obtained, "foo")
 
     def test_prefix_value_use_to_delete_data(self):
-        backend_prefix = self.get_backend_prefix(prefix='prefix_')
+        backend_prefix = self.get_backend_prefix(prefix="prefix_")
         # Set the value
-        self.cache.set('prefix_key', 'foo', 42)
+        self.cache.set("prefix_key", "foo", 42)
 
         # Delete the value
-        backend_prefix.delete('key')
+        backend_prefix.delete("key")
 
         # Validate that the value was deleted
-        obtained = self.cache.get('prefix_key')
+        obtained = self.cache.get("prefix_key")
         self.assertEqual(obtained, None)
 
     def test_prefix_value_used_with_ttl(self):
-        backend_prefix = self.get_backend_prefix(prefix='prefix_')
+        backend_prefix = self.get_backend_prefix(prefix="prefix_")
 
-        self.cache.set('prefix_key', 'foo', 10)
+        self.cache.set("prefix_key", "foo", 10)
 
         # Validate that the ttl add the prefix to the key.
-        obtained = backend_prefix.ttl('key')
+        obtained = backend_prefix.ttl("key")
         self.assertLessEqual(obtained, 10)
         self.assertGreater(obtained, 9)
 
     def test_prefix_value_used_with_expire(self):
-        backend_prefix = self.get_backend_prefix(prefix='prefix_')
+        backend_prefix = self.get_backend_prefix(prefix="prefix_")
 
-        self.cache.set('prefix_foobar', 'toto', 10)
+        self.cache.set("prefix_foobar", "toto", 10)
 
         # expiring the ttl of key
-        backend_prefix.expire('foobar', 0)
+        backend_prefix.expire("foobar", 0)
 
         # Make sure the TTL was set accordingly.
-        ttl = self.cache.ttl('prefix_foobar')
+        ttl = self.cache.ttl("prefix_foobar")
         self.assertLessEqual(ttl, 0)
 
         # The record should have expired
-        retrieved = self.cache.get('prefix_foobar')
+        retrieved = self.cache.get("prefix_foobar")
         self.assertIsNone(retrieved)

--- a/kinto/core/decorators.py
+++ b/kinto/core/decorators.py
@@ -14,7 +14,7 @@ class cache_forever:
             self.saved = self.wrapped(request, *args, **kwargs)
             if isinstance(self.saved, Response):
                 self.saved = None
-                raise ValueError('cache_forever cannot cache Response only its body')
+                raise ValueError("cache_forever cannot cache Response only its body")
 
         request.response.write(self.saved)
         return request.response
@@ -26,12 +26,13 @@ def synchronized(method):
 
     The decorator installs a mutex on the class instance.
     """
+
     def decorated(self, *args, **kwargs):
         try:
-            lock = getattr(self, '__lock__')
+            lock = getattr(self, "__lock__")
         except AttributeError:
             lock = threading.RLock()
-            setattr(self, '__lock__', lock)
+            setattr(self, "__lock__", lock)
 
         lock.acquire()
         try:
@@ -39,4 +40,5 @@ def synchronized(method):
         finally:
             lock.release()
         return result
+
     return decorated

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -52,6 +52,7 @@ class ERRORS(Enum):
     | 410         | 202   | Service deprecated                             |
     +-------------+-------+------------------------------------------------+
     """
+
     MISSING_AUTH_TOKEN = 104
     INVALID_AUTH_TOKEN = 105
     BADJSON = 106
@@ -84,8 +85,9 @@ class ErrorSchema(colander.MappingSchema):
     details = colander.SchemaNode(Any(), missing=colander.drop)
 
 
-def http_error(httpexception, errno=None,
-               code=None, error=None, message=None, info=None, details=None):
+def http_error(
+    httpexception, errno=None, code=None, error=None, message=None, info=None, details=None
+):
     """Return a JSON formated response matching the error HTTP API.
 
     :param httpexception: Instance of :mod:`~pyramid:pyramid.httpexceptions`
@@ -104,18 +106,18 @@ def http_error(httpexception, errno=None,
         errno = errno.value
 
     body = {
-        'code': code or httpexception.code,
-        'errno': errno,
-        'error': error or httpexception.title,
-        'message': message,
-        'info': info,
-        'details': details or colander.drop,
+        "code": code or httpexception.code,
+        "errno": errno,
+        "error": error or httpexception.title,
+        "message": message,
+        "info": info,
+        "details": details or colander.drop,
     }
 
     response = httpexception
     response.errno = errno
     response.json = ErrorSchema().deserialize(body)
-    response.content_type = 'application/json'
+    response.content_type = "application/json"
     return response
 
 
@@ -136,36 +138,37 @@ def json_error_handler(request):
         (c.f. HTTP API).
     """
     errors = request.errors
-    sorted_errors = sorted(errors, key=lambda x: str(x['name']))
+    sorted_errors = sorted(errors, key=lambda x: str(x["name"]))
     # In Cornice, we call error handler if at least one error was set.
     error = sorted_errors[0]
-    name = error['name']
-    description = error['description']
+    name = error["name"]
+    description = error["description"]
 
     if isinstance(description, bytes):
-        description = error['description'].decode('utf-8')
+        description = error["description"].decode("utf-8")
 
     if name is not None:
         if name in description:
             message = description
         else:
-            message = '{name} in {location}: {description}'.format_map(error)
+            message = "{name} in {location}: {description}".format_map(error)
     else:
-        message = '{location}: {description}'.format_map(error)
+        message = "{location}: {description}".format_map(error)
 
-    response = http_error(httpexceptions.HTTPBadRequest(),
-                          code=errors.status,
-                          errno=ERRORS.INVALID_PARAMETERS.value,
-                          error='Invalid parameters',
-                          message=message,
-                          details=errors)
+    response = http_error(
+        httpexceptions.HTTPBadRequest(),
+        code=errors.status,
+        errno=ERRORS.INVALID_PARAMETERS.value,
+        error="Invalid parameters",
+        message=message,
+        details=errors,
+    )
     response.status = errors.status
     response = reapply_cors(request, response)
     return response
 
 
-def raise_invalid(request, location='body', name=None, description=None,
-                  **kwargs):
+def raise_invalid(request, location="body", name=None, description=None, **kwargs):
     """Helper to raise a validation error.
 
     :param location: location in request (e.g. ``'querystring'``)
@@ -179,7 +182,7 @@ def raise_invalid(request, location='body', name=None, description=None,
     raise response
 
 
-def send_alert(request, message=None, url=None, code='soft-eol'):
+def send_alert(request, message=None, url=None, code="soft-eol"):
     """Helper to add an Alert header to the response.
 
     :param code: The type of error 'soft-eol', 'hard-eol'
@@ -187,13 +190,9 @@ def send_alert(request, message=None, url=None, code='soft-eol'):
     :param url: The URL for more information, default to the documentation url.
     """
     if url is None:
-        url = request.registry.settings['project_docs']
+        url = request.registry.settings["project_docs"]
 
-    request.response.headers['Alert'] = json.dumps({
-        'code': code,
-        'message': message,
-        'url': url
-    })
+    request.response.headers["Alert"] = json.dumps({"code": code, "message": message, "url": url})
 
 
 def request_GET(request):
@@ -203,11 +202,12 @@ def request_GET(request):
     try:
         return request.GET
     except UnicodeDecodeError as e:
-        querystring = request.environ.get('QUERY_STRING', '')
+        querystring = request.environ.get("QUERY_STRING", "")
         logger = logging.getLogger(__name__)
-        logger.warn('Error decoding QUERY_STRING: %s' % request.environ)
+        logger.warn("Error decoding QUERY_STRING: %s" % request.environ)
         raise http_error(
             httpexceptions.HTTPBadRequest(),
             errno=ERRORS.INVALID_PARAMETERS,
-            message='A request with an incorrect encoding in the querystring was'
-            'received. Please make sure your requests are encoded in UTF-8: %s' % querystring)
+            message="A request with an incorrect encoding in the querystring was"
+            "received. Please make sure your requests are encoded in UTF-8: %s" % querystring,
+        )

--- a/kinto/core/events.py
+++ b/kinto/core/events.py
@@ -13,10 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 class ACTIONS(Enum):
-    CREATE = 'create'
-    DELETE = 'delete'
-    READ = 'read'
-    UPDATE = 'update'
+    CREATE = "create"
+    DELETE = "delete"
+    READ = "read"
+    UPDATE = "update"
 
     @staticmethod
     def from_string_list(elements):
@@ -29,14 +29,15 @@ class _ResourceEvent:
         self.request = request
 
     def __repr__(self):
-        return '<{klass} action={action} uri={uri}>'.format(
-            klass=self.__class__.__name__,
-            **self.payload)
+        return "<{klass} action={action} uri={uri}>".format(
+            klass=self.__class__.__name__, **self.payload
+        )
 
 
 class ResourceRead(_ResourceEvent):
     """Triggered when a resource is being read.
     """
+
     def __init__(self, payload, read_records, request):
         super().__init__(payload, request)
         self.read_records = read_records
@@ -45,6 +46,7 @@ class ResourceRead(_ResourceEvent):
 class ResourceChanged(_ResourceEvent):
     """Triggered when a resource is being changed.
     """
+
     def __init__(self, payload, impacted_records, request):
         super().__init__(payload, request)
         self.impacted_records = impacted_records
@@ -53,6 +55,7 @@ class ResourceChanged(_ResourceEvent):
 class AfterResourceRead(_ResourceEvent):
     """Triggered after a resource was successfully read.
     """
+
     def __init__(self, payload, read_records, request):
         super().__init__(payload, request)
         self.read_records = read_records
@@ -61,6 +64,7 @@ class AfterResourceRead(_ResourceEvent):
 class AfterResourceChanged(_ResourceEvent):
     """Triggered after a resource was successfully changed.
     """
+
     def __init__(self, payload, impacted_records, request):
         super().__init__(payload, request)
         self.impacted_records = impacted_records
@@ -116,6 +120,7 @@ class EventCollectorDrain(object):
     """An iterator that drains an EventCollector.
 
     Get one using EventCollector.drain()."""
+
     def __init__(self, event_collector):
         self.event_collector = event_collector
 
@@ -139,6 +144,7 @@ def notify_resource_events_before(handler, registry):
     This hook being a "commit veto" let us tell pyramid_tm to abort
     the transaction if the ResourceChanged listeners raise.
     """
+
     def tween(request):
         response = handler(request)
         for event in request.get_resource_events():
@@ -156,6 +162,7 @@ def setup_transaction_hook(config):
     Once a transaction is committed, ``AfterResourceRead`` and
     ``AfterResourceChanged`` events are sent.
     """
+
     def _notify_resource_events_after(success, request):
         """Notify the accumulated resource events if transaction succeeds.
         """
@@ -166,21 +173,21 @@ def setup_transaction_hook(config):
             try:
                 request.registry.notify(event)
             except Exception:
-                logger.error('Unable to notify', exc_info=True)
+                logger.error("Unable to notify", exc_info=True)
 
     def on_new_request(event):
         """When a new request comes in, hook on transaction commit.
         """
         # Since there is one transaction per batch, ignore subrequests.
-        if hasattr(event.request, 'parent'):
+        if hasattr(event.request, "parent"):
             return
         current = transaction.get()
-        current.addAfterCommitHook(_notify_resource_events_after,
-                                   args=(event.request,))
+        current.addAfterCommitHook(_notify_resource_events_after, args=(event.request,))
 
     config.add_subscriber(on_new_request, NewRequest)
-    config.add_tween('kinto.core.events.notify_resource_events_before',
-                     under=pyramid.tweens.EXCVIEW)
+    config.add_tween(
+        "kinto.core.events.notify_resource_events_before", under=pyramid.tweens.EXCVIEW
+    )
 
 
 def get_resource_events(request, after_commit=False):
@@ -197,7 +204,7 @@ def get_resource_events(request, after_commit=False):
 
     This generator must be completely consumed!
     """
-    by_resource = request.bound_data.get('resource_events', EventCollector())
+    by_resource = request.bound_data.get("resource_events", EventCollector())
     afterwards = EventCollector()
 
     for event_call in by_resource.drain():
@@ -217,11 +224,12 @@ def get_resource_events(request, after_commit=False):
 
         yield event_cls(payload, impacted, request)
 
-    request.bound_data['resource_events'] = afterwards
+    request.bound_data["resource_events"] = afterwards
 
 
-def notify_resource_event(request, parent_id, timestamp, data, action,
-                          old=None, resource_name=None, resource_data=None):
+def notify_resource_event(
+    request, parent_id, timestamp, data, action, old=None, resource_name=None, resource_data=None
+):
     """Request helper to stack a resource event.
 
     If a similar event (same resource, same action) already occured during the
@@ -243,33 +251,35 @@ def notify_resource_event(request, parent_id, timestamp, data, action,
             data = [data]
         impacted = data
     elif action == ACTIONS.CREATE:
-        impacted = [{'new': data}]
+        impacted = [{"new": data}]
     elif action == ACTIONS.DELETE:
         if not isinstance(data, list):
-            impacted = [{'new': data, 'old': old}]
+            impacted = [{"new": data, "old": old}]
         else:
             impacted = []
             for i, new in enumerate(data):
-                impacted.append({'new': new, 'old': old[i]})
+                impacted.append({"new": new, "old": old[i]})
     else:  # ACTIONS.UPDATE:
-        impacted = [{'new': data, 'old': old}]
+        impacted = [{"new": data, "old": old}]
 
     # Get previously triggered events.
-    events = request.bound_data.setdefault('resource_events', EventCollector())
+    events = request.bound_data.setdefault("resource_events", EventCollector())
 
     resource_name = resource_name or request.current_resource_name
     matchdict = resource_data or dict(request.matchdict)
 
-    payload = {'timestamp': timestamp,
-               'action': action.value,
-               # Deprecated: don't actually use URI (see #945).
-               'uri': strip_uri_prefix(request.path),
-               'user_id': request.prefixed_userid,
-               'resource_name': resource_name}
+    payload = {
+        "timestamp": timestamp,
+        "action": action.value,
+        # Deprecated: don't actually use URI (see #945).
+        "uri": strip_uri_prefix(request.path),
+        "user_id": request.prefixed_userid,
+        "resource_name": resource_name,
+    }
 
     # Deprecated: don't actually use `resource_name_id` either (see #945).
-    if 'id' in request.matchdict:
-        matchdict[resource_name + '_id'] = matchdict.pop('id')
+    if "id" in request.matchdict:
+        matchdict[resource_name + "_id"] = matchdict.pop("id")
 
     payload.update(**matchdict)
 

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -7,15 +7,13 @@ import random
 
 from pyramid.events import NewRequest, NewResponse
 from pyramid.exceptions import ConfigurationError
-from pyramid.httpexceptions import (HTTPTemporaryRedirect, HTTPGone,
-                                    HTTPBadRequest)
+from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPGone, HTTPBadRequest
 from pyramid.renderers import JSON as JSONRenderer
 from pyramid.response import Response
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.interfaces import IAuthenticationPolicy
 from pyramid.settings import asbool, aslist
-from pyramid_multiauth import (MultiAuthenticationPolicy,
-                               MultiAuthPolicySelected)
+from pyramid_multiauth import MultiAuthenticationPolicy, MultiAuthPolicySelected
 
 try:
     import newrelic.agent
@@ -35,17 +33,18 @@ from kinto.core.events import ResourceRead, ResourceChanged, ACTIONS
 
 
 logger = logging.getLogger(__name__)
-summary_logger = logging.getLogger('request.summary')
+summary_logger = logging.getLogger("request.summary")
 
 
 def setup_request_bound_data(config):
     """Attach custom data on request object, and share it with parent
     requests during batch."""
+
     def attach_bound_data(request):
-        parent = getattr(request, 'parent', None)
+        parent = getattr(request, "parent", None)
         return parent.bound_data if parent else {}
 
-    config.add_request_method(attach_bound_data, name='bound_data', reify=True)
+    config.add_request_method(attach_bound_data, name="bound_data", reify=True)
 
 
 def setup_json_serializer(config):
@@ -58,14 +57,14 @@ def setup_json_serializer(config):
 
     # Override json renderer using ujson
     renderer = JSONRenderer(serializer=utils.json_serializer)
-    config.add_renderer('json', renderer)
+    config.add_renderer("json", renderer)
 
 
 def setup_version_redirection(config):
     """Add a view which redirects to the current version of the API.
     """
     settings = config.get_settings()
-    redirect_enabled = settings['version_prefix_redirect_enabled']
+    redirect_enabled = settings["version_prefix_redirect_enabled"]
     version_prefix_redirection_enabled = asbool(redirect_enabled)
 
     route_prefix = config.route_prefix
@@ -78,24 +77,24 @@ def setup_version_redirection(config):
         return
 
     def _redirect_to_version_view(request):
-        if request.method.lower() == 'options':
+        if request.method.lower() == "options":
             # CORS responses should always have status 200.
             return utils.reapply_cors(request, Response())
 
-        querystring = request.url[(request.url.rindex(request.path) +
-                                   len(request.path)):]
-        redirect = '/{}{}{}'.format(route_prefix, request.path, querystring)
+        querystring = request.url[(request.url.rindex(request.path) + len(request.path)) :]
+        redirect = "/{}{}{}".format(route_prefix, request.path, querystring)
         raise HTTPTemporaryRedirect(redirect)
 
     # Disable the route prefix passed by the app.
     config.route_prefix = None
 
-    config.add_route(name='redirect_to_version',
-                     pattern=r'/{path:(?!v[0-9]+)[^\r\n]*}')
+    config.add_route(name="redirect_to_version", pattern=r"/{path:(?!v[0-9]+)[^\r\n]*}")
 
-    config.add_view(view=_redirect_to_version_view,
-                    route_name='redirect_to_version',
-                    permission=NO_PERMISSION_REQUIRED)
+    config.add_view(
+        view=_redirect_to_version_view,
+        route_name="redirect_to_version",
+        permission=NO_PERMISSION_REQUIRED,
+    )
 
     config.route_prefix = route_prefix
 
@@ -104,19 +103,19 @@ def setup_authentication(config):
     """Let pyramid_multiauth manage authentication and authorization
     from configuration.
     """
-    config.include('pyramid_multiauth')
+    config.include("pyramid_multiauth")
     settings = config.get_settings()
 
-    policies = aslist(settings['multiauth.policies'])
-    if 'basicauth' in policies:
-        config.include('kinto.core.authentication')
+    policies = aslist(settings["multiauth.policies"])
+    if "basicauth" in policies:
+        config.include("kinto.core.authentication")
 
     # Track policy used, for prefixing user_id and for logging.
     def on_policy_selected(event):
         request = event.request
         # If the authn policy has a name attribute, we use it rather
         # than using the one specified in settings.
-        authn_type = getattr(event.policy, 'name', event.policy_name.lower())
+        authn_type = getattr(event.policy, "name", event.policy_name.lower())
         request.authn_type = authn_type
         request.selected_userid = event.userid
         # Add authentication info to context.
@@ -131,16 +130,17 @@ def setup_backoff(config):
     This is useful to attach objects to the request object for easier
     access, and to pre-process responses.
     """
+
     def on_new_response(event):
         # Add backoff in response headers.
-        backoff = config.registry.settings['backoff']
+        backoff = config.registry.settings["backoff"]
         if backoff is not None:
-            backoff_percentage = config.registry.settings['backoff_percentage']
+            backoff_percentage = config.registry.settings["backoff_percentage"]
             if backoff_percentage is not None:
                 if random.random() < (float(backoff_percentage) / 100.0):
-                    event.response.headers['Backoff'] = str(backoff)
+                    event.response.headers["Backoff"] = str(backoff)
             else:
-                event.response.headers['Backoff'] = str(backoff)
+                event.response.headers["Backoff"] = str(backoff)
 
     config.add_subscriber(on_new_response, NewResponse)
 
@@ -149,8 +149,8 @@ def setup_requests_scheme(config):
     """Force server scheme, host and port at the application level."""
     settings = config.get_settings()
 
-    http_scheme = settings['http_scheme']
-    http_host = settings['http_host']
+    http_scheme = settings["http_scheme"]
+    http_host = settings["http_host"]
 
     def on_new_request(event):
         if http_scheme:
@@ -163,31 +163,29 @@ def setup_requests_scheme(config):
 
 
 def setup_deprecation(config):
-    config.add_tween('kinto.core.initialization._end_of_life_tween_factory')
+    config.add_tween("kinto.core.initialization._end_of_life_tween_factory")
 
 
 def _end_of_life_tween_factory(handler, registry):
     """Pyramid tween to handle service end of life."""
-    deprecation_msg = ('The service you are trying to connect no longer exists'
-                       ' at this location.')
+    deprecation_msg = "The service you are trying to connect no longer exists" " at this location."
 
     def eos_tween(request):
-        eos_date = registry.settings['eos']
-        eos_url = registry.settings['eos_url']
-        eos_message = registry.settings['eos_message']
+        eos_date = registry.settings["eos"]
+        eos_url = registry.settings["eos_url"]
+        eos_message = registry.settings["eos_message"]
         if not eos_date:
             return handler(request)
 
         eos_date = dateparser.parse(eos_date)
         if eos_date > datetime.now():
-            code = 'soft-eol'
+            code = "soft-eol"
             request.response = handler(request)
         else:
-            code = 'hard-eol'
+            code = "hard-eol"
             request.response = errors.http_error(
-                HTTPGone(),
-                errno=errors.ERRORS.SERVICE_DEPRECATED,
-                message=deprecation_msg)
+                HTTPGone(), errno=errors.ERRORS.SERVICE_DEPRECATED, message=deprecation_msg
+            )
 
         errors.send_alert(request, eos_message, url=eos_url, code=code)
         return request.response
@@ -201,84 +199,82 @@ def setup_storage(config):
     # Id generators by resource name.
     config.registry.id_generators = {}
     for key, value in settings.items():
-        m = re.match(r'^([^_]*)_?id_generator', key)
+        m = re.match(r"^([^_]*)_?id_generator", key)
         if m is None:
             continue
         resource_name = m.group(1)
         id_generator = config.maybe_dotted(value)
         config.registry.id_generators[resource_name] = id_generator()
 
-    storage_mod = settings['storage_backend']
+    storage_mod = settings["storage_backend"]
     if not storage_mod:
         return
 
     storage_mod = config.maybe_dotted(storage_mod)
     backend = storage_mod.load_from_config(config)
     if not isinstance(backend, storage.StorageBase):
-        raise ConfigurationError('Invalid storage backend: {}'.format(backend))
+        raise ConfigurationError("Invalid storage backend: {}".format(backend))
     config.registry.storage = backend
 
     heartbeat = storage.heartbeat(backend)
-    config.registry.heartbeats['storage'] = heartbeat
+    config.registry.heartbeats["storage"] = heartbeat
 
 
 def setup_permission(config):
     settings = config.get_settings()
-    permission_mod = settings['permission_backend']
+    permission_mod = settings["permission_backend"]
     if not permission_mod:
         return
 
     permission_mod = config.maybe_dotted(permission_mod)
     backend = permission_mod.load_from_config(config)
     if not isinstance(backend, permission.PermissionBase):
-        raise ConfigurationError('Invalid permission backend: {}'.format(backend))
+        raise ConfigurationError("Invalid permission backend: {}".format(backend))
     config.registry.permission = backend
 
     heartbeat = permission.heartbeat(backend)
-    config.registry.heartbeats['permission'] = heartbeat
+    config.registry.heartbeats["permission"] = heartbeat
 
 
 def setup_cache(config):
     settings = config.get_settings()
-    cache_mod = settings['cache_backend']
+    cache_mod = settings["cache_backend"]
     if not cache_mod:
         return
 
     cache_mod = config.maybe_dotted(cache_mod)
     backend = cache_mod.load_from_config(config)
     if not isinstance(backend, cache.CacheBase):
-        raise ConfigurationError('Invalid cache backend: {}'.format(backend))
+        raise ConfigurationError("Invalid cache backend: {}".format(backend))
     config.registry.cache = backend
 
     heartbeat = cache.heartbeat(backend)
-    config.registry.heartbeats['cache'] = heartbeat
+    config.registry.heartbeats["cache"] = heartbeat
 
 
 def setup_statsd(config):
     settings = config.get_settings()
     config.registry.statsd = None
 
-    if settings['statsd_url']:
-        statsd_mod = settings['statsd_backend']
+    if settings["statsd_url"]:
+        statsd_mod = settings["statsd_backend"]
         statsd_mod = config.maybe_dotted(statsd_mod)
         client = statsd_mod.load_from_config(config)
 
         config.registry.statsd = client
 
-        client.watch_execution_time(config.registry.cache, prefix='backend')
-        client.watch_execution_time(config.registry.storage, prefix='backend')
-        client.watch_execution_time(config.registry.permission, prefix='backend')
+        client.watch_execution_time(config.registry.cache, prefix="backend")
+        client.watch_execution_time(config.registry.storage, prefix="backend")
+        client.watch_execution_time(config.registry.permission, prefix="backend")
 
         # Commit so that configured policy can be queried.
         config.commit()
         policy = config.registry.queryUtility(IAuthenticationPolicy)
         if isinstance(policy, MultiAuthenticationPolicy):
             for name, subpolicy in policy.get_policies():
-                client.watch_execution_time(subpolicy,
-                                            prefix='authentication',
-                                            classname=name)
+                client.watch_execution_time(subpolicy, prefix="authentication", classname=name)
         else:
-            client.watch_execution_time(policy, prefix='authentication')
+            client.watch_execution_time(policy, prefix="authentication")
 
         def on_new_response(event):
             request = event.request
@@ -287,17 +283,17 @@ def setup_statsd(config):
             user_id = request.prefixed_userid
             if user_id:
                 # Get rid of colons in metric packet (see #1282).
-                user_id = user_id.replace(':', '.')
-                client.count('users', unique=user_id)
+                user_id = user_id.replace(":", ".")
+                client.count("users", unique=user_id)
 
             # Count authentication verifications.
-            if hasattr(request, 'authn_type'):
-                client.count('authn_type.{}'.format(request.authn_type))
+            if hasattr(request, "authn_type"):
+                client.count("authn_type.{}".format(request.authn_type))
 
             # Count view calls.
             service = request.current_service
             if service:
-                client.count('view.{}.{}'.format(service.name, request.method))
+                client.count("view.{}.{}".format(service.name, request.method))
 
         config.add_subscriber(on_new_response, NewResponse)
 
@@ -305,19 +301,18 @@ def setup_statsd(config):
 
 
 def install_middlewares(app, settings):
-    'Install a set of middlewares defined in the ini file on the given app.'
+    "Install a set of middlewares defined in the ini file on the given app."
     # Setup new-relic.
-    if settings.get('newrelic_config'):
-        ini_file = settings['newrelic_config']
-        env = settings['newrelic_env']
+    if settings.get("newrelic_config"):
+        ini_file = settings["newrelic_config"]
+        env = settings["newrelic_env"]
         newrelic.agent.initialize(ini_file, env)
         app = newrelic.agent.WSGIApplicationWrapper(app)
 
     # Adds the Werkzeug profiler.
-    if asbool(settings.get('profiler_enabled')):
-        profile_dir = settings['profiler_dir']
-        app = ProfilerMiddleware(app, profile_dir=profile_dir,
-                                 restrictions=('*kinto.core*'))
+    if asbool(settings.get("profiler_enabled")):
+        profile_dir = settings["profiler_dir"]
+        app = ProfilerMiddleware(app, profile_dir=profile_dir, restrictions=("*kinto.core*"))
 
     return app
 
@@ -329,6 +324,7 @@ def setup_logging(config):
     * https://mana.mozilla.org/wiki/display/CLOUDSERVICES/Logging+Standard
     * http://12factor.net/logs
     """
+
     def on_new_request(event):
         request = event.request
         # Save the time the request was received by the server.
@@ -341,20 +337,22 @@ def setup_logging(config):
             raise errors.http_error(
                 HTTPBadRequest(),
                 errno=errors.ERRORS.INVALID_PARAMETERS,
-                message='Invalid URL path.')
+                message="Invalid URL path.",
+            )
 
-        request.log_context(agent=request.headers.get('User-Agent'),
-                            path=request_path,
-                            method=request.method,
-                            lang=request.headers.get('Accept-Language'),
-                            errno=0)
+        request.log_context(
+            agent=request.headers.get("User-Agent"),
+            path=request_path,
+            method=request.method,
+            lang=request.headers.get("Accept-Language"),
+            errno=0,
+        )
         qs = dict(errors.request_GET(request))
         if qs:
             request.log_context(querystring=qs)
 
         if summary_logger.level == logging.DEBUG:
-            request.log_context(headers=dict(request.headers),
-                                body=request.body)
+            request.log_context(headers=dict(request.headers), body=request.body)
 
     config.add_subscriber(on_new_request, NewRequest)
 
@@ -364,17 +362,14 @@ def setup_logging(config):
 
         # Compute the request processing time in msec (-1 if unknown)
         current = utils.msec_time()
-        duration = current - getattr(request, '_received_at', current - 1)
-        isotimestamp = datetime.fromtimestamp(current/1000).isoformat()
+        duration = current - getattr(request, "_received_at", current - 1)
+        isotimestamp = datetime.fromtimestamp(current / 1000).isoformat()
 
         # Bind infos for request summary logger.
-        request.log_context(time=isotimestamp,
-                            code=response.status_code,
-                            t=duration)
+        request.log_context(time=isotimestamp, code=response.status_code, t=duration)
 
         if summary_logger.level == logging.DEBUG:
-            request.log_context(response=dict(headers=dict(response.headers),
-                                              body=response.body))
+            request.log_context(response=dict(headers=dict(response.headers), body=response.body))
 
         try:
             # If error response, bind errno.
@@ -382,9 +377,9 @@ def setup_logging(config):
         except AttributeError:
             pass
 
-        if not hasattr(request, 'parent'):
+        if not hasattr(request, "parent"):
             # Ouput application request summary.
-            summary_logger.info('', extra=request.log_context())
+            summary_logger.info("", extra=request.log_context())
 
     config.add_subscriber(on_new_response, NewResponse)
 
@@ -395,10 +390,10 @@ class EventActionFilter:
         self.actions = [action.value for action in actions]
 
     def phash(self):
-        return 'for_actions = {}'.format(','.join(self.actions))
+        return "for_actions = {}".format(",".join(self.actions))
 
     def __call__(self, event):
-        action = event.payload.get('action')
+        action = event.payload.get("action")
         return not action or action in self.actions
 
 
@@ -407,50 +402,52 @@ class EventResourceFilter:
         self.resources = resources
 
     def phash(self):
-        return 'for_resources = {}'.format(','.join(self.resources))
+        return "for_resources = {}".format(",".join(self.resources))
 
     def __call__(self, event):
-        resource = event.payload.get('resource_name')
+        resource = event.payload.get("resource_name")
         return not resource or not self.resources or resource in self.resources
 
 
 def setup_listeners(config):
     # Register basic subscriber predicates, to filter events.
-    config.add_subscriber_predicate('for_actions', EventActionFilter)
-    config.add_subscriber_predicate('for_resources', EventResourceFilter)
+    config.add_subscriber_predicate("for_actions", EventActionFilter)
+    config.add_subscriber_predicate("for_resources", EventResourceFilter)
 
     write_actions = (ACTIONS.CREATE, ACTIONS.UPDATE, ACTIONS.DELETE)
     settings = config.get_settings()
-    settings_prefix = settings.get('settings_prefix', '')
-    listeners = aslist(settings['event_listeners'])
+    settings_prefix = settings.get("settings_prefix", "")
+    listeners = aslist(settings["event_listeners"])
 
     for name in listeners:
         logger.info("Setting up '{}' listener".format(name))
-        prefix = 'event_listeners.{}.'.format(name)
+        prefix = "event_listeners.{}.".format(name)
 
         try:
             listener_mod = config.maybe_dotted(name)
-            prefix = 'event_listeners.{}.'.format(name.split('.')[-1])
+            prefix = "event_listeners.{}.".format(name.split(".")[-1])
             listener = listener_mod.load_from_config(config, prefix)
         except (ImportError, AttributeError):
-            module_setting = prefix + 'use'
+            module_setting = prefix + "use"
             # Read from ENV or settings.
-            module_value = utils.read_env('{}.{}'.format(settings_prefix, module_setting),
-                                          settings.get(module_setting))
+            module_value = utils.read_env(
+                "{}.{}".format(settings_prefix, module_setting), settings.get(module_setting)
+            )
             listener_mod = config.maybe_dotted(module_value)
             listener = listener_mod.load_from_config(config, prefix)
 
         # If StatsD is enabled, monitor execution time of listeners.
-        if getattr(config.registry, 'statsd', None):
+        if getattr(config.registry, "statsd", None):
             statsd_client = config.registry.statsd
-            key = 'listeners.{}'.format(name)
+            key = "listeners.{}".format(name)
             listener = statsd_client.timer(key)(listener.__call__)
 
         # Optional filter by event action.
-        actions_setting = prefix + 'actions'
+        actions_setting = prefix + "actions"
         # Read from ENV or settings.
-        actions_value = utils.read_env('{}.{}'.format(settings_prefix, actions_setting),
-                                       settings.get(actions_setting, ''))
+        actions_value = utils.read_env(
+            "{}.{}".format(settings_prefix, actions_setting), settings.get(actions_setting, "")
+        )
         actions = aslist(actions_value)
         if len(actions) > 0:
             actions = ACTIONS.from_string_list(actions)
@@ -458,10 +455,11 @@ def setup_listeners(config):
             actions = write_actions
 
         # Optional filter by event resource name.
-        resource_setting = prefix + 'resources'
+        resource_setting = prefix + "resources"
         # Read from ENV or settings.
-        resource_value = utils.read_env('{}.{}'.format(settings_prefix, resource_setting),
-                                        settings.get(resource_setting, ''))
+        resource_value = utils.read_env(
+            "{}.{}".format(settings_prefix, resource_setting), settings.get(resource_setting, "")
+        )
         resource_names = aslist(resource_value)
 
         # Pyramid event predicates.
@@ -481,13 +479,13 @@ def load_default_settings(config, default_settings):
     """
     settings = config.get_settings()
 
-    settings_prefix = settings['settings_prefix']
+    settings_prefix = settings["settings_prefix"]
 
     def _prefixed_keys(key):
         unprefixed = key
-        if key.startswith(settings_prefix + '.'):
-            unprefixed = key.split('.', 1)[1]
-        project_prefix = '{}.{}'.format(settings_prefix, unprefixed)
+        if key.startswith(settings_prefix + "."):
+            unprefixed = key.split(".", 1)[1]
+        project_prefix = "{}.{}".format(settings_prefix, unprefixed)
         return unprefixed, project_prefix
 
     # Fill settings with default values if not defined.
@@ -518,7 +516,7 @@ def load_default_settings(config, default_settings):
     config.add_settings(settings)
 
 
-def initialize(config, version=None, settings_prefix='', default_settings=None):
+def initialize(config, version=None, settings_prefix="", default_settings=None):
     """Initialize kinto.core with the given configuration, version and project
     name.
 
@@ -537,11 +535,12 @@ def initialize(config, version=None, settings_prefix='', default_settings=None):
 
     settings = config.get_settings()
 
-    settings_prefix = settings.pop('kinto.settings_prefix',
-                                   settings.get('settings_prefix')) or settings_prefix
-    settings['settings_prefix'] = settings_prefix
+    settings_prefix = (
+        settings.pop("kinto.settings_prefix", settings.get("settings_prefix")) or settings_prefix
+    )
+    settings["settings_prefix"] = settings_prefix
     if not settings_prefix:
-        warnings.warn('No value specified for `settings_prefix`')
+        warnings.warn("No value specified for `settings_prefix`")
 
     kinto_core_defaults = {**DEFAULT_SETTINGS}
 
@@ -550,25 +549,25 @@ def initialize(config, version=None, settings_prefix='', default_settings=None):
 
     load_default_settings(config, kinto_core_defaults)
 
-    http_scheme = settings['http_scheme']
-    if http_scheme != 'https':
-        warnings.warn('HTTPS is not enabled')
+    http_scheme = settings["http_scheme"]
+    if http_scheme != "https":
+        warnings.warn("HTTPS is not enabled")
 
     # Override project version from settings.
-    project_version = settings.get('project_version') or version
+    project_version = settings.get("project_version") or version
     if not project_version:
-        error_msg = 'Invalid project version: {}'.format(project_version)
+        error_msg = "Invalid project version: {}".format(project_version)
         raise ConfigurationError(error_msg)
-    settings['project_version'] = project_version = str(project_version)
+    settings["project_version"] = project_version = str(project_version)
 
     # HTTP API version.
-    http_api_version = settings.get('http_api_version')
+    http_api_version = settings.get("http_api_version")
     if http_api_version is None:
         # The API version is derivated from the module version if not provided.
-        http_api_version = '.'.join(project_version.split('.')[0:2])
-    settings['http_api_version'] = http_api_version = str(http_api_version)
-    api_version = 'v{}'.format(http_api_version.split('.')[0])
+        http_api_version = ".".join(project_version.split(".")[0:2])
+    settings["http_api_version"] = http_api_version = str(http_api_version)
+    api_version = "v{}".format(http_api_version.split(".")[0])
 
     # Include kinto.core views with the correct api version prefix.
-    config.include('kinto.core', route_prefix=api_version)
+    config.include("kinto.core", route_prefix=api_version)
     config.route_prefix = api_version

--- a/kinto/core/openapi.py
+++ b/kinto/core/openapi.py
@@ -48,7 +48,7 @@ class OpenAPI(CorniceSwagger):
 
         """
         cls.security_definitions[method_name] = definition
-        cls.security_roles[method_name] = definition.get('scopes', {}).keys()
+        cls.security_roles[method_name] = definition.get("scopes", {}).keys()
 
     def __init__(self, services, request):
         super().__init__(services)
@@ -56,18 +56,18 @@ class OpenAPI(CorniceSwagger):
         self.request = request
         self.settings = request.registry.settings
 
-        self.api_title = self.settings['project_name']
-        self.api_version = self.settings['http_api_version']
-        self.ignore_ctypes = ['application/json-patch+json']
+        self.api_title = self.settings["project_name"]
+        self.api_version = self.settings["http_api_version"]
+        self.ignore_ctypes = ["application/json-patch+json"]
 
         # Matches the base routing address - See kinto.core.initialization
-        self.base_path = '/v{}'.format(self.api_version.split('.')[0])
+        self.base_path = "/v{}".format(self.api_version.split(".")[0])
 
     def generate(self):
         base_spec = {
-            'host': self.request.host,
-            'schemes': [self.settings.get('http_scheme') or 'http'],
-            'securityDefinitions': self.security_definitions,
+            "host": self.request.host,
+            "schemes": [self.settings.get("http_scheme") or "http"],
+            "securityDefinitions": self.security_definitions,
         }
 
         return super(OpenAPI, self).generate(swagger=base_spec)
@@ -76,8 +76,8 @@ class OpenAPI(CorniceSwagger):
         """Povides default tags to views."""
 
         base_tag = service.name.capitalize()
-        base_tag = base_tag.replace('-collection', 's')
-        base_tag = base_tag.replace('-record', 's')
+        base_tag = base_tag.replace("-collection", "s")
+        base_tag = base_tag.replace("-record", "s")
 
         return [base_tag]
 
@@ -85,20 +85,17 @@ class OpenAPI(CorniceSwagger):
         """Povides default operation ids to methods if not defined on view."""
 
         method = method.lower()
-        method_mapping = {
-            'post': 'create',
-            'put': 'update'
-        }
+        method_mapping = {"post": "create", "put": "update"}
         if method in method_mapping:
             method = method_mapping[method]
 
         resource = service.name
-        if method == 'create':
-            resource = resource.replace('-collection', '')
+        if method == "create":
+            resource = resource.replace("-collection", "")
 
-        resource = resource.replace('-collection', 's')
-        resource = resource.replace('-record', '')
-        op_id = '{}_{}'.format(method, resource)
+        resource = resource.replace("-collection", "s")
+        resource = resource.replace("-record", "")
+        op_id = "{}_{}".format(method, resource)
 
         return op_id
 
@@ -113,7 +110,7 @@ class OpenAPI(CorniceSwagger):
             if met == method:
                 break
 
-        if args.get('permission') == '__no_permission_required__':
+        if args.get("permission") == "__no_permission_required__":
             return []
         else:
             return [{name: list(roles)} for name, roles in self.security_roles.items()]

--- a/kinto/core/permission/__init__.py
+++ b/kinto/core/permission/__init__.py
@@ -6,11 +6,10 @@ from pyramid.settings import asbool
 logger = logging.getLogger(__name__)
 
 
-__HEARTBEAT_KEY__ = '__heartbeat__'
+__HEARTBEAT_KEY__ = "__heartbeat__"
 
 
 class PermissionBase:
-
     def __init__(self, *args, **kwargs):
         pass
 
@@ -189,14 +188,15 @@ def heartbeat(backend):
         :rtype: bool
         """
         try:
-            if asbool(request.registry.settings.get('readonly')):
+            if asbool(request.registry.settings.get("readonly")):
                 # Do not try to write in readonly mode.
                 backend.get_user_principals(__HEARTBEAT_KEY__)
             else:
-                backend.add_user_principal(__HEARTBEAT_KEY__, 'alive')
-                backend.remove_user_principal(__HEARTBEAT_KEY__, 'alive')
+                backend.add_user_principal(__HEARTBEAT_KEY__, "alive")
+                backend.remove_user_principal(__HEARTBEAT_KEY__, "alive")
         except Exception:
-            logger.exception('Heartbeat Error')
+            logger.exception("Heartbeat Error")
             return False
         return True
+
     return ping

--- a/kinto/core/permission/memory.py
+++ b/kinto/core/permission/memory.py
@@ -27,14 +27,14 @@ class Permission(PermissionBase):
 
     @synchronized
     def add_user_principal(self, user_id, principal):
-        user_key = 'user:{}'.format(user_id)
+        user_key = "user:{}".format(user_id)
         user_principals = self._store.get(user_key, set())
         user_principals.add(principal)
         self._store[user_key] = user_principals
 
     @synchronized
     def remove_user_principal(self, user_id, principal):
-        user_key = 'user:{}'.format(user_id)
+        user_key = "user:{}".format(user_id)
         user_principals = self._store.get(user_key, set())
         try:
             user_principals.remove(principal)
@@ -57,22 +57,22 @@ class Permission(PermissionBase):
     @synchronized
     def get_user_principals(self, user_id):
         # Fetch the groups the user is in.
-        user_key = 'user:{}'.format(user_id)
+        user_key = "user:{}".format(user_id)
         members = self._store.get(user_key, set())
         # Fetch the groups system.Authenticated is in.
-        group_authenticated = self._store.get('user:system.Authenticated', set())
+        group_authenticated = self._store.get("user:system.Authenticated", set())
         return members | group_authenticated
 
     @synchronized
     def add_principal_to_ace(self, object_id, permission, principal):
-        permission_key = 'permission:{}:{}'.format(object_id, permission)
+        permission_key = "permission:{}:{}".format(object_id, permission)
         object_permission_principals = self._store.get(permission_key, set())
         object_permission_principals.add(principal)
         self._store[permission_key] = object_permission_principals
 
     @synchronized
     def remove_principal_from_ace(self, object_id, permission, principal):
-        permission_key = 'permission:{}:{}'.format(object_id, permission)
+        permission_key = "permission:{}:{}".format(object_id, permission)
         object_permission_principals = self._store.get(permission_key, set())
         try:
             object_permission_principals.remove(principal)
@@ -86,7 +86,7 @@ class Permission(PermissionBase):
 
     @synchronized
     def get_object_permission_principals(self, object_id, permission):
-        permission_key = 'permission:{}:{}'.format(object_id, permission)
+        permission_key = "permission:{}:{}".format(object_id, permission)
         members = self._store.get(permission_key, set())
         return members
 
@@ -96,15 +96,15 @@ class Permission(PermissionBase):
         candidates = []
         if bound_permissions is None:
             for key, value in self._store.items():
-                _, object_id, permission = key.split(':', 2)
+                _, object_id, permission = key.split(":", 2)
                 candidates.append((object_id, permission, value))
         else:
             for pattern, perm in bound_permissions:
-                id_match = '.*' if with_children else '[^/]+'
-                regexp = re.compile('^{}$'.format(pattern.replace('*', id_match)))
+                id_match = ".*" if with_children else "[^/]+"
+                regexp = re.compile("^{}$".format(pattern.replace("*", id_match)))
                 for key, value in self._store.items():
                     if key.endswith(perm):
-                        object_id = key.split(':')[1]
+                        object_id = key.split(":")[1]
                         if regexp.match(object_id):
                             candidates.append((object_id, perm, value))
 
@@ -126,15 +126,19 @@ class Permission(PermissionBase):
         result = []
         for object_id in objects_ids:
             if permissions is None:
-                aces = [k for k in self._store.keys()
-                        if k.startswith('permission:{}:'.format(object_id))]
+                aces = [
+                    k
+                    for k in self._store.keys()
+                    if k.startswith("permission:{}:".format(object_id))
+                ]
             else:
-                aces = ['permission:{}:{}'.format(object_id, permission)
-                        for permission in permissions]
+                aces = [
+                    "permission:{}:{}".format(object_id, permission) for permission in permissions
+                ]
             perms = {}
             for ace in aces:
                 # Should work with 'permission:/url/id:record:create'.
-                permission = ace.split(':', 2)[2]
+                permission = ace.split(":", 2)[2]
                 perms[permission] = set(self._store[ace])
             result.append(perms)
         return result
@@ -142,7 +146,7 @@ class Permission(PermissionBase):
     @synchronized
     def replace_object_permissions(self, object_id, permissions):
         for permission, principals in permissions.items():
-            permission_key = 'permission:{}:{}'.format(object_id, permission)
+            permission_key = "permission:{}:{}".format(object_id, permission)
             if permission_key in self._store and len(principals) == 0:
                 del self._store[permission_key]
             elif principals:
@@ -153,9 +157,9 @@ class Permission(PermissionBase):
     def delete_object_permissions(self, *object_id_list):
         to_delete = []
         for key in self._store.keys():
-            object_id = key.split(':')[1]
+            object_id = key.split(":")[1]
             for pattern in object_id_list:
-                regexp = re.compile('^{}$'.format(pattern.replace('*', '.*')))
+                regexp = re.compile("^{}$".format(pattern.replace("*", ".*")))
                 if regexp.match(object_id):
                     to_delete.append(key)
         for k in to_delete:

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -67,10 +67,10 @@ class Permission(PermissionBase, MigratorMixin):
     :noindex:
     """  # NOQA
 
-    name = 'permission'
+    name = "permission"
     schema_version = 2
-    schema_file = os.path.join(HERE, 'schema.sql')
-    migrations_directory = os.path.join(HERE, 'migrations')
+    schema_file = os.path.join(HERE, "schema.sql")
+    migrations_directory = os.path.join(HERE, "migrations")
 
     def __init__(self, client, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -113,7 +113,7 @@ class Permission(PermissionBase, MigratorMixin):
             with self.client.connect() as conn:
                 result = conn.execute(query)
                 if result.rowcount > 0:
-                    return int(result.fetchone()['version'])
+                    return int(result.fetchone()["version"])
 
         # Either the metadata table doesn't exist, or it doesn't have
         # a permission_schema_version row. Many possiblities exist:
@@ -151,7 +151,7 @@ class Permission(PermissionBase, MigratorMixin):
         # Since called outside request (e.g. tests), force commit.
         with self.client.connect(force_commit=True) as conn:
             conn.execute(query)
-        logger.debug('Flushed PostgreSQL permission tables')
+        logger.debug("Flushed PostgreSQL permission tables")
 
     def add_user_principal(self, user_id, principal):
         query = """
@@ -190,7 +190,7 @@ class Permission(PermissionBase, MigratorMixin):
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query, dict(user_id=user_id))
             results = result.fetchall()
-        return set([r['principal'] for r in results])
+        return set([r["principal"] for r in results])
 
     def add_principal_to_ace(self, object_id, permission, principal):
         query = """
@@ -204,9 +204,9 @@ class Permission(PermissionBase, MigratorMixin):
                AND principal = :principal
         );"""
         with self.client.connect() as conn:
-            conn.execute(query, dict(object_id=object_id,
-                                     permission=permission,
-                                     principal=principal))
+            conn.execute(
+                query, dict(object_id=object_id, permission=permission, principal=principal)
+            )
 
     def remove_principal_from_ace(self, object_id, permission, principal):
         query = """
@@ -215,9 +215,9 @@ class Permission(PermissionBase, MigratorMixin):
            AND permission = :permission
            AND principal = :principal;"""
         with self.client.connect() as conn:
-            conn.execute(query, dict(object_id=object_id,
-                                     permission=permission,
-                                     principal=principal))
+            conn.execute(
+                query, dict(object_id=object_id, permission=permission, principal=principal)
+            )
 
     def get_object_permission_principals(self, object_id, permission):
         query = """
@@ -226,10 +226,9 @@ class Permission(PermissionBase, MigratorMixin):
          WHERE object_id = :object_id
            AND permission = :permission;"""
         with self.client.connect(readonly=True) as conn:
-            result = conn.execute(query, dict(object_id=object_id,
-                                              permission=permission))
+            result = conn.execute(query, dict(object_id=object_id, permission=permission))
             results = result.fetchall()
-        return set([r['principal'] for r in results])
+        return set([r["principal"] for r in results])
 
     def get_authorized_principals(self, bound_permissions):
         # XXX: this method is not used, except in test suites :(
@@ -239,9 +238,9 @@ class Permission(PermissionBase, MigratorMixin):
         placeholders = {}
         perm_values = []
         for i, (obj, perm) in enumerate(bound_permissions):
-            placeholders['obj_{}'.format(i)] = obj
-            placeholders['perm_{}'.format(i)] = perm
-            perm_values.append('(:obj_{0}, :perm_{0})'.format(i))
+            placeholders["obj_{}".format(i)] = obj
+            placeholders["perm_{}".format(i)] = perm
+            perm_values.append("(:obj_{0}, :perm_{0})".format(i))
 
         query = """
         WITH required_perms AS (
@@ -250,11 +249,13 @@ class Permission(PermissionBase, MigratorMixin):
         SELECT principal
           FROM required_perms JOIN access_control_entries
             ON (object_id = column1 AND permission = column2);
-        """.format(','.join(perm_values))
+        """.format(
+            ",".join(perm_values)
+        )
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query, placeholders)
             results = result.fetchall()
-        return set([r['principal'] for r in results])
+        return set([r["principal"] for r in results])
 
     def get_accessible_objects(self, principals, bound_permissions=None, with_children=True):
         placeholders = {}
@@ -268,7 +269,7 @@ class Permission(PermissionBase, MigratorMixin):
               FROM access_control_entries
              WHERE principal IN :principals
             """
-            placeholders['principals'] = tuple(principals)
+            placeholders["principals"] = tuple(principals)
 
         elif len(bound_permissions) == 0:
             # If the list of object permissions to filter on is empty, then
@@ -278,20 +279,21 @@ class Permission(PermissionBase, MigratorMixin):
         else:
             principals_values = []
             for i, principal in enumerate(principals):
-                placeholders['principal_{}'.format(i)] = principal
-                principals_values.append('(:principal_{})'.format(i))
+                placeholders["principal_{}".format(i)] = principal
+                principals_values.append("(:principal_{})".format(i))
 
             perm_values = []
             for i, (obj, perm) in enumerate(bound_permissions):
-                placeholders['obj_{}'.format(i)] = obj.replace('*', '%')
-                placeholders['perm_{}'.format(i)] = perm
-                perm_values.append('(:obj_{0}, :perm_{0})'.format(i))
+                placeholders["obj_{}".format(i)] = obj.replace("*", "%")
+                placeholders["perm_{}".format(i)] = perm
+                perm_values.append("(:obj_{0}, :perm_{0})".format(i))
 
             if with_children:
-                object_id_condition = 'object_id LIKE pattern'
+                object_id_condition = "object_id LIKE pattern"
             else:
-                object_id_condition = ('object_id LIKE pattern '
-                                       "AND object_id NOT LIKE pattern || '/%'")
+                object_id_condition = (
+                    "object_id LIKE pattern " "AND object_id NOT LIKE pattern || '/%'"
+                )
             query = """
             WITH required_perms AS (
               VALUES {perms}
@@ -310,9 +312,11 @@ class Permission(PermissionBase, MigratorMixin):
             SELECT object_id, permission
               FROM potential_objects
              WHERE {object_id_condition};
-            """.format(perms=','.join(perm_values),
-                       principals=','.join(principals_values),
-                       object_id_condition=object_id_condition)
+            """.format(
+                perms=",".join(perm_values),
+                principals=",".join(principals_values),
+                object_id_condition=object_id_condition,
+            )
 
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query, placeholders)
@@ -320,7 +324,7 @@ class Permission(PermissionBase, MigratorMixin):
 
         perms_by_id = {}
         for r in results:
-            perms_by_id.setdefault(r['object_id'], set()).add(r['permission'])
+            perms_by_id.setdefault(r["object_id"], set()).add(r["permission"])
         return perms_by_id
 
     def check_permission(self, principals, bound_permissions):
@@ -330,14 +334,14 @@ class Permission(PermissionBase, MigratorMixin):
         placeholders = {}
         perms_values = []
         for i, (obj, perm) in enumerate(bound_permissions):
-            placeholders['obj_{}'.format(i)] = obj
-            placeholders['perm_{}'.format(i)] = perm
-            perms_values.append('(:obj_{0}, :perm_{0})'.format(i))
+            placeholders["obj_{}".format(i)] = obj
+            placeholders["perm_{}".format(i)] = perm
+            perms_values.append("(:obj_{0}, :perm_{0})".format(i))
 
         principals_values = []
         for i, principal in enumerate(principals):
-            placeholders['principal_{}'.format(i)] = principal
-            principals_values.append('(:principal_{})'.format(i))
+            placeholders["principal_{}".format(i)] = principal
+            principals_values.append("(:principal_{})".format(i))
 
         query = """
         WITH required_perms AS (
@@ -354,20 +358,21 @@ class Permission(PermissionBase, MigratorMixin):
         SELECT COUNT(*) AS matched
           FROM required_principals JOIN allowed_principals
             ON (required_principals.column1 = principal);
-        """.format(perms=','.join(perms_values),
-                   principals=','.join(principals_values))
+        """.format(
+            perms=",".join(perms_values), principals=",".join(principals_values)
+        )
 
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query, placeholders)
             total = result.fetchone()
-        return total['matched'] > 0
+        return total["matched"] > 0
 
     def get_objects_permissions(self, objects_ids, permissions=None):
         object_ids_values = []
         placeholders = {}
         for i, obj_id in enumerate(objects_ids):
-            object_ids_values.append('({0}, :obj_id_{0})'.format(i))
-            placeholders['obj_id_{}'.format(i)] = obj_id
+            object_ids_values.append("({0}, :obj_id_{0})".format(i))
+            placeholders["obj_id_{}".format(i)] = obj_id
 
         query = """
         WITH required_object_ids AS (
@@ -379,14 +384,13 @@ class Permission(PermissionBase, MigratorMixin):
               {permissions_condition}
         ORDER BY column1 ASC;
         """
-        safeholders = {
-            'objects_ids': ','.join(object_ids_values),
-            'permissions_condition': ''
-        }
+        safeholders = {"objects_ids": ",".join(object_ids_values), "permissions_condition": ""}
         if permissions is not None:
-            safeholders['permissions_condition'] = """
+            safeholders[
+                "permissions_condition"
+            ] = """
               WHERE permission IN :permissions"""
-            placeholders['permissions'] = tuple(permissions)
+            placeholders["permissions"] = tuple(permissions)
 
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query.format_map(safeholders), placeholders)
@@ -396,9 +400,11 @@ class Permission(PermissionBase, MigratorMixin):
         for object_id in objects_ids:
             groupby_id[object_id] = {}
         for row in rows:
-            object_id, permission, principal = (row['object_id'],
-                                                row['permission'],
-                                                row['principal'])
+            object_id, permission, principal = (
+                row["object_id"],
+                row["permission"],
+                row["principal"],
+            )
             groupby_id[object_id].setdefault(permission, set()).add(principal)
         return list(groupby_id.values())
 
@@ -406,19 +412,17 @@ class Permission(PermissionBase, MigratorMixin):
         if not permissions:
             return
 
-        placeholders = {
-            'object_id': object_id
-        }
+        placeholders = {"object_id": object_id}
 
         new_aces = []
         specified_perms = []
         for i, (perm, principals) in enumerate(permissions.items()):
-            placeholders['perm_{}'.format(i)] = perm
-            specified_perms.append('(:perm_{})'.format(i))
+            placeholders["perm_{}".format(i)] = perm
+            specified_perms.append("(:perm_{})".format(i))
             for principal in set(principals):
                 j = len(new_aces)
-                placeholders['principal_{}'.format(j)] = principal
-                new_aces.append('(:perm_{}, :principal_{})'.format(i, j))
+                placeholders["principal_{}".format(j)] = principal
+                new_aces.append("(:perm_{}, :principal_{})".format(i, j))
 
         if not new_aces:
             query = """
@@ -428,7 +432,9 @@ class Permission(PermissionBase, MigratorMixin):
             DELETE FROM access_control_entries
              USING specified_perms
              WHERE object_id = :object_id AND permission = column1
-            """.format(specified_perms=','.join(specified_perms))
+            """.format(
+                specified_perms=",".join(specified_perms)
+            )
 
         else:
             query = """
@@ -451,8 +457,9 @@ class Permission(PermissionBase, MigratorMixin):
             INSERT INTO access_control_entries(object_id, permission, principal)
               SELECT DISTINCT d.object_id, n.column1, n.column2
                 FROM new_aces AS n, affected_object AS d;
-            """.format(specified_perms=','.join(specified_perms),
-                       new_aces=','.join(new_aces))
+            """.format(
+                specified_perms=",".join(specified_perms), new_aces=",".join(new_aces)
+            )
 
         with self.client.connect() as conn:
             conn.execute(query, placeholders)
@@ -464,8 +471,8 @@ class Permission(PermissionBase, MigratorMixin):
         object_ids_values = []
         placeholders = {}
         for i, obj_id in enumerate(object_id_list):
-            object_ids_values.append('(:obj_id_{})'.format(i))
-            placeholders['obj_id_{}'.format(i)] = obj_id.replace('*', '%')
+            object_ids_values.append("(:obj_id_{})".format(i))
+            placeholders["obj_id_{}".format(i)] = obj_id.replace("*", "%")
 
         query = """
         WITH object_ids AS (
@@ -475,9 +482,7 @@ class Permission(PermissionBase, MigratorMixin):
          USING object_ids
          WHERE object_id LIKE column1;"""
 
-        safeholders = {
-            'object_ids_values': ','.join(object_ids_values)
-        }
+        safeholders = {"object_ids_values": ",".join(object_ids_values)}
 
         if len(object_id_list) == 1:
             # Optimized version for just one object ID.  This can be
@@ -497,5 +502,5 @@ class Permission(PermissionBase, MigratorMixin):
 
 
 def load_from_config(config):
-    client = create_from_config(config, prefix='permission_')
+    client = create_from_config(config, prefix="permission_")
     return Permission(client=client)

--- a/kinto/core/permission/testing.py
+++ b/kinto/core/permission/testing.py
@@ -35,17 +35,17 @@ class PermissionTest:
             patch.start()
         calls = [
             (self.permission.flush,),
-            (self.permission.add_user_principal, '', ''),
-            (self.permission.remove_user_principal, '', ''),
-            (self.permission.get_user_principals, ''),
-            (self.permission.add_principal_to_ace, '', '', ''),
-            (self.permission.remove_principal_from_ace, '', '', ''),
-            (self.permission.get_object_permission_principals, '', ''),
-            (self.permission.get_object_permissions, ''),
-            (self.permission.replace_object_permissions, '', {'write': []}),
-            (self.permission.delete_object_permissions, ''),
+            (self.permission.add_user_principal, "", ""),
+            (self.permission.remove_user_principal, "", ""),
+            (self.permission.get_user_principals, ""),
+            (self.permission.add_principal_to_ace, "", "", ""),
+            (self.permission.remove_principal_from_ace, "", "", ""),
+            (self.permission.get_object_permission_principals, "", ""),
+            (self.permission.get_object_permissions, ""),
+            (self.permission.replace_object_permissions, "", {"write": []}),
+            (self.permission.delete_object_permissions, ""),
             (self.permission.get_accessible_objects, []),
-            (self.permission.get_authorized_principals, [('*', 'read')]),
+            (self.permission.get_authorized_principals, [("*", "read")]),
         ]
         for call in calls:
             self.assertRaises(exceptions.BackendError, *call)
@@ -65,14 +65,15 @@ class PermissionTest:
         self.assertTrue(ping(self.request))
 
     def test_ping_returns_false_if_unavailable_in_readonly_mode(self):
-        self.request.registry.settings['readonly'] = 'true'
+        self.request.registry.settings["readonly"] = "true"
         ping = heartbeat(self.permission)
-        with mock.patch.object(self.permission, 'get_user_principals',
-                               side_effect=exceptions.BackendError('Boom!')):
+        with mock.patch.object(
+            self.permission, "get_user_principals", side_effect=exceptions.BackendError("Boom!")
+        ):
             self.assertFalse(ping(self.request))
 
     def test_ping_returns_true_if_available_in_readonly_mode(self):
-        self.request.registry.settings['readonly'] = 'true'
+        self.request.registry.settings["readonly"] = "true"
         ping = heartbeat(self.permission)
         self.assertTrue(ping(self.request))
 
@@ -81,34 +82,33 @@ class PermissionTest:
             patch.start()
         ping = heartbeat(self.permission)
 
-        with mock.patch('kinto.core.permission.logger.exception') as \
-                exc_handler:
+        with mock.patch("kinto.core.permission.logger.exception") as exc_handler:
             self.assertFalse(ping(self.request))
 
         self.assertTrue(exc_handler.called)
 
     def test_can_add_a_principal_to_a_user(self):
-        user_id = 'foo'
-        principal = 'bar'
+        user_id = "foo"
+        principal = "bar"
         self.permission.add_user_principal(user_id, principal)
         retrieved = self.permission.get_user_principals(user_id)
         self.assertEqual(retrieved, {principal})
 
     def test_add_twice_a_principal_to_a_user_add_it_once(self):
-        user_id = 'foo'
-        principal = 'bar'
+        user_id = "foo"
+        principal = "bar"
         self.permission.add_user_principal(user_id, principal)
         self.permission.add_user_principal(user_id, principal)
         retrieved = self.permission.get_user_principals(user_id)
         self.assertEqual(retrieved, {principal})
 
     def test_can_remove_a_principal_for_an_unknown_user(self):
-        self.permission.remove_user_principal('foo', 'bar')
+        self.permission.remove_user_principal("foo", "bar")
 
     def test_can_remove_a_principal_for_a_user(self):
-        user_id = 'foo'
-        principal = 'bar'
-        principal2 = 'foobar'
+        user_id = "foo"
+        principal = "bar"
+        principal2 = "foobar"
         self.permission.add_user_principal(user_id, principal)
         self.permission.add_user_principal(user_id, principal2)
         self.permission.remove_user_principal(user_id, principal)
@@ -116,9 +116,9 @@ class PermissionTest:
         self.assertEqual(retrieved, {principal2})
 
     def test_can_remove_a_unexisting_principal_to_a_user(self):
-        user_id = 'foo'
-        principal = 'bar'
-        principal2 = 'foobar'
+        user_id = "foo"
+        principal = "bar"
+        principal2 = "foobar"
         self.permission.add_user_principal(user_id, principal2)
         self.permission.remove_user_principal(user_id, principal)
         self.permission.remove_user_principal(user_id, principal2)
@@ -126,15 +126,15 @@ class PermissionTest:
         self.assertEqual(retrieved, set())
 
     def test_can_remove_principal_from_every_users(self):
-        user_id1 = 'foo1'
-        user_id2 = 'foo2'
-        principal1 = 'bar'
-        principal2 = 'foobar'
+        user_id1 = "foo1"
+        user_id2 = "foo2"
+        principal1 = "bar"
+        principal2 = "foobar"
         self.permission.add_user_principal(user_id1, principal1)
         self.permission.add_user_principal(user_id2, principal1)
         self.permission.add_user_principal(user_id2, principal2)
         self.permission.remove_principal(principal1)
-        self.permission.remove_principal('unknown')
+        self.permission.remove_principal("unknown")
 
         retrieved = self.permission.get_user_principals(user_id1)
         self.assertEqual(retrieved, set())
@@ -142,9 +142,9 @@ class PermissionTest:
         self.assertEqual(retrieved, {principal2})
 
     def test_authenticated_is_returned_for_everybody(self):
-        user_id = 'foo'
-        principal = 'bar'
-        self.permission.add_user_principal('system.Authenticated', principal)
+        user_id = "foo"
+        principal = "bar"
+        self.permission.add_user_principal("system.Authenticated", principal)
         retrieved = self.permission.get_user_principals(user_id)
         self.assertEqual(retrieved, {principal})
 
@@ -153,58 +153,50 @@ class PermissionTest:
     #
 
     def test_can_add_a_principal_to_an_object_permission(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
         self.permission.add_principal_to_ace(object_id, permission, principal)
-        retrieved = self.permission.get_object_permission_principals(
-            object_id, permission)
+        retrieved = self.permission.get_object_permission_principals(object_id, permission)
         self.assertEqual(retrieved, {principal})
 
     def test_add_twice_a_principal_to_an_object_permission_add_it_once(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
         self.permission.add_principal_to_ace(object_id, permission, principal)
         self.permission.add_principal_to_ace(object_id, permission, principal)
-        retrieved = self.permission.get_object_permission_principals(
-            object_id, permission)
+        retrieved = self.permission.get_object_permission_principals(object_id, permission)
         self.assertEqual(retrieved, {principal})
 
     def test_can_remove_a_principal_from_an_object_permission(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
-        principal2 = 'foobar'
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
+        principal2 = "foobar"
         self.permission.add_principal_to_ace(object_id, permission, principal)
         self.permission.add_principal_to_ace(object_id, permission, principal2)
-        self.permission.remove_principal_from_ace(object_id, permission,
-                                                  principal)
-        retrieved = self.permission.get_object_permission_principals(
-            object_id, permission)
+        self.permission.remove_principal_from_ace(object_id, permission, principal)
+        retrieved = self.permission.get_object_permission_principals(object_id, permission)
         self.assertEqual(retrieved, {principal2})
 
     def test_principals_is_empty_if_no_permission(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
         self.permission.add_principal_to_ace(object_id, permission, principal)
-        self.permission.remove_principal_from_ace(object_id, permission,
-                                                  principal)
-        retrieved = self.permission.get_object_permission_principals(
-            object_id, permission)
+        self.permission.remove_principal_from_ace(object_id, permission, principal)
+        retrieved = self.permission.get_object_permission_principals(object_id, permission)
         self.assertEqual(retrieved, set())
 
     def test_can_remove_an_unexisting_principal_to_an_object_permission(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
-        principal2 = 'foobar'
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
+        principal2 = "foobar"
         self.permission.add_principal_to_ace(object_id, permission, principal2)
-        self.permission.remove_principal_from_ace(object_id, permission,
-                                                  principal)
-        retrieved = self.permission.get_object_permission_principals(
-            object_id, permission)
+        self.permission.remove_principal_from_ace(object_id, permission, principal)
+        retrieved = self.permission.get_object_permission_principals(object_id, permission)
         self.assertEqual(retrieved, {principal2})
 
     #
@@ -212,48 +204,44 @@ class PermissionTest:
     #
 
     def test_check_permission_returns_true_for_userid(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
         self.permission.add_principal_to_ace(object_id, permission, principal)
-        check_permission = self.permission.check_permission(
-            {principal},
-            [(object_id, permission)])
+        check_permission = self.permission.check_permission({principal}, [(object_id, permission)])
         self.assertTrue(check_permission)
 
     def test_check_permission_returns_true_for_userid_group(self):
-        object_id = 'foo'
-        permission = 'write'
-        group_id = 'bar'
-        user_id = 'foobar'
+        object_id = "foo"
+        permission = "write"
+        group_id = "bar"
+        user_id = "foobar"
         self.permission.add_user_principal(user_id, group_id)
         self.permission.add_principal_to_ace(object_id, permission, group_id)
         check_permission = self.permission.check_permission(
-            {user_id, group_id},
-            [(object_id, permission)])
+            {user_id, group_id}, [(object_id, permission)]
+        )
         self.assertTrue(check_permission)
 
     def test_check_permission_returns_true_for_object_inherited(self):
-        object_id = 'foo'
-        user_id = 'bar'
-        self.permission.add_principal_to_ace(object_id, 'write', user_id)
+        object_id = "foo"
+        user_id = "bar"
+        self.permission.add_principal_to_ace(object_id, "write", user_id)
         check_permission = self.permission.check_permission(
-            {user_id},
-            [(object_id, 'write'), (object_id, 'read')])
+            {user_id}, [(object_id, "write"), (object_id, "read")]
+        )
         self.assertTrue(check_permission)
 
     def test_check_permissions_handles_empty_set(self):
-        principal = 'bar'
+        principal = "bar"
         permits = self.permission.check_permission({principal}, [])
         self.assertFalse(permits)
 
     def test_check_permission_return_false_for_unknown_principal(self):
-        object_id = 'foo'
-        permission = 'write'
-        principal = 'bar'
-        check_permission = self.permission.check_permission(
-            {principal},
-            [(object_id, permission)])
+        object_id = "foo"
+        permission = "write"
+        principal = "bar"
+        check_permission = self.permission.check_permission({principal}, [(object_id, permission)])
         self.assertFalse(check_permission)
 
     #
@@ -261,11 +249,12 @@ class PermissionTest:
     #
 
     def test_get_authorized_principals_inherit_principals(self):
-        object_id = 'foo'
-        user_id = 'bar'
-        self.permission.add_principal_to_ace(object_id, 'write', user_id)
+        object_id = "foo"
+        user_id = "bar"
+        self.permission.add_principal_to_ace(object_id, "write", user_id)
         principals = self.permission.get_authorized_principals(
-            [(object_id, 'write'), (object_id, 'read')])
+            [(object_id, "write"), (object_id, "read")]
+        )
         self.assertEqual(principals, {user_id})
 
     def test_get_authorized_principals_handles_empty_set(self):
@@ -277,232 +266,206 @@ class PermissionTest:
     #
 
     def test_accessible_objects(self):
-        self.permission.add_principal_to_ace('id1', 'write', 'user1')
-        self.permission.add_principal_to_ace('id1', 'record:create', 'group')
-        self.permission.add_principal_to_ace('id2', 'read', 'user1')
-        self.permission.add_principal_to_ace('id2', 'read', 'user2')
-        self.permission.add_principal_to_ace('id3', 'write', 'user2')
-        per_object_ids = self.permission.get_accessible_objects(
-            ['user1', 'group'])
-        self.assertEqual(sorted(per_object_ids.keys()), ['id1', 'id2'])
-        self.assertEqual(per_object_ids['id1'],
-                         set(['write', 'record:create']))
-        self.assertEqual(per_object_ids['id2'], set(['read']))
+        self.permission.add_principal_to_ace("id1", "write", "user1")
+        self.permission.add_principal_to_ace("id1", "record:create", "group")
+        self.permission.add_principal_to_ace("id2", "read", "user1")
+        self.permission.add_principal_to_ace("id2", "read", "user2")
+        self.permission.add_principal_to_ace("id3", "write", "user2")
+        per_object_ids = self.permission.get_accessible_objects(["user1", "group"])
+        self.assertEqual(sorted(per_object_ids.keys()), ["id1", "id2"])
+        self.assertEqual(per_object_ids["id1"], set(["write", "record:create"]))
+        self.assertEqual(per_object_ids["id2"], set(["read"]))
 
     def test_accessible_objects_supports_empty_list(self):
-        per_object_ids = self.permission.get_accessible_objects(['user1', 'group'], [])
+        per_object_ids = self.permission.get_accessible_objects(["user1", "group"], [])
         self.assertEqual(per_object_ids, {})
 
     def test_accessible_objects_from_permission(self):
-        self.permission.add_principal_to_ace('id1', 'write', 'user1')
-        self.permission.add_principal_to_ace('id1', 'read', 'user1')
-        self.permission.add_principal_to_ace('id1', 'read', 'group')
-        self.permission.add_principal_to_ace('id2', 'write', 'user1')
-        self.permission.add_principal_to_ace('id2', 'read', 'user2')
-        self.permission.add_principal_to_ace('id2', 'read', 'group')
-        self.permission.add_principal_to_ace('id3', 'read', 'user2')
+        self.permission.add_principal_to_ace("id1", "write", "user1")
+        self.permission.add_principal_to_ace("id1", "read", "user1")
+        self.permission.add_principal_to_ace("id1", "read", "group")
+        self.permission.add_principal_to_ace("id2", "write", "user1")
+        self.permission.add_principal_to_ace("id2", "read", "user2")
+        self.permission.add_principal_to_ace("id2", "read", "group")
+        self.permission.add_principal_to_ace("id3", "read", "user2")
         per_object_ids = self.permission.get_accessible_objects(
-            ['user1', 'group'],
-            [('*', 'read')])
-        self.assertEqual(sorted(per_object_ids.keys()), ['id1', 'id2'])
+            ["user1", "group"], [("*", "read")]
+        )
+        self.assertEqual(sorted(per_object_ids.keys()), ["id1", "id2"])
 
     def test_accessible_objects_with_pattern(self):
-        self.permission.add_principal_to_ace('/url1/id', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url2/id', 'write', 'user1')
-        per_object_ids = self.permission.get_accessible_objects(
-            ['user1'],
-            [('*url1*', 'write')])
-        self.assertEqual(sorted(per_object_ids.keys()), ['/url1/id'])
+        self.permission.add_principal_to_ace("/url1/id", "write", "user1")
+        self.permission.add_principal_to_ace("/url2/id", "write", "user1")
+        per_object_ids = self.permission.get_accessible_objects(["user1"], [("*url1*", "write")])
+        self.assertEqual(sorted(per_object_ids.keys()), ["/url1/id"])
 
     def test_accessible_objects_with_pattern_matches_whole_id(self):
-        self.permission.add_principal_to_ace('/url1/id', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url1/id/sub', 'write', 'user1')
-        self.permission.add_principal_to_ace('/a/url1/id', 'write', 'user1')
+        self.permission.add_principal_to_ace("/url1/id", "write", "user1")
+        self.permission.add_principal_to_ace("/url1/id/sub", "write", "user1")
+        self.permission.add_principal_to_ace("/a/url1/id", "write", "user1")
         per_object_ids = self.permission.get_accessible_objects(
-            ['user1'],
-            [('/url1/*', 'write')],
-            with_children=False)
-        self.assertEqual(sorted(per_object_ids.keys()), ['/url1/id'])
+            ["user1"], [("/url1/*", "write")], with_children=False
+        )
+        self.assertEqual(sorted(per_object_ids.keys()), ["/url1/id"])
 
     def test_accessible_objects_several_bound_permissions(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/2', 'read', 'user1')
-        self.permission.add_principal_to_ace('/url/_/id/2', 'read', 'user1')
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/2", "read", "user1")
+        self.permission.add_principal_to_ace("/url/_/id/2", "read", "user1")
         per_object_ids = self.permission.get_accessible_objects(
-            ['user1'],
-            [('/url/a/id/*', 'read'),
-             ('/url/a/id/*', 'write')])
-        self.assertEqual(sorted(per_object_ids.keys()),
-                         ['/url/a/id/1', '/url/a/id/2'])
+            ["user1"], [("/url/a/id/*", "read"), ("/url/a/id/*", "write")]
+        )
+        self.assertEqual(sorted(per_object_ids.keys()), ["/url/a/id/1", "/url/a/id/2"])
 
     def test_accessible_objects_without_match(self):
-        self.permission.add_principal_to_ace('/url/a', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/b/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/2', 'read', 'user1')
-        self.permission.add_principal_to_ace('/url/b/id/2', 'read', 'user1')
+        self.permission.add_principal_to_ace("/url/a", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/b/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/2", "read", "user1")
+        self.permission.add_principal_to_ace("/url/b/id/2", "read", "user1")
         per_object_ids = self.permission.get_accessible_objects(
-            ['user1'],
-            [('/url/a', 'write'),
-             ('/url/a', 'read'),
-             ('/url/a/id/*', 'write'),
-             ('/url/a/id/*', 'read')])
-        self.assertEqual(sorted(per_object_ids.keys()),
-                         ['/url/a', '/url/a/id/1', '/url/a/id/2'])
+            ["user1"],
+            [
+                ("/url/a", "write"),
+                ("/url/a", "read"),
+                ("/url/a/id/*", "write"),
+                ("/url/a/id/*", "read"),
+            ],
+        )
+        self.assertEqual(sorted(per_object_ids.keys()), ["/url/a", "/url/a/id/1", "/url/a/id/2"])
 
     #
     # get_object_permissions()
     #
 
     def test_object_permissions_return_all_object_acls(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user2')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'read', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'obj:del', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1/sub', 'create', 'me')
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
-        self.assertDictEqual(permissions, {
-            'write': {'user1', 'user2'},
-            'read': {'user3'},
-            'obj:del': {'user1'}
-        })
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user2")
+        self.permission.add_principal_to_ace("/url/a/id/1", "read", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/1", "obj:del", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1/sub", "create", "me")
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
+        self.assertDictEqual(
+            permissions, {"write": {"user1", "user2"}, "read": {"user3"}, "obj:del": {"user1"}}
+        )
 
     def test_object_permissions_return_listed_object_acls(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user2')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'read', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'create', 'user1')
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user2")
+        self.permission.add_principal_to_ace("/url/a/id/1", "read", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/1", "create", "user1")
         object_permissions = self.permission.get_object_permissions(
-            '/url/a/id/1', ['write', 'read'])
-        self.assertDictEqual(object_permissions, {
-            'write': {'user1', 'user2'},
-            'read': {'user3'}
-        })
+            "/url/a/id/1", ["write", "read"]
+        )
+        self.assertDictEqual(object_permissions, {"write": {"user1", "user2"}, "read": {"user3"}})
 
     def test_objects_permissions_returns_empty_if_unknown(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/3', 'read', 'user3')
-        objects_permissions = self.permission.get_objects_permissions([
-            '/url/a/id/1', '/abc', '/url/a/id/3'])
-        self.assertEqual(objects_permissions, [
-            {'write': {'user1'}}, {}, {'read': {'user3'}}])
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/3", "read", "user3")
+        objects_permissions = self.permission.get_objects_permissions(
+            ["/url/a/id/1", "/abc", "/url/a/id/3"]
+        )
+        self.assertEqual(objects_permissions, [{"write": {"user1"}}, {}, {"read": {"user3"}}])
 
     def test_object_permissions_return_empty_dict(self):
-        self.assertDictEqual(self.permission.get_object_permissions('abc'), {})
+        self.assertDictEqual(self.permission.get_object_permissions("abc"), {})
 
     def test_replace_object_permission_replace_all_given_sets(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user2')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'read', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'update', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'obj:del', 'user1')
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user2")
+        self.permission.add_principal_to_ace("/url/a/id/1", "read", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/1", "update", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "obj:del", "user1")
 
-        self.permission.replace_object_permissions('/url/a/id/1', {
-            'write': ['user1'],
-            'read': ['user2'],
-            'update': [],
-            'obj:del': ['user1'],
-            'new': ['user3']
-        })
+        self.permission.replace_object_permissions(
+            "/url/a/id/1",
+            {
+                "write": ["user1"],
+                "read": ["user2"],
+                "update": [],
+                "obj:del": ["user1"],
+                "new": ["user3"],
+            },
+        )
 
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
-        self.assertDictEqual(permissions, {
-            'write': {'user1'},
-            'read': {'user2'},
-            'obj:del': {'user1'},
-            'new': {'user3'}
-        })
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
+        self.assertDictEqual(
+            permissions,
+            {"write": {"user1"}, "read": {"user2"}, "obj:del": {"user1"}, "new": {"user3"}},
+        )
 
     def test_replace_object_permission_only_replace_given_sets(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user2')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'read', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'obj:del', 'user1')
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user2")
+        self.permission.add_principal_to_ace("/url/a/id/1", "read", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/1", "obj:del", "user1")
 
-        self.permission.replace_object_permissions('/url/a/id/1', {
-            'write': ['user1'],
-            'new': set(['user2'])
-        })
+        self.permission.replace_object_permissions(
+            "/url/a/id/1", {"write": ["user1"], "new": set(["user2"])}
+        )
 
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
-        self.assertDictEqual(permissions, {
-            'write': {'user1'},
-            'read': {'user3'},
-            'new': {'user2'},
-            'obj:del': {'user1'}
-        })
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
+        self.assertDictEqual(
+            permissions,
+            {"write": {"user1"}, "read": {"user3"}, "new": {"user2"}, "obj:del": {"user1"}},
+        )
 
     def test_replace_object_permission_supports_empty_existing_entries(self):
-        self.permission.replace_object_permissions('/url/a/id/1',
-                                                   {'write': ['user1']})
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
-        self.assertDictEqual(permissions, {
-            'write': {'user1'}
-        })
+        self.permission.replace_object_permissions("/url/a/id/1", {"write": ["user1"]})
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
+        self.assertDictEqual(permissions, {"write": {"user1"}})
 
     def test_replace_object_permission_supports_empty_input(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.replace_object_permissions('/url/a/id/1', {})
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
-        self.assertDictEqual(permissions, {
-            'write': {'user1'}
-        })
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.replace_object_permissions("/url/a/id/1", {})
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
+        self.assertDictEqual(permissions, {"write": {"user1"}})
 
     def test_replace_object_permission_supports_duplicated_entries(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.replace_object_permissions('/url/a/id/1', {
-            'write': ['user1', 'user1']
-        })
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
-        self.assertDictEqual(permissions, {
-            'write': {'user1'}
-        })
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.replace_object_permissions("/url/a/id/1", {"write": ["user1", "user1"]})
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
+        self.assertDictEqual(permissions, {"write": {"user1"}})
 
     def test_replace_object_permission_supports_empty_list(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.replace_object_permissions('/url/a/id/1', {
-            'write': set()
-        })
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.replace_object_permissions("/url/a/id/1", {"write": set()})
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
         self.assertEqual(len(permissions), 0)
 
     def test_replace_object_permission_supports_empty_list_to_new_object(self):
-        self.permission.replace_object_permissions('/url/a/id/1', {
-            'write': set()
-        })
-        permissions = self.permission.get_object_permissions('/url/a/id/1')
+        self.permission.replace_object_permissions("/url/a/id/1", {"write": set()})
+        permissions = self.permission.get_object_permissions("/url/a/id/1")
         self.assertEqual(len(permissions), 0)
 
     def test_delete_object_permissions_remove_all_given_objects_acls(self):
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user2')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'read', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'create', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/2', 'create', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/3', 'create', 'user4')
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user2")
+        self.permission.add_principal_to_ace("/url/a/id/1", "read", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/1", "create", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/2", "create", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/3", "create", "user4")
 
-        self.permission.delete_object_permissions('/url/a/id/1',
-                                                  '/url/a/id/2')
+        self.permission.delete_object_permissions("/url/a/id/1", "/url/a/id/2")
 
-        self.assertDictEqual(self.permission.get_object_permissions(
-            '/url/a/id/1'), {})
-        self.assertDictEqual(self.permission.get_object_permissions(
-            '/url/a/id/2'), {})
-        self.assertDictEqual(self.permission.get_object_permissions(
-            '/url/a/id/3'), {'create': {'user4'}})
+        self.assertDictEqual(self.permission.get_object_permissions("/url/a/id/1"), {})
+        self.assertDictEqual(self.permission.get_object_permissions("/url/a/id/2"), {})
+        self.assertDictEqual(
+            self.permission.get_object_permissions("/url/a/id/3"), {"create": {"user4"}}
+        )
 
     def test_delete_object_permissions_supports_empty_list(self):
         self.permission.delete_object_permissions()  # Not failing
 
     def test_delete_object_permissions_supports_pattern_matching(self):
-        self.permission.add_principal_to_ace('/url/b/id/1', 'write', 'user1')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'write', 'user2')
-        self.permission.add_principal_to_ace('/url/a/id/1', 'read', 'user3')
-        self.permission.add_principal_to_ace('/url/a/id/3', 'create', 'user4')
+        self.permission.add_principal_to_ace("/url/b/id/1", "write", "user1")
+        self.permission.add_principal_to_ace("/url/a/id/1", "write", "user2")
+        self.permission.add_principal_to_ace("/url/a/id/1", "read", "user3")
+        self.permission.add_principal_to_ace("/url/a/id/3", "create", "user4")
 
-        self.permission.delete_object_permissions('/url/a*')
+        self.permission.delete_object_permissions("/url/a*")
 
-        self.assertDictEqual(self.permission.get_object_permissions('/url/a/id/1'), {})
+        self.assertDictEqual(self.permission.get_object_permissions("/url/a/id/1"), {})
         self.assertDictEqual(
-            self.permission.get_object_permissions('/url/b/id/1'),
-            {'write': {'user1'}})
+            self.permission.get_object_permissions("/url/b/id/1"), {"write": {"user1"}}
+        )

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -9,16 +9,27 @@ import venusian
 from pyramid import exceptions as pyramid_exceptions
 from pyramid.decorator import reify
 from pyramid.security import Everyone
-from pyramid.httpexceptions import (HTTPNotModified, HTTPPreconditionFailed,
-                                    HTTPNotFound, HTTPServiceUnavailable)
+from pyramid.httpexceptions import (
+    HTTPNotModified,
+    HTTPPreconditionFailed,
+    HTTPNotFound,
+    HTTPServiceUnavailable,
+)
 
 from kinto.core import Service
 from kinto.core.errors import http_error, raise_invalid, send_alert, ERRORS, request_GET
 from kinto.core.events import ACTIONS
 from kinto.core.storage import exceptions as storage_exceptions, Filter, Sort, MISSING
 from kinto.core.utils import (
-    COMPARISON, classname, decode64, encode64, json, find_nested_value,
-    dict_subset, recursive_update_dict, apply_json_patch
+    COMPARISON,
+    classname,
+    decode64,
+    encode64,
+    json,
+    find_nested_value,
+    dict_subset,
+    recursive_update_dict,
+    apply_json_patch,
 )
 
 from .model import Model, ShareableModel
@@ -36,14 +47,15 @@ def register(depth=1, **kwargs):
     Pass all its keyword arguments to the register_resource
     function.
     """
+
     def wrapped(resource):
         register_resource(resource, depth=depth + 1, **kwargs)
         return resource
+
     return wrapped
 
 
-def register_resource(resource_cls, settings=None, viewset=None, depth=1,
-                      **kwargs):
+def register_resource(resource_cls, settings=None, viewset=None, depth=1, **kwargs):
     """Register a resource in the cornice registry.
 
     :param resource_cls:
@@ -71,14 +83,13 @@ def register_resource(resource_cls, settings=None, viewset=None, depth=1,
     def register_service(endpoint_type, settings):
         """Registers a service in cornice, for the given type.
         """
-        path_pattern = getattr(viewset, '{}_path'.format(endpoint_type))
-        path_values = {'resource_name': resource_name}
+        path_pattern = getattr(viewset, "{}_path".format(endpoint_type))
+        path_values = {"resource_name": resource_name}
         path = path_pattern.format_map(path_values)
 
         name = viewset.get_service_name(endpoint_type, resource_cls)
 
-        service = Service(name, path, depth=depth,
-                          **viewset.get_service_arguments())
+        service = Service(name, path, depth=depth, **viewset.get_service_arguments())
 
         # Attach viewset and resource to the service for later reference.
         service.viewset = viewset
@@ -86,16 +97,20 @@ def register_resource(resource_cls, settings=None, viewset=None, depth=1,
         service.type = endpoint_type
         # Attach collection and record paths.
         service.collection_path = viewset.collection_path.format_map(path_values)
-        service.record_path = (viewset.record_path.format_map(path_values)
-                               if viewset.record_path is not None else None)
+        service.record_path = (
+            viewset.record_path.format_map(path_values)
+            if viewset.record_path is not None
+            else None
+        )
 
-        methods = getattr(viewset, '{}_methods'.format(endpoint_type))
+        methods = getattr(viewset, "{}_methods".format(endpoint_type))
         for method in methods:
             if not viewset.is_endpoint_enabled(
-                    endpoint_type, resource_name, method.lower(), settings):
+                endpoint_type, resource_name, method.lower(), settings
+            ):
                 continue
 
-            argument_getter = getattr(viewset, '{}_arguments'.format(endpoint_type))
+            argument_getter = getattr(viewset, "{}_arguments".format(endpoint_type))
             view_args = argument_getter(resource_cls, method)
 
             view = viewset.get_view(endpoint_type, method.lower())
@@ -106,9 +121,9 @@ def register_resource(resource_cls, settings=None, viewset=None, depth=1,
             # use the same schema as for other PATCH protocols. We add another
             # dedicated view for PATCH, but targetting a different content_type
             # predicate.
-            if method.lower() == 'patch':
-                view_args['content_type'] = 'application/json-patch+json'
-                view_args['schema'] = JsonPatchRequestSchema()
+            if method.lower() == "patch":
+                view_args["content_type"] = "application/json-patch+json"
+                view_args["schema"] = JsonPatchRequestSchema()
                 service.add_view(method, view, klass=resource_cls, **view_args)
 
         return service
@@ -120,19 +135,19 @@ def register_resource(resource_cls, settings=None, viewset=None, depth=1,
         config = context.config.with_package(info.module)
 
         # Storage is mandatory for resources.
-        if not hasattr(config.registry, 'storage'):
-            msg = 'Mandatory storage backend is missing from configuration.'
+        if not hasattr(config.registry, "storage"):
+            msg = "Mandatory storage backend is missing from configuration."
             raise pyramid_exceptions.ConfigurationError(msg)
 
         # A service for the list.
-        service = register_service('collection', config.registry.settings)
+        service = register_service("collection", config.registry.settings)
         config.add_cornice_service(service)
         # An optional one for record endpoint.
-        if getattr(viewset, 'record_path') is not None:
-            service = register_service('record', config.registry.settings)
+        if getattr(viewset, "record_path") is not None:
+            service = register_service("record", config.registry.settings)
             config.add_cornice_service(service)
 
-    info = venusian.attach(resource_cls, callback, category='pyramid', depth=depth)
+    info = venusian.attach(resource_cls, callback, category="pyramid", depth=depth)
     return callback
 
 
@@ -166,26 +181,27 @@ class UserResource:
     def __init__(self, request, context=None):
         self.request = request
         self.context = context
-        self.record_id = self.request.matchdict.get('id')
+        self.record_id = self.request.matchdict.get("id")
         self.force_patch_update = False
 
-        content_type = str(self.request.headers.get('Content-Type')).lower()
-        self._is_json_patch = content_type == 'application/json-patch+json'
-        self._is_merge_patch = content_type == 'application/merge-patch+json'
+        content_type = str(self.request.headers.get("Content-Type")).lower()
+        self._is_json_patch = content_type == "application/json-patch+json"
+        self._is_merge_patch = content_type == "application/merge-patch+json"
 
         # Models are isolated by user.
         parent_id = self.get_parent_id(request)
 
         # Authentication to storage is transmitted as is (cf. cloud_storage).
-        auth = request.headers.get('Authorization')
+        auth = request.headers.get("Authorization")
 
-        if not hasattr(self, 'model'):
+        if not hasattr(self, "model"):
             self.model = self.default_model(
                 storage=request.registry.storage,
                 id_generator=self.id_generator,
                 collection_id=classname(self),
                 parent_id=parent_id,
-                auth=auth)
+                auth=auth,
+            )
 
         # Initialize timestamp as soon as possible.
         self.timestamp
@@ -193,10 +209,9 @@ class UserResource:
     @reify
     def id_generator(self):
         # ID generator by resource name in settings.
-        default_id_generator = self.request.registry.id_generators['']
+        default_id_generator = self.request.registry.id_generators[""]
         resource_name = self.request.current_resource_name
-        id_generator = self.request.registry.id_generators.get(resource_name,
-                                                               default_id_generator)
+        id_generator = self.request.registry.id_generators.get(resource_name, default_id_generator)
         return id_generator
 
     @reify
@@ -208,19 +223,19 @@ class UserResource:
         try:
             return self.model.timestamp()
         except storage_exceptions.BackendError as e:
-            is_readonly = self.request.registry.settings['readonly']
+            is_readonly = self.request.registry.settings["readonly"]
             if not is_readonly:
                 raise e
             # If the instance is configured to be readonly, and if the
             # collection is empty, the backend will try to bump the timestamp.
             # It fails if the configured db user has not write privileges.
             logger.exception(e)
-            error_msg = ('Collection timestamp cannot be written. '
-                         'Records endpoint must be hit at least once from a '
-                         'writable instance.')
-            raise http_error(HTTPServiceUnavailable(),
-                             errno=ERRORS.BACKEND,
-                             message=error_msg)
+            error_msg = (
+                "Collection timestamp cannot be written. "
+                "Records endpoint must be hit at least once from a "
+                "writable instance."
+            )
+            raise http_error(HTTPServiceUnavailable(), errno=ERRORS.BACKEND, message=error_msg)
 
     def get_parent_id(self, request):
         """Return the parent_id of the resource with regards to the current
@@ -236,10 +251,11 @@ class UserResource:
 
     def _get_known_fields(self):
         """Return all the `field` defined in the ressource schema."""
-        known_fields = [c.name for c in self.schema().children] + \
-                       [self.model.id_field,
-                        self.model.modified_field,
-                        self.model.deleted_field]
+        known_fields = [c.name for c in self.schema().children] + [
+            self.model.id_field,
+            self.model.modified_field,
+            self.model.deleted_field,
+        ]
         return known_fields
 
     def is_known_field(self, field):
@@ -251,12 +267,12 @@ class UserResource:
         :rtype: bool
 
         """
-        if self.schema.get_option('preserve_unknown'):
+        if self.schema.get_option("preserve_unknown"):
             return True
 
         known_fields = self._get_known_fields()
         # Test first level only: ``target.data.id`` -> ``target``
-        field = field.split('.', 1)[0]
+        field = field.split(".", 1)[0]
         return field in known_fields
 
     #
@@ -293,29 +309,26 @@ class UserResource:
         filter_fields = [f.field for f in filters]
         include_deleted = self.model.modified_field in filter_fields
 
-        pagination_rules, offset = self._extract_pagination_rules_from_token(
-            limit, sorting)
+        pagination_rules, offset = self._extract_pagination_rules_from_token(limit, sorting)
 
         records, total_records = self.model.get_records(
             filters=filters,
             sorting=sorting,
             limit=limit,
             pagination_rules=pagination_rules,
-            include_deleted=include_deleted)
+            include_deleted=include_deleted,
+        )
 
         offset = offset + len(records)
         if limit and len(records) == limit and offset < total_records:
             lastrecord = records[-1]
             next_page = self._next_page_url(sorting, limit, lastrecord, offset)
-            headers['Next-Page'] = next_page
+            headers["Next-Page"] = next_page
 
         if partial_fields:
-            records = [
-                dict_subset(record, partial_fields)
-                for record in records
-            ]
+            records = [dict_subset(record, partial_fields) for record in records]
 
-        headers['Total-Records'] = str(total_records)
+        headers["Total-Records"] = str(total_records)
 
         return self.postprocess(records)
 
@@ -336,12 +349,12 @@ class UserResource:
             Add custom behaviour by overriding
             :meth:`kinto.core.resource.UserResource.process_record`
         """
-        new_record = self.request.validated['body'].get('data', {})
+        new_record = self.request.validated["body"].get("data", {})
         try:
             # Since ``id`` does not belong to schema, it is not in validated
             # data. Must look up in body.
             id_field = self.model.id_field
-            new_record[id_field] = _id = self.request.json['data'][id_field]
+            new_record[id_field] = _id = self.request.json["data"][id_field]
             self._raise_400_if_invalid_id(_id)
             existing = self._get_record_or_404(_id)
         except (HTTPNotFound, KeyError, ValueError):
@@ -382,14 +395,12 @@ class UserResource:
         sorting = self._extract_sorting(limit)
         pagination_rules, offset = self._extract_pagination_rules_from_token(limit, sorting)
 
-        records, total_records = self.model.get_records(filters=filters,
-                                                        sorting=sorting,
-                                                        limit=limit,
-                                                        pagination_rules=pagination_rules)
-        deleted = self.model.delete_records(filters=filters,
-                                            sorting=sorting,
-                                            limit=limit,
-                                            pagination_rules=pagination_rules)
+        records, total_records = self.model.get_records(
+            filters=filters, sorting=sorting, limit=limit, pagination_rules=pagination_rules
+        )
+        deleted = self.model.delete_records(
+            filters=filters, sorting=sorting, limit=limit, pagination_rules=pagination_rules
+        )
         if deleted:
             lastrecord = deleted[-1]
             # Get timestamp of the last deleted field
@@ -399,12 +410,12 @@ class UserResource:
             # Add pagination header
             if limit and len(deleted) == limit and total_records > 1:
                 next_page = self._next_page_url(sorting, limit, lastrecord, offset)
-                self.request.response.headers['Next-Page'] = next_page
+                self.request.response.headers["Next-Page"] = next_page
         else:
             self._add_timestamp_header(self.request.response)
 
         headers = self.request.response.headers
-        headers['Total-Records'] = str(total_records)
+        headers["Total-Records"] = str(total_records)
 
         action = len(deleted) > 0 and ACTIONS.DELETE or ACTIONS.READ
         return self.postprocess(deleted, action=action, old=records)
@@ -466,7 +477,7 @@ class UserResource:
         self._raise_412_if_modified(record=existing)
 
         # If `data` is not provided, use existing record (or empty if creation)
-        post_record = self.request.validated['body'].get('data', existing) or {}
+        post_record = self.request.validated["body"].get("data", existing) or {}
 
         record_id = post_record.setdefault(self.model.id_field, self.record_id)
         self._raise_400_if_id_mismatch(record_id, self.record_id)
@@ -513,31 +524,32 @@ class UserResource:
 
         # patch is specified as a list of of operations (RFC 6902)
         if self._is_json_patch:
-            requested_changes = self.request.validated['body']
+            requested_changes = self.request.validated["body"]
         else:
             # `data` attribute may not be present if only perms are patched.
-            body = self.request.validated['body']
+            body = self.request.validated["body"]
             if not body:
                 # If no `data` nor `permissions` is provided in patch, reject!
                 # XXX: This should happen in schema instead (c.f. ShareableViewSet)
                 error_details = {
-                    'name': 'data',
-                    'description': 'Provide at least one of data or permissions',
+                    "name": "data",
+                    "description": "Provide at least one of data or permissions",
                 }
                 raise_invalid(self.request, **error_details)
-            requested_changes = body.get('data', {})
+            requested_changes = body.get("data", {})
 
-        updated, applied_changes = self.apply_changes(existing,
-                                                      requested_changes=requested_changes)
+        updated, applied_changes = self.apply_changes(
+            existing, requested_changes=requested_changes
+        )
 
-        record_id = updated.setdefault(self.model.id_field,
-                                       self.record_id)
+        record_id = updated.setdefault(self.model.id_field, self.record_id)
         self._raise_400_if_id_mismatch(record_id, self.record_id)
 
         new_record = self.process_record(updated, old=existing)
 
-        changed_fields = [k for k in applied_changes.keys()
-                          if existing.get(k) != new_record.get(k)]
+        changed_fields = [
+            k for k in applied_changes.keys() if existing.get(k) != new_record.get(k)
+        ]
 
         # Save in storage if necessary.
         if changed_fields or self.force_patch_update:
@@ -545,26 +557,27 @@ class UserResource:
 
         else:
             # Behave as if storage would have added `id` and `last_modified`.
-            for extra_field in [self.model.modified_field,
-                                self.model.id_field]:
+            for extra_field in [self.model.modified_field, self.model.id_field]:
                 new_record[extra_field] = existing[extra_field]
 
         # Adjust response according to ``Response-Behavior`` header
-        body_behavior = self.request.validated['header'].get('Response-Behavior', 'full')
+        body_behavior = self.request.validated["header"].get("Response-Behavior", "full")
 
-        if body_behavior.lower() == 'light':
+        if body_behavior.lower() == "light":
             # Only fields that were changed.
             data = {k: new_record[k] for k in changed_fields}
 
-        elif body_behavior.lower() == 'diff':
+        elif body_behavior.lower() == "diff":
             # Only fields that are different from those provided.
-            data = {k: new_record[k] for k in changed_fields
-                    if applied_changes.get(k) != new_record.get(k)}
+            data = {
+                k: new_record[k]
+                for k in changed_fields
+                if applied_changes.get(k) != new_record.get(k)
+            }
         else:
             data = new_record
 
-        timestamp = new_record.get(self.model.modified_field,
-                                   existing[self.model.modified_field])
+        timestamp = new_record.get(self.model.modified_field, existing[self.model.modified_field])
         self._add_timestamp_header(self.request.response, timestamp=timestamp)
 
         return self.postprocess(data, action=ACTIONS.UPDATE, old=existing)
@@ -585,7 +598,7 @@ class UserResource:
         self._raise_412_if_modified(record)
 
         # Retreive the last_modified information from a querystring if present.
-        last_modified = self.request.validated['querystring'].get('last_modified')
+        last_modified = self.request.validated["querystring"].get("last_modified")
 
         # If less or equal than current record. Ignore it.
         if last_modified and last_modified <= record[self.model.modified_field]:
@@ -660,8 +673,7 @@ class UserResource:
             return new
 
         # Drop the new last_modified if lesser or equal to the old one.
-        is_less_or_equal = (old is not None and
-                            new_last_modified <= old[modified_field])
+        is_less_or_equal = old is not None and new_last_modified <= old[modified_field]
         if is_less_or_equal:
             new.pop(modified_field, None)
 
@@ -692,12 +704,12 @@ class UserResource:
         """
         if self._is_json_patch:
             try:
-                applied_changes = apply_json_patch(record, requested_changes)['data']
+                applied_changes = apply_json_patch(record, requested_changes)["data"]
                 updated = {**applied_changes}
             except ValueError as e:
                 error_details = {
-                    'location': 'body',
-                    'description': 'JSON Patch operation failed: {}'.format(e)
+                    "location": "body",
+                    "description": "JSON Patch operation failed: {}".format(e),
                 }
                 raise_invalid(self.request, **error_details)
 
@@ -714,10 +726,7 @@ class UserResource:
         for field, value in applied_changes.items():
             has_changed = record.get(field, value) != value
             if self.schema.is_readonly(field) and has_changed:
-                error_details = {
-                    'name': field,
-                    'description': 'Cannot modify {}'.format(field)
-                }
+                error_details = {"name": field, "description": "Cannot modify {}".format(field)}
                 raise_invalid(self.request, **error_details)
 
         try:
@@ -732,9 +741,7 @@ class UserResource:
         return validated, applied_changes
 
     def postprocess(self, result, action=ACTIONS.READ, old=None):
-        body = {
-            'data': result
-        }
+        body = {"data": result}
 
         parent_id = self.get_parent_id(self.request)
         # Use self.model.timestamp() instead of self.timestamp because
@@ -742,11 +749,9 @@ class UserResource:
         # so doesn't correspond to any time that is relevant to the
         # event. See #1769.
         timestamp = self.model.timestamp()
-        self.request.notify_resource_event(parent_id=parent_id,
-                                           timestamp=timestamp,
-                                           data=result,
-                                           action=action,
-                                           old=old)
+        self.request.notify_resource_event(
+            parent_id=parent_id, timestamp=timestamp, data=result, action=action, old=old
+        )
 
         return body
 
@@ -755,12 +760,8 @@ class UserResource:
     #
 
     def _404_for_record(self, record_id):
-        details = {
-            'id': record_id,
-            'resource_name': self.request.current_resource_name
-        }
-        return http_error(HTTPNotFound(), errno=ERRORS.INVALID_RESOURCE_ID,
-                          details=details)
+        details = {"id": record_id, "resource_name": self.request.current_resource_name}
+        return http_error(HTTPNotFound(), errno=ERRORS.INVALID_RESOURCE_ID, details=details)
 
     def _get_record_or_404(self, record_id):
         """Retrieve record from storage and raise ``404 Not found`` if missing.
@@ -786,7 +787,7 @@ class UserResource:
         # Pyramid takes care of converting.
         response.last_modified = timestamp / 1000.0
         # Return timestamp as ETag.
-        response.headers['ETag'] = '"{}"'.format(timestamp)
+        response.headers["ETag"] = '"{}"'.format(timestamp)
 
     def _add_cache_header(self, response):
         """Add Cache-Control and Expire headers, based a on a setting for the
@@ -802,8 +803,8 @@ class UserResource:
             conditional request to the server and check that a
             ``304 Not modified`` is returned before serving content from cache.
         """
-        resource_name = self.context.resource_name if self.context else ''
-        setting_key = '{}_cache_expires_seconds'.format(resource_name)
+        resource_name = self.context.resource_name if self.context else ""
+        setting_key = "{}_cache_expires_seconds".format(resource_name)
         collection_expires = self.request.registry.settings.get(setting_key)
         is_anonymous = self.request.prefixed_userid is None
         if collection_expires and is_anonymous:
@@ -823,10 +824,7 @@ class UserResource:
         """
         is_string = isinstance(record_id, str)
         if not is_string or not self.model.id_generator.match(record_id):
-            error_details = {
-                'location': 'path',
-                'description': 'Invalid record id'
-            }
+            error_details = {"location": "path", "description": "Invalid record id"}
             raise_invalid(self.request, **error_details)
 
     def _raise_304_if_not_modified(self, record=None):
@@ -835,12 +833,12 @@ class UserResource:
 
         :raises: :exc:`~pyramid:pyramid.httpexceptions.HTTPNotModified`
         """
-        if_none_match = self.request.validated['header'].get('If-None-Match')
+        if_none_match = self.request.validated["header"].get("If-None-Match")
 
         if not if_none_match:
             return
 
-        if if_none_match == '*':
+        if if_none_match == "*":
             return
 
         if record:
@@ -860,8 +858,8 @@ class UserResource:
         :raises:
             :exc:`~pyramid:pyramid.httpexceptions.HTTPPreconditionFailed`
         """
-        if_match = self.request.validated['header'].get('If-Match')
-        if_none_match = self.request.validated['header'].get('If-None-Match')
+        if_match = self.request.validated["header"].get("If-Match")
+        if_none_match = self.request.validated["header"].get("If-None-Match")
 
         # Check if record exists
         record_exists = record is not None
@@ -871,7 +869,7 @@ class UserResource:
             return
 
         # If-None-Match: * should always raise if a record exists
-        if if_none_match == '*' and record_exists:
+        if if_none_match == "*" and record_exists:
             modified_since = -1  # Always raise.
 
         # If-Match should always raise if a record doesn't exist
@@ -879,7 +877,7 @@ class UserResource:
             modified_since = -1
 
         # If-Match with ETag value on existing records should compare ETag
-        elif if_match and if_match != '*':
+        elif if_match and if_match != "*":
             modified_since = if_match
 
         # If none of the above applies, don't raise
@@ -892,12 +890,14 @@ class UserResource:
             current_timestamp = self.model.timestamp()
 
         if current_timestamp != modified_since:
-            error_msg = 'Resource was modified meanwhile'
-            details = {'existing': record} if record else {}
-            response = http_error(HTTPPreconditionFailed(),
-                                  errno=ERRORS.MODIFIED_MEANWHILE,
-                                  message=error_msg,
-                                  details=details)
+            error_msg = "Resource was modified meanwhile"
+            details = {"existing": record} if record else {}
+            response = http_error(
+                HTTPPreconditionFailed(),
+                errno=ERRORS.MODIFIED_MEANWHILE,
+                message=error_msg,
+                details=details,
+            )
             self._add_timestamp_header(response, timestamp=current_timestamp)
             raise response
 
@@ -908,28 +908,22 @@ class UserResource:
         :raises: :class:`pyramid.httpexceptions.HTTPBadRequest`
         """
         if new_id != record_id:
-            error_msg = 'Record id does not match existing record'
-            error_details = {
-                'name': self.model.id_field,
-                'description': error_msg
-            }
+            error_msg = "Record id does not match existing record"
+            error_details = {"name": self.model.id_field, "description": error_msg}
             raise_invalid(self.request, **error_details)
 
     def _extract_partial_fields(self):
         """Extract the fields to do the projection from QueryString parameters.
         """
-        fields = self.request.validated['querystring'].get('_fields')
+        fields = self.request.validated["querystring"].get("_fields")
         if fields:
-            root_fields = [f.split('.')[0] for f in fields]
+            root_fields = [f.split(".")[0] for f in fields]
             known_fields = self._get_known_fields()
             invalid_fields = set(root_fields) - set(known_fields)
-            preserve_unknown = self.schema.get_option('preserve_unknown')
+            preserve_unknown = self.schema.get_option("preserve_unknown")
             if not preserve_unknown and invalid_fields:
-                error_msg = 'Fields {} do not exist'.format(','.join(invalid_fields))
-                error_details = {
-                    'name': 'Invalid _fields parameter',
-                    'description': error_msg
-                }
+                error_msg = "Fields {} do not exist".format(",".join(invalid_fields))
+                error_details = {"name": "Invalid _fields parameter", "description": error_msg}
                 raise_invalid(self.request, **error_details)
 
             # Since id and last_modified are part of the synchronisation
@@ -940,9 +934,9 @@ class UserResource:
 
     def _extract_limit(self):
         """Extract limit value from QueryString parameters."""
-        paginate_by = self.request.registry.settings['paginate_by']
-        max_fetch_size = self.request.registry.settings['storage_max_fetch_size']
-        limit = self.request.validated['querystring'].get('_limit', paginate_by)
+        paginate_by = self.request.registry.settings["paginate_by"]
+        max_fetch_size = self.request.registry.settings["storage_max_fetch_size"]
+        limit = self.request.validated["querystring"].get("_limit", paginate_by)
 
         # If limit is higher than paginate_by setting, ignore it.
         if limit and paginate_by:
@@ -955,7 +949,7 @@ class UserResource:
 
     def _extract_filters(self):
         """Extracts filters from QueryString parameters."""
-        queryparams = self.request.validated['querystring']
+        queryparams = self.request.validated["querystring"]
 
         filters = []
 
@@ -963,42 +957,39 @@ class UserResource:
             param = param.strip()
 
             error_details = {
-                'name': param,
-                'location': 'querystring',
-                'description': 'Invalid value for {}'.format(param)
+                "name": param,
+                "location": "querystring",
+                "description": "Invalid value for {}".format(param),
             }
 
             # Ignore specific fields
-            if param.startswith('_') and param not in ('_since',
-                                                       '_to',
-                                                       '_before'):
+            if param.startswith("_") and param not in ("_since", "_to", "_before"):
                 continue
 
             # Handle the _since specific filter.
-            if param in ('_since', '_to', '_before'):
+            if param in ("_since", "_to", "_before"):
 
-                if param == '_since':
+                if param == "_since":
                     operator = COMPARISON.GT
                 else:
-                    if param == '_to':
-                        message = ('_to is now deprecated, '
-                                   'you should use _before instead')
-                        url = ('https://kinto.readthedocs.io/en/2.4.0/api/'
-                               'resource.html#list-of-available-url-'
-                               'parameters')
+                    if param == "_to":
+                        message = "_to is now deprecated, " "you should use _before instead"
+                        url = (
+                            "https://kinto.readthedocs.io/en/2.4.0/api/"
+                            "resource.html#list-of-available-url-"
+                            "parameters"
+                        )
                         send_alert(self.request, message, url)
                     operator = COMPARISON.LT
 
-                if value == '':
+                if value == "":
                     raise_invalid(self.request, **error_details)
 
-                filters.append(
-                    Filter(self.model.modified_field, value, operator)
-                )
+                filters.append(Filter(self.model.modified_field, value, operator))
                 continue
 
-            all_keywords = '|'.join([i.name.lower() for i in COMPARISON])
-            m = re.match(r'^(' + all_keywords + r')_([\w\.]+)$', param)
+            all_keywords = "|".join([i.name.lower() for i in COMPARISON])
+            m = re.match(r"^(" + all_keywords + r")_([\w\.]+)$", param)
             if m:
                 keyword, field = m.groups()
                 operator = getattr(COMPARISON, keyword.upper())
@@ -1007,26 +998,23 @@ class UserResource:
 
             if not self.is_known_field(field):
                 error_msg = "Unknown filter field '{}'".format(param)
-                error_details['description'] = error_msg
+                error_details["description"] = error_msg
                 raise_invalid(self.request, **error_details)
 
             if operator in (COMPARISON.IN, COMPARISON.EXCLUDE):
-                all_integers = all([isinstance(v, int)
-                                    for v in value])
-                all_strings = all([isinstance(v, str)
-                                   for v in value])
-                has_invalid_value = (
-                    (field == self.model.id_field and not all_strings) or
-                    (field == self.model.modified_field and not all_integers)
+                all_integers = all([isinstance(v, int) for v in value])
+                all_strings = all([isinstance(v, str) for v in value])
+                has_invalid_value = (field == self.model.id_field and not all_strings) or (
+                    field == self.model.modified_field and not all_integers
                 )
                 if has_invalid_value:
                     raise_invalid(self.request, **error_details)
 
-            if '\x00' in field or '\x00' in str(value):
-                error_details['description'] = "Invalid character 0x00"
+            if "\x00" in field or "\x00" in str(value):
+                error_details["description"] = "Invalid character 0x00"
                 raise_invalid(self.request, **error_details)
 
-            if field == self.model.modified_field and value == '':
+            if field == self.model.modified_field and value == "":
                 raise_invalid(self.request, **error_details)
 
             filters.append(Filter(field, value, operator))
@@ -1035,23 +1023,23 @@ class UserResource:
 
     def _extract_sorting(self, limit):
         """Extracts filters from QueryString parameters."""
-        specified = self.request.validated['querystring'].get('_sort', [])
+        specified = self.request.validated["querystring"].get("_sort", [])
         sorting = []
         modified_field_used = self.model.modified_field in specified
         for field in specified:
             field = field.strip()
-            m = re.match(r'^([\-+]?)([\w\.]+)$', field)
+            m = re.match(r"^([\-+]?)([\w\.]+)$", field)
             if m:
                 order, field = m.groups()
 
                 if not self.is_known_field(field):
                     error_details = {
-                        'location': 'querystring',
-                        'description': "Unknown sort field '{}'".format(field)
+                        "location": "querystring",
+                        "description": "Unknown sort field '{}'".format(field),
                     }
                     raise_invalid(self.request, **error_details)
 
-                direction = -1 if order == '-' else 1
+                direction = -1 if order == "-" else 1
                 sorting.append(Sort(field, direction))
 
         if not modified_field_used:
@@ -1090,7 +1078,7 @@ class UserResource:
 
     def _extract_pagination_rules_from_token(self, limit, sorting):
         """Get pagination params."""
-        token = self.request.validated['querystring'].get('_token', None)
+        token = self.request.validated["querystring"].get("_token", None)
         filters = []
         offset = 0
         if token:
@@ -1099,25 +1087,22 @@ class UserResource:
                 tokeninfo = json.loads(decode64(token))
                 if not isinstance(tokeninfo, dict):
                     raise ValueError()
-                last_record = tokeninfo['last_record']
-                offset = tokeninfo['offset']
-                nonce = tokeninfo['nonce']
+                last_record = tokeninfo["last_record"]
+                offset = tokeninfo["offset"]
+                nonce = tokeninfo["nonce"]
             except (ValueError, KeyError, TypeError):
-                error_msg = '_token has invalid content'
+                error_msg = "_token has invalid content"
 
             # We don't want pagination tokens to be reused several times (#1171).
             # The cache backend is used to keep track of "nonces".
-            if self.request.method.lower() == 'delete' and error_msg is None:
+            if self.request.method.lower() == "delete" and error_msg is None:
                 registry = self.request.registry
                 deleted = registry.cache.delete(nonce)
                 if deleted is None:
-                    error_msg = '_token was already used or has expired.'
+                    error_msg = "_token was already used or has expired."
 
             if error_msg:
-                error_details = {
-                    'location': 'querystring',
-                    'description': error_msg
-                }
+                error_details = {"location": "querystring", "description": error_msg}
                 raise_invalid(self.request, **error_details)
 
             filters = self._build_pagination_rules(sorting, last_record)
@@ -1128,11 +1113,12 @@ class UserResource:
         """Build the Next-Page header from where we stopped."""
         token = self._build_pagination_token(sorting, last_record, offset)
 
-        params = {**request_GET(self.request), '_limit': limit, '_token': token}
+        params = {**request_GET(self.request), "_limit": limit, "_token": token}
 
         service = self.request.current_service
-        next_page_url = self.request.route_url(service.name, _query=params,
-                                               **self.request.matchdict)
+        next_page_url = self.request.route_url(
+            service.name, _query=params, **self.request.matchdict
+        )
         return next_page_url
 
     def _build_pagination_token(self, sorting, last_record, offset):
@@ -1142,22 +1128,18 @@ class UserResource:
         the last_record.
 
         """
-        nonce = 'pagination-token-{}'.format(uuid4())
-        if self.request.method.lower() == 'delete':
+        nonce = "pagination-token-{}".format(uuid4())
+        if self.request.method.lower() == "delete":
             registry = self.request.registry
-            validity = registry.settings['pagination_token_validity_seconds']
-            registry.cache.set(nonce, '', validity)
+            validity = registry.settings["pagination_token_validity_seconds"]
+            registry.cache.set(nonce, "", validity)
 
-        token = {
-            'last_record': {},
-            'offset': offset,
-            'nonce': nonce,
-        }
+        token = {"last_record": {}, "offset": offset, "nonce": nonce}
 
         for field, _ in sorting:
             last_value = find_nested_value(last_record, field, MISSING)
             if last_value is not MISSING:
-                token['last_record'][field] = last_value
+                token["last_record"][field] = last_value
 
         return encode64(json.dumps(token))
 
@@ -1166,9 +1148,10 @@ class ShareableResource(UserResource):
     """Shareable resources allow to set permissions on records, in order to
     share their access or protect their modification.
     """
+
     default_model = ShareableModel
     default_viewset = ShareableViewSet
-    permissions = ('read', 'write')
+    permissions = ("read", "write")
     """List of allowed permissions names."""
 
     def __init__(self, *args, **kwargs):
@@ -1189,8 +1172,8 @@ class ShareableResource(UserResource):
 
         if self.context:
             self.model.get_permission_object_id = functools.partial(
-                self.context.get_permission_object_id,
-                self.request)
+                self.context.get_permission_object_id, self.request
+            )
 
     def get_parent_id(self, request):
         """Unlike :class:`kinto.core.resource.UserResource`, records are not
@@ -1200,7 +1183,7 @@ class ShareableResource(UserResource):
 
         :returns: A constant empty value.
         """
-        return ''
+        return ""
 
     def _extract_filters(self):
         """Override default filters extraction from QueryString to allow
@@ -1234,26 +1217,25 @@ class ShareableResource(UserResource):
 
         # patch is specified as a list of of operations (RFC 6902)
 
-        payload = self.request.validated['body']
+        payload = self.request.validated["body"]
 
         if self._is_json_patch:
-            permissions = apply_json_patch(old, payload)['permissions']
+            permissions = apply_json_patch(old, payload)["permissions"]
 
         elif self._is_merge_patch:
             existing = old or {}
-            permissions = existing.get('__permissions__', {})
-            recursive_update_dict(permissions,
-                                  payload.get('permissions', {}),
-                                  ignores=(None,))
+            permissions = existing.get("__permissions__", {})
+            recursive_update_dict(permissions, payload.get("permissions", {}), ignores=(None,))
 
         else:
-            permissions = {k: v for k, v in payload.get('permissions', {}).items()
-                           if v is not None}
+            permissions = {
+                k: v for k, v in payload.get("permissions", {}).items() if v is not None
+            }
 
         annotated = {**new}
 
         if permissions:
-            is_put = (self.request.method.lower() == 'put')
+            is_put = self.request.method.lower() == "put"
             if is_put or self._is_merge_patch:
                 # Remove every existing ACEs using empty lists.
                 for perm in self.permissions:
@@ -1274,7 +1256,7 @@ class ShareableResource(UserResource):
             # record endpoint.
             perms = result.pop(self.model.permissions_field, None)
             if perms is not None:
-                body['permissions'] = {k: list(p) for k, p in perms.items()}
+                body["permissions"] = {k: list(p) for k, p in perms.items()}
 
             if old:
                 # Remove permissions from event payload.

--- a/kinto/core/resource/model.py
+++ b/kinto/core/resource/model.py
@@ -10,17 +10,17 @@ class Model:
     `parent_id` can be the current *user id* or *a group* where the collection
     belongs. If left empty, the collection records are not isolated.
     """
-    id_field = 'id'
+
+    id_field = "id"
     """Name of `id` field in records"""
 
-    modified_field = 'last_modified'
+    modified_field = "last_modified"
     """Name of `last modified` field in records"""
 
-    deleted_field = 'deleted'
+    deleted_field = "deleted"
     """Name of `deleted` field in deleted records"""
 
-    def __init__(self, storage, id_generator=None, collection_id='',
-                 parent_id='', auth=None):
+    def __init__(self, storage, id_generator=None, collection_id="", parent_id="", auth=None):
         """
         :param storage: an instance of storage
         :type storage: :class:`kinto.core.storage.Storage`
@@ -44,12 +44,18 @@ class Model:
         """
         parent_id = parent_id or self.parent_id
         return self.storage.collection_timestamp(
-            collection_id=self.collection_id,
-            parent_id=parent_id,
-            auth=self.auth)
+            collection_id=self.collection_id, parent_id=parent_id, auth=self.auth
+        )
 
-    def get_records(self, filters=None, sorting=None, pagination_rules=None,
-                    limit=None, include_deleted=False, parent_id=None):
+    def get_records(
+        self,
+        filters=None,
+        sorting=None,
+        pagination_rules=None,
+        limit=None,
+        include_deleted=False,
+        parent_id=None,
+    ):
         """Fetch the collection records.
 
         Override to post-process records after feching them from storage.
@@ -97,11 +103,13 @@ class Model:
             id_field=self.id_field,
             modified_field=self.modified_field,
             deleted_field=self.deleted_field,
-            auth=self.auth)
+            auth=self.auth,
+        )
         return records, total_records
 
-    def delete_records(self, filters=None, sorting=None, pagination_rules=None,
-                       limit=None, parent_id=None):
+    def delete_records(
+        self, filters=None, sorting=None, pagination_rules=None, limit=None, parent_id=None
+    ):
         """Delete multiple collection records.
 
         Override to post-process records after their deletion from storage.
@@ -133,16 +141,18 @@ class Model:
         :returns: The list of deleted records from storage.
         """
         parent_id = parent_id or self.parent_id
-        return self.storage.delete_all(collection_id=self.collection_id,
-                                       parent_id=parent_id,
-                                       filters=filters,
-                                       sorting=sorting,
-                                       pagination_rules=pagination_rules,
-                                       limit=limit,
-                                       id_field=self.id_field,
-                                       modified_field=self.modified_field,
-                                       deleted_field=self.deleted_field,
-                                       auth=self.auth)
+        return self.storage.delete_all(
+            collection_id=self.collection_id,
+            parent_id=parent_id,
+            filters=filters,
+            sorting=sorting,
+            pagination_rules=pagination_rules,
+            limit=limit,
+            id_field=self.id_field,
+            modified_field=self.modified_field,
+            deleted_field=self.deleted_field,
+            auth=self.auth,
+        )
 
     def get_record(self, record_id, parent_id=None):
         """Fetch current view related record, and raise 404 if missing.
@@ -154,12 +164,14 @@ class Model:
         :rtype: dict
         """
         parent_id = parent_id or self.parent_id
-        return self.storage.get(collection_id=self.collection_id,
-                                parent_id=parent_id,
-                                object_id=record_id,
-                                id_field=self.id_field,
-                                modified_field=self.modified_field,
-                                auth=self.auth)
+        return self.storage.get(
+            collection_id=self.collection_id,
+            parent_id=parent_id,
+            object_id=record_id,
+            id_field=self.id_field,
+            modified_field=self.modified_field,
+            auth=self.auth,
+        )
 
     def create_record(self, record, parent_id=None):
         """Create a record in the collection.
@@ -182,13 +194,15 @@ class Model:
         :rtype: dict
         """
         parent_id = parent_id or self.parent_id
-        return self.storage.create(collection_id=self.collection_id,
-                                   parent_id=parent_id,
-                                   record=record,
-                                   id_generator=self.id_generator,
-                                   id_field=self.id_field,
-                                   modified_field=self.modified_field,
-                                   auth=self.auth)
+        return self.storage.create(
+            collection_id=self.collection_id,
+            parent_id=parent_id,
+            record=record,
+            id_generator=self.id_generator,
+            id_field=self.id_field,
+            modified_field=self.modified_field,
+            auth=self.auth,
+        )
 
     def update_record(self, record, parent_id=None):
         """Update a record in the collection.
@@ -211,13 +225,15 @@ class Model:
         """
         parent_id = parent_id or self.parent_id
         record_id = record[self.id_field]
-        return self.storage.update(collection_id=self.collection_id,
-                                   parent_id=parent_id,
-                                   object_id=record_id,
-                                   record=record,
-                                   id_field=self.id_field,
-                                   modified_field=self.modified_field,
-                                   auth=self.auth)
+        return self.storage.update(
+            collection_id=self.collection_id,
+            parent_id=parent_id,
+            object_id=record_id,
+            record=record,
+            id_field=self.id_field,
+            modified_field=self.modified_field,
+            auth=self.auth,
+        )
 
     def delete_record(self, record, parent_id=None, last_modified=None):
         """Delete a record in the collection.
@@ -241,20 +257,23 @@ class Model:
         """
         parent_id = parent_id or self.parent_id
         record_id = record[self.id_field]
-        return self.storage.delete(collection_id=self.collection_id,
-                                   parent_id=parent_id,
-                                   object_id=record_id,
-                                   id_field=self.id_field,
-                                   modified_field=self.modified_field,
-                                   deleted_field=self.deleted_field,
-                                   auth=self.auth,
-                                   last_modified=last_modified)
+        return self.storage.delete(
+            collection_id=self.collection_id,
+            parent_id=parent_id,
+            object_id=record_id,
+            id_field=self.id_field,
+            modified_field=self.modified_field,
+            deleted_field=self.deleted_field,
+            auth=self.auth,
+            last_modified=last_modified,
+        )
 
 
 class ShareableModel(Model):
     """A protected collection interacts with the permission backend.
     """
-    permissions_field = '__permissions__'
+
+    permissions_field = "__permissions__"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -269,14 +288,12 @@ class ShareableModel(Model):
     def _allow_write(self, perm_object_id):
         """Helper to give the ``write`` permission to the current user.
         """
-        self.permission.add_principal_to_ace(perm_object_id,
-                                             'write',
-                                             self.current_principal)
+        self.permission.add_principal_to_ace(perm_object_id, "write", self.current_principal)
 
     def _annotate(self, record, perm_object_id):
         permissions = self.permission.get_object_permissions(perm_object_id)
         # Permissions are not returned if user only has read permission.
-        writers = permissions.get('write', [])
+        writers = permissions.get("write", [])
         principals = self.prefixed_principals + [self.current_principal]
         if len(set(writers) & set(principals)) == 0:
             permissions = {}
@@ -284,17 +301,17 @@ class ShareableModel(Model):
         annotated = {**record, self.permissions_field: permissions}
         return annotated
 
-    def delete_records(self, filters=None, sorting=None, pagination_rules=None,
-                       limit=None, parent_id=None):
+    def delete_records(
+        self, filters=None, sorting=None, pagination_rules=None, limit=None, parent_id=None
+    ):
         """Delete permissions when collection records are deleted in bulk.
         """
         deleted = super().delete_records(filters, sorting, pagination_rules, limit, parent_id)
         # Take a huge shortcut in case we want to delete everything.
         if not filters:
-            perm_ids = [self.get_permission_object_id(object_id='*')]
+            perm_ids = [self.get_permission_object_id(object_id="*")]
         else:
-            perm_ids = [self.get_permission_object_id(object_id=r[self.id_field])
-                        for r in deleted]
+            perm_ids = [self.get_permission_object_id(object_id=r[self.id_field]) for r in deleted]
         self.permission.delete_object_permissions(*perm_ids)
         return deleted
 
@@ -340,8 +357,7 @@ class ShareableModel(Model):
     def delete_record(self, record_id, parent_id=None, last_modified=None):
         """Delete record and its associated permissions.
         """
-        record = super().delete_record(
-            record_id, parent_id, last_modified=last_modified)
+        record = super().delete_record(record_id, parent_id, last_modified=last_modified)
         perm_object_id = self.get_permission_object_id(record_id)
         self.permission.delete_object_permissions(perm_object_id)
 

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -2,12 +2,19 @@ import warnings
 
 import colander
 
-from kinto.core.schema import (Any, HeaderField, QueryField, HeaderQuotedInteger,
-                               FieldList, TimeStamp, URL)
+from kinto.core.schema import (
+    Any,
+    HeaderField,
+    QueryField,
+    HeaderQuotedInteger,
+    FieldList,
+    TimeStamp,
+    URL,
+)
 from kinto.core.errors import ErrorSchema
 from kinto.core.utils import native_value
 
-POSTGRESQL_MAX_INTEGER_VALUE = 2**63
+POSTGRESQL_MAX_INTEGER_VALUE = 2 ** 63
 
 positive_big_integer = colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE)
 
@@ -16,8 +23,10 @@ class TimeStamp(TimeStamp):
     """This schema is deprecated, you shoud use `kinto.core.schema.TimeStamp` instead."""
 
     def __init__(self, *args, **kwargs):
-        message = ('`kinto.core.resource.schema.TimeStamp` is deprecated, '
-                   'use `kinto.core.schema.TimeStamp` instead.')
+        message = (
+            "`kinto.core.resource.schema.TimeStamp` is deprecated, "
+            "use `kinto.core.schema.TimeStamp` instead."
+        )
         warnings.warn(message, DeprecationWarning)
         super().__init__(*args, **kwargs)
 
@@ -26,8 +35,10 @@ class URL(URL):
     """This schema is deprecated, you shoud use `kinto.core.schema.URL` instead."""
 
     def __init__(self, *args, **kwargs):
-        message = ('`kinto.core.resource.schema.URL` is deprecated, '
-                   'use `kinto.core.schema.URL` instead.')
+        message = (
+            "`kinto.core.resource.schema.URL` is deprecated, "
+            "use `kinto.core.schema.URL` instead."
+        )
         warnings.warn(message, DeprecationWarning)
         super().__init__(*args, **kwargs)
 
@@ -52,6 +63,7 @@ class ResourceSchema(colander.MappingSchema):
                 class Options:
                     readonly_fields = ('reference',)
         """
+
         readonly_fields = tuple()
         """Fields that cannot be updated. Values for fields will have to be
         provided either during record creation, through default values using
@@ -70,7 +82,7 @@ class ResourceSchema(colander.MappingSchema):
     @classmethod
     def get_option(cls, attr):
         default_value = getattr(ResourceSchema.Options, attr)
-        return getattr(cls.Options, attr,  default_value)
+        return getattr(cls.Options, attr, default_value)
 
     @classmethod
     def is_readonly(cls, field):
@@ -81,13 +93,13 @@ class ResourceSchema(colander.MappingSchema):
             ``False`` otherwise.
         :rtype: bool
         """
-        return field in cls.get_option('readonly_fields')
+        return field in cls.get_option("readonly_fields")
 
     def schema_type(self):
-        if self.get_option('preserve_unknown') is True:
-            unknown = 'preserve'
+        if self.get_option("preserve_unknown") is True:
+            unknown = "preserve"
         else:
-            unknown = 'ignore'
+            unknown = "ignore"
         return colander.Mapping(unknown=unknown)
 
 
@@ -106,7 +118,7 @@ class PermissionsSchema(colander.SchemaNode):
     """
 
     def __init__(self, *args, **kwargs):
-        self.known_perms = kwargs.pop('permissions', tuple())
+        self.known_perms = kwargs.pop("permissions", tuple())
         super().__init__(*args, **kwargs)
 
         for perm in self.known_perms:
@@ -114,9 +126,9 @@ class PermissionsSchema(colander.SchemaNode):
 
     def schema_type(self):
         if self.known_perms:
-            return colander.Mapping(unknown='raise')
+            return colander.Mapping(unknown="raise")
         else:
-            return colander.Mapping(unknown='preserve')
+            return colander.Mapping(unknown="preserve")
 
     def deserialize(self, cstruct=colander.null):
         # If permissions are not a mapping (e.g null or invalid), try deserializing
@@ -144,8 +156,9 @@ class PermissionsSchema(colander.SchemaNode):
 
     def _get_node_principals(self, perm):
         principal = colander.SchemaNode(colander.String())
-        return colander.SchemaNode(colander.Sequence(), principal, name=perm,
-                                   missing=colander.drop)
+        return colander.SchemaNode(
+            colander.Sequence(), principal, name=perm, missing=colander.drop
+        )
 
     @staticmethod
     def _preprocess_null_perms(cstruct):
@@ -158,6 +171,7 @@ class PermissionsSchema(colander.SchemaNode):
         validated.update({k: None for k in keys})
         return validated
 
+
 # Header schemas
 
 
@@ -166,22 +180,23 @@ class HeaderSchema(colander.MappingSchema):
 
     missing = colander.drop
 
-    if_match = HeaderQuotedInteger(name='If-Match')
-    if_none_match = HeaderQuotedInteger(name='If-None-Match')
+    if_match = HeaderQuotedInteger(name="If-Match")
+    if_none_match = HeaderQuotedInteger(name="If-None-Match")
 
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='preserve')
+        return colander.Mapping(unknown="preserve")
 
 
 class PatchHeaderSchema(HeaderSchema):
     """Header schema used with PATCH requests."""
 
     def response_behavior_validator():
-        return colander.OneOf(['full', 'light', 'diff'])
+        return colander.OneOf(["full", "light", "diff"])
 
-    response_behaviour = HeaderField(colander.String(), name='Response-Behavior',
-                                     validator=response_behavior_validator())
+    response_behaviour = HeaderField(
+        colander.String(), name="Response-Behavior", validator=response_behavior_validator()
+    )
 
 
 # Querystring schemas
@@ -192,11 +207,12 @@ class QuerySchema(colander.MappingSchema):
     Schema used for validating and deserializing querystrings. It will include
     and try to guess the type of unknown fields (field filters) on deserialization.
     """
+
     missing = colander.drop
 
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='ignore')
+        return colander.Mapping(unknown="ignore")
 
     def deserialize(self, cstruct=colander.null):
         """
@@ -215,7 +231,7 @@ class QuerySchema(colander.MappingSchema):
         # Deserialize querystring field filters (see docstring e.g)
         for k, v in cstruct.items():
             # Deserialize lists used on contains_ and contains_any_ filters
-            if k.startswith('contains_'):
+            if k.startswith("contains_"):
                 as_list = native_value(v)
 
                 if not isinstance(as_list, list):
@@ -224,7 +240,7 @@ class QuerySchema(colander.MappingSchema):
                     values[k] = as_list
 
             # Deserialize lists used on in_ and exclude_ filters
-            elif k.startswith('in_') or k.startswith('exclude_'):
+            elif k.startswith("in_") or k.startswith("exclude_"):
                 as_list = FieldList().deserialize(v)
                 values[k] = [native_value(v) for v in as_list]
             else:
@@ -263,10 +279,9 @@ class CollectionGetQuerySchema(CollectionQuerySchema):
 
 
 class RecordSchema(colander.MappingSchema):
-
     @colander.deferred
     def data(node, kwargs):
-        data = kwargs.get('data')
+        data = kwargs.get("data")
         if data:
             # Check if empty record is allowed.
             # (e.g every schema fields have defaults)
@@ -282,35 +297,37 @@ class RecordSchema(colander.MappingSchema):
     @colander.deferred
     def permissions(node, kwargs):
         def get_perms(node, kwargs):
-            return kwargs.get('permissions')
+            return kwargs.get("permissions")
+
         # Set if node is provided, else keep deferred. This allows binding the body
         # on Resource first and bind permissions later if using SharableResource.
         return get_perms(node, kwargs) or colander.deferred(get_perms)
 
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='raise')
+        return colander.Mapping(unknown="raise")
 
 
 class JsonPatchOperationSchema(colander.MappingSchema):
     """Single JSON Patch Operation."""
 
     def op_validator():
-        op_values = ['test', 'add', 'remove', 'replace', 'move', 'copy']
+        op_values = ["test", "add", "remove", "replace", "move", "copy"]
         return colander.OneOf(op_values)
 
     def path_validator():
-        return colander.Regex('(/\\w*)+')
+        return colander.Regex("(/\\w*)+")
 
     op = colander.SchemaNode(colander.String(), validator=op_validator())
     path = colander.SchemaNode(colander.String(), validator=path_validator())
-    from_ = colander.SchemaNode(colander.String(), name='from',
-                                validator=path_validator(), missing=colander.drop)
+    from_ = colander.SchemaNode(
+        colander.String(), name="from", validator=path_validator(), missing=colander.drop
+    )
     value = colander.SchemaNode(Any(), missing=colander.drop)
 
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='raise')
+        return colander.Mapping(unknown="raise")
 
 
 class JsonPatchBodySchema(colander.SequenceSchema):
@@ -327,18 +344,18 @@ class RequestSchema(colander.MappingSchema):
 
     @colander.deferred
     def header(node, kwargs):
-        return kwargs.get('header')
+        return kwargs.get("header")
 
     @colander.deferred
     def querystring(node, kwargs):
-        return kwargs.get('querystring')
+        return kwargs.get("querystring")
 
     def after_bind(self, node, kw):
         # Set default bindings
-        if not self.get('header'):
-            self['header'] = HeaderSchema()
-        if not self.get('querystring'):
-            self['querystring'] = QuerySchema()
+        if not self.get("header"):
+            self["header"] = HeaderSchema()
+        if not self.get("querystring"):
+            self["querystring"] = QuerySchema()
 
 
 class PayloadRequestSchema(RequestSchema):
@@ -347,7 +364,8 @@ class PayloadRequestSchema(RequestSchema):
     @colander.deferred
     def body(node, kwargs):
         def get_body(node, kwargs):
-            return kwargs.get('body')
+            return kwargs.get("body")
+
         # Set if node is provided, else keep deferred (and allow bindind later)
         return get_body(node, kwargs) or colander.deferred(get_body)
 
@@ -366,38 +384,42 @@ class JsonPatchRequestSchema(RequestSchema):
 class ResponseHeaderSchema(colander.MappingSchema):
     """Kinto API custom response headers."""
 
-    etag = HeaderQuotedInteger(name='Etag')
-    last_modified = colander.SchemaNode(colander.String(), name='Last-Modified')
+    etag = HeaderQuotedInteger(name="Etag")
+    last_modified = colander.SchemaNode(colander.String(), name="Last-Modified")
 
 
 class ErrorResponseSchema(colander.MappingSchema):
     """Response schema used on 4xx and 5xx errors."""
+
     body = ErrorSchema()
 
 
 class NotModifiedResponseSchema(colander.MappingSchema):
     """Response schema used on 304 Not Modified responses."""
+
     header = ResponseHeaderSchema()
 
 
 class RecordResponseSchema(colander.MappingSchema):
     """Response schema used with sigle resource endpoints."""
+
     header = ResponseHeaderSchema()
 
     @colander.deferred
     def body(node, kwargs):
-        return kwargs.get('record')
+        return kwargs.get("record")
 
 
 class CollectionResponseSchema(colander.MappingSchema):
     """Response schema used with plural endpoints."""
+
     header = ResponseHeaderSchema()
 
     @colander.deferred
     def body(node, kwargs):
-        resource = kwargs.get('record')['data']
+        resource = kwargs.get("record")["data"]
         collection = colander.MappingSchema()
-        collection['data'] = colander.SequenceSchema(resource, missing=[])
+        collection["data"] = colander.SequenceSchema(resource, missing=[])
         return collection
 
 
@@ -405,50 +427,51 @@ class ResourceReponses:
     """Class that wraps and handles Resource responses."""
 
     default_schemas = {
-        '400': ErrorResponseSchema(description='The request is invalid.'),
-        '406': ErrorResponseSchema(
-            description="The client doesn't accept supported responses Content-Type."),
-        '412': ErrorResponseSchema(
-            description='Record was changed or deleted since value in `If-Match` header.'),
-        'default': ErrorResponseSchema(description='Unexpected error.'),
-
+        "400": ErrorResponseSchema(description="The request is invalid."),
+        "406": ErrorResponseSchema(
+            description="The client doesn't accept supported responses Content-Type."
+        ),
+        "412": ErrorResponseSchema(
+            description="Record was changed or deleted since value in `If-Match` header."
+        ),
+        "default": ErrorResponseSchema(description="Unexpected error."),
     }
-    default_record_schemas = {
-        '200': RecordResponseSchema(description='Return the target object.')
-    }
+    default_record_schemas = {"200": RecordResponseSchema(description="Return the target object.")}
     default_collection_schemas = {
-        '200': CollectionResponseSchema(description='Return a list of matching objects.')
+        "200": CollectionResponseSchema(description="Return a list of matching objects.")
     }
     default_get_schemas = {
-        '304': NotModifiedResponseSchema(
-            description='Reponse has not changed since value in If-None-Match header')
+        "304": NotModifiedResponseSchema(
+            description="Reponse has not changed since value in If-None-Match header"
+        )
     }
     default_post_schemas = {
-        '200': RecordResponseSchema(description='Return an existing object.'),
-        '201': RecordResponseSchema(description='Return a created object.'),
-        '415': ErrorResponseSchema(
-            description='The client request was not sent with a correct Content-Type.')
+        "200": RecordResponseSchema(description="Return an existing object."),
+        "201": RecordResponseSchema(description="Return a created object."),
+        "415": ErrorResponseSchema(
+            description="The client request was not sent with a correct Content-Type."
+        ),
     }
     default_put_schemas = {
-        '201': RecordResponseSchema(description='Return created object.'),
-        '415': ErrorResponseSchema(
-            description='The client request was not sent with a correct Content-Type.')
+        "201": RecordResponseSchema(description="Return created object."),
+        "415": ErrorResponseSchema(
+            description="The client request was not sent with a correct Content-Type."
+        ),
     }
     default_patch_schemas = {
-        '415': ErrorResponseSchema(
-            description='The client request was not sent with a correct Content-Type.')
+        "415": ErrorResponseSchema(
+            description="The client request was not sent with a correct Content-Type."
+        )
     }
-    default_delete_schemas = {
-    }
+    default_delete_schemas = {}
     record_get_schemas = {
-        '404': ErrorResponseSchema(description='The object does not exist or was deleted.'),
+        "404": ErrorResponseSchema(description="The object does not exist or was deleted.")
     }
     record_patch_schemas = {
-        '404': ErrorResponseSchema(description='The object does not exist or was deleted.'),
+        "404": ErrorResponseSchema(description="The object does not exist or was deleted.")
     }
     record_delete_schemas = {
-        '404': ErrorResponseSchema(
-            description='The object does not exist or was already deleted.'),
+        "404": ErrorResponseSchema(description="The object does not exist or was already deleted.")
     }
 
     def get_and_bind(self, endpoint_type, method, **kwargs):
@@ -456,14 +479,14 @@ class ResourceReponses:
         of status codes mapping cloned and binded responses."""
 
         responses = self.default_schemas.copy()
-        type_responses = getattr(self, 'default_{}_schemas'.format(endpoint_type))
+        type_responses = getattr(self, "default_{}_schemas".format(endpoint_type))
         responses.update(**type_responses)
 
-        verb_responses = 'default_{}_schemas'.format(method.lower())
+        verb_responses = "default_{}_schemas".format(method.lower())
         method_args = getattr(self, verb_responses, {})
         responses.update(**method_args)
 
-        method_responses = '{}_{}_schemas'.format(endpoint_type, method.lower())
+        method_responses = "{}_{}_schemas".format(endpoint_type, method.lower())
         endpoint_args = getattr(self, method_responses, {})
         responses.update(**endpoint_args)
 
@@ -480,10 +503,14 @@ class ShareableResourseResponses(ResourceReponses):
 
         # Add permission related responses to defaults
         self.default_schemas = {
-            '401': ErrorResponseSchema(
-                description='The request is missing authentication headers.'),
-            '403': ErrorResponseSchema(
-                description=('The user is not allowed to perform the operation, '
-                             'or the resource is not accessible.')),
-            **self.default_schemas
+            "401": ErrorResponseSchema(
+                description="The request is missing authentication headers."
+            ),
+            "403": ErrorResponseSchema(
+                description=(
+                    "The user is not allowed to perform the operation, "
+                    "or the resource is not accessible."
+                )
+            ),
+            **self.default_schemas,
         }

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -7,33 +7,41 @@ from pyramid.settings import asbool
 
 from kinto.core import authorization
 
-from .schema import (PermissionsSchema, RequestSchema, PayloadRequestSchema,
-                     PatchHeaderSchema, CollectionQuerySchema, CollectionGetQuerySchema,
-                     RecordGetQuerySchema, RecordSchema, ResourceReponses,
-                     ShareableResourseResponses)
+from .schema import (
+    PermissionsSchema,
+    RequestSchema,
+    PayloadRequestSchema,
+    PatchHeaderSchema,
+    CollectionQuerySchema,
+    CollectionGetQuerySchema,
+    RecordGetQuerySchema,
+    RecordSchema,
+    ResourceReponses,
+    ShareableResourseResponses,
+)
 
 
-CONTENT_TYPES = ['application/json']
+CONTENT_TYPES = ["application/json"]
 
-PATCH_CONTENT_TYPES = ['application/merge-patch+json']
+PATCH_CONTENT_TYPES = ["application/merge-patch+json"]
 
 
 class StrictSchema(colander.MappingSchema):
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='raise')
+        return colander.Mapping(unknown="raise")
 
 
 class PartialSchema(colander.MappingSchema):
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='ignore')
+        return colander.Mapping(unknown="ignore")
 
 
 class SimpleSchema(colander.MappingSchema):
     @staticmethod
     def schema_type():
-        return colander.Mapping(unknown='preserve')
+        return colander.Mapping(unknown="preserve")
 
 
 class ViewSet:
@@ -45,68 +53,63 @@ class ViewSet:
     It provides the same features as ``cornice.resource()``, except
     that it is much more flexible and extensible.
     """
-    service_name = '{resource_name}-{endpoint_type}'
-    collection_path = '/{resource_name}s'
-    record_path = '/{resource_name}s/{{id}}'
 
-    collection_methods = ('GET', 'POST', 'DELETE')
-    record_methods = ('GET', 'PUT', 'PATCH', 'DELETE')
+    service_name = "{resource_name}-{endpoint_type}"
+    collection_path = "/{resource_name}s"
+    record_path = "/{resource_name}s/{{id}}"
 
-    readonly_methods = ('GET', 'OPTIONS', 'HEAD')
+    collection_methods = ("GET", "POST", "DELETE")
+    record_methods = ("GET", "PUT", "PATCH", "DELETE")
+
+    readonly_methods = ("GET", "OPTIONS", "HEAD")
 
     factory = authorization.RouteFactory
 
     responses = ResourceReponses()
 
-    service_arguments = {
-        'description': 'Collection of {resource_name}',
-    }
+    service_arguments = {"description": "Collection of {resource_name}"}
 
     default_arguments = {
-        'permission': authorization.PRIVATE,
-        'accept': CONTENT_TYPES,
-        'schema': RequestSchema(),
+        "permission": authorization.PRIVATE,
+        "accept": CONTENT_TYPES,
+        "schema": RequestSchema(),
     }
 
-    default_post_arguments = {
-        'content_type': CONTENT_TYPES,
-        'schema': PayloadRequestSchema(),
-    }
+    default_post_arguments = {"content_type": CONTENT_TYPES, "schema": PayloadRequestSchema()}
 
-    default_put_arguments = {
-        'content_type': CONTENT_TYPES,
-        'schema': PayloadRequestSchema(),
-    }
+    default_put_arguments = {"content_type": CONTENT_TYPES, "schema": PayloadRequestSchema()}
 
     default_patch_arguments = {
-        'content_type': CONTENT_TYPES + PATCH_CONTENT_TYPES,
-        'schema': PayloadRequestSchema().bind(header=PatchHeaderSchema()),
+        "content_type": CONTENT_TYPES + PATCH_CONTENT_TYPES,
+        "schema": PayloadRequestSchema().bind(header=PatchHeaderSchema()),
     }
 
     default_collection_arguments = {
-        'schema': RequestSchema().bind(querystring=CollectionQuerySchema()),
+        "schema": RequestSchema().bind(querystring=CollectionQuerySchema())
     }
     collection_get_arguments = {
-        'schema': RequestSchema().bind(querystring=CollectionGetQuerySchema()),
-        'cors_headers': ('Next-Page', 'Total-Records', 'Last-Modified', 'ETag',
-                         'Cache-Control', 'Expires', 'Pragma')
+        "schema": RequestSchema().bind(querystring=CollectionGetQuerySchema()),
+        "cors_headers": (
+            "Next-Page",
+            "Total-Records",
+            "Last-Modified",
+            "ETag",
+            "Cache-Control",
+            "Expires",
+            "Pragma",
+        ),
     }
-    collection_post_arguments = {
-        'schema': PayloadRequestSchema(),
-    }
+    collection_post_arguments = {"schema": PayloadRequestSchema()}
     default_record_arguments = {}
     record_get_arguments = {
-        'schema': RequestSchema().bind(querystring=RecordGetQuerySchema()),
-        'cors_headers': ('Last-Modified', 'ETag',
-                         'Cache-Control', 'Expires', 'Pragma')
+        "schema": RequestSchema().bind(querystring=RecordGetQuerySchema()),
+        "cors_headers": ("Last-Modified", "ETag", "Cache-Control", "Expires", "Pragma"),
     }
 
     def __init__(self, **kwargs):
         self.update(**kwargs)
-        self.record_arguments = functools.partial(self.get_view_arguments,
-                                                  'record')
-        self.collection_arguments = functools.partial(self.get_view_arguments,
-                                                      'collection')
+        self.record_arguments = functools.partial(self.get_view_arguments, "record")
+        self.collection_arguments = functools.partial(self.get_view_arguments, "collection")
 
     def update(self, **kwargs):
         """Update viewset attributes with provided values."""
@@ -121,42 +124,40 @@ class ViewSet:
         :param str method: the HTTP method.
         """
         args = {**self.default_arguments}
-        default_arguments = getattr(self,
-                                    'default_{}_arguments'.format(endpoint_type))
+        default_arguments = getattr(self, "default_{}_arguments".format(endpoint_type))
         args.update(**default_arguments)
 
-        by_http_verb = 'default_{}_arguments'.format(method.lower())
+        by_http_verb = "default_{}_arguments".format(method.lower())
         method_args = getattr(self, by_http_verb, {})
         args.update(**method_args)
 
-        by_method = '{}_{}_arguments'.format(endpoint_type, method.lower())
+        by_method = "{}_{}_arguments".format(endpoint_type, method.lower())
         endpoint_args = getattr(self, by_method, {})
         args.update(**endpoint_args)
 
-        request_schema = args.get('schema', RequestSchema())
+        request_schema = args.get("schema", RequestSchema())
         record_schema = self.get_record_schema(resource_cls, method)
         request_schema = request_schema.bind(body=record_schema)
-        response_schemas = self.responses.get_and_bind(endpoint_type, method,
-                                                       record=record_schema)
+        response_schemas = self.responses.get_and_bind(endpoint_type, method, record=record_schema)
 
-        args['schema'] = request_schema
-        args['response_schemas'] = response_schemas
+        args["schema"] = request_schema
+        args["response_schemas"] = response_schemas
 
-        validators = args.get('validators', [])
+        validators = args.get("validators", [])
         validators.append(colander_validator)
-        args['validators'] = validators
+        args["validators"] = validators
 
         return args
 
     def get_record_schema(self, resource_cls, method):
         """Return the Cornice schema for the given method.
         """
-        if method.lower() in ('patch', 'delete'):
+        if method.lower() in ("patch", "delete"):
             resource_schema = SimpleSchema
         else:
             resource_schema = resource_cls.schema
-            if hasattr(resource_cls, 'mapping'):
-                message = 'Resource `mapping` is deprecated, use `schema`'
+            if hasattr(resource_cls, "mapping"):
+                message = "Resource `mapping` is deprecated, use `schema`"
                 warnings.warn(message, DeprecationWarning)
                 resource_schema = resource_cls.mapping.__class__
 
@@ -171,20 +172,19 @@ class ViewSet:
         * For collections, this will be "collection_{method|lower}
         * For records, this will be "{method|lower}.
         """
-        if endpoint_type == 'record':
+        if endpoint_type == "record":
             return method.lower()
-        return '{}_{}'.format(endpoint_type, method.lower())
+        return "{}_{}".format(endpoint_type, method.lower())
 
     def get_name(self, resource_cls):
         """Returns the name of the resource.
         """
         # Provided on viewset during registration.
-        if 'name' in self.__dict__:
-            return self.__dict__['name']
+        if "name" in self.__dict__:
+            return self.__dict__["name"]
 
         # Attribute on resource class (but not @property)
-        has_class_attr = (hasattr(resource_cls, 'name') and
-                          not callable(resource_cls.name))
+        has_class_attr = hasattr(resource_cls, "name") and not callable(resource_cls.name)
         if has_class_attr:
             return resource_cls.name
 
@@ -196,26 +196,23 @@ class ViewSet:
         resource.
         """
         return self.service_name.format(
-            resource_name=self.get_name(resource_cls),
-            endpoint_type=endpoint_type)
+            resource_name=self.get_name(resource_cls), endpoint_type=endpoint_type
+        )
 
     def get_service_arguments(self):
         return {**self.service_arguments}
 
-    def is_endpoint_enabled(self, endpoint_type, resource_name, method,
-                            settings):
+    def is_endpoint_enabled(self, endpoint_type, resource_name, method, settings):
         """Returns if the given endpoint is enabled or not.
 
         Uses the settings to tell so.
         """
-        readonly_enabled = asbool(settings.get('readonly'))
-        readonly_method = method.lower() in [m.lower() for m in
-                                             self.readonly_methods]
+        readonly_enabled = asbool(settings.get("readonly"))
+        readonly_method = method.lower() in [m.lower() for m in self.readonly_methods]
         if readonly_enabled and not readonly_method:
             return False
 
-        setting_enabled = '{}_{}_{}_enabled'.format(
-            endpoint_type, resource_name, method.lower())
+        setting_enabled = "{}_{}_{}_enabled".format(endpoint_type, resource_name, method.lower())
         return asbool(settings.get(setting_enabled, True))
 
 
@@ -234,17 +231,18 @@ class ShareableViewSet(ViewSet):
         """
         record_schema = super(ShareableViewSet, self).get_record_schema(resource_cls, method)
         allowed_permissions = resource_cls.permissions
-        permissions = PermissionsSchema(name='permissions', missing=colander.drop,
-                                        permissions=allowed_permissions)
+        permissions = PermissionsSchema(
+            name="permissions", missing=colander.drop, permissions=allowed_permissions
+        )
         record_schema = record_schema.bind(permissions=permissions)
         return record_schema
 
     def get_view_arguments(self, endpoint_type, resource_cls, method):
         args = super().get_view_arguments(endpoint_type, resource_cls, method)
-        args['permission'] = authorization.DYNAMIC
+        args["permission"] = authorization.DYNAMIC
         return args
 
     def get_service_arguments(self):
         args = super().get_service_arguments()
-        args['factory'] = self.factory
+        args["factory"] = self.factory
         return args

--- a/kinto/core/schema.py
+++ b/kinto/core/schema.py
@@ -22,9 +22,10 @@ class TimeStamp(colander.SchemaNode):
             added_on = TimeStamp()
             read_on = TimeStamp(auto_now=False, missing=-1)
     """
+
     schema_type = colander.Integer
 
-    title = 'Epoch timestamp'
+    title = "Epoch timestamp"
     """Default field title."""
 
     auto_now = True
@@ -49,6 +50,7 @@ class URL(colander.SchemaNode):
         class BookmarkSchema(ResourceSchema):
             url = URL()
     """
+
     schema_type = colander.String
     validator = colander.All(colander.url, colander.Length(min=1, max=2048))
 
@@ -71,9 +73,9 @@ class HeaderField(colander.SchemaNode):
     def deserialize(self, cstruct=colander.null):
         if isinstance(cstruct, bytes):
             try:
-                cstruct = cstruct.decode('utf-8')
+                cstruct = cstruct.decode("utf-8")
             except UnicodeDecodeError:
-                raise colander.Invalid(self, msg='Headers should be UTF-8 encoded')
+                raise colander.Invalid(self, msg="Headers should be UTF-8 encoded")
         return super(HeaderField, self).deserialize(cstruct)
 
 
@@ -92,13 +94,13 @@ class FieldList(QueryField):
     """String field representing a list of attributes."""
 
     schema_type = colander.Sequence
-    error_message = 'The value should be a list of comma separated attributes'
+    error_message = "The value should be a list of comma separated attributes"
     missing = colander.drop
     fields = colander.SchemaNode(colander.String(), missing=colander.drop)
 
     def deserialize(self, cstruct=colander.null):
         if isinstance(cstruct, str):
-            cstruct = cstruct.split(',')
+            cstruct = cstruct.split(",")
         return super(FieldList, self).deserialize(cstruct)
 
 
@@ -106,12 +108,12 @@ class HeaderQuotedInteger(HeaderField):
     """Integer between "" used in precondition headers."""
 
     schema_type = colander.String
-    error_message = 'The value should be integer between double quotes.'
+    error_message = "The value should be integer between double quotes."
     validator = colander.Regex('^"([0-9]+?)"$|\\*', msg=error_message)
 
     def deserialize(self, cstruct=colander.null):
         param = super(HeaderQuotedInteger, self).deserialize(cstruct)
-        if param is colander.drop or param == '*':
+        if param is colander.drop or param == "*":
             return param
 
         return int(param[1:-1])

--- a/kinto/core/scripts.py
+++ b/kinto/core/scripts.py
@@ -17,74 +17,70 @@ def migrate(env, dry_run=False):
     """
     User-friendly frontend to run database migrations.
     """
-    registry = env['registry']
+    registry = env["registry"]
     settings = registry.settings
-    readonly_backends = ('storage', 'permission')
-    readonly_mode = asbool(settings.get('readonly', False))
+    readonly_backends = ("storage", "permission")
+    readonly_mode = asbool(settings.get("readonly", False))
 
-    for backend in ('cache', 'storage', 'permission'):
+    for backend in ("cache", "storage", "permission"):
         if hasattr(registry, backend):
             if readonly_mode and backend in readonly_backends:
-                message = ('Cannot migrate the {} backend while '
-                           'in readonly mode.'.format(backend))
+                message = "Cannot migrate the {} backend while " "in readonly mode.".format(
+                    backend
+                )
                 logger.error(message)
             else:
                 getattr(registry, backend).initialize_schema(dry_run=dry_run)
 
 
 def delete_collection(env, bucket_id, collection_id):
-    registry = env['registry']
+    registry = env["registry"]
     settings = registry.settings
-    readonly_mode = asbool(settings.get('readonly', False))
+    readonly_mode = asbool(settings.get("readonly", False))
 
     if readonly_mode:
-        message = ('Cannot delete the collection while in readonly mode.')
+        message = "Cannot delete the collection while in readonly mode."
         logger.error(message)
         return 31
 
-    bucket = '/buckets/{}'.format(bucket_id)
-    collection = '/buckets/{}/collections/{}'.format(bucket_id, collection_id)
+    bucket = "/buckets/{}".format(bucket_id)
+    collection = "/buckets/{}/collections/{}".format(bucket_id, collection_id)
 
     try:
-        registry.storage.get(collection_id='bucket',
-                             parent_id='',
-                             object_id=bucket_id)
+        registry.storage.get(collection_id="bucket", parent_id="", object_id=bucket_id)
     except storage_exceptions.RecordNotFoundError:
         logger.error("Bucket '{}' does not exist.".format(bucket))
         return 32
 
     try:
-        registry.storage.get(collection_id='collection',
-                             parent_id=bucket,
-                             object_id=collection_id)
+        registry.storage.get(collection_id="collection", parent_id=bucket, object_id=collection_id)
     except storage_exceptions.RecordNotFoundError:
         logger.error("Collection '{}' does not exist.".format(collection))
         return 33
 
-    deleted = registry.storage.delete_all(collection_id='record',
-                                          parent_id=collection,
-                                          with_deleted=False)
+    deleted = registry.storage.delete_all(
+        collection_id="record", parent_id=collection, with_deleted=False
+    )
     if len(deleted) == 0:
         logger.info("No records found for '{}'.".format(collection))
     else:
-        logger.info('{} record(s) were deleted.'.format(len(deleted)))
+        logger.info("{} record(s) were deleted.".format(len(deleted)))
 
-    registry.storage.delete(collection_id='collection',
-                            parent_id=bucket,
-                            object_id=collection_id,
-                            with_deleted=False)
+    registry.storage.delete(
+        collection_id="collection", parent_id=bucket, object_id=collection_id, with_deleted=False
+    )
     logger.info("'{}' collection object was deleted.".format(collection))
 
-    record = ('/buckets/{bucket_id}'
-              '/collections/{collection_id}'
-              '/records/{record_id}')
+    record = "/buckets/{bucket_id}" "/collections/{collection_id}" "/records/{record_id}"
 
     registry.permission.delete_object_permissions(
         collection,
-        *[record.format(bucket_id=bucket_id,
-                        collection_id=collection_id,
-                        record_id=r['id']) for r in deleted])
-    logger.info('Related permissions were deleted.')
+        *[
+            record.format(bucket_id=bucket_id, collection_id=collection_id, record_id=r["id"])
+            for r in deleted
+        ]
+    )
+    logger.info("Related permissions were deleted.")
 
     current_transaction.commit()
 
@@ -100,21 +96,21 @@ def rebuild_quotas(env, dry_run=False):
     cleaning up after a bug like e.g.
     https://github.com/Kinto/kinto/issues/1226.
     """
-    registry = env['registry']
+    registry = env["registry"]
     settings = registry.settings
-    readonly_mode = asbool(settings.get('readonly', False))
+    readonly_mode = asbool(settings.get("readonly", False))
 
     # FIXME: readonly_mode is not meant to be a "maintenance mode" but
     # rather used with a database user that has read-only permissions.
     # If we ever introduce a maintenance mode, we should maybe enforce
     # it here.
     if readonly_mode:
-        message = ('Cannot rebuild quotas while in readonly mode.')
+        message = "Cannot rebuild quotas while in readonly mode."
         logger.error(message)
         return 41
 
-    if 'kinto.plugins.quotas' not in settings['includes']:
-        message = ('Cannot rebuild quotas when quotas plugin is not installed.')
+    if "kinto.plugins.quotas" not in settings["includes"]:
+        message = "Cannot rebuild quotas when quotas plugin is not installed."
         logger.error(message)
         return 42
 

--- a/kinto/core/statsd.py
+++ b/kinto/core/statsd.py
@@ -15,14 +15,14 @@ class Client:
     def __init__(self, host, port, prefix):
         self._client = statsd_module.StatsClient(host, port, prefix=prefix)
 
-    def watch_execution_time(self, obj, prefix='', classname=None):
+    def watch_execution_time(self, obj, prefix="", classname=None):
         classname = classname or utils.classname(obj)
         members = dir(obj)
         for name in members:
             value = getattr(obj, name)
             is_method = isinstance(value, types.MethodType)
-            if not name.startswith('_') and is_method:
-                statsd_key = '{}.{}.{}'.format(prefix, classname, name)
+            if not name.startswith("_") and is_method:
+                statsd_key = "{}.{}.{}".format(prefix, classname, name)
                 decorated_method = self.timer(statsd_key)(value)
                 setattr(obj, name, decorated_method)
 
@@ -47,16 +47,16 @@ def load_from_config(config):
     # (see ``kinto.core.initialization``)
     # Raise a proper error if the ``statsd`` module is not installed.
     if statsd_module is None:
-        error_msg = 'Please install Kinto with monitoring dependencies (e.g. statsd package)'
+        error_msg = "Please install Kinto with monitoring dependencies (e.g. statsd package)"
         raise ConfigurationError(error_msg)
 
     settings = config.get_settings()
-    uri = settings['statsd_url']
+    uri = settings["statsd_url"]
     uri = urlparse(uri)
 
-    if settings['project_name'] != '':
-        prefix = settings['project_name']
+    if settings["project_name"] != "":
+        prefix = settings["project_name"]
     else:
-        prefix = settings['statsd_prefix']
+        prefix = settings["statsd_prefix"]
 
     return Client(uri.hostname, uri.port, prefix)

--- a/kinto/core/storage/__init__.py
+++ b/kinto/core/storage/__init__.py
@@ -9,11 +9,12 @@ import ujson
 from . import generators
 
 
-class Missing():
+class Missing:
     """Dummy value to represent a value that is completely absent from a record.
 
     Handling these correctly is important for pagination.
     """
+
     pass
 
 
@@ -23,20 +24,20 @@ MISSING = Missing()
 logger = logging.getLogger(__name__)
 
 
-Filter = namedtuple('Filter', ['field', 'value', 'operator'])
+Filter = namedtuple("Filter", ["field", "value", "operator"])
 """Filtering properties."""
 
-Sort = namedtuple('Sort', ['field', 'direction'])
+Sort = namedtuple("Sort", ["field", "direction"])
 """Sorting properties."""
 
-DEFAULT_ID_FIELD = 'id'
-DEFAULT_MODIFIED_FIELD = 'last_modified'
-DEFAULT_DELETED_FIELD = 'deleted'
+DEFAULT_ID_FIELD = "id"
+DEFAULT_MODIFIED_FIELD = "last_modified"
+DEFAULT_DELETED_FIELD = "deleted"
 
 _HEARTBEAT_DELETE_RATE = 0.6
-_HEARTBEAT_COLLECTION_ID = '__heartbeat__'
+_HEARTBEAT_COLLECTION_ID = "__heartbeat__"
 _HEART_PARENT_ID = _HEARTBEAT_COLLECTION_ID
-_HEARTBEAT_RECORD = {'__heartbeat__': True}
+_HEARTBEAT_RECORD = {"__heartbeat__": True}
 
 
 class StorageBase:
@@ -93,10 +94,16 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def create(self, collection_id, parent_id, record, id_generator=None,
-               id_field=DEFAULT_ID_FIELD,
-               modified_field=DEFAULT_MODIFIED_FIELD,
-               auth=None):
+    def create(
+        self,
+        collection_id,
+        parent_id,
+        record,
+        id_generator=None,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         """Create the specified `object` in this `collection_id` for this `parent_id`.
         Assign the id to the object, using the attribute
         :attr:`kinto.core.resource.model.Model.id_field`.
@@ -116,10 +123,15 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def get(self, collection_id, parent_id, object_id,
-            id_field=DEFAULT_ID_FIELD,
-            modified_field=DEFAULT_MODIFIED_FIELD,
-            auth=None):
+    def get(
+        self,
+        collection_id,
+        parent_id,
+        object_id,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         """Retrieve the object with specified `object_id`, or raise error
         if not found.
 
@@ -135,10 +147,16 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def update(self, collection_id, parent_id, object_id, record,
-               id_field=DEFAULT_ID_FIELD,
-               modified_field=DEFAULT_MODIFIED_FIELD,
-               auth=None):
+    def update(
+        self,
+        collection_id,
+        parent_id,
+        object_id,
+        record,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         """Overwrite the `object` with the specified `object_id`.
 
         If the specified id is not found, the object is created with the
@@ -158,11 +176,18 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def delete(self, collection_id, parent_id, object_id,
-               id_field=DEFAULT_ID_FIELD, with_deleted=True,
-               modified_field=DEFAULT_MODIFIED_FIELD,
-               deleted_field=DEFAULT_DELETED_FIELD,
-               auth=None, last_modified=None):
+    def delete(
+        self,
+        collection_id,
+        parent_id,
+        object_id,
+        id_field=DEFAULT_ID_FIELD,
+        with_deleted=True,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        deleted_field=DEFAULT_DELETED_FIELD,
+        auth=None,
+        last_modified=None,
+    ):
         """Delete the object with specified `object_id`, and raise error
         if not found.
 
@@ -187,12 +212,20 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def delete_all(self, collection_id, parent_id, filters=None,
-                   sorting=None, pagination_rules=None, limit=None,
-                   id_field=DEFAULT_ID_FIELD, with_deleted=True,
-                   modified_field=DEFAULT_MODIFIED_FIELD,
-                   deleted_field=DEFAULT_DELETED_FIELD,
-                   auth=None):
+    def delete_all(
+        self,
+        collection_id,
+        parent_id,
+        filters=None,
+        sorting=None,
+        pagination_rules=None,
+        limit=None,
+        id_field=DEFAULT_ID_FIELD,
+        with_deleted=True,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        deleted_field=DEFAULT_DELETED_FIELD,
+        auth=None,
+    ):
         """Delete all objects in this `collection_id` for this `parent_id`.
 
         :param str collection_id: the collection id.
@@ -223,10 +256,15 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def purge_deleted(self, collection_id, parent_id, before=None,
-                      id_field=DEFAULT_ID_FIELD,
-                      modified_field=DEFAULT_MODIFIED_FIELD,
-                      auth=None):
+    def purge_deleted(
+        self,
+        collection_id,
+        parent_id,
+        before=None,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         """Delete all deleted object tombstones in this `collection_id`
         for this `parent_id`.
 
@@ -241,12 +279,20 @@ class StorageBase:
         """
         raise NotImplementedError
 
-    def get_all(self, collection_id, parent_id, filters=None, sorting=None,
-                pagination_rules=None, limit=None, include_deleted=False,
-                id_field=DEFAULT_ID_FIELD,
-                modified_field=DEFAULT_MODIFIED_FIELD,
-                deleted_field=DEFAULT_DELETED_FIELD,
-                auth=None):
+    def get_all(
+        self,
+        collection_id,
+        parent_id,
+        filters=None,
+        sorting=None,
+        pagination_rules=None,
+        limit=None,
+        include_deleted=False,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        deleted_field=DEFAULT_DELETED_FIELD,
+        auth=None,
+    ):
         """Retrieve all objects in this `collection_id` for this `parent_id`.
 
         :param str collection_id: the collection id.
@@ -298,11 +344,11 @@ def heartbeat(backend):
         :rtype: bool
         """
         try:
-            auth = request.headers.get('Authorization')
-            storage_kw = dict(collection_id=_HEARTBEAT_COLLECTION_ID,
-                              parent_id=_HEART_PARENT_ID,
-                              auth=auth)
-            if asbool(request.registry.settings.get('readonly')):
+            auth = request.headers.get("Authorization")
+            storage_kw = dict(
+                collection_id=_HEARTBEAT_COLLECTION_ID, parent_id=_HEART_PARENT_ID, auth=auth
+            )
+            if asbool(request.registry.settings.get("readonly")):
                 # Do not try to write in readonly mode.
                 backend.get_all(**storage_kw)
             else:
@@ -313,7 +359,7 @@ def heartbeat(backend):
                     backend.create(record=_HEARTBEAT_RECORD, **storage_kw)
             return True
         except Exception:
-            logger.exception('Heartbeat Error')
+            logger.exception("Heartbeat Error")
             return False
 
     return ping

--- a/kinto/core/storage/exceptions.py
+++ b/kinto/core/storage/exceptions.py
@@ -8,11 +8,11 @@ class BackendError(Exception):
     :param Exception original: the wrapped exception raised by underlying
         library.
     """
+
     def __init__(self, original=None, message=None, *args, **kwargs):
         self.original = original
         if message is None:
-            message = '{}: {}'.format(original.__class__.__name__,
-                                      original)
+            message = "{}: {}".format(original.__class__.__name__, original)
         super().__init__(message, *args, **kwargs)
 
 
@@ -20,6 +20,7 @@ class RecordNotFoundError(Exception):
     """An exception raised when a specific record could not be found.
 
     """
+
     pass
 
 
@@ -34,8 +35,9 @@ class UnicityError(IntegrityError):
     record violates the unicity constraints defined by the resource.
 
     """
+
     def __init__(self, field, record, *args, **kwargs):
         self.field = field
         self.record = record
-        self.msg = '{} is not unique: {}'.format(field, record)
+        self.msg = "{} is not unique: {}".format(field, record)
         super().__init__(*args, **kwargs)

--- a/kinto/core/storage/generators.py
+++ b/kinto/core/storage/generators.py
@@ -9,7 +9,7 @@ class Generator:
     resource level to validate record id in requests paths.
     """
 
-    regexp = r'^[a-zA-Z0-9][a-zA-Z0-9_-]*$'
+    regexp = r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
     """Default record id pattern. Can be changed to comply with custom ids."""
 
     def __init__(self, config=None):
@@ -17,7 +17,7 @@ class Generator:
         self._regexp = None
 
         if not self.match(self()):
-            error_msg = 'Generated record id does comply with regexp.'
+            error_msg = "Generated record id does comply with regexp."
             raise ValueError(error_msg)
 
     def match(self, record_id):
@@ -50,8 +50,8 @@ class UUID4(Generator):
     duplicate would be about 50% (`source <http://en.wikipedia.org/wiki/\
 Universally_unique_identifier#Random_UUID_probability_of_duplicates>`_).
     """
-    regexp = (r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
-              r'[0-9a-f]{4}-[0-9a-f]{12}$')
+
+    regexp = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-" r"[0-9a-f]{4}-[0-9a-f]{12}$"
     """UUID4 accurate pattern."""
 
     def __call__(self):

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -4,9 +4,13 @@ import warnings
 from collections import defaultdict
 
 from kinto.core.storage import (
-    StorageBase, exceptions,
-    DEFAULT_ID_FIELD, DEFAULT_MODIFIED_FIELD, DEFAULT_DELETED_FIELD,
-    MISSING)
+    StorageBase,
+    exceptions,
+    DEFAULT_ID_FIELD,
+    DEFAULT_MODIFIED_FIELD,
+    DEFAULT_DELETED_FIELD,
+    MISSING,
+)
 from kinto.core.storage.postgresql.client import create_from_config
 from kinto.core.storage.postgresql.migrator import MigratorMixin
 from kinto.core.utils import COMPARISON
@@ -72,10 +76,10 @@ class Storage(StorageBase, MigratorMixin):
     """  # NOQA
 
     # MigratorMixin attributes.
-    name = 'storage'
+    name = "storage"
     schema_version = 20
-    schema_file = os.path.join(HERE, 'schema.sql')
-    migrations_directory = os.path.join(HERE, 'migrations')
+    schema_file = os.path.join(HERE, "schema.sql")
+    migrations_directory = os.path.join(HERE, "migrations")
 
     def __init__(self, client, max_fetch_size, *args, readonly=False, **kwargs):
         super().__init__(*args, **kwargs)
@@ -99,9 +103,9 @@ class Storage(StorageBase, MigratorMixin):
         with self.client.connect() as conn:
             result = conn.execute(query)
             record = result.fetchone()
-        timezone = record['timezone'].upper()
-        if timezone != 'UTC':  # pragma: no cover
-            msg = 'Database timezone is not UTC ({})'.format(timezone)
+        timezone = record["timezone"].upper()
+        if timezone != "UTC":  # pragma: no cover
+            msg = "Database timezone is not UTC ({})".format(timezone)
             warnings.warn(msg)
             logger.warning(msg)
 
@@ -115,9 +119,9 @@ class Storage(StorageBase, MigratorMixin):
         with self.client.connect() as conn:
             result = conn.execute(query)
             record = result.fetchone()
-        encoding = record['encoding'].lower()
-        if encoding != 'utf8':  # pragma: no cover
-            raise AssertionError('Unexpected database encoding {}'.format(encoding))
+        encoding = record["encoding"].lower()
+        if encoding != "utf8":  # pragma: no cover
+            raise AssertionError("Unexpected database encoding {}".format(encoding))
 
     def get_installed_version(self):
         """Return current version of schema or None if not any found.
@@ -144,7 +148,7 @@ class Storage(StorageBase, MigratorMixin):
 
             result = conn.execute(schema_version_metadata_query)
             if result.rowcount > 0:
-                return int(result.fetchone()['version'])
+                return int(result.fetchone()["version"])
 
             # No storage_schema_version row.
             # Perhaps it got flush()ed by a pre-8.1.2 Kinto (which
@@ -157,7 +161,7 @@ class Storage(StorageBase, MigratorMixin):
             result = conn.execute(query)
             was_flushed = int(result.fetchone()[0]) == 0
             if not was_flushed:
-                error_msg = 'No schema history; assuming migration from Cliquet (version 1).'
+                error_msg = "No schema history; assuming migration from Cliquet (version 1)."
                 logger.warning(error_msg)
                 return 1
 
@@ -184,7 +188,7 @@ class Storage(StorageBase, MigratorMixin):
         """
         with self.client.connect(force_commit=True) as conn:
             conn.execute(query)
-        logger.debug('Flushed PostgreSQL storage tables')
+        logger.debug("Flushed PostgreSQL storage tables")
 
     def collection_timestamp(self, collection_id, parent_id, auth=None):
         query_existing = """
@@ -223,26 +227,34 @@ class Storage(StorageBase, MigratorMixin):
             existing_ts = None
             ts_result = conn.execute(query_existing, placeholders)
             row = ts_result.fetchone()  # Will return (None, None) when empty.
-            existing_ts = row['last_modified']
+            existing_ts = row["last_modified"]
 
             # If the backend is readonly, we should not try to create the timestamp.
             if self.readonly:
                 if existing_ts is None:
-                    error_msg = ('Cannot initialize empty collection timestamp '
-                                 'when running in readonly.')
+                    error_msg = (
+                        "Cannot initialize empty collection timestamp " "when running in readonly."
+                    )
                     raise exceptions.BackendError(message=error_msg)
                 record = row
             else:
-                create_result = conn.execute(create_if_missing,
-                                             dict(last_modified=existing_ts, **placeholders))
+                create_result = conn.execute(
+                    create_if_missing, dict(last_modified=existing_ts, **placeholders)
+                )
                 record = create_result.fetchone() or row
 
-        return record['last_epoch']
+        return record["last_epoch"]
 
-    def create(self, collection_id, parent_id, record, id_generator=None,
-               id_field=DEFAULT_ID_FIELD,
-               modified_field=DEFAULT_MODIFIED_FIELD,
-               auth=None):
+    def create(
+        self,
+        collection_id,
+        parent_id,
+        record,
+        id_generator=None,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         id_generator = id_generator or self.id_generator
         record = {**record}
         if id_field in record:
@@ -296,28 +308,35 @@ class Storage(StorageBase, MigratorMixin):
         """
 
         safe_holders = {}
-        placeholders = dict(object_id=record[id_field],
-                            parent_id=parent_id,
-                            collection_id=collection_id,
-                            last_modified=record.get(modified_field),
-                            data=self.json.dumps(query_record))
+        placeholders = dict(
+            object_id=record[id_field],
+            parent_id=parent_id,
+            collection_id=collection_id,
+            last_modified=record.get(modified_field),
+            data=self.json.dumps(query_record),
+        )
         with self.client.connect() as conn:
             result = conn.execute(query % safe_holders, placeholders)
             inserted = result.fetchone()
 
-        if not inserted['inserted']:
-            record = inserted['data']
-            record[id_field] = inserted['id']
-            record[modified_field] = inserted['last_modified']
+        if not inserted["inserted"]:
+            record = inserted["data"]
+            record[id_field] = inserted["id"]
+            record[modified_field] = inserted["last_modified"]
             raise exceptions.UnicityError(id_field, record)
 
-        record[modified_field] = inserted['last_modified']
+        record[modified_field] = inserted["last_modified"]
         return record
 
-    def get(self, collection_id, parent_id, object_id,
-            id_field=DEFAULT_ID_FIELD,
-            modified_field=DEFAULT_MODIFIED_FIELD,
-            auth=None):
+    def get(
+        self,
+        collection_id,
+        parent_id,
+        object_id,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         query = """
         SELECT as_epoch(last_modified) AS last_modified, data
           FROM records
@@ -326,9 +345,7 @@ class Storage(StorageBase, MigratorMixin):
            AND collection_id = :collection_id
            AND NOT deleted;
         """
-        placeholders = dict(object_id=object_id,
-                            parent_id=parent_id,
-                            collection_id=collection_id)
+        placeholders = dict(object_id=object_id, parent_id=parent_id, collection_id=collection_id)
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query, placeholders)
             if result.rowcount == 0:
@@ -336,15 +353,21 @@ class Storage(StorageBase, MigratorMixin):
             else:
                 existing = result.fetchone()
 
-        record = existing['data']
+        record = existing["data"]
         record[id_field] = object_id
-        record[modified_field] = existing['last_modified']
+        record[modified_field] = existing["last_modified"]
         return record
 
-    def update(self, collection_id, parent_id, object_id, record,
-               id_field=DEFAULT_ID_FIELD,
-               modified_field=DEFAULT_MODIFIED_FIELD,
-               auth=None):
+    def update(
+        self,
+        collection_id,
+        parent_id,
+        object_id,
+        record,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
 
         # Remove redundancy in data field
         query_record = {**record}
@@ -364,25 +387,34 @@ class Storage(StorageBase, MigratorMixin):
                                      EXCLUDED.last_modified)
         RETURNING as_epoch(last_modified) AS last_modified;
         """
-        placeholders = dict(object_id=object_id,
-                            parent_id=parent_id,
-                            collection_id=collection_id,
-                            last_modified=record.get(modified_field),
-                            data=self.json.dumps(query_record))
+        placeholders = dict(
+            object_id=object_id,
+            parent_id=parent_id,
+            collection_id=collection_id,
+            last_modified=record.get(modified_field),
+            data=self.json.dumps(query_record),
+        )
 
         with self.client.connect() as conn:
             result = conn.execute(query, placeholders)
             updated = result.fetchone()
 
         record = {**record, id_field: object_id}
-        record[modified_field] = updated['last_modified']
+        record[modified_field] = updated["last_modified"]
         return record
 
-    def delete(self, collection_id, parent_id, object_id,
-               id_field=DEFAULT_ID_FIELD, with_deleted=True,
-               modified_field=DEFAULT_MODIFIED_FIELD,
-               deleted_field=DEFAULT_DELETED_FIELD,
-               auth=None, last_modified=None):
+    def delete(
+        self,
+        collection_id,
+        parent_id,
+        object_id,
+        id_field=DEFAULT_ID_FIELD,
+        with_deleted=True,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        deleted_field=DEFAULT_DELETED_FIELD,
+        auth=None,
+        last_modified=None,
+    ):
         if with_deleted:
             query = """
             UPDATE records
@@ -405,11 +437,13 @@ class Storage(StorageBase, MigratorMixin):
             RETURNING as_epoch(last_modified) AS last_modified;
             """
         deleted_data = self.json.dumps(dict([(deleted_field, True)]))
-        placeholders = dict(object_id=object_id,
-                            parent_id=parent_id,
-                            collection_id=collection_id,
-                            last_modified=last_modified,
-                            deleted_data=deleted_data)
+        placeholders = dict(
+            object_id=object_id,
+            parent_id=parent_id,
+            collection_id=collection_id,
+            last_modified=last_modified,
+            deleted_data=deleted_data,
+        )
 
         with self.client.connect() as conn:
             result = conn.execute(query, placeholders)
@@ -418,18 +452,26 @@ class Storage(StorageBase, MigratorMixin):
             inserted = result.fetchone()
 
         record = {}
-        record[modified_field] = inserted['last_modified']
+        record[modified_field] = inserted["last_modified"]
         record[id_field] = object_id
 
         record[deleted_field] = True
         return record
 
-    def delete_all(self, collection_id, parent_id, filters=None,
-                   sorting=None, pagination_rules=None, limit=None,
-                   id_field=DEFAULT_ID_FIELD, with_deleted=True,
-                   modified_field=DEFAULT_MODIFIED_FIELD,
-                   deleted_field=DEFAULT_DELETED_FIELD,
-                   auth=None):
+    def delete_all(
+        self,
+        collection_id,
+        parent_id,
+        filters=None,
+        sorting=None,
+        pagination_rules=None,
+        limit=None,
+        id_field=DEFAULT_ID_FIELD,
+        with_deleted=True,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        deleted_field=DEFAULT_DELETED_FIELD,
+        auth=None,
+    ):
         if with_deleted:
             query = """
             WITH matching_records AS (
@@ -478,45 +520,41 @@ class Storage(StorageBase, MigratorMixin):
         id_field = id_field or self.id_field
         modified_field = modified_field or self.modified_field
         deleted_data = self.json.dumps(dict([(deleted_field, True)]))
-        placeholders = dict(parent_id=parent_id,
-                            collection_id=collection_id,
-                            deleted_data=deleted_data)
+        placeholders = dict(
+            parent_id=parent_id, collection_id=collection_id, deleted_data=deleted_data
+        )
         # Safe strings
         safeholders = defaultdict(str)
         # Handle parent_id as a regex only if it contains *
-        if '*' in parent_id:
-            safeholders['parent_id_filter'] = 'parent_id LIKE :parent_id'
-            placeholders['parent_id'] = parent_id.replace('*', '%')
+        if "*" in parent_id:
+            safeholders["parent_id_filter"] = "parent_id LIKE :parent_id"
+            placeholders["parent_id"] = parent_id.replace("*", "%")
         else:
-            safeholders['parent_id_filter'] = 'parent_id = :parent_id'
+            safeholders["parent_id_filter"] = "parent_id = :parent_id"
         # If collection is None, remove it from query.
         if collection_id is None:
-            safeholders['collection_id_filter'] = ''
+            safeholders["collection_id_filter"] = ""
         else:
-            safeholders['collection_id_filter'] = 'AND collection_id = :collection_id'  # NOQA
+            safeholders["collection_id_filter"] = "AND collection_id = :collection_id"  # NOQA
 
         if filters:
-            safe_sql, holders = self._format_conditions(filters,
-                                                        id_field,
-                                                        modified_field)
-            safeholders['conditions_filter'] = 'AND {}'.format(safe_sql)
+            safe_sql, holders = self._format_conditions(filters, id_field, modified_field)
+            safeholders["conditions_filter"] = "AND {}".format(safe_sql)
             placeholders.update(**holders)
 
         if sorting:
-            sql, holders = self._format_sorting(sorting, id_field,
-                                                modified_field)
-            safeholders['sorting'] = sql
+            sql, holders = self._format_sorting(sorting, id_field, modified_field)
+            safeholders["sorting"] = sql
             placeholders.update(**holders)
 
         if pagination_rules:
-            sql, holders = self._format_pagination(pagination_rules, id_field,
-                                                   modified_field)
-            safeholders['pagination_rules'] = 'AND {}'.format(sql)
+            sql, holders = self._format_pagination(pagination_rules, id_field, modified_field)
+            safeholders["pagination_rules"] = "AND {}".format(sql)
             placeholders.update(**holders)
 
         # Limit the number of results (pagination).
         limit = min(self._max_fetch_size, limit) if limit else self._max_fetch_size
-        placeholders['pagination_limit'] = limit
+        placeholders["pagination_limit"] = limit
 
         with self.client.connect() as conn:
             result = conn.execute(query.format_map(safeholders), placeholders)
@@ -525,17 +563,22 @@ class Storage(StorageBase, MigratorMixin):
         records = []
         for result in deleted:
             record = {}
-            record[id_field] = result['id']
-            record[modified_field] = result['last_modified']
+            record[id_field] = result["id"]
+            record[modified_field] = result["last_modified"]
             record[deleted_field] = True
             records.append(record)
 
         return records
 
-    def purge_deleted(self, collection_id, parent_id, before=None,
-                      id_field=DEFAULT_ID_FIELD,
-                      modified_field=DEFAULT_MODIFIED_FIELD,
-                      auth=None):
+    def purge_deleted(
+        self,
+        collection_id,
+        parent_id,
+        before=None,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        auth=None,
+    ):
         delete_tombstones = """
         DELETE
         FROM records
@@ -545,26 +588,24 @@ class Storage(StorageBase, MigratorMixin):
         """
         id_field = id_field or self.id_field
         modified_field = modified_field or self.modified_field
-        placeholders = dict(parent_id=parent_id,
-                            collection_id=collection_id)
+        placeholders = dict(parent_id=parent_id, collection_id=collection_id)
         # Safe strings
         safeholders = defaultdict(str)
         # Handle parent_id as a regex only if it contains *
-        if '*' in parent_id:
-            safeholders['parent_id_filter'] = 'parent_id LIKE :parent_id'
-            placeholders['parent_id'] = parent_id.replace('*', '%')
+        if "*" in parent_id:
+            safeholders["parent_id_filter"] = "parent_id LIKE :parent_id"
+            placeholders["parent_id"] = parent_id.replace("*", "%")
         else:
-            safeholders['parent_id_filter'] = 'parent_id = :parent_id'
+            safeholders["parent_id_filter"] = "parent_id = :parent_id"
         # If collection is None, remove it from query.
         if collection_id is None:
-            safeholders['collection_id_filter'] = ''
+            safeholders["collection_id_filter"] = ""
         else:
-            safeholders['collection_id_filter'] = 'AND collection_id = :collection_id'  # NOQA
+            safeholders["collection_id_filter"] = "AND collection_id = :collection_id"  # NOQA
 
         if before is not None:
-            safeholders['conditions_filter'] = (
-                'AND as_epoch(last_modified) < :before')
-            placeholders['before'] = before
+            safeholders["conditions_filter"] = "AND as_epoch(last_modified) < :before"
+            placeholders["before"] = before
 
         with self.client.connect() as conn:
             result = conn.execute(delete_tombstones.format_map(safeholders), placeholders)
@@ -581,12 +622,20 @@ class Storage(StorageBase, MigratorMixin):
 
         return deleted
 
-    def get_all(self, collection_id, parent_id, filters=None, sorting=None,
-                pagination_rules=None, limit=None, include_deleted=False,
-                id_field=DEFAULT_ID_FIELD,
-                modified_field=DEFAULT_MODIFIED_FIELD,
-                deleted_field=DEFAULT_DELETED_FIELD,
-                auth=None):
+    def get_all(
+        self,
+        collection_id,
+        parent_id,
+        filters=None,
+        sorting=None,
+        pagination_rules=None,
+        limit=None,
+        include_deleted=False,
+        id_field=DEFAULT_ID_FIELD,
+        modified_field=DEFAULT_MODIFIED_FIELD,
+        deleted_field=DEFAULT_DELETED_FIELD,
+        auth=None,
+    ):
         query = """
         WITH collection_filtered AS (
             SELECT id, last_modified, data, deleted
@@ -611,44 +660,39 @@ class Storage(StorageBase, MigratorMixin):
         """
 
         # Unsafe strings escaped by PostgreSQL
-        placeholders = dict(parent_id=parent_id,
-                            collection_id=collection_id)
+        placeholders = dict(parent_id=parent_id, collection_id=collection_id)
 
         # Safe strings
         safeholders = defaultdict(str)
 
         # Handle parent_id as a regex only if it contains *
-        if '*' in parent_id:
-            safeholders['parent_id_filter'] = 'parent_id LIKE :parent_id'
-            placeholders['parent_id'] = parent_id.replace('*', '%')
+        if "*" in parent_id:
+            safeholders["parent_id_filter"] = "parent_id LIKE :parent_id"
+            placeholders["parent_id"] = parent_id.replace("*", "%")
         else:
-            safeholders['parent_id_filter'] = 'parent_id = :parent_id'
+            safeholders["parent_id_filter"] = "parent_id = :parent_id"
 
         if filters:
-            safe_sql, holders = self._format_conditions(filters,
-                                                        id_field,
-                                                        modified_field)
-            safeholders['conditions_filter'] = 'AND {}'.format(safe_sql)
+            safe_sql, holders = self._format_conditions(filters, id_field, modified_field)
+            safeholders["conditions_filter"] = "AND {}".format(safe_sql)
             placeholders.update(**holders)
 
         if not include_deleted:
-            safeholders['conditions_deleted'] = 'AND NOT deleted'
+            safeholders["conditions_deleted"] = "AND NOT deleted"
 
         if sorting:
-            sql, holders = self._format_sorting(sorting, id_field,
-                                                modified_field)
-            safeholders['sorting'] = sql
+            sql, holders = self._format_sorting(sorting, id_field, modified_field)
+            safeholders["sorting"] = sql
             placeholders.update(**holders)
 
         if pagination_rules:
-            sql, holders = self._format_pagination(pagination_rules, id_field,
-                                                   modified_field)
-            safeholders['pagination_rules'] = 'WHERE {}'.format(sql)
+            sql, holders = self._format_pagination(pagination_rules, id_field, modified_field)
+            safeholders["pagination_rules"] = "WHERE {}".format(sql)
             placeholders.update(**holders)
 
         # Limit the number of results (pagination).
         limit = min(self._max_fetch_size, limit) if limit else self._max_fetch_size
-        placeholders['pagination_limit'] = limit
+        placeholders["pagination_limit"] = limit
 
         with self.client.connect(readonly=True) as conn:
             result = conn.execute(query.format_map(safeholders), placeholders)
@@ -657,19 +701,18 @@ class Storage(StorageBase, MigratorMixin):
         if len(retrieved) == 0:
             return [], 0
 
-        count_total = retrieved[0]['count_total']
+        count_total = retrieved[0]["count_total"]
 
         records = []
         for result in retrieved:
-            record = result['data']
-            record[id_field] = result['id']
-            record[modified_field] = result['last_modified']
+            record = result["data"]
+            record[id_field] = result["id"]
+            record[modified_field] = result["last_modified"]
             records.append(record)
 
         return records, count_total
 
-    def _format_conditions(self, filters, id_field, modified_field,
-                           prefix='filters'):
+    def _format_conditions(self, filters, id_field, modified_field, prefix="filters"):
         """Format the filters list in SQL, with placeholders for safe escaping.
 
         .. note::
@@ -684,12 +727,12 @@ class Storage(StorageBase, MigratorMixin):
         :rtype: tuple
         """
         operators = {
-            COMPARISON.EQ: '=',
-            COMPARISON.NOT: '<>',
-            COMPARISON.IN: 'IN',
-            COMPARISON.EXCLUDE: 'NOT IN',
-            COMPARISON.LIKE: 'ILIKE',
-            COMPARISON.CONTAINS: '@>',
+            COMPARISON.EQ: "=",
+            COMPARISON.NOT: "<>",
+            COMPARISON.IN: "IN",
+            COMPARISON.EXCLUDE: "NOT IN",
+            COMPARISON.LIKE: "ILIKE",
+            COMPARISON.CONTAINS: "@>",
         }
 
         conditions = []
@@ -699,30 +742,33 @@ class Storage(StorageBase, MigratorMixin):
             is_like_query = filtr.operator == COMPARISON.LIKE
 
             if filtr.field == id_field:
-                sql_field = 'id'
+                sql_field = "id"
                 if isinstance(value, int):
                     value = str(value)
             elif filtr.field == modified_field:
-                sql_field = 'as_epoch(last_modified)'
+                sql_field = "as_epoch(last_modified)"
             else:
-                column_name = 'data'
+                column_name = "data"
                 # Subfields: ``person.name`` becomes ``data->person->>name``
-                subfields = filtr.field.split('.')
+                subfields = filtr.field.split(".")
                 for j, subfield in enumerate(subfields):
                     # Safely escape field name
-                    field_holder = '{}_field_{}_{}'.format(prefix, i, j)
+                    field_holder = "{}_field_{}_{}".format(prefix, i, j)
                     holders[field_holder] = subfield
                     # Use ->> to convert the last level to text if
                     # needed for LIKE query. (Other queries do JSONB comparison.)
-                    column_name += '->>' if j == len(subfields) - 1 and is_like_query else '->'
-                    column_name += ':{}'.format(field_holder)
+                    column_name += "->>" if j == len(subfields) - 1 and is_like_query else "->"
+                    column_name += ":{}".format(field_holder)
                 sql_field = column_name
 
             string_field = filtr.field in (id_field, modified_field) or is_like_query
             if not string_field and value != MISSING:
                 # JSONB-ify the value.
-                if filtr.operator not in (COMPARISON.IN, COMPARISON.EXCLUDE,
-                                          COMPARISON.CONTAINS_ANY):
+                if filtr.operator not in (
+                    COMPARISON.IN,
+                    COMPARISON.EXCLUDE,
+                    COMPARISON.CONTAINS_ANY,
+                ):
                     value = self.json.dumps(value)
                 else:
                     value = [self.json.dumps(v) for v in value]
@@ -736,16 +782,16 @@ class Storage(StorageBase, MigratorMixin):
             if is_like_query:
                 # Operand should be a string.
                 # Add implicit start/end wildcards if none is specified.
-                if '*' not in value:
-                    value = '*{}*'.format(value)
-                value = value.replace('*', '%')
+                if "*" not in value:
+                    value = "*{}*".format(value)
+                value = value.replace("*", "%")
 
             if filtr.operator == COMPARISON.HAS:
-                operator = 'IS NOT NULL' if filtr.value else 'IS NULL'
-                cond = '{} {}'.format(sql_field, operator)
+                operator = "IS NOT NULL" if filtr.value else "IS NULL"
+                cond = "{} {}".format(sql_field, operator)
 
             elif filtr.operator == COMPARISON.CONTAINS_ANY:
-                value_holder = '{}_value_{}'.format(prefix, i)
+                value_holder = "{}_value_{}".format(prefix, i)
                 holders[value_holder] = value
                 # In case the field is not a sequence, we ignore the record.
                 is_json_sequence = "jsonb_typeof({}) = 'array'".format(sql_field)
@@ -753,20 +799,22 @@ class Storage(StorageBase, MigratorMixin):
                 # However, it does support Postgres arrays of any
                 # type. Assume that the referenced field is a JSON
                 # array and convert it to a Postgres array.
-                data_as_array = '''
+                data_as_array = """
                 (SELECT array_agg(elems) FROM jsonb_array_elements({}) elems)
-                '''.format(sql_field)
-                cond = '{} AND {} && (:{})::jsonb[]'.format(
-                    is_json_sequence, data_as_array, value_holder)
+                """.format(
+                    sql_field
+                )
+                cond = "{} AND {} && (:{})::jsonb[]".format(
+                    is_json_sequence, data_as_array, value_holder
+                )
 
             elif value != MISSING:
                 # Safely escape value. MISSINGs get handled below.
-                value_holder = '{}_value_{}'.format(prefix, i)
+                value_holder = "{}_value_{}".format(prefix, i)
                 holders[value_holder] = value
 
-                sql_operator = operators.setdefault(filtr.operator,
-                                                    filtr.operator.value)
-                cond = '{} {} :{}'.format(sql_field, sql_operator, value_holder)
+                sql_operator = operators.setdefault(filtr.operator, filtr.operator.value)
+                cond = "{} {} :{}".format(sql_field, sql_operator, value_holder)
 
             # If the field is missing, column_name will produce
             # NULL. NULL has strange properties with comparisons
@@ -794,7 +842,8 @@ class Storage(StorageBase, MigratorMixin):
                 # Match Postgres's default sort behavior
                 # (NULLS LAST) by allowing NULLs to
                 # automatically be greater than everything.
-                COMPARISON.GT, COMPARISON.MIN,
+                COMPARISON.GT,
+                COMPARISON.MIN,
             )
 
             if not (filtr.field == id_field or filtr.field == modified_field):
@@ -815,26 +864,26 @@ class Storage(StorageBase, MigratorMixin):
                         # (for the purposes of pagination).
                         # >= NULL should only match rows that are
                         # NULL, since there's nothing higher.
-                        cond = '{} IS NULL'.format(sql_field)
+                        cond = "{} IS NULL".format(sql_field)
                     elif filtr.operator == COMPARISON.LT:
                         # If we're looking for < NULL, match only
                         # non-nulls.
-                        cond = '{} IS NOT NULL'.format(sql_field)
+                        cond = "{} IS NOT NULL".format(sql_field)
                     elif filtr.operator == COMPARISON.MAX:
                         # <= NULL should include everything -- NULL
                         # because it's equal, and non-nulls because
                         # they're <.
-                        cond = 'TRUE'
+                        cond = "TRUE"
                     elif filtr.operator == COMPARISON.GT:
                         # Nothing can be greater than NULL (that is,
                         # higher in search order).
-                        cond = 'FALSE'
+                        cond = "FALSE"
                     else:
-                        raise ValueError('Somehow we got a filter with MISSING value')
+                        raise ValueError("Somehow we got a filter with MISSING value")
                 elif filtr.operator in null_false_operators:
-                    cond = '({} IS NOT NULL AND {})'.format(sql_field, cond)
+                    cond = "({} IS NOT NULL AND {})".format(sql_field, cond)
                 elif filtr.operator in null_true_operators:
-                    cond = '({} IS NULL OR {})'.format(sql_field, cond)
+                    cond = "({} IS NULL OR {})".format(sql_field, cond)
                 else:
                     # No need to check for LT and MAX because NULL < foo
                     # is NULL, which is falsy in SQL.
@@ -842,7 +891,7 @@ class Storage(StorageBase, MigratorMixin):
 
             conditions.append(cond)
 
-        safe_sql = ' AND '.join(conditions)
+        safe_sql = " AND ".join(conditions)
         return safe_sql, holders
 
     def _format_pagination(self, pagination_rules, id_field, modified_field):
@@ -865,15 +914,14 @@ class Storage(StorageBase, MigratorMixin):
         placeholders = {}
 
         for i, rule in enumerate(pagination_rules):
-            prefix = 'rules_{}'.format(i)
-            safe_sql, holders = self._format_conditions(rule,
-                                                        id_field,
-                                                        modified_field,
-                                                        prefix=prefix)
+            prefix = "rules_{}".format(i)
+            safe_sql, holders = self._format_conditions(
+                rule, id_field, modified_field, prefix=prefix
+            )
             rules.append(safe_sql)
             placeholders.update(**holders)
 
-        safe_sql = ' OR '.join(['({})'.format(r) for r in rules])
+        safe_sql = " OR ".join(["({})".format(r) for r in rules])
         return safe_sql, placeholders
 
     def _format_sorting(self, sorting, id_field, modified_field):
@@ -892,35 +940,36 @@ class Storage(StorageBase, MigratorMixin):
         for i, sort in enumerate(sorting):
 
             if sort.field == id_field:
-                sql_field = 'id'
+                sql_field = "id"
             elif sort.field == modified_field:
-                sql_field = 'last_modified'
+                sql_field = "last_modified"
             else:
                 # Subfields: ``person.name`` becomes ``data->person->name``
-                subfields = sort.field.split('.')
-                sql_field = 'data'
+                subfields = sort.field.split(".")
+                sql_field = "data"
                 for j, subfield in enumerate(subfields):
                     # Safely escape field name
-                    field_holder = 'sort_field_{}_{}'.format(i, j)
+                    field_holder = "sort_field_{}_{}".format(i, j)
                     holders[field_holder] = subfield
-                    sql_field += '->(:{})'.format(field_holder)
+                    sql_field += "->(:{})".format(field_holder)
 
-            sql_direction = 'ASC' if sort.direction > 0 else 'DESC'
-            sql_sort = '{} {}'.format(sql_field, sql_direction)
+            sql_direction = "ASC" if sort.direction > 0 else "DESC"
+            sql_sort = "{} {}".format(sql_field, sql_direction)
             sorts.append(sql_sort)
 
-        safe_sql = 'ORDER BY {}'.format(', '.join(sorts))
+        safe_sql = "ORDER BY {}".format(", ".join(sorts))
         return safe_sql, holders
 
 
 def load_from_config(config):
     settings = config.get_settings()
-    max_fetch_size = int(settings['storage_max_fetch_size'])
-    strict = settings.get('storage_strict_json', False)
-    readonly = settings.get('readonly', False)
-    client = create_from_config(config, prefix='storage_')
-    return Storage(client=client, max_fetch_size=max_fetch_size, strict_json=strict,
-                   readonly=readonly)
+    max_fetch_size = int(settings["storage_max_fetch_size"])
+    strict = settings.get("storage_strict_json", False)
+    readonly = settings.get("readonly", False)
+    client = create_from_config(config, prefix="storage_")
+    return Storage(
+        client=client, max_fetch_size=max_fetch_size, strict_json=strict, readonly=readonly
+    )
 
 
 UNKNOWN_SCHEMA_VERSION_MESSAGE = """

--- a/kinto/core/storage/postgresql/client.py
+++ b/kinto/core/storage/postgresql/client.py
@@ -9,8 +9,14 @@ import transaction as zope_transaction
 
 logger = logging.getLogger(__name__)
 
-BLACKLISTED_SETTINGS = ['backend', 'max_fetch_size',
-                        'max_size_bytes', 'prefix', 'strict_json', 'hosts']
+BLACKLISTED_SETTINGS = [
+    "backend",
+    "max_fetch_size",
+    "max_size_bytes",
+    "prefix",
+    "strict_json",
+    "hosts",
+]
 
 
 class PostgreSQLClient:
@@ -65,12 +71,14 @@ class PostgreSQLClient:
 _CLIENTS = defaultdict(dict)
 
 
-def create_from_config(config, prefix='', with_transaction=True):
+def create_from_config(config, prefix="", with_transaction=True):
     """Create a PostgreSQLClient client using settings in the provided config.
     """
     if sqlalchemy is None:
-        message = ('PostgreSQL SQLAlchemy dependency missing. '
-                   'Refer to installation section in documentation.')
+        message = (
+            "PostgreSQL SQLAlchemy dependency missing. "
+            "Refer to installation section in documentation."
+        )
         raise ImportWarning(message)
 
     from zope.sqlalchemy import ZopeTransactionExtension, invalidate
@@ -80,22 +88,24 @@ def create_from_config(config, prefix='', with_transaction=True):
 
     # Custom Kinto settings, unsupported by SQLAlchemy.
     blacklist = [prefix + setting for setting in BLACKLISTED_SETTINGS]
-    filtered_settings = {k: v for k, v in settings.items()
-                         if k not in blacklist}
-    transaction_per_request = with_transaction \
-        and filtered_settings.pop('transaction_per_request', False)
-    url = filtered_settings[prefix + 'url']
+    filtered_settings = {k: v for k, v in settings.items() if k not in blacklist}
+    transaction_per_request = with_transaction and filtered_settings.pop(
+        "transaction_per_request", False
+    )
+    url = filtered_settings[prefix + "url"]
     existing_client = _CLIENTS[transaction_per_request].get(url)
     if existing_client:
-        msg = ('Reuse existing PostgreSQL connection. '
-               'Parameters {}* will be ignored.'.format(prefix))
+        msg = "Reuse existing PostgreSQL connection. " "Parameters {}* will be ignored.".format(
+            prefix
+        )
         warnings.warn(msg)
         return existing_client
 
     # Initialize SQLAlchemy engine from filtered_settings.
-    poolclass_key = prefix + 'poolclass'
-    filtered_settings.setdefault(poolclass_key, ('kinto.core.storage.postgresql.'
-                                                 'pool.QueuePoolWithMaxBacklog'))
+    poolclass_key = prefix + "poolclass"
+    filtered_settings.setdefault(
+        poolclass_key, ("kinto.core.storage.postgresql." "pool.QueuePoolWithMaxBacklog")
+    )
     filtered_settings[poolclass_key] = config.maybe_dotted(filtered_settings[poolclass_key])
     engine = sqlalchemy.engine_from_config(filtered_settings, prefix=prefix, url=url)
 
@@ -103,11 +113,11 @@ def create_from_config(config, prefix='', with_transaction=True):
     options = {}
     if transaction_per_request:
         # Plug with Pyramid transaction manager
-        options['extension'] = ZopeTransactionExtension()
+        options["extension"] = ZopeTransactionExtension()
     session_factory = scoped_session(sessionmaker(bind=engine, **options))
 
     # Store one client per URI.
-    commit_manually = (not transaction_per_request)
+    commit_manually = not transaction_per_request
     client = PostgreSQLClient(session_factory, commit_manually, invalidate)
     _CLIENTS[transaction_per_request][url] = client
     return client

--- a/kinto/core/storage/postgresql/migrator.py
+++ b/kinto/core/storage/postgresql/migrator.py
@@ -8,7 +8,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class MigratorMixin():
+class MigratorMixin:
     """Mixin to allow the running of migrations.
 
     Your class must provide a `client` attribute (a PostgreSQLClient),
@@ -37,7 +37,7 @@ class MigratorMixin():
 
         This may be called several times during a single migration.
         """
-        raise NotImplementedError('method not overridden')  # pragma: no cover
+        raise NotImplementedError("method not overridden")  # pragma: no cover
 
     def create_or_migrate_schema(self, dry_run=False):
         """Either create or migrate the schema, as needed."""
@@ -46,9 +46,9 @@ class MigratorMixin():
             self.create_schema(dry_run)
             return
 
-        logger.info('Detected PostgreSQL {} schema version {}.'.format(self.name, version))
+        logger.info("Detected PostgreSQL {} schema version {}.".format(self.name, version))
         if version == self.schema_version:
-            logger.info('PostgreSQL {} schema is up-to-date.'.format(self.name))
+            logger.info("PostgreSQL {} schema is up-to-date.".format(self.name))
             return
 
         self.migrate_schema(version, dry_run)
@@ -58,32 +58,39 @@ class MigratorMixin():
 
         You can override this if you want to add additional sanity checks.
         """
-        logger.info('Create PostgreSQL {} schema at version {} from {}'.format(
-            self.name, self.schema_version, self.schema_file))
+        logger.info(
+            "Create PostgreSQL {} schema at version {} from {}".format(
+                self.name, self.schema_version, self.schema_file
+            )
+        )
         if not dry_run:
             self._execute_sql_file(self.schema_file)
-            logger.info('Created PostgreSQL {} schema (version {}).'.format(
-                self.name, self.schema_version))
+            logger.info(
+                "Created PostgreSQL {} schema (version {}).".format(self.name, self.schema_version)
+            )
 
     def migrate_schema(self, start_version, dry_run):
         migrations = [(v, v + 1) for v in range(start_version, self.schema_version)]
         for migration in migrations:
             expected = migration[0]
             current = self.get_installed_version()
-            error_msg = 'PostgreSQL {} schema: Expected version {}. Found version {}.'
+            error_msg = "PostgreSQL {} schema: Expected version {}. Found version {}."
             if not dry_run and expected != current:
                 raise AssertionError(error_msg.format(self.name, expected, current))
 
-            logger.info('Migrate PostgreSQL {} schema from version {} to {}.'.format(
-                self.name, *migration))
-            filename = 'migration_{0:03d}_{1:03d}.sql'.format(*migration)
+            logger.info(
+                "Migrate PostgreSQL {} schema from version {} to {}.".format(self.name, *migration)
+            )
+            filename = "migration_{0:03d}_{1:03d}.sql".format(*migration)
             filepath = os.path.join(self.migrations_directory, filename)
-            logger.info('Execute PostgreSQL {} migration from {}'.format(self.name, filepath))
+            logger.info("Execute PostgreSQL {} migration from {}".format(self.name, filepath))
             if not dry_run:
                 self._execute_sql_file(filepath)
-        logger.info('PostgreSQL {} schema migration {}.'.format(
-            self.name,
-            'simulated' if dry_run else 'done'))
+        logger.info(
+            "PostgreSQL {} schema migration {}.".format(
+                self.name, "simulated" if dry_run else "done"
+            )
+        )
 
     def _execute_sql_file(self, filepath):
         """Helper method to execute the SQL in a file."""

--- a/kinto/core/storage/postgresql/pool.py
+++ b/kinto/core/storage/postgresql/pool.py
@@ -50,6 +50,5 @@ class QueuePoolWithMaxBacklog(QueuePool):
 
     def recreate(self):
         new_self = QueuePool.recreate(self)
-        new_self._pool = _QueueWithMaxBacklog(self._pool.maxsize,
-                                              self._pool.max_backlog)
+        new_self._pool = _QueueWithMaxBacklog(self._pool.maxsize, self._pool.max_backlog)
         return new_self

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -8,7 +8,7 @@ from kinto.core.testing import skip_if_travis, DummyRequest, ThreadMixin
 from kinto.core.storage import exceptions, Filter, Sort, heartbeat, MISSING
 
 
-RECORD_ID = '472be9ec-26fe-461b-8282-9c4e4b207ab3'
+RECORD_ID = "472be9ec-26fe-461b-8282-9c4e4b207ab3"
 
 
 class BaseTestStorage:
@@ -20,18 +20,14 @@ class BaseTestStorage:
         super().setUp()
         self.storage = self.backend.load_from_config(self._get_config())
         self.storage.initialize_schema()
-        self.id_field = 'id'
-        self.modified_field = 'last_modified'
+        self.id_field = "id"
+        self.modified_field = "last_modified"
         self.client_error_patcher = None
 
-        self.record = {'foo': 'bar'}
-        self.storage_kw = {
-            'collection_id': 'test',
-            'parent_id': '1234',
-            'auth': 'Basic bWF0OjI='
-        }
-        self.other_parent_id = '5678'
-        self.other_auth = 'Basic bWF0OjE='
+        self.record = {"foo": "bar"}
+        self.storage_kw = {"collection_id": "test", "parent_id": "1234", "auth": "Basic bWF0OjI="}
+        self.other_parent_id = "5678"
+        self.other_auth = "Basic bWF0OjE="
 
     def _get_config(self, settings=None):
         """Mock Pyramid config object.
@@ -50,15 +46,11 @@ class BaseTestStorage:
     def create_record(self, record=None, id_generator=None, **kwargs):
         record = record or self.record
         kw = {**self.storage_kw, **kwargs}
-        return self.storage.create(record=record,
-                                   id_generator=id_generator,
-                                   **kw)
+        return self.storage.create(record=record, id_generator=id_generator, **kw)
 
     def test_raises_backend_error_if_error_occurs_on_client(self):
         self.client_error_patcher.start()
-        self.assertRaises(exceptions.BackendError,
-                          self.storage.get_all,
-                          **self.storage_kw)
+        self.assertRaises(exceptions.BackendError, self.storage.get_all, **self.storage_kw)
 
     def test_backend_error_provides_original_exception(self):
         self.client_error_patcher.start()
@@ -74,8 +66,8 @@ class BaseTestStorage:
             (self.storage.collection_timestamp, {}),
             (self.storage.create, dict(record={})),
             (self.storage.get, dict(object_id={})),
-            (self.storage.update, dict(object_id='', record={})),
-            (self.storage.delete, dict(object_id='')),
+            (self.storage.update, dict(object_id="", record={})),
+            (self.storage.delete, dict(object_id="")),
             (self.storage.delete_all, {}),
             (self.storage.purge_deleted, {}),
             (self.storage.get_all, {}),
@@ -83,9 +75,7 @@ class BaseTestStorage:
         for call, kwargs in calls:
             kwargs.update(**self.storage_kw)
             self.assertRaises(exceptions.BackendError, call, **kwargs)
-        self.assertRaises(exceptions.BackendError,
-                          self.storage.flush,
-                          auth=self.other_auth)
+        self.assertRaises(exceptions.BackendError, self.storage.flush, auth=self.other_auth)
 
     def test_initialize_schema_is_idempotent(self):
         self.storage.initialize_schema()
@@ -93,42 +83,43 @@ class BaseTestStorage:
 
     def test_ping_returns_false_if_unavailable(self):
         request = DummyRequest()
-        request.headers['Authorization'] = self.storage_kw['auth']
-        request.registry.settings = {'readonly': 'false'}
+        request.headers["Authorization"] = self.storage_kw["auth"]
+        request.registry.settings = {"readonly": "false"}
         ping = heartbeat(self.storage)
 
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.7):
             ping(request)
 
         self.client_error_patcher.start()
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.7):
             self.assertFalse(ping(request))
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.5):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.5):
             self.assertFalse(ping(request))
 
     def test_ping_returns_true_when_working(self):
         request = DummyRequest()
-        request.headers['Authorization'] = 'Basic bWF0OjI='
+        request.headers["Authorization"] = "Basic bWF0OjI="
         ping = heartbeat(self.storage)
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.7):
             self.assertTrue(ping(request))
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.5):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.5):
             self.assertTrue(ping(request))
 
     def test_ping_returns_true_when_working_in_readonly_mode(self):
         request = DummyRequest()
-        request.headers['Authorization'] = 'Basic bWF0OjI='
-        request.registry.settings = {'readonly': 'true'}
+        request.headers["Authorization"] = "Basic bWF0OjI="
+        request.registry.settings = {"readonly": "true"}
         ping = heartbeat(self.storage)
         self.assertTrue(ping(request))
 
     def test_ping_returns_false_if_unavailable_in_readonly_mode(self):
         request = DummyRequest()
-        request.headers['Authorization'] = 'Basic bWF0OjI='
-        request.registry.settings = {'readonly': 'true'}
+        request.headers["Authorization"] = "Basic bWF0OjI="
+        request.registry.settings = {"readonly": "true"}
         ping = heartbeat(self.storage)
-        with mock.patch.object(self.storage, 'get_all',
-                               side_effect=exceptions.BackendError('Boom!')):
+        with mock.patch.object(
+            self.storage, "get_all", side_effect=exceptions.BackendError("Boom!")
+        ):
             self.assertFalse(ping(request))
 
     def test_ping_logs_error_if_unavailable(self):
@@ -136,43 +127,43 @@ class BaseTestStorage:
         self.client_error_patcher.start()
         ping = heartbeat(self.storage)
 
-        with mock.patch('kinto.core.storage.logger.exception') as exc_handler:
+        with mock.patch("kinto.core.storage.logger.exception") as exc_handler:
             self.assertFalse(ping(request))
 
         self.assertTrue(exc_handler.called)
 
     def test_ping_leaves_no_tombstone(self):
         request = DummyRequest()
-        request.headers['Authorization'] = 'Basic bWF0OjI='
+        request.headers["Authorization"] = "Basic bWF0OjI="
         ping = heartbeat(self.storage)
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.7):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.7):
             ping(request)
-        with mock.patch('kinto.core.storage.random.SystemRandom.random', return_value=0.5):
+        with mock.patch("kinto.core.storage.random.SystemRandom.random", return_value=0.5):
             ping(request)
-        records, count = self.storage.get_all(parent_id='__heartbeat__',
-                                              collection_id='__heartbeat__',
-                                              include_deleted=True)
+        records, count = self.storage.get_all(
+            parent_id="__heartbeat__", collection_id="__heartbeat__", include_deleted=True
+        )
         self.assertEqual(len(records), 0)
 
     def test_create_adds_the_record_id(self):
         record = self.create_record()
-        self.assertIsNotNone(record['id'])
+        self.assertIsNotNone(record["id"])
 
     def test_create_works_as_expected(self):
         stored = self.create_record()
-        retrieved = self.storage.get(object_id=stored['id'], **self.storage_kw)
+        retrieved = self.storage.get(object_id=stored["id"], **self.storage_kw)
         self.assertEqual(retrieved, stored)
 
     def test_create_copies_the_record_before_modifying_it(self):
         self.create_record()
-        self.assertEqual(self.record.get('id'), None)
+        self.assertEqual(self.record.get("id"), None)
 
     def test_create_uses_the_resource_id_generator(self):
         record = self.create_record(id_generator=lambda: RECORD_ID)
-        self.assertEqual(record['id'], RECORD_ID)
+        self.assertEqual(record["id"], RECORD_ID)
 
     def test_create_supports_unicode_for_parent_and_id(self):
-        unicode_id = 'Rémy'
+        unicode_id = "Rémy"
         self.create_record(parent_id=unicode_id, collection_id=unicode_id)
 
     def test_create_does_not_overwrite_the_provided_id(self):
@@ -184,9 +175,7 @@ class BaseTestStorage:
         record = {**self.record, self.id_field: RECORD_ID}
         self.create_record(record=record)
         record = {**self.record, self.id_field: RECORD_ID}
-        self.assertRaises(exceptions.UnicityError,
-                          self.create_record,
-                          record=record)
+        self.assertRaises(exceptions.UnicityError, self.create_record, record=record)
 
     def test_create_does_generate_a_new_last_modified_field(self):
         record = {**self.record}
@@ -209,19 +198,15 @@ class BaseTestStorage:
             object_id=RECORD_ID,
             **self.storage_kw
         )
-        record = self.storage.update(object_id=RECORD_ID,
-                                     record=self.record,
-                                     **self.storage_kw)
-        retrieved = self.storage.get(object_id=RECORD_ID,
-                                     **self.storage_kw)
+        record = self.storage.update(object_id=RECORD_ID, record=self.record, **self.storage_kw)
+        retrieved = self.storage.get(object_id=RECORD_ID, **self.storage_kw)
         self.assertEqual(retrieved, record)
 
     def test_update_overwrites_record_id(self):
         stored = self.create_record()
         record_id = stored[self.id_field]
-        self.record[self.id_field] = 'this-will-be-ignored'
-        self.storage.update(object_id=record_id, record=self.record,
-                            **self.storage_kw)
+        self.record[self.id_field] = "this-will-be-ignored"
+        self.storage.update(object_id=record_id, record=self.record, **self.storage_kw)
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
         self.assertEqual(retrieved[self.id_field], record_id)
 
@@ -229,43 +214,37 @@ class BaseTestStorage:
         stored = self.create_record()
         record_id = stored[self.id_field]
         self.assertNotIn(self.modified_field, self.record)
-        self.storage.update(object_id=record_id, record=self.record,
-                            **self.storage_kw)
+        self.storage.update(object_id=record_id, record=self.record, **self.storage_kw)
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
         self.assertIn(self.modified_field, retrieved)
-        self.assertGreater(retrieved[self.modified_field],
-                           stored[self.modified_field])
+        self.assertGreater(retrieved[self.modified_field], stored[self.modified_field])
 
     def test_delete_works_properly(self):
         stored = self.create_record()
-        self.storage.delete(object_id=stored['id'], **self.storage_kw)
+        self.storage.delete(object_id=stored["id"], **self.storage_kw)
         self.assertRaises(  # Shouldn't exist.
             exceptions.RecordNotFoundError,
             self.storage.get,
-            object_id=stored['id'],
+            object_id=stored["id"],
             **self.storage_kw
         )
 
     def test_delete_works_even_on_second_time(self):
         # Create a record
-        self.storage.create('test', '1234', {'id': 'demo'})
+        self.storage.create("test", "1234", {"id": "demo"})
         # Delete the record
-        self.storage.delete('test', '1234', 'demo', with_deleted=True)
+        self.storage.delete("test", "1234", "demo", with_deleted=True)
         # Update a record (it recreates it.)
-        self.storage.update('test', '1234', 'demo', {'id': 'demo'})
+        self.storage.update("test", "1234", "demo", {"id": "demo"})
         # Delete the record without errors
-        self.storage.delete('test', '1234', 'demo', with_deleted=True)
+        self.storage.delete("test", "1234", "demo", with_deleted=True)
 
     def test_delete_can_specify_the_last_modified(self):
         stored = self.create_record()
         last_modified = stored[self.modified_field] + 10
-        self.storage.delete(
-            object_id=stored['id'],
-            last_modified=last_modified,
-            **self.storage_kw)
+        self.storage.delete(object_id=stored["id"], last_modified=last_modified, **self.storage_kw)
 
-        records, count = self.storage.get_all(
-            include_deleted=True, **self.storage_kw)
+        records, count = self.storage.get_all(include_deleted=True, **self.storage_kw)
         self.assertEqual(records[0][self.modified_field], last_modified)
 
     def test_delete_raise_when_unknown(self):
@@ -277,43 +256,48 @@ class BaseTestStorage:
         )
 
     def test_get_all_handles_parent_id_pattern_matching(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        record = self.create_record(parent_id='abc', collection_id='c')
-        self.storage.delete(object_id=record['id'], parent_id='abc', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
+        self.create_record(parent_id="abc", collection_id="c")
+        record = self.create_record(parent_id="abc", collection_id="c")
+        self.storage.delete(object_id=record["id"], parent_id="abc", collection_id="c")
+        self.create_record(parent_id="efg", collection_id="c")
 
-        records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
-                                                      include_deleted=True)
+        records, total_records = self.storage.get_all(
+            parent_id="ab*", collection_id="c", include_deleted=True
+        )
         self.assertEqual(len(records), 2)
         self.assertEqual(total_records, 1)
 
     def test_get_all_does_proper_parent_id_pattern_matching(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='xabcx', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="xabcx", collection_id="c")
+        self.create_record(parent_id="efg", collection_id="c")
 
-        records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
-                                                      include_deleted=True)
+        records, total_records = self.storage.get_all(
+            parent_id="ab*", collection_id="c", include_deleted=True
+        )
         self.assertEqual(len(records), 1)
         self.assertEqual(len(records), total_records)
 
     def test_get_all_parent_id_handles_collisions(self):
-        abc1 = self.create_record(parent_id='abc1', collection_id='c',
-                                  record={'id': 'abc', 'secret_data': 'abc1'})
-        abc2 = self.create_record(parent_id='abc2', collection_id='c',
-                                  record={'id': 'abc', 'secret_data': 'abc2'})
-        records, total_records = self.storage.get_all(parent_id='ab*', collection_id='c',
-                                                      include_deleted=True)
+        abc1 = self.create_record(
+            parent_id="abc1", collection_id="c", record={"id": "abc", "secret_data": "abc1"}
+        )
+        abc2 = self.create_record(
+            parent_id="abc2", collection_id="c", record={"id": "abc", "secret_data": "abc2"}
+        )
+        records, total_records = self.storage.get_all(
+            parent_id="ab*", collection_id="c", include_deleted=True
+        )
         self.assertEqual(len(records), 2)
         self.assertEqual(len(records), total_records)
-        records.sort(key=lambda record: record['secret_data'])
+        records.sort(key=lambda record: record["secret_data"])
         self.assertEqual(records[0], abc1)
         self.assertEqual(records[1], abc2)
 
     def test_get_all_return_all_values(self):
         for x in range(10):
             record = dict(self.record)
-            record['number'] = x
+            record["number"] = x
             self.create_record(record)
 
         records, total_records = self.storage.get_all(**self.storage_kw)
@@ -323,476 +307,452 @@ class BaseTestStorage:
     def test_get_all_handle_limit(self):
         for x in range(10):
             record = dict(self.record)
-            record['number'] = x
+            record["number"] = x
             self.create_record(record)
 
-        records, total_records = self.storage.get_all(include_deleted=True,
-                                                      limit=2,
-                                                      **self.storage_kw)
+        records, total_records = self.storage.get_all(
+            include_deleted=True, limit=2, **self.storage_kw
+        )
         self.assertEqual(total_records, 10)
         self.assertEqual(len(records), 2)
 
     def test_get_all_handle_sorting_on_id(self):
         for x in range(3):
             self.create_record()
-        sorting = [Sort('id', 1)]
-        records, _ = self.storage.get_all(sorting=sorting,
-                                          **self.storage_kw)
-        self.assertTrue(records[0]['id'] < records[-1]['id'])
+        sorting = [Sort("id", 1)]
+        records, _ = self.storage.get_all(sorting=sorting, **self.storage_kw)
+        self.assertTrue(records[0]["id"] < records[-1]["id"])
 
     def test_get_all_handle_sorting_on_subobject(self):
         for x in range(10):
             record = dict(**self.record)
-            record['person'] = dict(age=x)
+            record["person"] = dict(age=x)
             self.create_record(record)
-        sorting = [Sort('person.age', 1)]
-        records, _ = self.storage.get_all(sorting=sorting,
-                                          **self.storage_kw)
-        self.assertLess(records[0]['person']['age'],
-                        records[-1]['person']['age'])
+        sorting = [Sort("person.age", 1)]
+        records, _ = self.storage.get_all(sorting=sorting, **self.storage_kw)
+        self.assertLess(records[0]["person"]["age"], records[-1]["person"]["age"])
 
     def test_get_all_sorting_is_consistent_with_filtering(self):
-        self.create_record({'flavor': 'strawberry'})
-        self.create_record({'flavor': 'blueberry', 'author': None})
-        self.create_record({'flavor': 'raspberry', 'author': 1})
-        self.create_record({'flavor': 'orange', 'author': True})
-        self.create_record({'flavor': 'watermelon', 'author': 'Ethan'})
-        sorting = [Sort('author', 1)]
+        self.create_record({"flavor": "strawberry"})
+        self.create_record({"flavor": "blueberry", "author": None})
+        self.create_record({"flavor": "raspberry", "author": 1})
+        self.create_record({"flavor": "orange", "author": True})
+        self.create_record({"flavor": "watermelon", "author": "Ethan"})
+        sorting = [Sort("author", 1)]
         records, _ = self.storage.get_all(sorting=sorting, **self.storage_kw)
         # Some interesting values to compare against
-        values = ['A', 'Z', '', 0, 4, MISSING]
+        values = ["A", "Z", "", 0, 4, MISSING]
 
         for value in values:
             # Together, these filters should provide the entire list
-            filter_less = Filter('author', value, utils.COMPARISON.LT)
-            filter_min = Filter('author', value, utils.COMPARISON.MIN)
-            smaller_records, _ = self.storage.get_all(filters=[filter_less],
-                                                      sorting=sorting,
-                                                      **self.storage_kw)
-            greater_records, _ = self.storage.get_all(filters=[filter_min],
-                                                      sorting=sorting,
-                                                      **self.storage_kw)
+            filter_less = Filter("author", value, utils.COMPARISON.LT)
+            filter_min = Filter("author", value, utils.COMPARISON.MIN)
+            smaller_records, _ = self.storage.get_all(
+                filters=[filter_less], sorting=sorting, **self.storage_kw
+            )
+            greater_records, _ = self.storage.get_all(
+                filters=[filter_min], sorting=sorting, **self.storage_kw
+            )
             other_records = smaller_records + greater_records
-            self.assertEqual(records, other_records,
-                             'Filtering is not consistent with sorting when filtering '
-                             'using value {}: {} (LT) + {} (MIN) != {}'.format(
-                                 value, smaller_records, greater_records, records))
+            self.assertEqual(
+                records,
+                other_records,
+                "Filtering is not consistent with sorting when filtering "
+                "using value {}: {} (LT) + {} (MIN) != {}".format(
+                    value, smaller_records, greater_records, records
+                ),
+            )
 
         # Same test but with MAX and GT
         for value in values:
             # Together, these filters should provide the entire list
-            filter_less = Filter('author', value, utils.COMPARISON.MAX)
-            filter_min = Filter('author', value, utils.COMPARISON.GT)
-            smaller_records, _ = self.storage.get_all(filters=[filter_less],
-                                                      sorting=sorting,
-                                                      **self.storage_kw)
-            greater_records, _ = self.storage.get_all(filters=[filter_min],
-                                                      sorting=sorting,
-                                                      **self.storage_kw)
+            filter_less = Filter("author", value, utils.COMPARISON.MAX)
+            filter_min = Filter("author", value, utils.COMPARISON.GT)
+            smaller_records, _ = self.storage.get_all(
+                filters=[filter_less], sorting=sorting, **self.storage_kw
+            )
+            greater_records, _ = self.storage.get_all(
+                filters=[filter_min], sorting=sorting, **self.storage_kw
+            )
             other_records = smaller_records + greater_records
-            self.assertEqual(records, other_records,
-                             'Filtering is not consistent with sorting when filtering '
-                             'using value {}: {} (MAX) + {} (GT) != {}'.format(
-                                 value, smaller_records, greater_records, records))
+            self.assertEqual(
+                records,
+                other_records,
+                "Filtering is not consistent with sorting when filtering "
+                "using value {}: {} (MAX) + {} (GT) != {}".format(
+                    value, smaller_records, greater_records, records
+                ),
+            )
 
     def test_get_all_can_filter_with_list_of_values(self):
-        for l in ['a', 'b', 'c']:
-            self.create_record({'code': l})
-        filters = [Filter('code', ['a', 'b'], utils.COMPARISON.IN)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        for l in ["a", "b", "c"]:
+            self.create_record({"code": l})
+        filters = [Filter("code", ["a", "b"], utils.COMPARISON.IN)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
     def test_get_all_can_filter_on_array_that_contains_values(self):
-        self.create_record({'colors': ["red", "green", "blue"]})
-        self.create_record({'colors': ["gray", "blue"]})
-        self.create_record({'colors': ["red", "gray", "blue"]})
-        self.create_record({'colors': ["purple", "green", "blue"]})
+        self.create_record({"colors": ["red", "green", "blue"]})
+        self.create_record({"colors": ["gray", "blue"]})
+        self.create_record({"colors": ["red", "gray", "blue"]})
+        self.create_record({"colors": ["purple", "green", "blue"]})
 
-        filters = [Filter('colors', ['red'], utils.COMPARISON.CONTAINS)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("colors", ["red"], utils.COMPARISON.CONTAINS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
-        filters = [Filter('colors', ['red', 'gray'], utils.COMPARISON.CONTAINS)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("colors", ["red", "gray"], utils.COMPARISON.CONTAINS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_on_field_that_do_not_contains_an_array_with_contains_any(self):
-        self.create_record({'colors': ["red", "green", "blue"]})
-        self.create_record({'colors': {"html": "#00FF00"}})
+        self.create_record({"colors": ["red", "green", "blue"]})
+        self.create_record({"colors": {"html": "#00FF00"}})
 
-        filters = [Filter('colors', ["red"], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("colors", ["red"], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
-        filters = [Filter('colors', [{"html": "#00FF00"}], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("colors", [{"html": "#00FF00"}], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)
 
     def test_get_all_can_filter_on_array_that_contains_any_value(self):
-        self.create_record({'colors': ["red", "green", "blue"]})
-        self.create_record({'colors': ["gray", "blue"]})
-        self.create_record({'colors': ["red", "gray", "blue"]})
-        self.create_record({'colors': ["purple", "green", "blue"]})
+        self.create_record({"colors": ["red", "green", "blue"]})
+        self.create_record({"colors": ["gray", "blue"]})
+        self.create_record({"colors": ["red", "gray", "blue"]})
+        self.create_record({"colors": ["purple", "green", "blue"]})
 
-        filters = [Filter('colors', ['red'], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("colors", ["red"], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
-        filters = [Filter('colors', ['red', 'gray'], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("colors", ["red", "gray"], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 3)
 
     def test_get_all_can_filter_on_array_that_contains_numeric_values(self):
-        self.create_record({'fib': [1, 2, 3]})
-        self.create_record({'fib': [2, 3, 5]})
-        self.create_record({'fib': [3, 5, 8]})
-        self.create_record({'fib': [5, 8, 13]})
+        self.create_record({"fib": [1, 2, 3]})
+        self.create_record({"fib": [2, 3, 5]})
+        self.create_record({"fib": [3, 5, 8]})
+        self.create_record({"fib": [5, 8, 13]})
 
-        filters = [Filter('fib', [2], utils.COMPARISON.CONTAINS)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [2], utils.COMPARISON.CONTAINS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
-        filters = [Filter('fib', [2, 3], utils.COMPARISON.CONTAINS)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [2, 3], utils.COMPARISON.CONTAINS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
     def test_get_all_can_filter_on_array_that_contains_any_numeric_value(self):
-        self.create_record({'fib': [1, 2, 3]})
-        self.create_record({'fib': [2, 3, 5]})
-        self.create_record({'fib': [3, 5, 8]})
-        self.create_record({'fib': [5, 8, 13]})
+        self.create_record({"fib": [1, 2, 3]})
+        self.create_record({"fib": [2, 3, 5]})
+        self.create_record({"fib": [3, 5, 8]})
+        self.create_record({"fib": [5, 8, 13]})
 
-        filters = [Filter('fib', [2], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [2], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
-        filters = [Filter('fib', [2, 3], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [2, 3], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 3)
 
     def test_get_all_can_filter_on_array_with_contains_and_missing_field(self):
-        self.create_record({'code': 'black'})
-        self.create_record({'fib': [2, 3, 5]})
-        self.create_record({'fib': [3, 5, 8]})
-        self.create_record({'fib': [5, 8, 13]})
+        self.create_record({"code": "black"})
+        self.create_record({"fib": [2, 3, 5]})
+        self.create_record({"fib": [3, 5, 8]})
+        self.create_record({"fib": [5, 8, 13]})
 
-        filters = [Filter('fib', [2], utils.COMPARISON.CONTAINS)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [2], utils.COMPARISON.CONTAINS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_on_array_with_contains_any_and_missing_field(self):
-        self.create_record({'code': 'black'})
-        self.create_record({'fib': [2, 3, 5]})
-        self.create_record({'fib': [3, 5, 8]})
-        self.create_record({'fib': [5, 8, 13]})
+        self.create_record({"code": "black"})
+        self.create_record({"fib": [2, 3, 5]})
+        self.create_record({"fib": [3, 5, 8]})
+        self.create_record({"fib": [5, 8, 13]})
 
-        filters = [Filter('fib', [2], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [2], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_on_array_with_contains_and_unsupported_type(self):
-        self.create_record({'code': 'black'})
-        self.create_record({'fib': [2, 3, 5]})
-        self.create_record({'fib': [3, 5, 8]})
-        self.create_record({'fib': [5, 8, 13]})
+        self.create_record({"code": "black"})
+        self.create_record({"fib": [2, 3, 5]})
+        self.create_record({"fib": [3, 5, 8]})
+        self.create_record({"fib": [5, 8, 13]})
 
-        filters = [Filter('fib', [{"demo": "foobar"}], utils.COMPARISON.CONTAINS)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [{"demo": "foobar"}], utils.COMPARISON.CONTAINS)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)
 
     def test_get_all_can_filter_on_array_with_contains_any_and_unsupported_type(self):
-        self.create_record({'code': 'black'})
-        self.create_record({'fib': [2, 3, 5]})
-        self.create_record({'fib': [3, 5, 8]})
-        self.create_record({'fib': [5, 8, 13]})
+        self.create_record({"code": "black"})
+        self.create_record({"fib": [2, 3, 5]})
+        self.create_record({"fib": [3, 5, 8]})
+        self.create_record({"fib": [5, 8, 13]})
 
-        filters = [Filter('fib', [{"demo": "foobar"}], utils.COMPARISON.CONTAINS_ANY)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("fib", [{"demo": "foobar"}], utils.COMPARISON.CONTAINS_ANY)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)
 
     def test_get_all_can_filter_with_numeric_values(self):
-        self.create_record({'missing': 'code'})
+        self.create_record({"missing": "code"})
         for l in [1, 10, 6, 46]:
-            self.create_record({'code': l})
+            self.create_record({"code": l})
 
-        sorting = [Sort('code', 1)]
-        filters = [Filter('code', 10, utils.COMPARISON.MAX)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          **self.storage_kw)
-        self.assertEqual(records[0]['code'], 1)
-        self.assertEqual(records[1]['code'], 6)
-        self.assertEqual(records[2]['code'], 10)
+        sorting = [Sort("code", 1)]
+        filters = [Filter("code", 10, utils.COMPARISON.MAX)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters, **self.storage_kw)
+        self.assertEqual(records[0]["code"], 1)
+        self.assertEqual(records[1]["code"], 6)
+        self.assertEqual(records[2]["code"], 10)
         self.assertEqual(len(records), 3)
 
-        filters = [Filter('code', 10, utils.COMPARISON.LT)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          **self.storage_kw)
-        self.assertEqual(records[0]['code'], 1)
-        self.assertEqual(records[1]['code'], 6)
+        filters = [Filter("code", 10, utils.COMPARISON.LT)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters, **self.storage_kw)
+        self.assertEqual(records[0]["code"], 1)
+        self.assertEqual(records[1]["code"], 6)
         self.assertEqual(len(records), 2)
 
     def test_get_all_can_filter_with_numeric_id(self):
         for l in [0, 42]:
-            self.create_record({'id': str(l)})
+            self.create_record({"id": str(l)})
 
-        filters = [Filter('id', 0, utils.COMPARISON.EQ)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("id", 0, utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
-        filters = [Filter('id', 42, utils.COMPARISON.EQ)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        filters = [Filter("id", 42, utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_with_numeric_strings(self):
-        for l in ['0566199093', '0781566199']:
-            self.create_record({'phone': l})
-        filters = [Filter('phone', '0566199093', utils.COMPARISON.EQ)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        for l in ["0566199093", "0781566199"]:
+            self.create_record({"phone": l})
+        filters = [Filter("phone", "0566199093", utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_with_empty_numeric_strings(self):
-        for l in ['0566199093', '0781566199']:
-            self.create_record({'phone': l})
-        filters = [Filter('phone', '', utils.COMPARISON.EQ)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        for l in ["0566199093", "0781566199"]:
+            self.create_record({"phone": l})
+        filters = [Filter("phone", "", utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)
 
     def test_get_all_can_filter_with_float_values(self):
         for l in [10, 11.5, 8.5, 6, 7.5]:
-            self.create_record({'note': l})
-        filters = [Filter('note', 9.5, utils.COMPARISON.LT)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+            self.create_record({"note": l})
+        filters = [Filter("note", 9.5, utils.COMPARISON.LT)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 3)
 
     def test_get_all_can_filter_with_strings(self):
-        for l in ['Rémy', 'Alexis', 'Marie']:
-            self.create_record({'name': l})
-        sorting = [Sort('name', 1)]
-        filters = [Filter('name', 'Mathieu', utils.COMPARISON.LT)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          **self.storage_kw)
-        self.assertEqual(records[0]['name'], 'Alexis')
-        self.assertEqual(records[1]['name'], 'Marie')
+        for l in ["Rémy", "Alexis", "Marie"]:
+            self.create_record({"name": l})
+        sorting = [Sort("name", 1)]
+        filters = [Filter("name", "Mathieu", utils.COMPARISON.LT)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters, **self.storage_kw)
+        self.assertEqual(records[0]["name"], "Alexis")
+        self.assertEqual(records[1]["name"], "Marie")
         self.assertEqual(len(records), 2)
 
     def test_get_all_can_filter_minimum_value_with_strings(self):
-        for v in ['49.0', '6.0', '53.0b4']:
-            self.create_record({'product': {'version': v}})
-        sorting = [Sort('product.version', 1)]
-        filters = [Filter('product.version', '50.0', utils.COMPARISON.MIN)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          **self.storage_kw)
-        self.assertEqual(records[0]['product']['version'], '53.0b4')
-        self.assertEqual(records[1]['product']['version'], '6.0')
+        for v in ["49.0", "6.0", "53.0b4"]:
+            self.create_record({"product": {"version": v}})
+        sorting = [Sort("product.version", 1)]
+        filters = [Filter("product.version", "50.0", utils.COMPARISON.MIN)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters, **self.storage_kw)
+        self.assertEqual(records[0]["product"]["version"], "53.0b4")
+        self.assertEqual(records[1]["product"]["version"], "6.0")
         self.assertEqual(len(records), 2)
 
     def test_get_all_does_not_implicitly_cast(self):
-        for v in ['49.0', '6.0', '53.0b4']:
-            self.create_record({'product': {'version': v}})
-        sorting = [Sort('product.version', 1)]
-        filters = [Filter('product.version', 50.0, utils.COMPARISON.MIN)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          **self.storage_kw)
+        for v in ["49.0", "6.0", "53.0b4"]:
+            self.create_record({"product": {"version": v}})
+        sorting = [Sort("product.version", 1)]
+        filters = [Filter("product.version", 50.0, utils.COMPARISON.MIN)]
+        records, _ = self.storage.get_all(sorting=sorting, filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)  # 50 (number) > strings
 
     def test_get_all_can_deal_with_none_values(self):
-        self.create_record({'name': 'Alexis'})
-        self.create_record({'title': 'haha'})
-        self.create_record({'name': 'Mathieu'})
-        filters = [Filter('name', 'Fanny', utils.COMPARISON.GT)]
+        self.create_record({"name": "Alexis"})
+        self.create_record({"title": "haha"})
+        self.create_record({"name": "Mathieu"})
+        filters = [Filter("name", "Fanny", utils.COMPARISON.GT)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         # NULLs compare as greater than everything
         self.assertEqual(len(records), 2)
         # But we aren't clear on what the order will be
-        mathieu_record = records[0] if 'name' in records[0] else records[1]
-        haha_record = records[1] if 'name' in records[0] else records[0]
-        self.assertEqual(mathieu_record['name'], 'Mathieu')
-        self.assertEqual(haha_record['title'], 'haha')
+        mathieu_record = records[0] if "name" in records[0] else records[1]
+        haha_record = records[1] if "name" in records[0] else records[0]
+        self.assertEqual(mathieu_record["name"], "Mathieu")
+        self.assertEqual(haha_record["title"], "haha")
 
-        filters = [Filter('name', 'Fanny', utils.COMPARISON.LT)]
+        filters = [Filter("name", "Fanny", utils.COMPARISON.LT)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['name'], 'Alexis')
+        self.assertEqual(records[0]["name"], "Alexis")
 
     def test_get_all_can_filter_with_none_values(self):
-        self.create_record({'name': 'Alexis', 'salary': None})
-        self.create_record({'name': 'Mathieu', 'salary': 'null'})
-        self.create_record({'name': 'Niko', 'salary': ''})
-        self.create_record({'name': 'Ethan'})   # missing salary
-        filters = [Filter('salary', None, utils.COMPARISON.EQ)]
+        self.create_record({"name": "Alexis", "salary": None})
+        self.create_record({"name": "Mathieu", "salary": "null"})
+        self.create_record({"name": "Niko", "salary": ""})
+        self.create_record({"name": "Ethan"})  # missing salary
+        filters = [Filter("salary", None, utils.COMPARISON.EQ)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['name'], 'Alexis')
+        self.assertEqual(records[0]["name"], "Alexis")
 
     def test_filter_none_values_can_be_combined(self):
-        self.create_record({'name': 'Alexis', 'salary': None})
-        self.create_record({'name': 'Mathieu', 'salary': 'null'})
-        self.create_record({'name': 'Niko', 'salary': ''})
-        self.create_record({'name': 'Ethan'})   # missing salary
+        self.create_record({"name": "Alexis", "salary": None})
+        self.create_record({"name": "Mathieu", "salary": "null"})
+        self.create_record({"name": "Niko", "salary": ""})
+        self.create_record({"name": "Ethan"})  # missing salary
         filters = [
-            Filter('salary', 0, utils.COMPARISON.GT),
-            Filter('salary', True, utils.COMPARISON.HAS)
+            Filter("salary", 0, utils.COMPARISON.GT),
+            Filter("salary", True, utils.COMPARISON.HAS),
         ]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
-        self.assertEqual(len([r for r in records if 'salary' not in r]), 0)
+        self.assertEqual(len([r for r in records if "salary" not in r]), 0)
 
     def test_get_all_can_filter_with_list_of_values_on_id(self):
-        record1 = self.create_record({'code': 'a'})
-        record2 = self.create_record({'code': 'b'})
-        filters = [Filter('id', [record1['id'], record2['id']],
-                          utils.COMPARISON.IN)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        record1 = self.create_record({"code": "a"})
+        record2 = self.create_record({"code": "b"})
+        filters = [Filter("id", [record1["id"], record2["id"]], utils.COMPARISON.IN)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
     def test_get_all_returns_empty_when_including_list_of_empty_values(self):
-        self.create_record({'code': 'a'})
-        self.create_record({'code': 'b'})
-        filters = [Filter('id', [], utils.COMPARISON.IN)]
+        self.create_record({"code": "a"})
+        self.create_record({"code": "b"})
+        filters = [Filter("id", [], utils.COMPARISON.IN)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)
 
     def test_get_all_can_filter_with_list_of_excluded_values(self):
-        for l in ['a', 'b', 'c']:
-            self.create_record({'code': l})
-        filters = [Filter('code', ('a', 'b'), utils.COMPARISON.EXCLUDE)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        for l in ["a", "b", "c"]:
+            self.create_record({"code": l})
+        filters = [Filter("code", ("a", "b"), utils.COMPARISON.EXCLUDE)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_a_list_of_integer_values(self):
         for l in [1, 2, 3]:
-            self.create_record({'code': l})
-        filters = [Filter('code', (1, 2), utils.COMPARISON.EXCLUDE)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+            self.create_record({"code": l})
+        filters = [Filter("code", (1, 2), utils.COMPARISON.EXCLUDE)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_a_list_of_mixed_typed_values(self):
         for l in [1, 2, 3]:
-            self.create_record({'code': l})
-        filters = [Filter('code', (1, 'b'), utils.COMPARISON.EXCLUDE)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+            self.create_record({"code": l})
+        filters = [Filter("code", (1, "b"), utils.COMPARISON.EXCLUDE)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 2)
 
     def test_get_all_can_filter_a_list_of_integer_values_on_subobjects(self):
         for l in [1, 2, 3]:
-            self.create_record({'code': {'city': l}})
-        filters = [Filter('code.city', (1, 2), utils.COMPARISON.EXCLUDE)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+            self.create_record({"code": {"city": l}})
+        filters = [Filter("code.city", (1, 2), utils.COMPARISON.EXCLUDE)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_matching_a_list(self):
-        self.create_record({'flavor': 'strawberry', 'orders': []})
-        self.create_record({'flavor': 'blueberry', 'orders': [1]})
-        self.create_record({'flavor': 'pineapple', 'orders': [1, 2]})
-        self.create_record({'flavor': 'watermelon', 'orders': ''})
-        self.create_record({'flavor': 'raspberry', 'orders': {}})
-        filters = [Filter('orders', [], utils.COMPARISON.EQ)]
+        self.create_record({"flavor": "strawberry", "orders": []})
+        self.create_record({"flavor": "blueberry", "orders": [1]})
+        self.create_record({"flavor": "pineapple", "orders": [1, 2]})
+        self.create_record({"flavor": "watermelon", "orders": ""})
+        self.create_record({"flavor": "raspberry", "orders": {}})
+        filters = [Filter("orders", [], utils.COMPARISON.EQ)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['flavor'], 'strawberry')
+        self.assertEqual(records[0]["flavor"], "strawberry")
 
-        filters = [Filter('orders', [1], utils.COMPARISON.EQ)]
+        filters = [Filter("orders", [1], utils.COMPARISON.EQ)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['flavor'], 'blueberry')
+        self.assertEqual(records[0]["flavor"], "blueberry")
 
     def test_get_all_can_filter_matching_an_object(self):
-        self.create_record({'flavor': 'strawberry', 'attributes': {}})
-        self.create_record({
-            'flavor': 'blueberry',
-            'attributes': {'ibu': 25, 'seen_on': '2017-06-01'},
-        })
-        self.create_record({
-            'flavor': 'watermelon',
-            'attributes': {'ibu': 25, 'seen_on': '2017-06-01', 'price': 9.99},
-        })
-        self.create_record({'flavor': 'raspberry', 'attributes': []})
-        filters = [Filter('attributes', {}, utils.COMPARISON.EQ)]
+        self.create_record({"flavor": "strawberry", "attributes": {}})
+        self.create_record(
+            {"flavor": "blueberry", "attributes": {"ibu": 25, "seen_on": "2017-06-01"}}
+        )
+        self.create_record(
+            {
+                "flavor": "watermelon",
+                "attributes": {"ibu": 25, "seen_on": "2017-06-01", "price": 9.99},
+            }
+        )
+        self.create_record({"flavor": "raspberry", "attributes": []})
+        filters = [Filter("attributes", {}, utils.COMPARISON.EQ)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['flavor'], 'strawberry')
+        self.assertEqual(records[0]["flavor"], "strawberry")
 
-        filters = [Filter('attributes', {'ibu': 25, 'seen_on': '2017-06-01'}, utils.COMPARISON.EQ)]
+        filters = [Filter("attributes", {"ibu": 25, "seen_on": "2017-06-01"}, utils.COMPARISON.EQ)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['flavor'], 'blueberry')
+        self.assertEqual(records[0]["flavor"], "blueberry")
 
     def test_get_all_supports_has(self):
-        self.create_record({'flavor': 'strawberry'})
-        self.create_record({'flavor': 'blueberry', 'author': None})
-        self.create_record({'flavor': 'raspberry', 'author': ''})
-        self.create_record({'flavor': 'watermelon', 'author': 'hello'})
-        self.create_record({'flavor': 'pineapple', 'author': 'null'})
-        filters = [Filter('author', True, utils.COMPARISON.HAS)]
+        self.create_record({"flavor": "strawberry"})
+        self.create_record({"flavor": "blueberry", "author": None})
+        self.create_record({"flavor": "raspberry", "author": ""})
+        self.create_record({"flavor": "watermelon", "author": "hello"})
+        self.create_record({"flavor": "pineapple", "author": "null"})
+        filters = [Filter("author", True, utils.COMPARISON.HAS)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 4)
-        self.assertEqual(sorted([r['flavor'] for r in records]),
-                         ['blueberry', 'pineapple', 'raspberry', 'watermelon'])
+        self.assertEqual(
+            sorted([r["flavor"] for r in records]),
+            ["blueberry", "pineapple", "raspberry", "watermelon"],
+        )
 
-        filters = [Filter('author', False, utils.COMPARISON.HAS)]
+        filters = [Filter("author", False, utils.COMPARISON.HAS)]
         records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['flavor'], 'strawberry')
+        self.assertEqual(records[0]["flavor"], "strawberry")
 
     def test_get_all_can_filter_by_subobjects_values(self):
-        for l in ['a', 'b', 'c']:
-            self.create_record({'code': {'sub': l}})
-        filters = [Filter('code.sub', 'a', utils.COMPARISON.EQ)]
-        records, _ = self.storage.get_all(filters=filters,
-                                          **self.storage_kw)
+        for l in ["a", "b", "c"]:
+            self.create_record({"code": {"sub": l}})
+        filters = [Filter("code.sub", "a", utils.COMPARISON.EQ)]
+        records, _ = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 1)
 
     def test_get_all_can_filter_with_like_and_implicit_wildchars(self):
-        self.create_record({'name': 'foo'})
-        self.create_record({'name': 'aafooll'})
-        self.create_record({'name': 'bar'})
-        self.create_record({'name': 'FOOBAR'})
+        self.create_record({"name": "foo"})
+        self.create_record({"name": "aafooll"})
+        self.create_record({"name": "bar"})
+        self.create_record({"name": "FOOBAR"})
 
-        filters = [Filter('name', 'FoO', utils.COMPARISON.LIKE)]
+        filters = [Filter("name", "FoO", utils.COMPARISON.LIKE)]
         results, count = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(results), 3)
 
     def test_get_all_can_filter_with_wildchars(self):
-        self.create_record({'name': 'eabcg'})
-        self.create_record({'name': 'aabcc'})
-        self.create_record({'name': 'abc'})
-        self.create_record({'name': 'aec'})
-        self.create_record({'name': 'efg'})
+        self.create_record({"name": "eabcg"})
+        self.create_record({"name": "aabcc"})
+        self.create_record({"name": "abc"})
+        self.create_record({"name": "aec"})
+        self.create_record({"name": "efg"})
 
-        filters = [Filter('name', 'a*b*c', utils.COMPARISON.LIKE)]
+        filters = [Filter("name", "a*b*c", utils.COMPARISON.LIKE)]
         results, count = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(results), 2)
 
     def test_records_filtered_when_searched_by_string_field(self):
-        self.create_record({'name': 'foo'})
-        self.create_record({'name': 'bar'})
-        self.create_record({'name': 'FOOBAR'})
+        self.create_record({"name": "foo"})
+        self.create_record({"name": "bar"})
+        self.create_record({"name": "FOOBAR"})
 
-        filters = [Filter('name', 'FoO', utils.COMPARISON.LIKE)]
+        filters = [Filter("name", "FoO", utils.COMPARISON.LIKE)]
         results, count = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(results), 2)
 
@@ -807,16 +767,15 @@ class TimestampsTest:
 
     def test_timestamp_are_incremented_on_update(self):
         stored = self.create_record()
-        _id = stored['id']
+        _id = stored["id"]
         before = self.storage.collection_timestamp(**self.storage_kw)
-        self.storage.update(object_id=_id, record={'bar': 'foo'},
-                            **self.storage_kw)
+        self.storage.update(object_id=_id, record={"bar": "foo"}, **self.storage_kw)
         after = self.storage.collection_timestamp(**self.storage_kw)
         self.assertTrue(before < after)
 
     def test_timestamp_are_incremented_on_delete(self):
         stored = self.create_record()
-        _id = stored['id']
+        _id = stored["id"]
         before = self.storage.collection_timestamp(**self.storage_kw)
         self.storage.delete(object_id=_id, **self.storage_kw)
         after = self.storage.collection_timestamp(**self.storage_kw)
@@ -829,7 +788,7 @@ class TimestampsTest:
         def create_item():
             for i in range(100):
                 record = self.create_record()
-                obtained.append((record['last_modified'], record['id']))
+                obtained.append((record["last_modified"], record["id"]))
 
         thread1 = self._create_thread(target=create_item)
         thread2 = self._create_thread(target=create_item)
@@ -857,37 +816,35 @@ class TimestampsTest:
         before = utils.msec_time()
         time.sleep(0.002)  # 2 msec
         record = self.create_record()
-        now = record['last_modified']
+        now = record["last_modified"]
         time.sleep(0.002)  # 2 msec
         after = utils.msec_time()
-        self.assertTrue(before < now < after,
-                        '{} < {} < {}'.format(before, now, after))
+        self.assertTrue(before < now < after, "{} < {} < {}".format(before, now, after))
 
     def test_timestamp_are_always_incremented_above_existing_value(self):
         # Create a record with normal clock
         record = self.create_record()
-        current = record['last_modified']
+        current = record["last_modified"]
 
         # Patch the clock to return a time in the past, before the big bang
-        with mock.patch('kinto.core.utils.msec_time') as time_mocked:
+        with mock.patch("kinto.core.utils.msec_time") as time_mocked:
             time_mocked.return_value = -1
 
             record = self.create_record()
-            after = record['last_modified']
+            after = record["last_modified"]
 
         # Expect the last one to be based on the highest value
-        self.assertTrue(0 < current < after,
-                        '0 < {} < {}'.format(current, after))
+        self.assertTrue(0 < current < after, "0 < {} < {}".format(current, after))
 
     def test_collection_timestamp_raises_error_when_empty_and_readonly(self):
-        kw = {**self.storage_kw, 'collection_id': 'will-be-empty'}
+        kw = {**self.storage_kw, "collection_id": "will-be-empty"}
         self.storage.readonly = True
         with self.assertRaises(exceptions.BackendError):
             self.storage.collection_timestamp(**kw)
         self.storage.readonly = False
 
     def test_collection_timestamp_returns_current_while_readonly(self):
-        kw = {**self.storage_kw, 'collection_id': 'will-be-empty'}
+        kw = {**self.storage_kw, "collection_id": "will-be-empty"}
         ts1 = self.storage.collection_timestamp(**kw)
         self.storage.readonly = True
         ts2 = self.storage.collection_timestamp(**kw)
@@ -914,9 +871,11 @@ class TimestampsTest:
         timestamp_before = first_record[self.modified_field]
 
         # Create a new record with its timestamp in the past.
-        record = {**self.record,
-                  self.id_field: RECORD_ID,
-                  self.modified_field: timestamp_before - 10}
+        record = {
+            **self.record,
+            self.id_field: RECORD_ID,
+            self.modified_field: timestamp_before - 10,
+        }
         self.create_record(record=record)
 
         # Check that record timestamp is the one specified.
@@ -935,16 +894,13 @@ class TimestampsTest:
         timestamp_before = first_record[self.modified_field]
 
         # Create a new record with its timestamp in the past.
-        record = {**self.record,
-                  self.id_field: RECORD_ID,
-                  self.modified_field: timestamp_before}
+        record = {**self.record, self.id_field: RECORD_ID, self.modified_field: timestamp_before}
         self.create_record(record=record)
 
         # Check that record timestamp is the one specified.
         retrieved = self.storage.get(object_id=RECORD_ID, **self.storage_kw)
         self.assertGreater(retrieved[self.modified_field], timestamp_before)
-        self.assertGreater(retrieved[self.modified_field],
-                           record[self.modified_field])
+        self.assertGreater(retrieved[self.modified_field], record[self.modified_field])
 
         # Check that collection timestamp was bumped (change happened).
         timestamp = self.storage.collection_timestamp(**self.storage_kw)
@@ -957,14 +913,12 @@ class TimestampsTest:
 
         # Set timestamp manually in the future.
         stored[self.modified_field] = timestamp_before + 10
-        self.storage.update(object_id=record_id, record=stored,
-                            **self.storage_kw)
+        self.storage.update(object_id=record_id, record=stored, **self.storage_kw)
 
         # Check that record timestamp is the one specified.
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
         self.assertGreater(retrieved[self.modified_field], timestamp_before)
-        self.assertGreaterEqual(retrieved[self.modified_field],
-                                stored[self.modified_field])
+        self.assertGreaterEqual(retrieved[self.modified_field], stored[self.modified_field])
 
         # Check that collection timestamp took the one specified (in future).
         timestamp = self.storage.collection_timestamp(**self.storage_kw)
@@ -978,14 +932,12 @@ class TimestampsTest:
 
         # Set timestamp manually in the past.
         stored[self.modified_field] = timestamp_before - 10
-        self.storage.update(object_id=record_id, record=stored,
-                            **self.storage_kw)
+        self.storage.update(object_id=record_id, record=stored, **self.storage_kw)
 
         # Check that record timestamp is the one specified.
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
         self.assertLess(retrieved[self.modified_field], timestamp_before)
-        self.assertEqual(retrieved[self.modified_field],
-                         stored[self.modified_field])
+        self.assertEqual(retrieved[self.modified_field], stored[self.modified_field])
 
         # Check that collection timestamp was not changed. Someone importing
         # records in the past must assume the synchronization consequences.
@@ -998,14 +950,12 @@ class TimestampsTest:
         timestamp_before = stored[self.modified_field]
 
         # Do not change the timestamp.
-        self.storage.update(object_id=record_id, record=stored,
-                            **self.storage_kw)
+        self.storage.update(object_id=record_id, record=stored, **self.storage_kw)
 
         # Check that record timestamp was bumped.
         retrieved = self.storage.get(object_id=record_id, **self.storage_kw)
         self.assertGreater(retrieved[self.modified_field], timestamp_before)
-        self.assertGreater(retrieved[self.modified_field],
-                           stored[self.modified_field])
+        self.assertGreater(retrieved[self.modified_field], stored[self.modified_field])
 
         # Check that collection timestamp was bumped (change happened).
         timestamp = self.storage.collection_timestamp(**self.storage_kw)
@@ -1016,67 +966,67 @@ class DeletedRecordsTest:
     def _get_last_modified_filters(self):
         start = self.storage.collection_timestamp(**self.storage_kw)
         time.sleep(0.1)
-        return [
-            Filter(self.modified_field, start, utils.COMPARISON.GT)
-        ]
+        return [Filter(self.modified_field, start, utils.COMPARISON.GT)]
 
     def create_and_delete_record(self, record=None):
         """Helper to create and delete a record."""
-        record = record or {'challenge': 'accepted'}
+        record = record or {"challenge": "accepted"}
         record = self.create_record(record)
         time.sleep(0.001)  # 1 msec
-        deleted = self.storage.delete(object_id=record['id'],
-                                      **self.storage_kw)
+        deleted = self.storage.delete(object_id=record["id"], **self.storage_kw)
         time.sleep(0.001)  # 1 msec
         return deleted
 
     def test_get_should_not_return_deleted_items(self):
         record = self.create_and_delete_record()
-        self.assertRaises(exceptions.RecordNotFoundError,
-                          self.storage.get,
-                          object_id=record['id'],
-                          **self.storage_kw)
+        self.assertRaises(
+            exceptions.RecordNotFoundError,
+            self.storage.get,
+            object_id=record["id"],
+            **self.storage_kw
+        )
 
     def test_deleting_a_deleted_item_should_raise_not_found(self):
         record = self.create_and_delete_record()
-        self.assertRaises(exceptions.RecordNotFoundError,
-                          self.storage.delete,
-                          object_id=record['id'],
-                          **self.storage_kw)
+        self.assertRaises(
+            exceptions.RecordNotFoundError,
+            self.storage.delete,
+            object_id=record["id"],
+            **self.storage_kw
+        )
 
     def test_recreating_a_deleted_record_should_delete_its_tombstone(self):
-        record = {'id': 'jesus', 'rebirth': True}
+        record = {"id": "jesus", "rebirth": True}
         self.create_and_delete_record(record)
         self.create_record(record)
-        records, count = self.storage.get_all(include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(include_deleted=True, **self.storage_kw)
         self.assertEqual(count, 1)  # One existing.
         self.assertEqual(len(records), 1)  # No tombstone.
 
     def test_deleting_a_record_twice_should_update_its_tombstone(self):
-        record = {'id': 'jesus', 'rebirth': True}
+        record = {"id": "jesus", "rebirth": True}
         deleted = self.create_and_delete_record(record)
-        before = deleted['last_modified']
+        before = deleted["last_modified"]
         deleted = self.create_and_delete_record(record)
-        after = deleted['last_modified']
+        after = deleted["last_modified"]
         self.assertNotEqual(before, after)
 
     def test_deleted_items_have_deleted_set_to_true(self):
         record = self.create_and_delete_record()
-        self.assertTrue(record['deleted'])
+        self.assertTrue(record["deleted"])
 
     def test_deleted_items_have_only_basic_fields(self):
         record = self.create_and_delete_record()
-        self.assertIn('id', record)
-        self.assertIn('last_modified', record)
-        self.assertNotIn('challenge', record)
+        self.assertIn("id", record)
+        self.assertIn("last_modified", record)
+        self.assertNotIn("challenge", record)
 
     def test_last_modified_of_a_deleted_item_is_deletion_time(self):
         before = self.storage.collection_timestamp(**self.storage_kw)
         record = self.create_and_delete_record()
         now = self.storage.collection_timestamp(**self.storage_kw)
-        self.assertEqual(now, record['last_modified'])
-        self.assertTrue(before < record['last_modified'])
+        self.assertEqual(now, record["last_modified"])
+        self.assertTrue(before < record["last_modified"])
 
     def test_get_all_does_not_include_deleted_items_by_default(self):
         self.create_and_delete_record()
@@ -1086,32 +1036,30 @@ class DeletedRecordsTest:
     def test_get_all_count_does_not_include_deleted_items(self):
         filters = self._get_last_modified_filters()
         self.create_and_delete_record()
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 1)
         self.assertEqual(count, 0)
 
     def test_get_all_can_return_deleted_items(self):
         filters = self._get_last_modified_filters()
         record = self.create_and_delete_record()
-        records, _ = self.storage.get_all(filters=filters,
-                                          include_deleted=True,
-                                          **self.storage_kw)
+        records, _ = self.storage.get_all(filters=filters, include_deleted=True, **self.storage_kw)
         deleted = records[0]
-        self.assertEqual(deleted['id'], record['id'])
-        self.assertEqual(deleted['last_modified'], record['last_modified'])
-        self.assertEqual(deleted['deleted'], True)
-        self.assertNotIn('challenge', deleted)
+        self.assertEqual(deleted["id"], record["id"])
+        self.assertEqual(deleted["last_modified"], record["last_modified"])
+        self.assertEqual(deleted["deleted"], True)
+        self.assertNotIn("challenge", deleted)
 
     def test_delete_all_keeps_track_of_deleted_records(self):
         filters = self._get_last_modified_filters()
-        record = {'challenge': 'accepted'}
+        record = {"challenge": "accepted"}
         record = self.create_record(record)
         self.storage.delete_all(**self.storage_kw)
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 1)
         self.assertEqual(count, 0)
 
@@ -1119,41 +1067,40 @@ class DeletedRecordsTest:
         # Create 2 records, one becomes tombstone.
         filters = self._get_last_modified_filters()
         r = self.create_and_delete_record()
-        self.create_record({'challenge': 'accepted'})
+        self.create_record({"challenge": "accepted"})
 
         # Delete records, without creating new tombstones.
-        old = self.storage.delete_all(filters=filters,
-                                      with_deleted=False,
-                                      **self.storage_kw)
+        old = self.storage.delete_all(filters=filters, with_deleted=False, **self.storage_kw)
         self.assertEqual(len(old), 1)  # Not 2, because one is tombstone.
 
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 1)
-        self.assertTrue(records[0]['deleted'])
-        self.assertTrue(records[0]['id'], r['id'])
+        self.assertTrue(records[0]["deleted"])
+        self.assertTrue(records[0]["id"], r["id"])
         self.assertEqual(count, 0)
 
     def test_delete_can_delete_without_tombstones(self):
         filters = self._get_last_modified_filters()
-        record = {'challenge': 'accepted'}
+        record = {"challenge": "accepted"}
         record = self.create_record(record)
-        self.storage.delete(object_id=record['id'], with_deleted=False,
-                            **self.storage_kw)
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        self.storage.delete(object_id=record["id"], with_deleted=False, **self.storage_kw)
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 0)
         self.assertEqual(count, 0)
 
     def test_deleting_without_tombstone_should_raise_not_found(self):
         record = self.create_and_delete_record()
-        self.assertRaises(exceptions.RecordNotFoundError,
-                          self.storage.delete,
-                          object_id=record['id'],
-                          with_deleted=False,
-                          **self.storage_kw)
+        self.assertRaises(
+            exceptions.RecordNotFoundError,
+            self.storage.delete,
+            object_id=record["id"],
+            with_deleted=False,
+            **self.storage_kw
+        )
 
     def test_delete_all_deletes_records(self):
         self.create_record()
@@ -1163,78 +1110,70 @@ class DeletedRecordsTest:
         self.assertEqual(count, 0)
 
     def test_delete_all_can_delete_by_parent_id(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
-        self.storage.delete_all(parent_id='ab*',
-                                collection_id=None,
-                                with_deleted=False)
-        records, count = self.storage.get_all(parent_id='abc',
-                                              collection_id='c',
-                                              include_deleted=True)
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="efg", collection_id="c")
+        self.storage.delete_all(parent_id="ab*", collection_id=None, with_deleted=False)
+        records, count = self.storage.get_all(
+            parent_id="abc", collection_id="c", include_deleted=True
+        )
         self.assertEqual(count, 0)
         self.assertEqual(len(records), 0)
-        records, count = self.storage.get_all(parent_id='efg',
-                                              collection_id='c',
-                                              include_deleted=True)
+        records, count = self.storage.get_all(
+            parent_id="efg", collection_id="c", include_deleted=True
+        )
         self.assertEqual(count, 1)
         self.assertEqual(len(records), 1)
 
     def test_delete_all_does_proper_parent_id_matching(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='xabcx', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
-        self.storage.delete_all(parent_id='ab*',
-                                collection_id=None,
-                                with_deleted=False)
-        records, count = self.storage.get_all(parent_id='xabcx',
-                                              collection_id='c',
-                                              include_deleted=True)
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="xabcx", collection_id="c")
+        self.create_record(parent_id="efg", collection_id="c")
+        self.storage.delete_all(parent_id="ab*", collection_id=None, with_deleted=False)
+        records, count = self.storage.get_all(
+            parent_id="xabcx", collection_id="c", include_deleted=True
+        )
         self.assertEqual(count, 1)
         self.assertEqual(len(records), 1)
-        records, count = self.storage.get_all(parent_id='efg',
-                                              collection_id='c',
-                                              include_deleted=True)
+        records, count = self.storage.get_all(
+            parent_id="efg", collection_id="c", include_deleted=True
+        )
         self.assertEqual(count, 1)
         self.assertEqual(len(records), 1)
 
     def test_delete_all_does_proper_matching(self):
-        self.create_record(parent_id='abc', collection_id='c', record={'id': 'id1'})
-        self.create_record(parent_id='def', collection_id='g', record={'id': 'id1'})
-        self.storage.delete_all(parent_id='ab*',
-                                collection_id=None,
-                                with_deleted=False)
-        records, count = self.storage.get_all(parent_id='def',
-                                              collection_id='g',
-                                              include_deleted=True)
+        self.create_record(parent_id="abc", collection_id="c", record={"id": "id1"})
+        self.create_record(parent_id="def", collection_id="g", record={"id": "id1"})
+        self.storage.delete_all(parent_id="ab*", collection_id=None, with_deleted=False)
+        records, count = self.storage.get_all(
+            parent_id="def", collection_id="g", include_deleted=True
+        )
         self.assertEqual(count, 1)
         self.assertEqual(len(records), 1)
 
     def test_delete_all_can_delete_by_parent_id_with_tombstones(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
-        self.storage.delete_all(parent_id='ab*',
-                                collection_id=None,
-                                with_deleted=True)
-        records, count = self.storage.get_all(parent_id='efg',
-                                              collection_id='c',
-                                              include_deleted=True)
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="efg", collection_id="c")
+        self.storage.delete_all(parent_id="ab*", collection_id=None, with_deleted=True)
+        records, count = self.storage.get_all(
+            parent_id="efg", collection_id="c", include_deleted=True
+        )
         self.assertEqual(count, 1)
         self.assertEqual(len(records), 1)
 
-        records, count = self.storage.get_all(parent_id='abc',
-                                              collection_id='c',
-                                              include_deleted=True)
+        records, count = self.storage.get_all(
+            parent_id="abc", collection_id="c", include_deleted=True
+        )
         self.assertEqual(count, 0)
         self.assertEqual(len(records), 2)
-        self.assertTrue(records[0]['deleted'])
-        self.assertTrue(records[1]['deleted'])
+        self.assertTrue(records[0]["deleted"])
+        self.assertTrue(records[1]["deleted"])
 
     def test_delete_all_can_delete_partially(self):
-        self.create_record({'foo': 'po'})
+        self.create_record({"foo": "po"})
         self.create_record()
-        filters = [Filter('foo', 'bar', utils.COMPARISON.EQ)]
+        filters = [Filter("foo", "bar", utils.COMPARISON.EQ)]
         self.storage.delete_all(filters=filters, **self.storage_kw)
         _, count = self.storage.get_all(**self.storage_kw)
         self.assertEqual(count, 1)
@@ -1248,12 +1187,12 @@ class DeletedRecordsTest:
 
     def test_delete_all_supports_sorting(self):
         for i in range(5):
-            self.create_record({'foo': i})
-        sorting = [Sort('foo', -1)]
+            self.create_record({"foo": i})
+        sorting = [Sort("foo", -1)]
         self.storage.delete_all(limit=2, sorting=sorting, **self.storage_kw)
         records, count = self.storage.get_all(sorting=sorting, **self.storage_kw)
         self.assertEqual(count, 3)
-        self.assertEqual(records[0]['foo'], 2)
+        self.assertEqual(records[0]["foo"], 2)
 
     def test_purge_deleted_remove_all_tombstones(self):
         self.create_record()
@@ -1261,38 +1200,36 @@ class DeletedRecordsTest:
         self.storage.delete_all(**self.storage_kw)
         num_removed = self.storage.purge_deleted(**self.storage_kw)
         self.assertEqual(num_removed, 2)
-        records, count = self.storage.get_all(include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(include_deleted=True, **self.storage_kw)
         self.assertEqual(count, 0)
         self.assertEqual(len(records), 0)
 
     def test_purge_deleted_remove_all_tombstones_by_parent_id(self):
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='abc', collection_id='c')
-        self.create_record(parent_id='efg', collection_id='c')
-        self.storage.delete_all(parent_id='abc', collection_id='c')
-        self.storage.delete_all(parent_id='efg', collection_id='c')
-        num_removed = self.storage.purge_deleted(parent_id='ab*',
-                                                 collection_id=None)
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="abc", collection_id="c")
+        self.create_record(parent_id="efg", collection_id="c")
+        self.storage.delete_all(parent_id="abc", collection_id="c")
+        self.storage.delete_all(parent_id="efg", collection_id="c")
+        num_removed = self.storage.purge_deleted(parent_id="ab*", collection_id=None)
         self.assertEqual(num_removed, 2)
 
     def test_purge_deleted_removes_timestamps_by_parent_id(self):
-        self.create_record(parent_id='/abc/a', collection_id='c')
-        self.create_record(parent_id='/abc/a', collection_id='c')
-        self.create_record(parent_id='/efg', collection_id='c')
+        self.create_record(parent_id="/abc/a", collection_id="c")
+        self.create_record(parent_id="/abc/a", collection_id="c")
+        self.create_record(parent_id="/efg", collection_id="c")
 
-        before1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
+        before1 = self.storage.collection_timestamp(parent_id="/abc/a", collection_id="c")
         # Different parent_id with record.
-        before2 = self.storage.collection_timestamp(parent_id='/efg', collection_id='c')
+        before2 = self.storage.collection_timestamp(parent_id="/efg", collection_id="c")
         # Different parent_id without record.
-        before3 = self.storage.collection_timestamp(parent_id='/ijk', collection_id='c')
+        before3 = self.storage.collection_timestamp(parent_id="/ijk", collection_id="c")
 
-        self.storage.delete_all(parent_id='/abc/*', collection_id=None, with_deleted=False)
-        self.storage.purge_deleted(parent_id='/abc/*', collection_id=None)
+        self.storage.delete_all(parent_id="/abc/*", collection_id=None, with_deleted=False)
+        self.storage.purge_deleted(parent_id="/abc/*", collection_id=None)
 
-        after1 = self.storage.collection_timestamp(parent_id='/abc/a', collection_id='c')
-        after2 = self.storage.collection_timestamp(parent_id='/efg', collection_id='c')
-        after3 = self.storage.collection_timestamp(parent_id='/ijk', collection_id='c')
+        after1 = self.storage.collection_timestamp(parent_id="/abc/a", collection_id="c")
+        after2 = self.storage.collection_timestamp(parent_id="/efg", collection_id="c")
+        after3 = self.storage.collection_timestamp(parent_id="/ijk", collection_id="c")
 
         self.assertNotEqual(before1, after1)
         self.assertEqual(before2, after2)
@@ -1305,18 +1242,16 @@ class DeletedRecordsTest:
     def test_purge_deleted_remove_with_before_remove_olders_exclusive(self):
         older = self.create_record()
         newer = self.create_record()
-        self.storage.delete(object_id=older['id'], **self.storage_kw)
-        self.storage.delete(object_id=newer['id'], **self.storage_kw)
-        records, count = self.storage.get_all(include_deleted=True,
-                                              **self.storage_kw)
+        self.storage.delete(object_id=older["id"], **self.storage_kw)
+        self.storage.delete(object_id=newer["id"], **self.storage_kw)
+        records, count = self.storage.get_all(include_deleted=True, **self.storage_kw)
         self.assertEqual(count, 0)
         self.assertEqual(len(records), 2)
         num_removed = self.storage.purge_deleted(
-            before=max([r['last_modified'] for r in records]),
-            **self.storage_kw)
+            before=max([r["last_modified"] for r in records]), **self.storage_kw
+        )
         self.assertEqual(num_removed, 1)
-        records, count = self.storage.get_all(include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(include_deleted=True, **self.storage_kw)
         self.assertEqual(count, 0)
         self.assertEqual(len(records), 1)
 
@@ -1332,10 +1267,10 @@ class DeletedRecordsTest:
             first = record if i == 1 else first
             last = record if i == 20 else last
 
-        sorting = [Sort('last_modified', -1)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          include_deleted=True,
-                                          **self.storage_kw)
+        sorting = [Sort("last_modified", -1)]
+        records, _ = self.storage.get_all(
+            sorting=sorting, filters=filters, include_deleted=True, **self.storage_kw
+        )
 
         self.assertDictEqual(records[0], first)
         self.assertDictEqual(records[-1], last)
@@ -1346,28 +1281,28 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        sorting = [Sort('last_modified', 1)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          include_deleted=True,
-                                          **self.storage_kw)
+        sorting = [Sort("last_modified", 1)]
+        records, _ = self.storage.get_all(
+            sorting=sorting, filters=filters, include_deleted=True, **self.storage_kw
+        )
 
-        self.assertIn('deleted', records[0])
-        self.assertNotIn('deleted', records[1])
-        self.assertIn('deleted', records[2])
+        self.assertIn("deleted", records[0])
+        self.assertNotIn("deleted", records[1])
+        self.assertIn("deleted", records[2])
 
     def test_sorting_on_arbitrary_field_groups_deleted_at_last(self):
         filters = self._get_last_modified_filters()
-        self.create_record({'status': 0})
-        self.create_and_delete_record({'status': 1})
-        self.create_and_delete_record({'status': 2})
+        self.create_record({"status": 0})
+        self.create_and_delete_record({"status": 1})
+        self.create_and_delete_record({"status": 2})
 
-        sorting = [Sort('status', 1)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          include_deleted=True,
-                                          **self.storage_kw)
-        self.assertNotIn('deleted', records[0])
-        self.assertIn('deleted', records[1])
-        self.assertIn('deleted', records[2])
+        sorting = [Sort("status", 1)]
+        records, _ = self.storage.get_all(
+            sorting=sorting, filters=filters, include_deleted=True, **self.storage_kw
+        )
+        self.assertNotIn("deleted", records[0])
+        self.assertIn("deleted", records[1])
+        self.assertIn("deleted", records[2])
 
     def test_support_sorting_on_deleted_field_groups_deleted_at_first(self):
         filters = self._get_last_modified_filters()
@@ -1376,27 +1311,27 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        sorting = [Sort('deleted', 1)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          include_deleted=True,
-                                          **self.storage_kw)
-        self.assertIn('deleted', records[0])
-        self.assertIn('deleted', records[1])
-        self.assertNotIn('deleted', records[2])
+        sorting = [Sort("deleted", 1)]
+        records, _ = self.storage.get_all(
+            sorting=sorting, filters=filters, include_deleted=True, **self.storage_kw
+        )
+        self.assertIn("deleted", records[0])
+        self.assertIn("deleted", records[1])
+        self.assertNotIn("deleted", records[2])
 
     def test_sorting_on_numeric_arbitrary_field(self):
         filters = self._get_last_modified_filters()
         for l in [1, 10, 6, 46]:
-            self.create_record({'status': l})
+            self.create_record({"status": l})
 
-        sorting = [Sort('status', -1)]
-        records, _ = self.storage.get_all(sorting=sorting, filters=filters,
-                                          include_deleted=True,
-                                          **self.storage_kw)
-        self.assertEqual(records[0]['status'], 46)
-        self.assertEqual(records[1]['status'], 10)
-        self.assertEqual(records[2]['status'], 6)
-        self.assertEqual(records[3]['status'], 1)
+        sorting = [Sort("status", -1)]
+        records, _ = self.storage.get_all(
+            sorting=sorting, filters=filters, include_deleted=True, **self.storage_kw
+        )
+        self.assertEqual(records[0]["status"], 46)
+        self.assertEqual(records[1]["status"], 10)
+        self.assertEqual(records[2]["status"], 6)
+        self.assertEqual(records[3]["status"], 1)
 
     #
     # Filtering
@@ -1408,21 +1343,21 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 2)
         self.assertEqual(count, 1)
 
     def test_filtering_on_arbitrary_field_excludes_deleted_records(self):
         filters = self._get_last_modified_filters()
-        self.create_record({'status': 0})
-        self.create_and_delete_record({'status': 0})
+        self.create_record({"status": 0})
+        self.create_and_delete_record({"status": 0})
 
-        filters += [Filter('status', 0, utils.COMPARISON.EQ)]
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        filters += [Filter("status", 0, utils.COMPARISON.EQ)]
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 1)
         self.assertEqual(count, 1)
 
@@ -1431,11 +1366,11 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        filters += [Filter('deleted', True, utils.COMPARISON.EQ)]
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
-        self.assertIn('deleted', records[0])
+        filters += [Filter("deleted", True, utils.COMPARISON.EQ)]
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
+        self.assertIn("deleted", records[0])
         self.assertEqual(len(records), 1)
         self.assertEqual(count, 0)
 
@@ -1444,12 +1379,12 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        filters += [Filter('deleted', True, utils.COMPARISON.NOT)]
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        filters += [Filter("deleted", True, utils.COMPARISON.NOT)]
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(count, 1)
-        self.assertNotIn('deleted', records[0])
+        self.assertNotIn("deleted", records[0])
         self.assertEqual(len(records), 1)
 
     def test_return_empty_set_if_filtering_on_deleted_false(self):
@@ -1457,10 +1392,10 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        filters += [Filter('deleted', False, utils.COMPARISON.EQ)]
-        records, count = self.storage.get_all(filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        filters += [Filter("deleted", False, utils.COMPARISON.EQ)]
+        records, count = self.storage.get_all(
+            filters=filters, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 0)
         self.assertEqual(count, 0)
 
@@ -1468,9 +1403,8 @@ class DeletedRecordsTest:
         self.create_record()
         self.create_and_delete_record()
 
-        filters = [Filter('deleted', True, utils.COMPARISON.EQ)]
-        records, count = self.storage.get_all(filters=filters,
-                                              **self.storage_kw)
+        filters = [Filter("deleted", True, utils.COMPARISON.EQ)]
+        records, count = self.storage.get_all(filters=filters, **self.storage_kw)
         self.assertEqual(len(records), 0)
         self.assertEqual(count, 0)
 
@@ -1486,54 +1420,59 @@ class DeletedRecordsTest:
             else:
                 self.create_record()
 
-        pagination = [[Filter('last_modified', 314, utils.COMPARISON.GT)]]
-        sorting = [Sort('last_modified', 1)]
-        records, count = self.storage.get_all(sorting=sorting,
-                                              pagination_rules=pagination,
-                                              limit=5, filters=filters,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        pagination = [[Filter("last_modified", 314, utils.COMPARISON.GT)]]
+        sorting = [Sort("last_modified", 1)]
+        records, count = self.storage.get_all(
+            sorting=sorting,
+            pagination_rules=pagination,
+            limit=5,
+            filters=filters,
+            include_deleted=True,
+            **self.storage_kw
+        )
         self.assertEqual(len(records), 5)
         self.assertEqual(count, 7)
-        self.assertIn('deleted', records[0])
-        self.assertNotIn('deleted', records[1])
+        self.assertIn("deleted", records[0])
+        self.assertNotIn("deleted", records[1])
 
     def test_pagination_can_skip_everything(self):
         for i in range(5):
-            self.create_record({'i': i})
+            self.create_record({"i": i})
 
-        pagination = [[Filter('i', 7, utils.COMPARISON.GT)]]
-        records, count = self.storage.get_all(pagination_rules=pagination,
-                                              limit=5,
-                                              include_deleted=True,
-                                              **self.storage_kw)
+        pagination = [[Filter("i", 7, utils.COMPARISON.GT)]]
+        records, count = self.storage.get_all(
+            pagination_rules=pagination, limit=5, include_deleted=True, **self.storage_kw
+        )
         self.assertEqual(len(records), 0)
 
     def test_get_all_handle_a_pagination_rules(self):
         for x in range(10):
             record = dict(self.record)
-            record['number'] = x % 3
+            record["number"] = x % 3
             self.create_record(record)
 
         records, total_records = self.storage.get_all(
             limit=5,
-            pagination_rules=[
-                [Filter('number', 1, utils.COMPARISON.GT)]
-            ], **self.storage_kw)
+            pagination_rules=[[Filter("number", 1, utils.COMPARISON.GT)]],
+            **self.storage_kw
+        )
         self.assertEqual(total_records, 10)
         self.assertEqual(len(records), 3)
 
     def test_get_all_handle_all_pagination_rules(self):
         for x in range(10):
             record = dict(self.record)
-            record['number'] = x % 3
+            record["number"] = x % 3
             last_record = self.create_record(record)
 
         records, total_records = self.storage.get_all(
-            limit=5, pagination_rules=[
-                [Filter('number', 1, utils.COMPARISON.GT)],
-                [Filter('id', last_record['id'], utils.COMPARISON.EQ)],
-            ], **self.storage_kw)
+            limit=5,
+            pagination_rules=[
+                [Filter("number", 1, utils.COMPARISON.GT)],
+                [Filter("id", last_record["id"], utils.COMPARISON.EQ)],
+            ],
+            **self.storage_kw
+        )
         self.assertEqual(total_records, 10)
         self.assertEqual(len(records), 4)
 
@@ -1543,28 +1482,35 @@ class DeletedRecordsTest:
         # Create records with different parent IDs, but the same
         # record ID.
         for parent in range(10):
-            parent_id = 'abc{}'.format(parent)
-            self.storage.create(parent_id=parent_id, collection_id='c',
-                                record={'id': 'some_id', 'secret_data': parent_id})
+            parent_id = "abc{}".format(parent)
+            self.storage.create(
+                parent_id=parent_id,
+                collection_id="c",
+                record={"id": "some_id", "secret_data": parent_id},
+            )
 
-        real_records, _ = self.storage.get_all(parent_id='abc*', collection_id='c')
+        real_records, _ = self.storage.get_all(parent_id="abc*", collection_id="c")
         self.assertEqual(len(real_records), 10)
 
         def sort_by_secret_data(l):
-            return sorted(l, key=lambda r: r['secret_data'])
+            return sorted(l, key=lambda r: r["secret_data"])
 
         GT = utils.COMPARISON.GT
         LT = utils.COMPARISON.LT
-        for order in [('secret_data', 1), ('secret_data', -1)]:
-            sort = [Sort(*order), Sort('last_modified', -1)]
+        for order in [("secret_data", 1), ("secret_data", -1)]:
+            sort = [Sort(*order), Sort("last_modified", -1)]
             for limit in range(1, 10):
                 with self.subTest(order=order, limit=limit):
                     records = []
                     pagination = None
                     while True:
                         page, total_records = self.storage.get_all(
-                            parent_id='abc*', collection_id='c', sorting=sort,
-                            limit=limit, pagination_rules=pagination)
+                            parent_id="abc*",
+                            collection_id="c",
+                            sorting=sort,
+                            limit=limit,
+                            pagination_rules=pagination,
+                        )
 
                         self.assertEqual(total_records, len(real_records))
                         records.extend(page)
@@ -1581,23 +1527,27 @@ class DeletedRecordsTest:
                         order_field, order_direction = order
                         pagination_direction = GT if order_direction == 1 else LT
                         threshhold_field = last_record[order_field]
-                        threshhold_lm = last_record['last_modified']
+                        threshhold_lm = last_record["last_modified"]
                         pagination = [
-                            [Filter(order_field, threshhold_field, utils.COMPARISON.EQ),
-                             Filter('last_modified', threshhold_lm, utils.COMPARISON.LT)],
-                            [Filter(order_field, threshhold_field, pagination_direction)]
+                            [
+                                Filter(order_field, threshhold_field, utils.COMPARISON.EQ),
+                                Filter("last_modified", threshhold_lm, utils.COMPARISON.LT),
+                            ],
+                            [Filter(order_field, threshhold_field, pagination_direction)],
                         ]
 
-                    self.assertEqual(sort_by_secret_data(real_records),
-                                     sort_by_secret_data(records))
+                    self.assertEqual(
+                        sort_by_secret_data(real_records), sort_by_secret_data(records)
+                    )
 
     def test_delete_all_supports_pagination_rules(self):
         for i in range(6):
-            self.create_record({'foo': i})
+            self.create_record({"foo": i})
 
-        pagination_rules = [[Filter('foo', 3, utils.COMPARISON.GT)]]
-        deleted = self.storage.delete_all(limit=4, pagination_rules=pagination_rules,
-                                          **self.storage_kw)
+        pagination_rules = [[Filter("foo", 3, utils.COMPARISON.GT)]]
+        deleted = self.storage.delete_all(
+            limit=4, pagination_rules=pagination_rules, **self.storage_kw
+        )
         self.assertEqual(len(deleted), 2)
 
 
@@ -1607,62 +1557,63 @@ class ParentRecordAccessTest:
         self.assertRaises(
             exceptions.RecordNotFoundError,
             self.storage.get,
-            collection_id=self.storage_kw['collection_id'],
+            collection_id=self.storage_kw["collection_id"],
             parent_id=self.other_parent_id,
-            object_id=record['id'],
-            auth=self.other_auth)
+            object_id=record["id"],
+            auth=self.other_auth,
+        )
 
     def test_parent_cannot_delete_other_parent_record(self):
         record = self.create_record()
         self.assertRaises(
             exceptions.RecordNotFoundError,
             self.storage.delete,
-            collection_id=self.storage_kw['collection_id'],
+            collection_id=self.storage_kw["collection_id"],
             parent_id=self.other_parent_id,
-            object_id=record['id'],
-            auth=self.other_auth)
+            object_id=record["id"],
+            auth=self.other_auth,
+        )
 
     def test_parent_cannot_update_other_parent_record(self):
         record = self.create_record()
 
-        new_record = {'another': 'record'}
-        kw = {**self.storage_kw,
-              'parent_id': self.other_parent_id,
-              'auth': self.other_auth}
-        self.storage.update(object_id=record['id'], record=new_record, **kw)
+        new_record = {"another": "record"}
+        kw = {**self.storage_kw, "parent_id": self.other_parent_id, "auth": self.other_auth}
+        self.storage.update(object_id=record["id"], record=new_record, **kw)
 
-        not_updated = self.storage.get(object_id=record['id'],
-                                       **self.storage_kw)
-        self.assertNotIn('another', not_updated)
+        not_updated = self.storage.get(object_id=record["id"], **self.storage_kw)
+        self.assertNotIn("another", not_updated)
 
 
 class SerializationTest:
     def test_create_bytes_raises(self):
-        data = {'steak': 'haché'.encode(encoding='utf-8')}
-        self.assertIsInstance(data['steak'], bytes)
-        self.assertRaises(TypeError,
-                          self.create_record,
-                          data)
+        data = {"steak": "haché".encode(encoding="utf-8")}
+        self.assertIsInstance(data["steak"], bytes)
+        self.assertRaises(TypeError, self.create_record, data)
 
     def test_update_bytes_raises(self):
         record = self.create_record()
 
-        new_record = {'steak': 'haché'.encode(encoding='utf-8')}
-        self.assertIsInstance(new_record['steak'], bytes)
+        new_record = {"steak": "haché".encode(encoding="utf-8")}
+        self.assertIsInstance(new_record["steak"], bytes)
 
-        self.assertRaises(TypeError,
-                          self.storage.update,
-                          object_id=record['id'],
-                          record=new_record,
-                          **self.storage_kw
-                          )
+        self.assertRaises(
+            TypeError,
+            self.storage.update,
+            object_id=record["id"],
+            record=new_record,
+            **self.storage_kw
+        )
 
 
-class StorageTest(ThreadMixin,
-                  TimestampsTest,
-                  DeletedRecordsTest,
-                  ParentRecordAccessTest,
-                  SerializationTest,
-                  BaseTestStorage):
+class StorageTest(
+    ThreadMixin,
+    TimestampsTest,
+    DeletedRecordsTest,
+    ParentRecordAccessTest,
+    SerializationTest,
+    BaseTestStorage,
+):
     """Compound of all storage tests."""
+
     pass

--- a/kinto/core/storage/utils.py
+++ b/kinto/core/storage/utils.py
@@ -14,14 +14,14 @@ def paginated(storage, *args, sorting, batch_size=BATCH_SIZE, **kwargs):
     """
 
     if len(sorting) > 1:
-        raise NotImplementedError('FIXME: only supports one-length sorting')  # pragma: nocover
+        raise NotImplementedError("FIXME: only supports one-length sorting")  # pragma: nocover
     pagination_direction = COMPARISON.GT if sorting[0].direction > 0 else COMPARISON.LT
 
     record_pagination = None
     while True:
-        (records, _) = storage.get_all(sorting=sorting, limit=batch_size,
-                                       pagination_rules=record_pagination,
-                                       **kwargs)
+        (records, _) = storage.get_all(
+            sorting=sorting, limit=batch_size, pagination_rules=record_pagination, **kwargs
+        )
 
         if not records:
             break

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -13,42 +13,40 @@ from kinto.core import statsd
 from kinto.core.storage import generators
 from kinto.core.utils import sqlalchemy, memcache, follow_subrequest, encode64
 
-skip_if_travis = unittest.skipIf('TRAVIS' in os.environ, 'travis')
-skip_if_no_postgresql = unittest.skipIf(sqlalchemy is None, 'postgresql is not installed.')
-skip_if_no_memcached = unittest.skipIf(memcache is None, 'memcached is not installed.')
-skip_if_no_statsd = unittest.skipIf(not statsd.statsd_module, 'statsd is not installed.')
+skip_if_travis = unittest.skipIf("TRAVIS" in os.environ, "travis")
+skip_if_no_postgresql = unittest.skipIf(sqlalchemy is None, "postgresql is not installed.")
+skip_if_no_memcached = unittest.skipIf(memcache is None, "memcached is not installed.")
+skip_if_no_statsd = unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
 
 
 class DummyRequest(mock.MagicMock):
     """Fully mocked request.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.upath_info = '/v0/'
+        self.upath_info = "/v0/"
         self.registry = mock.MagicMock(settings={**DEFAULT_SETTINGS})
         self.registry.id_generators = defaultdict(generators.UUID4)
         self.GET = {}
         self.headers = {}
         self.errors = cornice_errors.Errors()
-        self.authenticated_userid = 'bob'
-        self.authn_type = 'basicauth'
-        self.prefixed_userid = 'basicauth:bob'
-        self.effective_principals = [
-            'system.Everyone',
-            'system.Authenticated',
-            'bob']
+        self.authenticated_userid = "bob"
+        self.authn_type = "basicauth"
+        self.prefixed_userid = "basicauth:bob"
+        self.effective_principals = ["system.Everyone", "system.Authenticated", "bob"]
         self.prefixed_principals = self.effective_principals + [self.prefixed_userid]
         self.json = {}
         self.validated = {}
         self.log_context = lambda **kw: kw
         self.matchdict = {}
         self.response = mock.MagicMock(headers={})
-        self.application_url = ''   # used by parse_url_overrides
+        self.application_url = ""  # used by parse_url_overrides
 
         def route_url(*a, **kw):
             # XXX: refactor DummyRequest to take advantage of `pyramid.testing`
             parts = parse_url_overrides(self, kw)
-            return ''.join([p for p in parts if p])
+            return "".join([p for p in parts if p])
 
         self.route_url = route_url
 
@@ -56,13 +54,11 @@ class DummyRequest(mock.MagicMock):
 
 
 def get_request_class(prefix):
-
     class PrefixedRequestClass(webtest.app.TestRequest):
-
         @classmethod
         def blank(cls, path, *args, **kwargs):
             if prefix:
-                path = '/{prefix}{path}'.format(prefix=prefix, path=path)
+                path = "/{prefix}{path}".format(prefix=prefix, path=path)
             return webtest.app.TestRequest.blank(path, *args, **kwargs)
 
     return PrefixedRequestClass
@@ -72,34 +68,31 @@ class FormattedErrorMixin:
     """Test mixin in order to perform advanced error responses assertions.
     """
 
-    def assertFormattedError(self, response, code, errno, error,
-                             message=None, info=None):
-        self.assertIn('application/json', response.headers['Content-Type'])
-        self.assertEqual(response.json['code'], code)
-        self.assertEqual(response.json['errno'], errno.value)
-        self.assertEqual(response.json['error'], error)
+    def assertFormattedError(self, response, code, errno, error, message=None, info=None):
+        self.assertIn("application/json", response.headers["Content-Type"])
+        self.assertEqual(response.json["code"], code)
+        self.assertEqual(response.json["errno"], errno.value)
+        self.assertEqual(response.json["error"], error)
         if message is not None:
-            self.assertIn(message, response.json['message'])
+            self.assertIn(message, response.json["message"])
         else:  # pragma: no cover
-            self.assertNotIn('message', response.json)
+            self.assertNotIn("message", response.json)
 
         if info is not None:
-            self.assertIn(info, response.json['info'])
+            self.assertIn(info, response.json["info"])
         else:  # pragma: no cover
-            self.assertNotIn('info', response.json)
+            self.assertNotIn("info", response.json)
 
 
-def get_user_headers(user, password='secret'):
+def get_user_headers(user, password="secret"):
     """Helper to obtain a Basic Auth authorization headers from the specified
     `user` (e.g. ``"user:pass"``)
 
     :rtype: dict
     """
-    credentials = '{}:{}'.format(user, password)
-    authorization = 'Basic {}'.format(encode64(credentials))
-    return {
-        'Authorization': authorization
-    }
+    credentials = "{}:{}".format(user, password)
+    authorization = "Basic {}".format(encode64(credentials))
+    return {"Authorization": authorization}
 
 
 class BaseWebTest:
@@ -108,15 +101,13 @@ class BaseWebTest:
     It setups the database before each test and delete it after.
     """
 
-    api_prefix = 'v0'
+    api_prefix = "v0"
     """URL version prefix"""
 
     entry_point = None
     """Main application entry"""
 
-    headers = {
-        'Content-Type': 'application/json'
-    }
+    headers = {"Content-Type": "application/json"}
 
     @classmethod
     def setUpClass(cls):
@@ -157,10 +148,10 @@ class BaseWebTest:
         """
         settings = {**DEFAULT_SETTINGS}
 
-        settings['storage_backend'] = 'kinto.core.storage.memory'
-        settings['storage_strict_json'] = True
-        settings['cache_backend'] = 'kinto.core.cache.memory'
-        settings['permission_backend'] = 'kinto.core.permission.memory'
+        settings["storage_backend"] = "kinto.core.storage.memory"
+        settings["storage_strict_json"] = True
+        settings["cache_backend"] = "kinto.core.cache.memory"
+        settings["permission_backend"] = "kinto.core.permission.memory"
 
         settings.update(extras or None)
 
@@ -174,7 +165,6 @@ class BaseWebTest:
 
 
 class ThreadMixin:
-
     def setUp(self):
         super().setUp()
         self._threads = []

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -43,7 +43,7 @@ def strip_whitespace(v):
     :param str v: the string to strip.
     :rtype: str
     """
-    return v.strip(' \t\n\r') if v is not null else v
+    return v.strip(" \t\n\r") if v is not null else v
 
 
 def msec_time():
@@ -100,7 +100,7 @@ def random_bytes_hex(bytes_length):
     :param int bytes_length: number of random bytes.
     :rtype: str
     """
-    return hexlify(os.urandom(bytes_length)).decode('utf-8')
+    return hexlify(os.urandom(bytes_length)).decode("utf-8")
 
 
 def native_value(value):
@@ -124,11 +124,11 @@ def read_env(key, value):
     :param value: default value if undefined in environment
     :returns: the value from environment, coerced to python type
     """
-    envkey = key.replace('.', '_').replace('-', '_').upper()
+    envkey = key.replace(".", "_").replace("-", "_").upper()
     return native_value(os.getenv(envkey, value))
 
 
-def encode64(content, encoding='utf-8'):
+def encode64(content, encoding="utf-8"):
     """Encode some content in base64.
 
     :rtype: str
@@ -136,7 +136,7 @@ def encode64(content, encoding='utf-8'):
     return b64encode(content.encode(encoding)).decode(encoding)
 
 
-def decode64(encoded_content, encoding='utf-8'):
+def decode64(encoded_content, encoding="utf-8"):
     """Decode some base64 encoded content.
 
     :rtype: str
@@ -144,13 +144,11 @@ def decode64(encoded_content, encoding='utf-8'):
     return b64decode(encoded_content.encode(encoding)).decode(encoding)
 
 
-def hmac_digest(secret, message, encoding='utf-8'):
+def hmac_digest(secret, message, encoding="utf-8"):
     """Return hex digest of a message HMAC using secret"""
     if isinstance(secret, str):
         secret = secret.encode(encoding)
-    return hmac.new(secret,
-                    message.encode(encoding),
-                    hashlib.sha256).hexdigest()
+    return hmac.new(secret, message.encode(encoding), hashlib.sha256).hexdigest()
 
 
 def dict_subset(d, keys):
@@ -158,8 +156,8 @@ def dict_subset(d, keys):
     result = {}
 
     for key in keys:
-        if '.' in key:
-            field, subfield = key.split('.', 1)
+        if "." in key:
+            field, subfield = key.split(".", 1)
             if isinstance(d.get(field), collections.Mapping):
                 subvalue = dict_subset(d[field], [subfield])
                 result[field] = dict_merge(subvalue, result.get(field, {}))
@@ -194,10 +192,10 @@ def find_nested_value(d, path, default=None):
 
     # the challenge is to identify what is the root key, as dict keys may
     # contain dot characters themselves
-    parts = path.split('.')
+    parts = path.split(".")
 
     # build a list of all possible root keys from all the path parts
-    candidates = ['.'.join(parts[:i + 1]) for i in range(len(parts))]
+    candidates = [".".join(parts[: i + 1]) for i in range(len(parts))]
 
     # we start with the longest candidate paths as they're most likely to be the
     # ones we want if they match
@@ -208,25 +206,25 @@ def find_nested_value(d, path, default=None):
         return default
 
     # we have our root key, extract the new subpath and recur
-    subpath = path.replace(root + '.', '', 1)
+    subpath = path.replace(root + ".", "", 1)
     return find_nested_value(d.get(root), subpath, default=default)
 
 
 class COMPARISON(Enum):
-    LT = '<'
-    MIN = '>='
-    MAX = '<='
-    NOT = '!='
-    EQ = '=='
-    GT = '>'
-    IN = 'in'
-    EXCLUDE = 'exclude'
-    LIKE = 'like'
-    HAS = 'has'
+    LT = "<"
+    MIN = ">="
+    MAX = "<="
+    NOT = "!="
+    EQ = "=="
+    GT = ">"
+    IN = "in"
+    EXCLUDE = "exclude"
+    LIKE = "like"
+    HAS = "has"
     # The order matters here because we want to match
     # contains_any before contains_
-    CONTAINS_ANY = 'contains_any'
-    CONTAINS = 'contains'
+    CONTAINS_ANY = "contains_any"
+    CONTAINS = "contains"
 
 
 def reapply_cors(request, response):
@@ -238,24 +236,25 @@ def reapply_cors(request, response):
     """
     service = request.current_service
     if service:
-        request.info['cors_checked'] = False
+        request.info["cors_checked"] = False
         cors.apply_cors_post_request(service, request, response)
         response = cors.ensure_origin(service, request, response)
     else:
         # No existing service is concerned, and Cornice is not implied.
-        origin = request.headers.get('Origin')
+        origin = request.headers.get("Origin")
         if origin:
             settings = request.registry.settings
-            allowed_origins = set(aslist(settings['cors_origins']))
-            required_origins = {'*', origin}
+            allowed_origins = set(aslist(settings["cors_origins"]))
+            required_origins = {"*", origin}
             if allowed_origins.intersection(required_origins):
-                response.headers['Access-Control-Allow-Origin'] = origin
+                response.headers["Access-Control-Allow-Origin"] = origin
 
         # Import service here because kinto.core import utils
         from kinto.core import Service
+
         if Service.default_cors_headers:  # pragma: no branch
-            headers = ','.join(Service.default_cors_headers)
-            response.headers['Access-Control-Expose-Headers'] = headers
+            headers = ",".join(Service.default_cors_headers)
+            response.headers["Access-Control-Expose-Headers"] = headers
     return response
 
 
@@ -308,9 +307,9 @@ def prefixed_userid(request):
     # If pyramid_multiauth is used, a ``authn_type`` is set on request
     # when a policy succesfully authenticates a user.
     # (see :func:`kinto.core.initialization.setup_authentication`)
-    authn_type = getattr(request, 'authn_type', None)
+    authn_type = getattr(request, "authn_type", None)
     if authn_type is not None:
-        return '{}:{}'.format(authn_type, request.selected_userid)
+        return "{}:{}".format(authn_type, request.selected_userid)
 
 
 def prefixed_principals(request):
@@ -323,7 +322,7 @@ def prefixed_principals(request):
 
     # Remove unprefixed user id on effective_principals to avoid conflicts.
     # (it is added via Pyramid Authn policy effective principals)
-    prefix, userid = request.prefixed_userid.split(':', 1)
+    prefix, userid = request.prefixed_userid.split(":", 1)
     principals = [p for p in principals if p != userid]
 
     if request.prefixed_userid not in principals:
@@ -342,32 +341,31 @@ def build_request(original, dict_obj):
     :param original: the original request.
     :param dict_obj: a dict object with the sub-request specifications.
     """
-    api_prefix = '/{}'.format(original.upath_info.split('/')[1])
-    path = dict_obj['path']
+    api_prefix = "/{}".format(original.upath_info.split("/")[1])
+    path = dict_obj["path"]
     if not path.startswith(api_prefix):
         path = api_prefix + path
 
-    path = path.encode('utf-8')
+    path = path.encode("utf-8")
 
-    method = dict_obj.get('method') or 'GET'
+    method = dict_obj.get("method") or "GET"
 
     headers = dict(original.headers)
-    headers.update(**dict_obj.get('headers') or {})
+    headers.update(**dict_obj.get("headers") or {})
     # Body can have different length, do not use original header.
-    headers.pop('Content-Length', None)
+    headers.pop("Content-Length", None)
 
-    payload = dict_obj.get('body') or ''
+    payload = dict_obj.get("body") or ""
 
     # Payload is always a dict (from ``BatchRequestSchema.body``).
     # Send it as JSON for subrequests.
     if isinstance(payload, dict):
-        headers['Content-Type'] = 'application/json; charset=utf-8'
+        headers["Content-Type"] = "application/json; charset=utf-8"
         payload = json.dumps(payload)
 
-    request = Request.blank(path=path.decode('latin-1'),
-                            headers=headers,
-                            POST=payload,
-                            method=method)
+    request = Request.blank(
+        path=path.decode("latin-1"), headers=headers, POST=payload, method=method
+    )
     request.registry = original.registry
     apply_request_extensions(request)
 
@@ -387,18 +385,18 @@ def build_response(response, request):
     :param request: the request that was used to get the response.
     """
     dict_obj = {}
-    dict_obj['path'] = unquote(request.path)
-    dict_obj['status'] = response.status_code
-    dict_obj['headers'] = dict(response.headers)
+    dict_obj["path"] = unquote(request.path)
+    dict_obj["status"] = response.status_code
+    dict_obj["headers"] = dict(response.headers)
 
-    body = ''
-    if request.method != 'HEAD':
+    body = ""
+    if request.method != "HEAD":
         # XXX : Pyramid should not have built response body for HEAD!
         try:
             body = response.json
         except ValueError:
             body = response.body
-    dict_obj['body'] = body
+    dict_obj["body"] = body
 
     return dict_obj
 
@@ -419,13 +417,15 @@ def follow_subrequest(request, subrequest, **kwargs):
                 raise e
             raise resp
     except httpexceptions.HTTPRedirection as e:
-        new_location = e.headers['Location']
-        new_request = Request.blank(path=new_location,
-                                    headers=subrequest.headers,
-                                    POST=subrequest.body,
-                                    method=subrequest.method)
+        new_location = e.headers["Location"]
+        new_request = Request.blank(
+            path=new_location,
+            headers=subrequest.headers,
+            POST=subrequest.body,
+            method=subrequest.method,
+        )
         new_request.bound_data = subrequest.bound_data
-        new_request.parent = getattr(subrequest, 'parent', None)
+        new_request.parent = getattr(subrequest, "parent", None)
         return request.invoke_subrequest(new_request, **kwargs), new_request
 
 
@@ -433,7 +433,7 @@ def strip_uri_prefix(path):
     """
     Remove potential version prefix in URI.
     """
-    return re.sub(r'^(/v\d+)?', '', str(path))
+    return re.sub(r"^(/v\d+)?", "", str(path))
 
 
 def view_lookup(request, uri):
@@ -458,27 +458,25 @@ def view_lookup_registry(registry, uri):
     :rtype: tuple
     :returns: the resource name and the associated matchdict.
     """
-    api_prefix = '/{}'.format(registry.route_prefix)
-    path = (api_prefix + uri)
+    api_prefix = "/{}".format(registry.route_prefix)
+    path = api_prefix + uri
 
     q = registry.queryUtility
     routes_mapper = q(IRoutesMapper)
 
     fakerequest = Request.blank(path=path)
     info = routes_mapper(fakerequest)
-    matchdict, route = info['match'], info['route']
+    matchdict, route = info["match"], info["route"]
     if route is None:
-        raise ValueError('URI has no route')
+        raise ValueError("URI has no route")
 
-    resource_name = route.name.replace('-record', '')\
-                              .replace('-collection', '')
+    resource_name = route.name.replace("-record", "").replace("-collection", "")
     return resource_name, matchdict
 
 
 def instance_uri(request, resource_name, **params):
     """Return the URI for the given resource."""
-    return strip_uri_prefix(request.route_path(
-        '{}-record'.format(resource_name), **params))
+    return strip_uri_prefix(request.route_path("{}-record".format(resource_name), **params))
 
 
 def instance_uri_registry(registry, resource_name, **params):
@@ -487,7 +485,7 @@ def instance_uri_registry(registry, resource_name, **params):
     This gins up a request using Request.blank and so does not support
     any routes with pregenerators.
     """
-    request = Request.blank(path='')
+    request = Request.blank(path="")
     request.registry = registry
     return instance_uri(request, resource_name, **params)
 
@@ -499,27 +497,25 @@ def parse_resource(resource):
     :returns: a dictionary with the bucket_id and collection_id of the resource
     """
 
-    error_msg = 'Resources should be defined as '
+    error_msg = "Resources should be defined as "
     "'/buckets/<bid>/collections/<cid>' or '<bid>/<cid>'. "
-    'with valid collection and bucket ids.'
+    "with valid collection and bucket ids."
 
     from kinto.views import NameGenerator
+
     id_generator = NameGenerator()
-    parts = resource.split('/')
+    parts = resource.split("/")
     if len(parts) == 2:
         bucket, collection = parts
     elif len(parts) == 5:
         _, _, bucket, _, collection = parts
     else:
         raise ValueError(error_msg)
-    if bucket == '' or collection == '':
+    if bucket == "" or collection == "":
         raise ValueError(error_msg)
     if not id_generator.match(bucket) or not id_generator.match(collection):
         raise ValueError(error_msg)
-    return {
-        'bucket': bucket,
-        'collection': collection
-    }
+    return {"bucket": bucket, "collection": collection}
 
 
 def apply_json_patch(record, ops):
@@ -535,23 +531,22 @@ def apply_json_patch(record, ops):
     data = {**record}
 
     # Permissions should always have read and write fields defined (to allow add)
-    permissions = {'read': set(), 'write': set()}
+    permissions = {"read": set(), "write": set()}
 
     # Get permissions if available on the resource (using SharableResource)
-    permissions.update(data.pop('__permissions__', {}))
+    permissions.update(data.pop("__permissions__", {}))
 
     # Permissions should be mapped as a dict, since jsonpatch doesn't accept
     # sets and lists are mapped as JSON arrays (not indexed by value)
     permissions = {k: {i: i for i in v} for k, v in permissions.items()}
 
-    resource = {'data': data, 'permissions': permissions}
+    resource = {"data": data, "permissions": permissions}
 
     # Allow patch permissions without value since key and value are equal on sets
     for op in ops:
         # 'path' is here since it was validated.
-        if op['path'].startswith(('/permissions/read/',
-                                  '/permissions/write/')):
-            op['value'] = op['path'].split('/')[-1]
+        if op["path"].startswith(("/permissions/read/", "/permissions/write/")):
+            op["value"] = op["path"].split("/")[-1]
 
     try:
         result = jsonpatch.apply_patch(resource, ops)

--- a/kinto/core/views/errors.py
+++ b/kinto/core/views/errors.py
@@ -14,123 +14,114 @@ from kinto.core.utils import reapply_cors
 logger = logging.getLogger()
 
 
-@view_config(context=httpexceptions.HTTPForbidden,
-             permission=NO_PERMISSION_REQUIRED)
+@view_config(context=httpexceptions.HTTPForbidden, permission=NO_PERMISSION_REQUIRED)
 def authorization_required(response, request):
     """Distinguish authentication required (``401 Unauthorized``) from
     not allowed (``403 Forbidden``).
     """
     if Authenticated not in request.effective_principals:
-        if response.content_type != 'application/json':
-            error_msg = 'Please authenticate yourself to use this endpoint.'
-            response = http_error(httpexceptions.HTTPUnauthorized(),
-                                  errno=ERRORS.MISSING_AUTH_TOKEN,
-                                  message=error_msg)
+        if response.content_type != "application/json":
+            error_msg = "Please authenticate yourself to use this endpoint."
+            response = http_error(
+                httpexceptions.HTTPUnauthorized(),
+                errno=ERRORS.MISSING_AUTH_TOKEN,
+                message=error_msg,
+            )
         response.headers.extend(forget(request))
         return response
 
-    if response.content_type != 'application/json':
-        error_msg = 'This user cannot access this resource.'
-        response = http_error(httpexceptions.HTTPForbidden(),
-                              errno=ERRORS.FORBIDDEN,
-                              message=error_msg)
+    if response.content_type != "application/json":
+        error_msg = "This user cannot access this resource."
+        response = http_error(
+            httpexceptions.HTTPForbidden(), errno=ERRORS.FORBIDDEN, message=error_msg
+        )
     return reapply_cors(request, response)
 
 
-@view_config(context=httpexceptions.HTTPNotFound,
-             permission=NO_PERMISSION_REQUIRED)
+@view_config(context=httpexceptions.HTTPNotFound, permission=NO_PERMISSION_REQUIRED)
 def page_not_found(response, request):
     """Return a JSON 404 error response."""
-    config_key = 'trailing_slash_redirect_enabled'
+    config_key = "trailing_slash_redirect_enabled"
     redirect_enabled = request.registry.settings[config_key]
     trailing_slash_redirection_enabled = asbool(redirect_enabled)
 
-    querystring = request.url[(request.url.rindex(request.path) +
-                               len(request.path)):]
+    querystring = request.url[(request.url.rindex(request.path) + len(request.path)) :]
 
     errno = ERRORS.MISSING_RESOURCE
-    error_msg = 'The resource you are looking for could not be found.'
+    error_msg = "The resource you are looking for could not be found."
 
-    if not request.path.startswith('/{}'.format(request.registry.route_prefix)):
+    if not request.path.startswith("/{}".format(request.registry.route_prefix)):
         errno = ERRORS.VERSION_NOT_AVAILABLE
-        error_msg = ('The requested API version is not available '
-                     'on this server.')
+        error_msg = "The requested API version is not available " "on this server."
     elif trailing_slash_redirection_enabled:
         redirect = None
 
-        if request.path.endswith('/'):
-            path = request.path.rstrip('/')
-            redirect = '{}{}'.format(path, querystring)
-        elif request.path == '/{}'.format(request.registry.route_prefix):
+        if request.path.endswith("/"):
+            path = request.path.rstrip("/")
+            redirect = "{}{}".format(path, querystring)
+        elif request.path == "/{}".format(request.registry.route_prefix):
             # Case for /v0 -> /v0/
-            redirect = '/{}/{}'.format(request.registry.route_prefix, querystring)
+            redirect = "/{}/{}".format(request.registry.route_prefix, querystring)
 
         if redirect:
             return reapply_cors(request, HTTPTemporaryRedirect(redirect))
 
-    if response.content_type != 'application/json':
-        response = http_error(httpexceptions.HTTPNotFound(),
-                              errno=errno,
-                              message=error_msg)
+    if response.content_type != "application/json":
+        response = http_error(httpexceptions.HTTPNotFound(), errno=errno, message=error_msg)
     return reapply_cors(request, response)
 
 
-@view_config(context=httpexceptions.HTTPServiceUnavailable,
-             permission=NO_PERMISSION_REQUIRED)
+@view_config(context=httpexceptions.HTTPServiceUnavailable, permission=NO_PERMISSION_REQUIRED)
 def service_unavailable(response, request):
-    if response.content_type != 'application/json':
-        error_msg = ('Service temporary unavailable '
-                     'due to overloading or maintenance, please retry later.')
-        response = http_error(response, errno=ERRORS.BACKEND,
-                              message=error_msg)
+    if response.content_type != "application/json":
+        error_msg = (
+            "Service temporary unavailable "
+            "due to overloading or maintenance, please retry later."
+        )
+        response = http_error(response, errno=ERRORS.BACKEND, message=error_msg)
 
-    retry_after = request.registry.settings['retry_after_seconds']
-    response.headers['Retry-After'] = str(retry_after)
+    retry_after = request.registry.settings["retry_after_seconds"]
+    response.headers["Retry-After"] = str(retry_after)
     return reapply_cors(request, response)
 
 
-@view_config(context=httpexceptions.HTTPMethodNotAllowed,
-             permission=NO_PERMISSION_REQUIRED)
+@view_config(context=httpexceptions.HTTPMethodNotAllowed, permission=NO_PERMISSION_REQUIRED)
 def method_not_allowed(context, request):
-    if context.content_type == 'application/json':
+    if context.content_type == "application/json":
         return context
 
-    response = http_error(context,
-                          errno=ERRORS.METHOD_NOT_ALLOWED,
-                          message='Method not allowed on this endpoint.')
+    response = http_error(
+        context, errno=ERRORS.METHOD_NOT_ALLOWED, message="Method not allowed on this endpoint."
+    )
     return reapply_cors(request, response)
 
 
 @view_config(context=Exception, permission=NO_PERMISSION_REQUIRED)
-@view_config(context=httpexceptions.HTTPException,
-             permission=NO_PERMISSION_REQUIRED)
+@view_config(context=httpexceptions.HTTPException, permission=NO_PERMISSION_REQUIRED)
 def error(context, request):
     """Catch server errors and trace them."""
     if isinstance(context, httpexceptions.Response):
         return reapply_cors(request, context)
 
     if isinstance(context, storage_exceptions.IntegrityError):
-        error_msg = 'Integrity constraint violated, please retry.'
-        response = http_error(httpexceptions.HTTPConflict(),
-                              errno=ERRORS.CONSTRAINT_VIOLATED,
-                              message=error_msg)
-        retry_after = request.registry.settings['retry_after_seconds']
-        response.headers['Retry-After'] = str(retry_after)
+        error_msg = "Integrity constraint violated, please retry."
+        response = http_error(
+            httpexceptions.HTTPConflict(), errno=ERRORS.CONSTRAINT_VIOLATED, message=error_msg
+        )
+        retry_after = request.registry.settings["retry_after_seconds"]
+        response.headers["Retry-After"] = str(retry_after)
         return reapply_cors(request, response)
 
     # Log some information about current request.
-    extra = {
-      'path': request.path,
-      'method': request.method,
-    }
+    extra = {"path": request.path, "method": request.method}
     qs = dict(request_GET(request))
     if qs:
-        extra['querystring'] = qs
+        extra["querystring"] = qs
     # Take errno from original exception, or undefined if unknown/unhandled.
     try:
-        extra['errno'] = context.errno.value
+        extra["errno"] = context.errno.value
     except AttributeError:
-        extra['errno'] = ERRORS.UNDEFINED.value
+        extra["errno"] = ERRORS.UNDEFINED.value
 
     if isinstance(context, storage_exceptions.BackendError):
         logger.critical(context.original, extra=extra, exc_info=context)
@@ -141,10 +132,8 @@ def error(context, request):
     # see https://github.com/python/cpython/blob/ce9e62544/Lib/logging/__init__.py#L1460-L1462
     logger.error(context, extra=extra, exc_info=context)
 
-    error_msg = 'A programmatic error occured, developers have been informed.'
-    info = request.registry.settings['error_info_link']
-    response = http_error(httpexceptions.HTTPInternalServerError(),
-                          message=error_msg,
-                          info=info)
+    error_msg = "A programmatic error occured, developers have been informed."
+    info = request.registry.settings["error_info_link"]
+    response = http_error(httpexceptions.HTTPInternalServerError(), message=error_msg, info=info)
 
     return reapply_cors(request, response)

--- a/kinto/core/views/heartbeat.py
+++ b/kinto/core/views/heartbeat.py
@@ -11,24 +11,25 @@ from kinto.core import Service
 logger = logging.getLogger(__name__)
 
 
-heartbeat = Service(name='heartbeat', path='/__heartbeat__',
-                    description='Server health')
+heartbeat = Service(name="heartbeat", path="/__heartbeat__", description="Server health")
 
 
 class HeartbeatResponseSchema(colander.MappingSchema):
-    body = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+    body = colander.SchemaNode(colander.Mapping(unknown="preserve"))
 
 
 heartbeat_responses = {
-    '200': HeartbeatResponseSchema(
-        description='Server is working properly.'),
-    '503': HeartbeatResponseSchema(
-        description='One or more subsystems failing.')
+    "200": HeartbeatResponseSchema(description="Server is working properly."),
+    "503": HeartbeatResponseSchema(description="One or more subsystems failing."),
 }
 
 
-@heartbeat.get(permission=NO_PERMISSION_REQUIRED, tags=['Utilities'],
-               operation_id='__heartbeat__', response_schemas=heartbeat_responses)
+@heartbeat.get(
+    permission=NO_PERMISSION_REQUIRED,
+    tags=["Utilities"],
+    operation_id="__heartbeat__",
+    response_schemas=heartbeat_responses,
+)
 def get_heartbeat(request):
     """Return information about server health."""
     status = {}
@@ -52,7 +53,7 @@ def get_heartbeat(request):
         futures.append(future)
 
     # Wait for the results, with timeout.
-    seconds = float(request.registry.settings['heartbeat_timeout_seconds'])
+    seconds = float(request.registry.settings["heartbeat_timeout_seconds"])
     done, not_done = wait(futures, timeout=seconds)
 
     # A heartbeat is supposed to return True or False, and never raise.
@@ -82,17 +83,19 @@ class LbHeartbeatResponseSchema(colander.MappingSchema):
 
 
 lbheartbeat_responses = {
-    '200': LbHeartbeatResponseSchema(
-        description='Returned if server is reachable.')
+    "200": LbHeartbeatResponseSchema(description="Returned if server is reachable.")
 }
 
 
-lbheartbeat = Service(name='lbheartbeat', path='/__lbheartbeat__',
-                      description='Web head health')
+lbheartbeat = Service(name="lbheartbeat", path="/__lbheartbeat__", description="Web head health")
 
 
-@lbheartbeat.get(permission=NO_PERMISSION_REQUIRED, tags=['Utilities'],
-                 operation_id='__lbheartbeat__', response_schemas=lbheartbeat_responses)
+@lbheartbeat.get(
+    permission=NO_PERMISSION_REQUIRED,
+    tags=["Utilities"],
+    operation_id="__lbheartbeat__",
+    response_schemas=lbheartbeat_responses,
+)
 def get_lbheartbeat(request):
     """Return successful healthy response.
 

--- a/kinto/core/views/hello.py
+++ b/kinto/core/views/hello.py
@@ -3,53 +3,56 @@ from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 
 from kinto.core import Service
 
-hello = Service(name='hello', path='/', description='Welcome')
+hello = Service(name="hello", path="/", description="Welcome")
 
 
 class HelloResponseSchema(colander.MappingSchema):
-    body = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+    body = colander.SchemaNode(colander.Mapping(unknown="preserve"))
 
 
 hello_response_schemas = {
-    '200': HelloResponseSchema(
-        description='Return information about the running Instance.')
+    "200": HelloResponseSchema(description="Return information about the running Instance.")
 }
 
 
-@hello.get(permission=NO_PERMISSION_REQUIRED, tags=['Utilities'],
-           operation_id='server_info', response_schemas=hello_response_schemas)
+@hello.get(
+    permission=NO_PERMISSION_REQUIRED,
+    tags=["Utilities"],
+    operation_id="server_info",
+    response_schemas=hello_response_schemas,
+)
 def get_hello(request):
     """Return information regarding the current instance."""
     settings = request.registry.settings
-    project_name = settings['project_name']
-    project_version = settings['project_version']
+    project_name = settings["project_name"]
+    project_version = settings["project_version"]
     data = dict(
         project_name=project_name,
         project_version=project_version,
-        http_api_version=settings['http_api_version'],
-        project_docs=settings['project_docs'],
-        url=request.route_url(hello.name)
+        http_api_version=settings["http_api_version"],
+        project_docs=settings["project_docs"],
+        url=request.route_url(hello.name),
     )
 
     eos = get_eos(request)
     if eos:
-        data['eos'] = eos
+        data["eos"] = eos
 
-    data['settings'] = {}
+    data["settings"] = {}
     public_settings = request.registry.public_settings
     for setting in list(public_settings):
-        data['settings'][setting] = settings[setting]
+        data["settings"][setting] = settings[setting]
 
     # If current user is authenticated, add user info:
     # (Note: this will call authenticated_userid() with multiauth+groupfinder)
     if Authenticated in request.effective_principals:
-        data['user'] = request.get_user_info()
+        data["user"] = request.get_user_info()
 
     # Application can register and expose arbitrary capabilities.
-    data['capabilities'] = request.registry.api_capabilities
+    data["capabilities"] = request.registry.api_capabilities
 
     return data
 
 
 def get_eos(request):
-    return request.registry.settings['eos']
+    return request.registry.settings["eos"]

--- a/kinto/core/views/openapi.py
+++ b/kinto/core/views/openapi.py
@@ -6,22 +6,26 @@ from kinto.core import Service
 from kinto.core.openapi import OpenAPI
 
 
-openapi = Service(name='openapi', path='/__api__', description='OpenAPI description')
+openapi = Service(name="openapi", path="/__api__", description="OpenAPI description")
 
 
 class OpenAPIResponseSchema(colander.MappingSchema):
-    body = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+    body = colander.SchemaNode(colander.Mapping(unknown="preserve"))
 
 
 openapi_response_schemas = {
-    '200': OpenAPIResponseSchema(
-        description='Return an OpenAPI description of the running instance.')
+    "200": OpenAPIResponseSchema(
+        description="Return an OpenAPI description of the running instance."
+    )
 }
 
 
-@openapi.get(permission=NO_PERMISSION_REQUIRED,
-             response_schemas=openapi_response_schemas,
-             tags=['Utilities'], operation_id='get_openapi_spec')
+@openapi.get(
+    permission=NO_PERMISSION_REQUIRED,
+    response_schemas=openapi_response_schemas,
+    tags=["Utilities"],
+    operation_id="get_openapi_spec",
+)
 def openapi_view(request):
 
     # Only build json once

--- a/kinto/core/views/version.py
+++ b/kinto/core/views/version.py
@@ -11,31 +11,34 @@ ORIGIN = os.path.dirname(HERE)
 
 
 class VersionResponseSchema(colander.MappingSchema):
-    body = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+    body = colander.SchemaNode(colander.Mapping(unknown="preserve"))
 
 
 version_response_schemas = {
-    '200': VersionResponseSchema(
-        description='Return the running Instance version information.')
+    "200": VersionResponseSchema(description="Return the running Instance version information.")
 }
 
 
-version = Service(name='version', path='/__version__', description='Version')
+version = Service(name="version", path="/__version__", description="Version")
 
 
-@version.get(permission=NO_PERMISSION_REQUIRED, tags=['Utilities'],
-             operation_id='__version__', response_schemas=version_response_schemas)
+@version.get(
+    permission=NO_PERMISSION_REQUIRED,
+    tags=["Utilities"],
+    operation_id="__version__",
+    response_schemas=version_response_schemas,
+)
 def version_view(request):
     try:
         return version_view.__json__
     except AttributeError:
         pass
 
-    location = request.registry.settings['version_json_path']
+    location = request.registry.settings["version_json_path"]
     files = [
         location,  # Default is current working dir.
-        os.path.join(ORIGIN, 'version.json'),  # Relative to the package root.
-        os.path.join(HERE, 'version.json')  # Relative to this file.
+        os.path.join(ORIGIN, "version.json"),  # Relative to the package root.
+        os.path.join(HERE, "version.json"),  # Relative to this file.
     ]
     for version_file in files:
         if os.path.exists(version_file):

--- a/kinto/plugins/accounts/__init__.py
+++ b/kinto/plugins/accounts/__init__.py
@@ -7,49 +7,51 @@ from .authentication import AccountsAuthenticationPolicy as AccountsPolicy
 from .utils import ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
 
 
-__all__ = ['ACCOUNT_CACHE_KEY', 'ACCOUNT_POLICY_NAME', 'AccountsPolicy']
+__all__ = ["ACCOUNT_CACHE_KEY", "ACCOUNT_POLICY_NAME", "AccountsPolicy"]
 
 DOCS_URL = "https://kinto.readthedocs.io/en/stable/api/1.x/accounts.html"
 
 
 def includeme(config):
     config.add_api_capability(
-        'accounts',
-        description='Manage user accounts.',
-        url='https://kinto.readthedocs.io/en/latest/api/1.x/accounts.html')
+        "accounts",
+        description="Manage user accounts.",
+        url="https://kinto.readthedocs.io/en/latest/api/1.x/accounts.html",
+    )
 
-    config.scan('kinto.plugins.accounts.views')
+    config.scan("kinto.plugins.accounts.views")
 
-    PERMISSIONS_INHERITANCE_TREE['root'].update({
-        'account:create': {}
-    })
-    PERMISSIONS_INHERITANCE_TREE['account'] = {
-        'write': {'account': ['write']},
-        'read': {'account': ['write', 'read']}
+    PERMISSIONS_INHERITANCE_TREE["root"].update({"account:create": {}})
+    PERMISSIONS_INHERITANCE_TREE["account"] = {
+        "write": {"account": ["write"]},
+        "read": {"account": ["write", "read"]},
     }
 
     settings = config.get_settings()
 
     # Check that the account policy is mentioned in config if included.
-    accountClass = 'AccountsPolicy'
+    accountClass = "AccountsPolicy"
     policy = None
     for k, v in settings.items():
-        m = re.match('multiauth\.policy\.(.*)\.use', k)
+        m = re.match("multiauth\.policy\.(.*)\.use", k)
         if m:
             if v.endswith(accountClass) or v.endswith("AccountsAuthenticationPolicy"):
                 policy = m.group(1)
 
     if not policy:
-        error_msg = ("Account policy missing the 'multiauth.policy.*.use' "
-                     "setting. See {} in docs {}.").format(accountClass, DOCS_URL)
+        error_msg = (
+            "Account policy missing the 'multiauth.policy.*.use' " "setting. See {} in docs {}."
+        ).format(accountClass, DOCS_URL)
         raise ConfigurationError(error_msg)
 
     # Add some safety to avoid weird behaviour with basicauth default policy.
-    auth_policies = settings['multiauth.policies']
-    if 'basicauth' in auth_policies and policy in auth_policies:
-        if auth_policies.index('basicauth') < auth_policies.index(policy):
-            error_msg = ("'basicauth' should not be mentioned before '%s' "
-                         "in 'multiauth.policies' setting.") % policy
+    auth_policies = settings["multiauth.policies"]
+    if "basicauth" in auth_policies and policy in auth_policies:
+        if auth_policies.index("basicauth") < auth_policies.index(policy):
+            error_msg = (
+                "'basicauth' should not be mentioned before '%s' "
+                "in 'multiauth.policies' setting."
+            ) % policy
             raise ConfigurationError(error_msg)
 
     # We assume anyone in account_create_principals is to create
@@ -58,17 +60,19 @@ def includeme(config):
     # "admin", defined as someone matching account_write_principals.
     # Therefore any account that is in account_create_principals
     # should be in account_write_principals too.
-    creators = set(settings.get('account_create_principals', '').split())
-    admins = set(settings.get('account_write_principals', '').split())
+    creators = set(settings.get("account_create_principals", "").split())
+    admins = set(settings.get("account_write_principals", "").split())
     cant_create_anything = creators.difference(admins)
     # system.Everyone isn't an account.
-    cant_create_anything.discard('system.Everyone')
+    cant_create_anything.discard("system.Everyone")
     if cant_create_anything:
-        message = ('Configuration has some principals in account_create_principals '
-                   'but not in account_write_principals. These principals will only be '
-                   'able to create their own accounts. This may not be what you want.\n'
-                   'If you want these users to be able to create accounts for other users, '
-                   'add them to account_write_principals.\n'
-                   'Affected users: {}'.format(list(cant_create_anything)))
+        message = (
+            "Configuration has some principals in account_create_principals "
+            "but not in account_write_principals. These principals will only be "
+            "able to create their own accounts. This may not be what you want.\n"
+            "If you want these users to be able to create accounts for other users, "
+            "add them to account_write_principals.\n"
+            "Affected users: {}".format(list(cant_create_anything))
+        )
 
         raise ConfigurationError(message)

--- a/kinto/plugins/accounts/authentication.py
+++ b/kinto/plugins/accounts/authentication.py
@@ -9,9 +9,9 @@ from .utils import ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
 
 def account_check(username, password, request):
     settings = request.registry.settings
-    hmac_secret = settings['userid_hmac_secret']
+    hmac_secret = settings["userid_hmac_secret"]
     cache_key = utils.hmac_digest(hmac_secret, ACCOUNT_CACHE_KEY.format(username))
-    cache_ttl = int(settings.get('account_cache_ttl_seconds', 30))
+    cache_ttl = int(settings.get("account_cache_ttl_seconds", 30))
     hashed_password = utils.hmac_digest(cache_key, password)
 
     # Check cache to see whether somebody has recently logged in with the same
@@ -28,14 +28,14 @@ def account_check(username, password, request):
     # Back to standard procedure
     parent_id = username
     try:
-        existing = request.registry.storage.get(parent_id=parent_id,
-                                                collection_id='account',
-                                                object_id=username)
+        existing = request.registry.storage.get(
+            parent_id=parent_id, collection_id="account", object_id=username
+        )
     except storage_exceptions.RecordNotFoundError:
         return None
 
-    hashed = existing['password'].encode(encoding='utf-8')
-    pwd_str = password.encode(encoding='utf-8')
+    hashed = existing["password"].encode(encoding="utf-8")
+    pwd_str = password.encode(encoding="utf-8")
     # Check if password is valid (it is a very expensive computation)
     if bcrypt.checkpw(pwd_str, hashed):
         cache.set(cache_key, hashed_password, ttl=cache_ttl)
@@ -47,6 +47,7 @@ class AccountsAuthenticationPolicy(base_auth.BasicAuthAuthenticationPolicy):
 
     It will check that the credentials exist in the account resource.
     """
+
     name = ACCOUNT_POLICY_NAME
 
     def __init__(self, *args, **kwargs):

--- a/kinto/plugins/accounts/scripts.py
+++ b/kinto/plugins/accounts/scripts.py
@@ -13,50 +13,49 @@ logger = logging.getLogger(__name__)
 
 def create_user(env, username=None, password=None):
     """Administrative command to create a new user."""
-    registry = env['registry']
+    registry = env["registry"]
     settings = registry.settings
-    readonly_mode = asbool(settings.get('readonly', False))
+    readonly_mode = asbool(settings.get("readonly", False))
     if readonly_mode:
-        message = 'Cannot create a user with a readonly server.'
+        message = "Cannot create a user with a readonly server."
         logger.error(message)
         return 51
 
-    if 'kinto.plugins.accounts' not in settings['includes']:
-        message = 'Cannot create a user when the accounts plugin is not installed.'
+    if "kinto.plugins.accounts" not in settings["includes"]:
+        message = "Cannot create a user when the accounts plugin is not installed."
         logger.error(message)
         return 52
 
     try:
         validator = AccountIdGenerator()
         if username is None:
-            username = input('Username: ')
+            username = input("Username: ")
         while not validator.match(username):
-            print('{} is not a valid username.')
-            print('Username should match {0!r}, please try again.'.format(validator.regexp))
-            username = input('Username: ')
+            print("{} is not a valid username.")
+            print("Username should match {0!r}, please try again.".format(validator.regexp))
+            username = input("Username: ")
 
         if password is None:
             while True:  # The user didn't entered twice the same password
-                password = getpass.getpass('Please enter a password for {}: '.format(username))
-                confirm = getpass.getpass('Please confirm the password: '.format(username))
+                password = getpass.getpass("Please enter a password for {}: ".format(username))
+                confirm = getpass.getpass("Please confirm the password: ".format(username))
 
                 if password != confirm:
-                    print('Sorry, passwords do not match, please try again.')
+                    print("Sorry, passwords do not match, please try again.")
                 else:
                     break
     except EOFError:
-        print('User creation aborted')
+        print("User creation aborted")
         return 53
 
     print("Creating user '{}'".format(username))
-    record = {'id': username, 'password': hash_password(password)}
-    registry.storage.update(collection_id='account',
-                            parent_id=username,
-                            object_id=username,
-                            record=record)
-    registry.permission.add_principal_to_ace('/accounts/{}'.format(username),
-                                             'write',
-                                             'account:{}'.format(username))
+    record = {"id": username, "password": hash_password(password)}
+    registry.storage.update(
+        collection_id="account", parent_id=username, object_id=username, record=record
+    )
+    registry.permission.add_principal_to_ace(
+        "/accounts/{}".format(username), "write", "account:{}".format(username)
+    )
 
     current_transaction.commit()
 

--- a/kinto/plugins/accounts/utils.py
+++ b/kinto/plugins/accounts/utils.py
@@ -1,13 +1,13 @@
 import bcrypt
 
 
-ACCOUNT_CACHE_KEY = 'accounts:{}:verified'
-ACCOUNT_POLICY_NAME = 'account'
+ACCOUNT_CACHE_KEY = "accounts:{}:verified"
+ACCOUNT_POLICY_NAME = "account"
 
 
 def hash_password(password):
     # Store password safely in database as str
     # (bcrypt.hashpw returns base64 bytes).
-    pwd_str = password.encode(encoding='utf-8')
+    pwd_str = password.encode(encoding="utf-8")
     hashed = bcrypt.hashpw(pwd_str, bcrypt.gensalt())
-    return hashed.decode(encoding='utf-8')
+    return hashed.decode(encoding="utf-8")

--- a/kinto/plugins/accounts/views.py
+++ b/kinto/plugins/accounts/views.py
@@ -16,24 +16,21 @@ from .utils import hash_password, ACCOUNT_CACHE_KEY, ACCOUNT_POLICY_NAME
 def _extract_posted_body_id(request):
     try:
         # Anonymous creation with POST.
-        return request.json['data']['id']
+        return request.json["data"]["id"]
     except (ValueError, KeyError):
         # Bad POST data.
-        if request.method.lower() == 'post':
-            error_details = {
-                'name': 'data.id',
-                'description': 'data.id in body: Required'
-            }
+        if request.method.lower() == "post":
+            error_details = {"name": "data.id", "description": "data.id in body: Required"}
             raise_invalid(request, **error_details)
         # Anonymous GET
-        error_msg = 'Cannot read accounts.'
+        error_msg = "Cannot read accounts."
         raise http_error(httpexceptions.HTTPUnauthorized(), error=error_msg)
 
 
 class AccountIdGenerator(NameGenerator):
     """Allow @ signs in account IDs."""
 
-    regexp = r'^[a-zA-Z0-9][.@a-zA-Z0-9_-]*$'
+    regexp = r"^[a-zA-Z0-9][.@a-zA-Z0-9_-]*$"
 
 
 class AccountSchema(resource.ResourceSchema):
@@ -47,9 +44,10 @@ class Account(resource.ShareableResource):
 
     def __init__(self, request, context):
         # Store if current user is administrator (before accessing get_parent_id())
-        allowed_from_settings = request.registry.settings.get('account_write_principals', [])
-        context.is_administrator = len(set(aslist(allowed_from_settings)) &
-                                       set(request.prefixed_principals)) > 0
+        allowed_from_settings = request.registry.settings.get("account_write_principals", [])
+        context.is_administrator = (
+            len(set(aslist(allowed_from_settings)) & set(request.prefixed_principals)) > 0
+        )
         # Shortcut to check if current is anonymous (before get_parent_id()).
         context.is_anonymous = Authenticated not in request.effective_principals
 
@@ -58,8 +56,9 @@ class Account(resource.ShareableResource):
         # Overwrite the current principal set by ShareableResource.
         if self.model.current_principal == Everyone or context.is_administrator:
             # Creation is anonymous, but author with write perm is this:
-            self.model.current_principal = '{}:{}'.format(ACCOUNT_POLICY_NAME,
-                                                          self.model.parent_id)
+            self.model.current_principal = "{}:{}".format(
+                ACCOUNT_POLICY_NAME, self.model.parent_id
+            )
 
     @reify
     def id_generator(self):
@@ -75,38 +74,36 @@ class Account(resource.ShareableResource):
         if self.context.is_administrator:
             if self.context.on_collection:
                 # Accounts created by admin should have userid as parent.
-                if request.method.lower() == 'post':
+                if request.method.lower() == "post":
                     return _extract_posted_body_id(request)
                 else:
                     # Admin see all accounts.
-                    return '*'
+                    return "*"
             else:
                 # No pattern matching for admin on single record.
-                return request.matchdict['id']
+                return request.matchdict["id"]
 
         if not self.context.is_anonymous:
             # Authenticated users see their own account only.
             return request.selected_userid
 
         # Anonymous creation with PUT.
-        if 'id' in request.matchdict:
-            return request.matchdict['id']
+        if "id" in request.matchdict:
+            return request.matchdict["id"]
 
         return _extract_posted_body_id(request)
 
     def collection_post(self):
         result = super(Account, self).collection_post()
         if self.context.is_anonymous and self.request.response.status_code == 200:
-            error_details = {
-                'message': 'Account ID %r already exists' % result['data']['id']
-            }
+            error_details = {"message": "Account ID %r already exists" % result["data"]["id"]}
             raise http_error(httpexceptions.HTTPForbidden(), **error_details)
         return result
 
     def process_record(self, new, old=None):
         new = super(Account, self).process_record(new, old)
 
-        new['password'] = hash_password(new['password'])
+        new["password"] = hash_password(new["password"])
 
         # Administrators can reach other accounts and anonymous have no
         # selected_userid. So do not try to enforce.
@@ -115,17 +112,14 @@ class Account(resource.ShareableResource):
 
         # Do not let accounts be created without usernames.
         if self.model.id_field not in new:
-            error_details = {
-                'name': 'data.id',
-                'description': 'Accounts must have an ID.',
-            }
+            error_details = {"name": "data.id", "description": "Accounts must have an ID."}
             raise_invalid(self.request, **error_details)
 
         # Otherwise, we force the id to match the authenticated username.
         if new[self.model.id_field] != self.request.selected_userid:
             error_details = {
-                'name': 'data.id',
-                'description': 'Username and account ID do not match.',
+                "name": "data.id",
+                "description": "Username and account ID do not match.",
             }
             raise_invalid(self.request, **error_details)
 
@@ -133,16 +127,16 @@ class Account(resource.ShareableResource):
 
 
 # Clear cache on account change
-@subscriber(ResourceChanged,
-            for_resources=('account',),
-            for_actions=(ACTIONS.UPDATE, ACTIONS.DELETE))
+@subscriber(
+    ResourceChanged, for_resources=("account",), for_actions=(ACTIONS.UPDATE, ACTIONS.DELETE)
+)
 def on_account_changed(event):
     request = event.request
     cache = request.registry.cache
     settings = request.registry.settings
     # Extract username and password from current user
-    username = request.matchdict['id']
-    hmac_secret = settings['userid_hmac_secret']
+    username = request.matchdict["id"]
+    hmac_secret = settings["userid_hmac_secret"]
     cache_key = utils.hmac_digest(hmac_secret, ACCOUNT_CACHE_KEY.format(username))
     # Delete cache
     cache.delete(cache_key)

--- a/kinto/plugins/admin/__init__.py
+++ b/kinto/plugins/admin/__init__.py
@@ -14,27 +14,27 @@ def includeme(config):
     # Process settings to remove storage wording.
 
     # Read version from package.json
-    package_json = json.load(open(os.path.join(HERE, 'package.json')))
-    admin_version = package_json['dependencies']['kinto-admin']
+    package_json = json.load(open(os.path.join(HERE, "package.json")))
+    admin_version = package_json["dependencies"]["kinto-admin"]
 
     # Expose capability.
     config.add_api_capability(
-        'admin',
+        "admin",
         version=admin_version,
-        description='Serves the admin console.',
-        url='https://github.com/Kinto/kinto-admin/',
+        description="Serves the admin console.",
+        url="https://github.com/Kinto/kinto-admin/",
     )
 
-    config.add_route('admin_home', '/admin/')
-    config.add_view(admin_home_view, route_name='admin_home')
+    config.add_route("admin_home", "/admin/")
+    config.add_view(admin_home_view, route_name="admin_home")
 
-    build_dir = static_view('kinto.plugins.admin:build', use_subpath=True)
-    config.add_route('catchall_static', '/admin/*subpath')
-    config.add_view(build_dir, route_name='catchall_static')
+    build_dir = static_view("kinto.plugins.admin:build", use_subpath=True)
+    config.add_route("catchall_static", "/admin/*subpath")
+    config.add_view(build_dir, route_name="catchall_static")
 
     # Setup redirect without trailing slash.
     def admin_redirect_view(request):
-        raise HTTPTemporaryRedirect(request.path + '/')
+        raise HTTPTemporaryRedirect(request.path + "/")
 
-    config.add_route('admin_redirect', '/admin')
-    config.add_view(admin_redirect_view, route_name='admin_redirect')
+    config.add_route("admin_redirect", "/admin")
+    config.add_view(admin_redirect_view, route_name="admin_redirect")

--- a/kinto/plugins/admin/release_hook.py
+++ b/kinto/plugins/admin/release_hook.py
@@ -19,4 +19,4 @@ def after_checkout(data):
 
         The ``node_modules`` folder is excluded using :file:`MANIFEST.in`.
     """
-    subprocess.run(['make', 'build-kinto-admin'])
+    subprocess.run(["make", "build-kinto-admin"])

--- a/kinto/plugins/admin/views.py
+++ b/kinto/plugins/admin/views.py
@@ -9,9 +9,9 @@ HERE = os.path.dirname(__file__)
 @cache_forever
 def admin_home_view(request):
     try:
-        with open(os.path.join(HERE, 'build/index.html')) as f:
+        with open(os.path.join(HERE, "build/index.html")) as f:
             page_content = f.read()
     except FileNotFoundError:  # pragma: no cover
-        with open(os.path.join(HERE, 'public/help.html')) as f:
+        with open(os.path.join(HERE, "public/help.html")) as f:
             page_content = f.read()
     return page_content

--- a/kinto/plugins/flush.py
+++ b/kinto/plugins/flush.py
@@ -4,9 +4,7 @@ from pyramid.security import NO_PERMISSION_REQUIRED
 from kinto.events import ServerFlushed
 
 
-flush = Service(name='flush',
-                description='Clear database content',
-                path='/__flush__')
+flush = Service(name="flush", description="Clear database content", path="/__flush__")
 
 
 @flush.post(permission=NO_PERMISSION_REQUIRED)
@@ -23,9 +21,8 @@ def flush_post(request):
 
 def includeme(config):
     config.add_api_capability(
-        'flush_endpoint',
-        description='The __flush__ endpoint can be used to remove '
-                    'all data from all backends.',
-        url='https://kinto.readthedocs.io/en/latest/api/1.x/flush.html'
+        "flush_endpoint",
+        description="The __flush__ endpoint can be used to remove " "all data from all backends.",
+        url="https://kinto.readthedocs.io/en/latest/api/1.x/flush.html",
     )
     config.add_cornice_service(flush)

--- a/kinto/plugins/history/__init__.py
+++ b/kinto/plugins/history/__init__.py
@@ -6,32 +6,27 @@ from .listener import on_resource_changed
 
 def includeme(config):
     config.add_api_capability(
-        'history',
-        description='Track changes on data.',
-        url='http://kinto.readthedocs.io/en/latest/api/1.x/history.html')
+        "history",
+        description="Track changes on data.",
+        url="http://kinto.readthedocs.io/en/latest/api/1.x/history.html",
+    )
 
     # Activate end-points.
-    config.scan('kinto.plugins.history.views')
+    config.scan("kinto.plugins.history.views")
 
     # If StatsD is enabled, monitor execution time of listener.
     listener = on_resource_changed
     if config.registry.statsd:
-        key = 'plugins.history'
+        key = "plugins.history"
         listener = config.registry.statsd.timer(key)(on_resource_changed)
 
     # Listen to every resources (except history)
-    config.add_subscriber(listener, ResourceChanged,
-                          for_resources=('bucket', 'group',
-                                         'collection', 'record'))
+    config.add_subscriber(
+        listener, ResourceChanged, for_resources=("bucket", "group", "collection", "record")
+    )
 
     # Register the permission inheritance for history entries.
-    PERMISSIONS_INHERITANCE_TREE['history'] = {
-        'read': {
-            'bucket': ['write', 'read'],
-            'history': ['write', 'read']
-        },
-        'write': {
-            'bucket': ['write'],
-            'history': ['write']
-        },
+    PERMISSIONS_INHERITANCE_TREE["history"] = {
+        "read": {"bucket": ["write", "read"], "history": ["write", "read"]},
+        "write": {"bucket": ["write"], "history": ["write"]},
     }

--- a/kinto/plugins/history/listener.py
+++ b/kinto/plugins/history/listener.py
@@ -11,8 +11,8 @@ def on_resource_changed(event):
     :mod:`kinto.plugins.history.views` module.
     """
     payload = event.payload
-    resource_name = payload['resource_name']
-    event_uri = payload['uri']
+    resource_name = payload["resource_name"]
+    event_uri = payload["uri"]
 
     bucket_id = None
     bucket_uri = None
@@ -22,41 +22,40 @@ def on_resource_changed(event):
     permission = event.request.registry.permission
     settings = event.request.registry.settings
 
-    excluded_resources = aslist(settings.get('history.exclude_resources', ''))
+    excluded_resources = aslist(settings.get("history.exclude_resources", ""))
 
     targets = []
     for impacted in event.impacted_records:
-        target = impacted['new']
-        obj_id = target['id']
+        target = impacted["new"]
+        obj_id = target["id"]
 
         try:
-            bucket_id = payload['bucket_id']
+            bucket_id = payload["bucket_id"]
         except KeyError:
             # e.g. DELETE /buckets
             bucket_id = obj_id
-        bucket_uri = instance_uri(event.request, 'bucket', id=bucket_id)
+        bucket_uri = instance_uri(event.request, "bucket", id=bucket_id)
 
         if bucket_uri in excluded_resources:
             continue
 
-        if 'collection_id' in payload:
-            collection_id = payload['collection_id']
-            collection_uri = instance_uri(event.request,
-                                          'collection',
-                                          bucket_id=bucket_id,
-                                          id=collection_id)
+        if "collection_id" in payload:
+            collection_id = payload["collection_id"]
+            collection_uri = instance_uri(
+                event.request, "collection", bucket_id=bucket_id, id=collection_id
+            )
             if collection_uri in excluded_resources:
                 continue
 
         # On POST .../records, the URI does not contain the newly created
         # record id.
-        parts = event_uri.split('/')
+        parts = event_uri.split("/")
         if resource_name in parts[-1]:
             parts.append(obj_id)
         else:
             # Make sure the id is correct on grouped events.
             parts[-1] = obj_id
-        uri = '/'.join(parts)
+        uri = "/".join(parts)
 
         if uri in excluded_resources:
             continue
@@ -83,38 +82,38 @@ def on_resource_changed(event):
 
     # The principals allowed to read the bucket and collection.
     # (Note: ``write`` means ``read``)
-    read_principals = set(bucket_perms.get('read', []))
-    read_principals.update(bucket_perms.get('write', []))
-    read_principals.update(collection_perms.get('read', []))
-    read_principals.update(collection_perms.get('write', []))
+    read_principals = set(bucket_perms.get("read", []))
+    read_principals.update(bucket_perms.get("write", []))
+    read_principals.update(collection_perms.get("read", []))
+    read_principals.update(collection_perms.get("write", []))
 
     # Create a history entry for each impacted record.
     for (uri, target) in targets:
-        obj_id = target['id']
+        obj_id = target["id"]
         # Prepare the history entry attributes.
         perms = {k: list(v) for k, v in perms_by_object_id[uri].items()}
         eventattrs = dict(**payload)
-        eventattrs.pop('timestamp', None)  # Already in target `last_modified`.
-        eventattrs.pop('bucket_id', None)
-        eventattrs['{}_id'.format(resource_name)] = obj_id
-        eventattrs['uri'] = uri
-        attrs = dict(date=datetime.now().isoformat(),
-                     target={'data': target, 'permissions': perms},
-                     **eventattrs)
+        eventattrs.pop("timestamp", None)  # Already in target `last_modified`.
+        eventattrs.pop("bucket_id", None)
+        eventattrs["{}_id".format(resource_name)] = obj_id
+        eventattrs["uri"] = uri
+        attrs = dict(
+            date=datetime.now().isoformat(),
+            target={"data": target, "permissions": perms},
+            **eventattrs
+        )
 
         # Create a record for the 'history' resource, whose parent_id is
         # the bucket URI (c.f. views.py).
         # Note: this will be rolledback if the transaction is rolledback.
-        entry = storage.create(parent_id=bucket_uri,
-                               collection_id='history',
-                               record=attrs)
+        entry = storage.create(parent_id=bucket_uri, collection_id="history", record=attrs)
 
         # The read permission on the newly created history entry is the union
         # of the record permissions with the one from bucket and collection.
         entry_principals = set(read_principals)
-        entry_principals.update(perms.get('read', []))
-        entry_principals.update(perms.get('write', []))
-        entry_perms = {'read': list(entry_principals)}
+        entry_principals.update(perms.get("read", []))
+        entry_principals.update(perms.get("write", []))
+        entry_perms = {"read": list(entry_principals)}
         # /buckets/{id}/history is the URI for the list of history entries.
-        entry_perm_id = '/buckets/{}/history/{}'.format(bucket_id, entry['id'])
+        entry_perm_id = "/buckets/{}/history/{}".format(bucket_id, entry["id"])
         permission.replace_object_permissions(entry_perm_id, entry_perms)

--- a/kinto/plugins/history/views.py
+++ b/kinto/plugins/history/views.py
@@ -23,35 +23,43 @@ class HistorySchema(resource.ResourceSchema):
 
 
 # Add custom OpenAPI tags/operation ids
-collection_get_arguments = getattr(ViewSet, 'collection_get_arguments', {})
-collection_delete_arguments = getattr(ViewSet, 'collection_delete_arguments', {})
+collection_get_arguments = getattr(ViewSet, "collection_get_arguments", {})
+collection_delete_arguments = getattr(ViewSet, "collection_delete_arguments", {})
 
-get_history_arguments = {'tags': ['History'], 'operation_id': 'get_history',
-                         **collection_get_arguments}
-delete_history_arguments = {'tags': ['History'], 'operation_id': 'delete_history',
-                            **collection_delete_arguments}
+get_history_arguments = {
+    "tags": ["History"],
+    "operation_id": "get_history",
+    **collection_get_arguments,
+}
+delete_history_arguments = {
+    "tags": ["History"],
+    "operation_id": "delete_history",
+    **collection_delete_arguments,
+}
 
 
-@resource.register(name='history',
-                   collection_path='/buckets/{{bucket_id}}/history',
-                   record_path=None,
-                   collection_methods=('GET', 'DELETE'),
-                   default_arguments={'tags': ['History']},
-                   collection_get_arguments=get_history_arguments,
-                   collection_delete_arguments=delete_history_arguments)
+@resource.register(
+    name="history",
+    collection_path="/buckets/{{bucket_id}}/history",
+    record_path=None,
+    collection_methods=("GET", "DELETE"),
+    default_arguments={"tags": ["History"]},
+    collection_get_arguments=get_history_arguments,
+    collection_delete_arguments=delete_history_arguments,
+)
 class History(resource.ShareableResource):
 
     schema = HistorySchema
 
     def get_parent_id(self, request):
-        self.bucket_id = request.matchdict['bucket_id']
-        return instance_uri(request, 'bucket', id=self.bucket_id)
+        self.bucket_id = request.matchdict["bucket_id"]
+        return instance_uri(request, "bucket", id=self.bucket_id)
 
     def _extract_filters(self):
         filters = super()._extract_filters()
         filters_str_id = []
         for filt in filters:
-            if filt.field in ('record_id', 'collection_id', 'bucket_id'):
+            if filt.field in ("record_id", "collection_id", "bucket_id"):
                 if isinstance(filt.value, int):
                     filt = Filter(filt.field, str(filt.value), filt.operator)
             filters_str_id.append(filt)

--- a/kinto/plugins/openid/__init__.py
+++ b/kinto/plugins/openid/__init__.py
@@ -1,4 +1,3 @@
-
 import requests
 from pyramid import authentication as base_auth
 from pyramid.settings import aslist
@@ -14,14 +13,14 @@ from .utils import fetch_openid_config
 
 @implementer(IAuthenticationPolicy)
 class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
-    def __init__(self, issuer, client_id, realm='Realm', **kwargs):
+    def __init__(self, issuer, client_id, realm="Realm", **kwargs):
         self.realm = realm
         self.issuer = issuer
         self.client_id = client_id
-        self.client_secret = kwargs.get('client_secret', '')
-        self.header_type = kwargs.get('header_type', 'Bearer')
-        self.userid_field = kwargs.get('userid_field', 'sub')
-        self.verification_ttl = int(kwargs.get('verification_ttl_seconds', 86400))
+        self.client_secret = kwargs.get("client_secret", "")
+        self.header_type = kwargs.get("header_type", "Bearer")
+        self.userid_field = kwargs.get("userid_field", "sub")
+        self.verification_ttl = int(kwargs.get("verification_ttl_seconds", 86400))
 
         # Fetch OpenID config (at instantiation, ie. startup)
         self.oid_config = fetch_openid_config(issuer)
@@ -32,11 +31,11 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
         """Return the userid or ``None`` if token could not be verified.
         """
         settings = request.registry.settings
-        hmac_secret = settings['userid_hmac_secret']
+        hmac_secret = settings["userid_hmac_secret"]
 
-        authorization = request.headers.get('Authorization', '')
+        authorization = request.headers.get("Authorization", "")
         try:
-            authmeth, access_token = authorization.split(' ', 1)
+            authmeth, access_token = authorization.split(" ", 1)
         except ValueError:
             return None
 
@@ -48,7 +47,7 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
 
         # Check cache if these tokens were already verified.
         hmac_tokens = core_utils.hmac_digest(hmac_secret, access_token)
-        cache_key = 'openid:verify:{}'.format(hmac_tokens)
+        cache_key = "openid:verify:{}".format(hmac_tokens)
         payload = request.registry.cache.get(cache_key)
         if payload is None:
             # This can take some time.
@@ -64,32 +63,32 @@ class OpenIDConnectPolicy(base_auth.CallbackAuthenticationPolicy):
         """A no-op. Credentials are sent on every request.
         Return WWW-Authenticate Realm header for Bearer token.
         """
-        return [('WWW-Authenticate', '%s realm="%s"' % (self.header_type, self.realm))]
+        return [("WWW-Authenticate", '%s realm="%s"' % (self.header_type, self.realm))]
 
     def _verify_token(self, access_token):
-        uri = self.oid_config['userinfo_endpoint']
+        uri = self.oid_config["userinfo_endpoint"]
         # Opaque access token string. Fetch user info from profile.
         try:
-            resp = requests.get(uri, headers={'Authorization': 'Bearer ' + access_token})
+            resp = requests.get(uri, headers={"Authorization": "Bearer " + access_token})
             resp.raise_for_status()
             userprofile = resp.json()
             return userprofile
 
         except (requests.exceptions.HTTPError, ValueError, KeyError) as e:
-            logger.debug('Unable to fetch user profile from %s (%s)' % (uri, e))
+            logger.debug("Unable to fetch user profile from %s (%s)" % (uri, e))
             return None
 
 
 def includeme(config):
     # Activate end-points.
-    config.scan('kinto.plugins.openid.views')
+    config.scan("kinto.plugins.openid.views")
 
     settings = config.get_settings()
 
     openid_policies = []
-    for policy in aslist(settings['multiauth.policies']):
-        v = settings.get('multiauth.policy.%s.use' % policy, '')
-        if v.endswith('OpenIDConnectPolicy'):
+    for policy in aslist(settings["multiauth.policies"]):
+        v = settings.get("multiauth.policy.%s.use" % policy, "")
+        if v.endswith("OpenIDConnectPolicy"):
             openid_policies.append(policy)
 
     if len(openid_policies) == 0:
@@ -98,28 +97,30 @@ def includeme(config):
 
     providers_infos = []
     for name in openid_policies:
-        issuer = settings['multiauth.policy.%s.issuer' % name]
+        issuer = settings["multiauth.policy.%s.issuer" % name]
         openid_config = fetch_openid_config(issuer)
 
-        client_id = settings['multiauth.policy.%s.client_id' % name]
-        header_type = settings.get('multiauth.policy.%s.header_type', 'Bearer')
+        client_id = settings["multiauth.policy.%s.client_id" % name]
+        header_type = settings.get("multiauth.policy.%s.header_type", "Bearer")
 
-        providers_infos.append({
-            'name': name,
-            'issuer': openid_config['issuer'],
-            'auth_path': '/openid/%s/login' % name,
-            'client_id': client_id,
-            'header_type': header_type,
-            'userinfo_endpoint': openid_config['userinfo_endpoint'],
-        })
+        providers_infos.append(
+            {
+                "name": name,
+                "issuer": openid_config["issuer"],
+                "auth_path": "/openid/%s/login" % name,
+                "client_id": client_id,
+                "header_type": header_type,
+                "userinfo_endpoint": openid_config["userinfo_endpoint"],
+            }
+        )
 
-        OpenAPI.expose_authentication_method(name, {
-            'type': 'oauth2',
-            'authorizationUrl': openid_config['authorization_endpoint'],
-        })
+        OpenAPI.expose_authentication_method(
+            name, {"type": "oauth2", "authorizationUrl": openid_config["authorization_endpoint"]}
+        )
 
     config.add_api_capability(
-        'openid',
-        description='OpenID connect support.',
-        url='http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html',
-        providers=providers_infos)
+        "openid",
+        description="OpenID connect support.",
+        url="http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html",
+        providers=providers_infos,
+    )

--- a/kinto/plugins/openid/utils.py
+++ b/kinto/plugins/openid/utils.py
@@ -8,7 +8,7 @@ def fetch_openid_config(issuer):
     global _configs
 
     if issuer not in _configs:
-        resp = requests.get(issuer.rstrip('/') + '/.well-known/openid-configuration')
+        resp = requests.get(issuer.rstrip("/") + "/.well-known/openid-configuration")
         _configs[issuer] = resp.json()
 
     return _configs[issuer]

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -20,17 +20,19 @@ DEFAULT_STATE_LENGTH = 32
 
 class RedirectHeadersSchema(colander.MappingSchema):
     """Redirect response headers."""
-    location = colander.SchemaNode(colander.String(), name='Location')
+
+    location = colander.SchemaNode(colander.String(), name="Location")
 
 
 class RedirectResponseSchema(colander.MappingSchema):
     """Redirect response schema."""
+
     headers = RedirectHeadersSchema()
 
 
 response_schemas = {
-    '307': RedirectResponseSchema(description='Successful redirection.'),
-    '400': ErrorResponseSchema(description='The request is invalid.'),
+    "307": RedirectResponseSchema(description="Successful redirection."),
+    "400": ErrorResponseSchema(description="The request is invalid."),
 }
 
 
@@ -39,80 +41,88 @@ def provider_validator(request, **kwargs):
     This validator verifies that the validator in URL (eg. /openid/auth0/login)
     is a configured OpenIDConnect policy.
     """
-    provider = request.matchdict['provider']
-    used = request.registry.settings.get('multiauth.policy.%s.use' % provider, '')
-    if not used.endswith('OpenIDConnectPolicy'):
-        request.errors.add('path', 'provider', 'Unknow provider %r' % provider)
+    provider = request.matchdict["provider"]
+    used = request.registry.settings.get("multiauth.policy.%s.use" % provider, "")
+    if not used.endswith("OpenIDConnectPolicy"):
+        request.errors.add("path", "provider", "Unknow provider %r" % provider)
 
 
 class LoginQuerystringSchema(colander.MappingSchema):
     """
     Querystring schema for the login endpoint.
     """
+
     callback = URL()
     scope = colander.SchemaNode(colander.String())
-    prompt = colander.SchemaNode(colander.String(),
-                                 validator=colander.Regex("none"),
-                                 missing=colander.drop)
+    prompt = colander.SchemaNode(
+        colander.String(), validator=colander.Regex("none"), missing=colander.drop
+    )
 
 
 class LoginSchema(colander.MappingSchema):
     querystring = LoginQuerystringSchema()
 
 
-login = Service(name='openid_login',
-                path='/openid/{provider}/login',
-                description='Initiate the OAuth2 login')
+login = Service(
+    name="openid_login", path="/openid/{provider}/login", description="Initiate the OAuth2 login"
+)
 
 
-@login.get(schema=LoginSchema(),
-           validators=(colander_validator, provider_validator),
-           response_schemas=response_schemas)
+@login.get(
+    schema=LoginSchema(),
+    validators=(colander_validator, provider_validator),
+    response_schemas=response_schemas,
+)
 def get_login(request):
     """Initiates to login dance for the specified scopes and callback URI
     using appropriate redirections."""
 
     # Settings.
-    provider = request.matchdict['provider']
-    settings_prefix = 'multiauth.policy.%s.' % provider
-    issuer = request.registry.settings[settings_prefix + 'issuer']
-    client_id = request.registry.settings[settings_prefix + 'client_id']
-    userid_field = request.registry.settings.get(settings_prefix + 'userid_field')
-    state_ttl = int(request.registry.settings.get(settings_prefix + 'state_ttl_seconds',
-                                                  DEFAULT_STATE_TTL_SECONDS))
-    state_length = int(request.registry.settings.get(settings_prefix + 'state_length',
-                                                     DEFAULT_STATE_LENGTH))
+    provider = request.matchdict["provider"]
+    settings_prefix = "multiauth.policy.%s." % provider
+    issuer = request.registry.settings[settings_prefix + "issuer"]
+    client_id = request.registry.settings[settings_prefix + "client_id"]
+    userid_field = request.registry.settings.get(settings_prefix + "userid_field")
+    state_ttl = int(
+        request.registry.settings.get(
+            settings_prefix + "state_ttl_seconds", DEFAULT_STATE_TTL_SECONDS
+        )
+    )
+    state_length = int(
+        request.registry.settings.get(settings_prefix + "state_length", DEFAULT_STATE_LENGTH)
+    )
 
     # Read OpenID configuration (cached by issuer)
     oid_config = fetch_openid_config(issuer)
-    auth_endpoint = oid_config['authorization_endpoint']
+    auth_endpoint = oid_config["authorization_endpoint"]
 
-    scope = request.GET['scope']
-    callback = request.GET['callback']
-    prompt = request.GET.get('prompt')
+    scope = request.GET["scope"]
+    callback = request.GET["callback"]
+    prompt = request.GET.get("prompt")
 
     # Check that email scope is requested if userid field is configured as email.
-    if userid_field == 'email' and 'email' not in scope:
+    if userid_field == "email" and "email" not in scope:
         error_details = {
-            'name': 'scope',
-            'description': "Provider %s requires 'email' scope" % provider,
+            "name": "scope",
+            "description": "Provider %s requires 'email' scope" % provider,
         }
         raise_invalid(request, **error_details)
 
     # Generate a random string as state.
     # And save it until code is traded.
     state = random_bytes_hex(state_length)
-    request.registry.cache.set('openid:state:' + state, callback, ttl=state_ttl)
+    request.registry.cache.set("openid:state:" + state, callback, ttl=state_ttl)
 
     # Redirect the client to the Identity Provider that will eventually redirect
     # to the OpenID token endpoint.
-    token_uri = request.route_url('openid_token', provider=provider) + '?'
-    params = dict(client_id=client_id, response_type='code', scope=scope,
-                  redirect_uri=token_uri, state=state)
+    token_uri = request.route_url("openid_token", provider=provider) + "?"
+    params = dict(
+        client_id=client_id, response_type="code", scope=scope, redirect_uri=token_uri, state=state
+    )
     if prompt:
         # The 'prompt' parameter is optional.
-        params['prompt'] = prompt
-    redirect = '{}?{}'.format(auth_endpoint, urllib.parse.urlencode(params))
+        params["prompt"] = prompt
+    redirect = "{}?{}".format(auth_endpoint, urllib.parse.urlencode(params))
     raise httpexceptions.HTTPTemporaryRedirect(redirect)
 
 
@@ -120,6 +130,7 @@ class TokenQuerystringSchema(colander.MappingSchema):
     """
     Querystring schema for the token endpoint.
     """
+
     code = colander.SchemaNode(colander.String())
     state = colander.SchemaNode(colander.String())
 
@@ -128,51 +139,48 @@ class TokenSchema(colander.MappingSchema):
     querystring = TokenQuerystringSchema()
 
 
-token = Service(name='openid_token',
-                path='/openid/{provider}/token',
-                description='')
+token = Service(name="openid_token", path="/openid/{provider}/token", description="")
 
 
-@token.get(schema=TokenSchema(),
-           validators=(colander_validator, provider_validator))
+@token.get(schema=TokenSchema(), validators=(colander_validator, provider_validator))
 def get_token(request):
     """Trades the specified code and state against access and ID tokens.
     The client is redirected to the original ``callback`` URI with the
     result in querystring."""
 
     # Settings.
-    provider = request.matchdict['provider']
-    settings_prefix = 'multiauth.policy.%s.' % provider
-    issuer = request.registry.settings[settings_prefix + 'issuer']
-    client_id = request.registry.settings[settings_prefix + 'client_id']
-    client_secret = request.registry.settings[settings_prefix + 'client_secret']
+    provider = request.matchdict["provider"]
+    settings_prefix = "multiauth.policy.%s." % provider
+    issuer = request.registry.settings[settings_prefix + "issuer"]
+    client_id = request.registry.settings[settings_prefix + "client_id"]
+    client_secret = request.registry.settings[settings_prefix + "client_secret"]
 
     # Read OpenID configuration (cached by issuer)
     oid_config = fetch_openid_config(issuer)
-    token_endpoint = oid_config['token_endpoint']
+    token_endpoint = oid_config["token_endpoint"]
 
-    code = request.GET['code']
-    state = request.GET['state']
+    code = request.GET["code"]
+    state = request.GET["state"]
 
     # State can be used only once.
-    callback = request.registry.cache.delete('openid:state:' + state)
+    callback = request.registry.cache.delete("openid:state:" + state)
     if callback is None:
         error_details = {
-            'name': 'state',
-            'description': 'Invalid state',
-            'errno': ERRORS.INVALID_AUTH_TOKEN.value,
+            "name": "state",
+            "description": "Invalid state",
+            "errno": ERRORS.INVALID_AUTH_TOKEN.value,
         }
         raise_invalid(request, **error_details)
 
     # Trade the code for tokens on the Identity Provider.
     # Google Identity requires to specify again redirect_uri.
-    redirect_uri = request.route_url('openid_token', provider=provider) + '?'
+    redirect_uri = request.route_url("openid_token", provider=provider) + "?"
     data = {
-        'code': code,
-        'client_id': client_id,
-        'client_secret': client_secret,
-        'redirect_uri': redirect_uri,
-        'grant_type': 'authorization_code',
+        "code": code,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "grant_type": "authorization_code",
     }
     resp = requests.post(token_endpoint, data=data)
 

--- a/kinto/plugins/quotas/__init__.py
+++ b/kinto/plugins/quotas/__init__.py
@@ -4,18 +4,19 @@ from .listener import on_resource_changed
 
 
 def includeme(config):
-    config.add_api_capability('quotas',
-                              description='Quotas Management on buckets '
-                                          'and collections.',
-                              url='https://kinto.readthedocs.io')
+    config.add_api_capability(
+        "quotas",
+        description="Quotas Management on buckets " "and collections.",
+        url="https://kinto.readthedocs.io",
+    )
 
     # If StatsD is enabled, monitor execution time of listener.
     listener = on_resource_changed
     if config.registry.statsd:
-        key = 'plugins.quotas'
+        key = "plugins.quotas"
         listener = config.registry.statsd.timer(key)(on_resource_changed)
 
     # Listen to every resources (except history)
-    config.add_subscriber(listener, ResourceChanged,
-                          for_resources=('bucket', 'group',
-                                         'collection', 'record'))
+    config.add_subscriber(
+        listener, ResourceChanged, for_resources=("bucket", "group", "collection", "record")
+    )

--- a/kinto/plugins/quotas/listener.py
+++ b/kinto/plugins/quotas/listener.py
@@ -8,33 +8,35 @@ from kinto.core.utils import instance_uri
 from .utils import record_size
 
 
-QUOTA_RESOURCE_NAME = 'quota'
-BUCKET_QUOTA_OBJECT_ID = 'bucket_info'
-COLLECTION_QUOTA_OBJECT_ID = 'collection_info'
+QUOTA_RESOURCE_NAME = "quota"
+BUCKET_QUOTA_OBJECT_ID = "bucket_info"
+COLLECTION_QUOTA_OBJECT_ID = "collection_info"
 
 
 def raise_insufficient_storage(message):
-    raise http_error(HTTPInsufficientStorage(),
-                     errno=ERRORS.FORBIDDEN.value,
-                     message=message)
+    raise http_error(HTTPInsufficientStorage(), errno=ERRORS.FORBIDDEN.value, message=message)
 
 
 def get_bucket_settings(settings, bucket_id, name):
     return settings.get(
         # Bucket specific
-        'quotas.bucket_{}_{}'.format(bucket_id, name),
+        "quotas.bucket_{}_{}".format(bucket_id, name),
         # Global to all buckets
-        settings.get('quotas.bucket_{}'.format(name), None))
+        settings.get("quotas.bucket_{}".format(name), None),
+    )
 
 
 def get_collection_settings(settings, bucket_id, collection_id, name):
     return settings.get(
         # Specific for a given bucket collection
-        'quotas.collection_{}_{}_{}'.format(bucket_id, collection_id, name),
+        "quotas.collection_{}_{}_{}".format(bucket_id, collection_id, name),
         # Specific to given bucket collections
-        settings.get('quotas.collection_{}_{}'.format(bucket_id, name),
-                     # Global to all buckets collections
-                     settings.get('quotas.collection_{}'.format(name), None)))
+        settings.get(
+            "quotas.collection_{}_{}".format(bucket_id, name),
+            # Global to all buckets collections
+            settings.get("quotas.collection_{}".format(name), None),
+        ),
+    )
 
 
 def on_resource_changed(event):
@@ -45,85 +47,80 @@ def on_resource_changed(event):
     If a new object exceeds the quotas, we reject the request.
     """
     payload = event.payload
-    action = payload['action']
-    resource_name = payload['resource_name']
+    action = payload["action"]
+    resource_name = payload["resource_name"]
 
-    if action == 'delete' and resource_name == 'bucket':
+    if action == "delete" and resource_name == "bucket":
         # Deleting a bucket already deletes everything underneath (including
         # quotas info). See kinto/views/bucket.
         return
 
     settings = event.request.registry.settings
 
-    event_uri = payload['uri']
-    bucket_id = payload['bucket_id']
-    bucket_uri = instance_uri(event.request, 'bucket', id=bucket_id)
+    event_uri = payload["uri"]
+    bucket_id = payload["bucket_id"]
+    bucket_uri = instance_uri(event.request, "bucket", id=bucket_id)
     collection_id = None
     collection_uri = None
-    if 'collection_id' in payload:
-        collection_id = payload['collection_id']
-        collection_uri = instance_uri(event.request,
-                                      'collection',
-                                      bucket_id=bucket_id,
-                                      id=collection_id)
+    if "collection_id" in payload:
+        collection_id = payload["collection_id"]
+        collection_uri = instance_uri(
+            event.request, "collection", bucket_id=bucket_id, id=collection_id
+        )
 
-    bucket_max_bytes = get_bucket_settings(settings, bucket_id, 'max_bytes')
-    bucket_max_items = get_bucket_settings(settings, bucket_id, 'max_items')
-    bucket_max_bytes_per_item = get_bucket_settings(settings, bucket_id,
-                                                    'max_bytes_per_item')
-    collection_max_bytes = get_collection_settings(settings, bucket_id,
-                                                   collection_id, 'max_bytes')
-    collection_max_items = get_collection_settings(settings, bucket_id,
-                                                   collection_id, 'max_items')
+    bucket_max_bytes = get_bucket_settings(settings, bucket_id, "max_bytes")
+    bucket_max_items = get_bucket_settings(settings, bucket_id, "max_items")
+    bucket_max_bytes_per_item = get_bucket_settings(settings, bucket_id, "max_bytes_per_item")
+    collection_max_bytes = get_collection_settings(settings, bucket_id, collection_id, "max_bytes")
+    collection_max_items = get_collection_settings(settings, bucket_id, collection_id, "max_items")
     collection_max_bytes_per_item = get_collection_settings(
-        settings, bucket_id, collection_id, 'max_bytes_per_item')
+        settings, bucket_id, collection_id, "max_bytes_per_item"
+    )
 
-    max_bytes_per_item = (collection_max_bytes_per_item or
-                          bucket_max_bytes_per_item)
+    max_bytes_per_item = collection_max_bytes_per_item or bucket_max_bytes_per_item
 
     storage = event.request.registry.storage
 
     targets = []
     for impacted in event.impacted_records:
-        target = impacted['new' if action != 'delete' else 'old']
+        target = impacted["new" if action != "delete" else "old"]
         # On POST .../records, the URI does not contain the newly created
         # record id.
-        obj_id = target['id']
-        parts = event_uri.split('/')
+        obj_id = target["id"]
+        parts = event_uri.split("/")
         if resource_name in parts[-1]:
             parts.append(obj_id)
         else:
             # Make sure the id is correct on grouped events.
             parts[-1] = obj_id
-        uri = '/'.join(parts)
+        uri = "/".join(parts)
 
-        old = impacted.get('old', {})
-        new = impacted.get('new', {})
+        old = impacted.get("old", {})
+        new = impacted.get("new", {})
 
         targets.append((uri, obj_id, old, new))
 
     try:
         bucket_info = copy.deepcopy(
-            storage.get(parent_id=bucket_uri,
-                        collection_id=QUOTA_RESOURCE_NAME,
-                        object_id=BUCKET_QUOTA_OBJECT_ID))
+            storage.get(
+                parent_id=bucket_uri,
+                collection_id=QUOTA_RESOURCE_NAME,
+                object_id=BUCKET_QUOTA_OBJECT_ID,
+            )
+        )
     except RecordNotFoundError:
-        bucket_info = {
-            'collection_count': 0,
-            'record_count': 0,
-            'storage_size': 0,
-        }
+        bucket_info = {"collection_count": 0, "record_count": 0, "storage_size": 0}
 
-    collection_info = {
-        'record_count': 0,
-        'storage_size': 0,
-    }
+    collection_info = {"record_count": 0, "storage_size": 0}
     if collection_id:
         try:
             collection_info = copy.deepcopy(
-                storage.get(parent_id=collection_uri,
-                            collection_id=QUOTA_RESOURCE_NAME,
-                            object_id=COLLECTION_QUOTA_OBJECT_ID))
+                storage.get(
+                    parent_id=collection_uri,
+                    collection_id=QUOTA_RESOURCE_NAME,
+                    object_id=COLLECTION_QUOTA_OBJECT_ID,
+                )
+            )
         except RecordNotFoundError:
             pass
 
@@ -132,90 +129,95 @@ def on_resource_changed(event):
         old_size = record_size(old)
         new_size = record_size(new)
 
-        if max_bytes_per_item is not None and action != 'delete':
+        if max_bytes_per_item is not None and action != "delete":
             if new_size > max_bytes_per_item:
-                message = ('Maximum bytes per object exceeded '
-                           '({} > {} Bytes.'.format(new_size, max_bytes_per_item))
+                message = "Maximum bytes per object exceeded " "({} > {} Bytes.".format(
+                    new_size, max_bytes_per_item
+                )
                 raise_insufficient_storage(message)
 
-        if action == 'create':
-            bucket_info['storage_size'] += new_size
-            if resource_name == 'collection':
-                bucket_info['collection_count'] += 1
-                collection_info['storage_size'] += new_size
-            if resource_name == 'record':
-                bucket_info['record_count'] += 1
-                collection_info['record_count'] += 1
-                collection_info['storage_size'] += new_size
-        elif action == 'update':
-            bucket_info['storage_size'] -= old_size
-            bucket_info['storage_size'] += new_size
-            if resource_name in ('collection', 'record'):
-                collection_info['storage_size'] -= old_size
-                collection_info['storage_size'] += new_size
-        else:   # action == 'delete':
-            bucket_info['storage_size'] -= old_size
-            if resource_name == 'collection':
+        if action == "create":
+            bucket_info["storage_size"] += new_size
+            if resource_name == "collection":
+                bucket_info["collection_count"] += 1
+                collection_info["storage_size"] += new_size
+            if resource_name == "record":
+                bucket_info["record_count"] += 1
+                collection_info["record_count"] += 1
+                collection_info["storage_size"] += new_size
+        elif action == "update":
+            bucket_info["storage_size"] -= old_size
+            bucket_info["storage_size"] += new_size
+            if resource_name in ("collection", "record"):
+                collection_info["storage_size"] -= old_size
+                collection_info["storage_size"] += new_size
+        else:  # action == 'delete':
+            bucket_info["storage_size"] -= old_size
+            if resource_name == "collection":
                 collection_uri = uri
-                bucket_info['collection_count'] -= 1
+                bucket_info["collection_count"] -= 1
                 # When we delete the collection all the records in it
                 # are deleted without notification.
                 collection_records, _ = storage.get_all(
-                    collection_id='record',
-                    parent_id=collection_uri)
+                    collection_id="record", parent_id=collection_uri
+                )
                 for r in collection_records:
                     old_record_size = record_size(r)
-                    bucket_info['record_count'] -= 1
-                    bucket_info['storage_size'] -= old_record_size
-                    collection_info['record_count'] -= 1
-                    collection_info['storage_size'] -= old_record_size
-                collection_info['storage_size'] -= old_size
+                    bucket_info["record_count"] -= 1
+                    bucket_info["storage_size"] -= old_record_size
+                    collection_info["record_count"] -= 1
+                    collection_info["storage_size"] -= old_record_size
+                collection_info["storage_size"] -= old_size
 
-            if resource_name == 'record':
-                bucket_info['record_count'] -= 1
-                collection_info['record_count'] -= 1
-                collection_info['storage_size'] -= old_size
+            if resource_name == "record":
+                bucket_info["record_count"] -= 1
+                collection_info["record_count"] -= 1
+                collection_info["storage_size"] -= old_size
 
     if bucket_max_bytes is not None:
-        if bucket_info['storage_size'] > bucket_max_bytes:
-            message = ('Bucket maximum total size exceeded '
-                       '({} > {} Bytes). '.format(bucket_info['storage_size'],
-                                                  bucket_max_bytes))
+        if bucket_info["storage_size"] > bucket_max_bytes:
+            message = "Bucket maximum total size exceeded " "({} > {} Bytes). ".format(
+                bucket_info["storage_size"], bucket_max_bytes
+            )
             raise_insufficient_storage(message)
 
     if bucket_max_items is not None:
-        if bucket_info['record_count'] > bucket_max_items:
-            message = ('Bucket maximum number of objects exceeded '
-                       '({} > {} objects).'.format(bucket_info['record_count'],
-                                                   bucket_max_items))
+        if bucket_info["record_count"] > bucket_max_items:
+            message = "Bucket maximum number of objects exceeded " "({} > {} objects).".format(
+                bucket_info["record_count"], bucket_max_items
+            )
             raise_insufficient_storage(message)
 
     if collection_max_bytes is not None:
-        if collection_info['storage_size'] > collection_max_bytes:
-            message = ('Collection maximum size exceeded '
-                       '({} > {} Bytes).'.format(collection_info['storage_size'],
-                                                 collection_max_bytes))
+        if collection_info["storage_size"] > collection_max_bytes:
+            message = "Collection maximum size exceeded " "({} > {} Bytes).".format(
+                collection_info["storage_size"], collection_max_bytes
+            )
             raise_insufficient_storage(message)
 
     if collection_max_items is not None:
-        if collection_info['record_count'] > collection_max_items:
-            message = ('Collection maximum number of objects exceeded '
-                       '({} > {} objects).'.format(collection_info['record_count'],
-                                                   collection_max_items))
+        if collection_info["record_count"] > collection_max_items:
+            message = "Collection maximum number of objects exceeded " "({} > {} objects).".format(
+                collection_info["record_count"], collection_max_items
+            )
             raise_insufficient_storage(message)
 
-    storage.update(parent_id=bucket_uri,
-                   collection_id=QUOTA_RESOURCE_NAME,
-                   object_id=BUCKET_QUOTA_OBJECT_ID,
-                   record=bucket_info)
+    storage.update(
+        parent_id=bucket_uri,
+        collection_id=QUOTA_RESOURCE_NAME,
+        object_id=BUCKET_QUOTA_OBJECT_ID,
+        record=bucket_info,
+    )
 
     if collection_id:
-        if action == 'delete' and resource_name == 'collection':
+        if action == "delete" and resource_name == "collection":
             # Deleting a collection already deletes everything underneath
             # (including quotas info). See kinto/views/collection.
             return
         else:
-            storage.update(parent_id=collection_uri,
-                           collection_id=QUOTA_RESOURCE_NAME,
-                           object_id=COLLECTION_QUOTA_OBJECT_ID,
-                           record=collection_info)
+            storage.update(
+                parent_id=collection_uri,
+                collection_id=QUOTA_RESOURCE_NAME,
+                object_id=COLLECTION_QUOTA_OBJECT_ID,
+                record=collection_info,
+            )

--- a/kinto/plugins/quotas/scripts.py
+++ b/kinto/plugins/quotas/scripts.py
@@ -10,20 +10,20 @@ from .utils import record_size
 
 logger = logging.getLogger(__name__)
 
-OLDEST_FIRST = Sort('last_modified', 1)
+OLDEST_FIRST = Sort("last_modified", 1)
 
 
 def rebuild_quotas(storage, dry_run=False):
-    for bucket in paginated(storage, collection_id='bucket',
-                            parent_id='', sorting=[OLDEST_FIRST]):
-        bucket_id = bucket['id']
-        bucket_path = '/buckets/{}'.format(bucket['id'])
+    for bucket in paginated(storage, collection_id="bucket", parent_id="", sorting=[OLDEST_FIRST]):
+        bucket_id = bucket["id"]
+        bucket_path = "/buckets/{}".format(bucket["id"])
         bucket_collection_count = 0
         bucket_record_count = 0
         bucket_storage_size = record_size(bucket)
 
-        for collection in paginated(storage, collection_id='collection',
-                                    parent_id=bucket_path, sorting=[OLDEST_FIRST]):
+        for collection in paginated(
+            storage, collection_id="collection", parent_id=bucket_path, sorting=[OLDEST_FIRST]
+        ):
             collection_info = rebuild_quotas_collection(storage, bucket_id, collection, dry_run)
             (collection_record_count, collection_storage_size) = collection_info
             bucket_collection_count += 1
@@ -31,36 +31,51 @@ def rebuild_quotas(storage, dry_run=False):
             bucket_storage_size += collection_storage_size
 
         bucket_record = {
-            'record_count': bucket_record_count,
-            'storage_size': bucket_storage_size,
-            'collection_count': bucket_collection_count,
+            "record_count": bucket_record_count,
+            "storage_size": bucket_storage_size,
+            "collection_count": bucket_collection_count,
         }
         if not dry_run:
-            storage.update(collection_id='quota', parent_id=bucket_path,
-                           object_id=BUCKET_QUOTA_OBJECT_ID, record=bucket_record)
+            storage.update(
+                collection_id="quota",
+                parent_id=bucket_path,
+                object_id=BUCKET_QUOTA_OBJECT_ID,
+                record=bucket_record,
+            )
 
-        logger.info('Bucket {}. Final size: {} collections, {} records, {} bytes.'.format(
-            bucket_id, bucket_collection_count, bucket_record_count, bucket_storage_size))
+        logger.info(
+            "Bucket {}. Final size: {} collections, {} records, {} bytes.".format(
+                bucket_id, bucket_collection_count, bucket_record_count, bucket_storage_size
+            )
+        )
 
 
 def rebuild_quotas_collection(storage, bucket_id, collection, dry_run=False):
     """Helper method for rebuild_quotas that updates a single collection."""
-    collection_id = collection['id']
+    collection_id = collection["id"]
     collection_record_count = 0
     collection_storage_size = record_size(collection)
-    collection_path = '/buckets/{}/collections/{}'.format(bucket_id, collection_id)
-    for record in paginated(storage, collection_id='record',
-                            parent_id=collection_path, sorting=[OLDEST_FIRST]):
+    collection_path = "/buckets/{}/collections/{}".format(bucket_id, collection_id)
+    for record in paginated(
+        storage, collection_id="record", parent_id=collection_path, sorting=[OLDEST_FIRST]
+    ):
         collection_record_count += 1
         collection_storage_size += record_size(record)
 
-    logger.info('Bucket {}, collection {}. Final size: {} records, {} bytes.'.format(
-        bucket_id, collection_id, collection_record_count, collection_storage_size))
+    logger.info(
+        "Bucket {}, collection {}. Final size: {} records, {} bytes.".format(
+            bucket_id, collection_id, collection_record_count, collection_storage_size
+        )
+    )
     new_quota_info = {
-        'record_count': collection_record_count,
-        'storage_size': collection_storage_size,
+        "record_count": collection_record_count,
+        "storage_size": collection_storage_size,
     }
     if not dry_run:
-        storage.update(collection_id='quota', parent_id=collection_path,
-                       object_id=COLLECTION_QUOTA_OBJECT_ID, record=new_quota_info)
+        storage.update(
+            collection_id="quota",
+            parent_id=collection_path,
+            object_id=COLLECTION_QUOTA_OBJECT_ID,
+            record=new_quota_info,
+        )
     return (collection_record_count, collection_storage_size)

--- a/kinto/plugins/quotas/utils.py
+++ b/kinto/plugins/quotas/utils.py
@@ -2,5 +2,5 @@ import json
 
 
 def record_size(record):
-    canonical_json = json.dumps(record, sort_keys=True, separators=(',', ':'))
+    canonical_json = json.dumps(record, sort_keys=True, separators=(",", ":"))
     return len(canonical_json)

--- a/kinto/schema_validation.py
+++ b/kinto/schema_validation.py
@@ -9,7 +9,7 @@ from kinto.views import object_exists_or_404
 
 class JSONSchemaMapping(colander.SchemaNode):
     def schema_type(self, **kw):
-        return colander.Mapping(unknown='preserve')
+        return colander.Mapping(unknown="preserve")
 
     def deserialize(self, cstruct=colander.null):
         # Start by deserializing a simple mapping.
@@ -34,14 +34,14 @@ def check_schema(data):
 
 
 def validate_schema(data, schema, ignore_fields=[]):
-    required_fields = [f for f in schema.get('required', []) if f not in ignore_fields]
+    required_fields = [f for f in schema.get("required", []) if f not in ignore_fields]
     # jsonschema doesn't accept 'required': [] yet.
     # See https://github.com/Julian/jsonschema/issues/337.
     # In the meantime, strip out 'required' if no other fields are required.
     if required_fields:
-        schema = {**schema, 'required': required_fields}
+        schema = {**schema, "required": required_fields}
     else:
-        schema = {f: v for f, v in schema.items() if f != 'required'}
+        schema = {f: v for f, v in schema.items() if f != "required"}
 
     data = {f: v for f, v in data.items() if f not in ignore_fields}
 
@@ -72,20 +72,19 @@ def validate_from_bucket_schema_or_400(data, resource_name, request, ignore_fiel
     data does not validate it/them, then it raises a 400 exception.
     """
     settings = request.registry.settings
-    schema_validation = 'experimental_collection_schema_validation'
+    schema_validation = "experimental_collection_schema_validation"
     # If disabled from settings, do nothing.
     if not asbool(settings.get(schema_validation)):
         return
 
     bucket_id = request.matchdict["bucket_id"]
-    bucket_uri = utils.instance_uri(request, 'bucket', id=bucket_id)
-    buckets = request.bound_data.setdefault('buckets', {})
+    bucket_uri = utils.instance_uri(request, "bucket", id=bucket_id)
+    buckets = request.bound_data.setdefault("buckets", {})
     if bucket_uri not in buckets:
         # Unknown yet, fetch from storage.
-        bucket = object_exists_or_404(request,
-                                      collection_id='bucket',
-                                      parent_id='',
-                                      object_id=bucket_id)
+        bucket = object_exists_or_404(
+            request, collection_id="bucket", parent_id="", object_id=bucket_id
+        )
         buckets[bucket_uri] = bucket
 
     # Let's see if the bucket defines a schema for this resource.
@@ -101,4 +100,4 @@ def validate_from_bucket_schema_or_400(data, resource_name, request, ignore_fiel
     except ValidationError as e:
         raise_invalid(request, name=e.field, description=e.message)
     except RefResolutionError as e:
-        raise_invalid(request, name='schema', description=str(e))
+        raise_invalid(request, name="schema", description=str(e))

--- a/kinto/views/__init__.py
+++ b/kinto/views/__init__.py
@@ -9,30 +9,26 @@ from kinto.core.errors import http_error, ERRORS
 class NameGenerator(generators.Generator):
     def __call__(self):
         alpha_num = string.ascii_letters + string.digits
-        alphabet = alpha_num + '-_'
+        alphabet = alpha_num + "-_"
         letters = [random.SystemRandom().choice(alpha_num)]
         letters += [random.SystemRandom().choice(alphabet) for x in range(7)]
 
-        return ''.join(letters)
+        return "".join(letters)
 
 
 class RelaxedUUID(generators.UUID4):
     """A generator that generates UUIDs but accepts any string.
     """
+
     regexp = generators.Generator.regexp
 
 
-def object_exists_or_404(request, collection_id, object_id, parent_id=''):
+def object_exists_or_404(request, collection_id, object_id, parent_id=""):
     storage = request.registry.storage
     try:
-        return storage.get(collection_id=collection_id,
-                           parent_id=parent_id,
-                           object_id=object_id)
+        return storage.get(collection_id=collection_id, parent_id=parent_id, object_id=object_id)
     except exceptions.RecordNotFoundError:
         # XXX: We gave up putting details about parent id here (See #53).
-        details = {
-            'id': object_id,
-            'resource_name': collection_id
-        }
+        details = {"id": object_id, "resource_name": collection_id}
         response = http_error(HTTPNotFound(), errno=ERRORS.MISSING_RESOURCE, details=details)
         raise response

--- a/kinto/views/buckets.py
+++ b/kinto/views/buckets.py
@@ -15,21 +15,17 @@ class BucketSchema(resource.ResourceSchema):
         self["record:schema"] = JSONSchemaMapping(missing=colander.drop)
 
 
-@resource.register(name='bucket',
-                   collection_path='/buckets',
-                   record_path='/buckets/{{id}}')
+@resource.register(name="bucket", collection_path="/buckets", record_path="/buckets/{{id}}")
 class Bucket(resource.ShareableResource):
     schema = BucketSchema
-    permissions = ('read', 'write', 'collection:create', 'group:create')
+    permissions = ("read", "write", "collection:create", "group:create")
 
     def get_parent_id(self, request):
         # Buckets are not isolated by user, unlike Kinto-Core resources.
-        return ''
+        return ""
 
 
-@subscriber(ResourceChanged,
-            for_resources=('bucket',),
-            for_actions=(ACTIONS.DELETE,))
+@subscriber(ResourceChanged, for_resources=("bucket",), for_actions=(ACTIONS.DELETE,))
 def on_buckets_deleted(event):
     """Some buckets were deleted, delete sub-resources.
     """
@@ -37,17 +33,14 @@ def on_buckets_deleted(event):
     permission = event.request.registry.permission
 
     for change in event.impacted_records:
-        bucket = change['old']
-        bucket_uri = instance_uri(event.request, 'bucket', id=bucket['id'])
+        bucket = change["old"]
+        bucket_uri = instance_uri(event.request, "bucket", id=bucket["id"])
 
         # Delete everything with current parent id (eg. collections, groups)
         # and descending children objects (eg. records).
-        for pattern in (bucket_uri, bucket_uri + '/*'):
-            storage.delete_all(parent_id=pattern,
-                               collection_id=None,
-                               with_deleted=False)
+        for pattern in (bucket_uri, bucket_uri + "/*"):
+            storage.delete_all(parent_id=pattern, collection_id=None, with_deleted=False)
             # Remove remaining tombstones too.
-            storage.purge_deleted(parent_id=pattern,
-                                  collection_id=None)
+            storage.purge_deleted(parent_id=pattern, collection_id=None)
             # Remove related permissions
             permission.delete_object_permissions(pattern)

--- a/kinto/views/collections.py
+++ b/kinto/views/collections.py
@@ -11,16 +11,18 @@ class CollectionSchema(resource.ResourceSchema):
     cache_expires = colander.SchemaNode(colander.Int(), missing=colander.drop)
 
 
-@resource.register(name='collection',
-                   collection_path='/buckets/{{bucket_id}}/collections',
-                   record_path='/buckets/{{bucket_id}}/collections/{{id}}')
+@resource.register(
+    name="collection",
+    collection_path="/buckets/{{bucket_id}}/collections",
+    record_path="/buckets/{{bucket_id}}/collections/{{id}}",
+)
 class Collection(resource.ShareableResource):
     schema = CollectionSchema
-    permissions = ('read', 'write', 'record:create')
+    permissions = ("read", "write", "record:create")
 
     def get_parent_id(self, request):
-        bucket_id = request.matchdict['bucket_id']
-        parent_id = utils.instance_uri(request, 'bucket', id=bucket_id)
+        bucket_id = request.matchdict["bucket_id"]
+        parent_id = utils.instance_uri(request, "bucket", id=bucket_id)
         return parent_id
 
     def process_record(self, new, old=None):
@@ -28,17 +30,18 @@ class Collection(resource.ShareableResource):
         new = super().process_record(new, old)
 
         # Remove internal and auto-assigned fields.
-        internal_fields = (self.model.id_field,
-                           self.model.modified_field,
-                           self.model.permissions_field)
-        validate_from_bucket_schema_or_400(new, resource_name="collection", request=self.request,
-                                           ignore_fields=internal_fields)
+        internal_fields = (
+            self.model.id_field,
+            self.model.modified_field,
+            self.model.permissions_field,
+        )
+        validate_from_bucket_schema_or_400(
+            new, resource_name="collection", request=self.request, ignore_fields=internal_fields
+        )
         return new
 
 
-@subscriber(ResourceChanged,
-            for_resources=('collection',),
-            for_actions=(ACTIONS.DELETE,))
+@subscriber(ResourceChanged, for_resources=("collection",), for_actions=(ACTIONS.DELETE,))
 def on_collections_deleted(event):
     """Some collections were deleted, delete records.
     """
@@ -46,14 +49,11 @@ def on_collections_deleted(event):
     permission = event.request.registry.permission
 
     for change in event.impacted_records:
-        collection = change['old']
-        bucket_id = event.payload['bucket_id']
-        parent_id = utils.instance_uri(event.request, 'collection',
-                                       bucket_id=bucket_id,
-                                       id=collection['id'])
-        storage.delete_all(collection_id=None,
-                           parent_id=parent_id,
-                           with_deleted=False)
-        storage.purge_deleted(collection_id=None,
-                              parent_id=parent_id)
-        permission.delete_object_permissions(parent_id + '/*')
+        collection = change["old"]
+        bucket_id = event.payload["bucket_id"]
+        parent_id = utils.instance_uri(
+            event.request, "collection", bucket_id=bucket_id, id=collection["id"]
+        )
+        storage.delete_all(collection_id=None, parent_id=parent_id, with_deleted=False)
+        storage.purge_deleted(collection_id=None, parent_id=parent_id)
+        permission.delete_object_permissions(parent_id + "/*")

--- a/kinto/views/contribute.py
+++ b/kinto/views/contribute.py
@@ -3,44 +3,36 @@ from cornice import Service
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 
-contribute = Service(name='contribute.json',
-                     description='Open-source information',
-                     path='/contribute.json')
+contribute = Service(
+    name="contribute.json", description="Open-source information", path="/contribute.json"
+)
 
 
 class ContributeResponseSchema(colander.MappingSchema):
-    body = colander.SchemaNode(colander.Mapping(unknown='preserve'))
+    body = colander.SchemaNode(colander.Mapping(unknown="preserve"))
 
 
 contribute_responses = {
-    '200': ContributeResponseSchema(
-        description='Return open source contributing information.')
+    "200": ContributeResponseSchema(description="Return open source contributing information.")
 }
 
 
-@contribute.get(permission=NO_PERMISSION_REQUIRED, tags=['Utilities'],
-                operation_id='contribute', response_schemas=contribute_responses)
+@contribute.get(
+    permission=NO_PERMISSION_REQUIRED,
+    tags=["Utilities"],
+    operation_id="contribute",
+    response_schemas=contribute_responses,
+)
 def contribute_get(request):
     return {
-        'name': 'kinto',
-        'description': 'A minimalist JSON storage service.',
-        'repository': {
-            'url': 'https://github.com/Kinto/kinto',
-            'license': 'Apache License (2.0)'
+        "name": "kinto",
+        "description": "A minimalist JSON storage service.",
+        "repository": {"url": "https://github.com/Kinto/kinto", "license": "Apache License (2.0)"},
+        "participate": {
+            "docs": "https://kinto.readthedocs.io/",
+            "mailing-list": "kinto@mozilla.org",
+            "irc": "irc://irc.freenode.net/#kinto",
         },
-        'participate': {
-            'docs': 'https://kinto.readthedocs.io/',
-            'mailing-list': 'kinto@mozilla.org',
-            'irc': 'irc://irc.freenode.net/#kinto',
-        },
-        'keywords': [
-            'JSON',
-            'Python',
-            'Offline',
-            'Sync',
-            'Storage',
-        ],
-        'urls': {
-            'dev': 'https://kinto.dev.mozaws.net/v1/'
-        }
+        "keywords": ["JSON", "Python", "Offline", "Sync", "Storage"],
+        "urls": {"dev": "https://kinto.dev.mozaws.net/v1/"},
     }

--- a/kinto/views/groups.py
+++ b/kinto/views/groups.py
@@ -7,26 +7,29 @@ from kinto.schema_validation import validate_from_bucket_schema_or_400
 
 
 def validate_member(node, member):
-    if member.startswith('/buckets/') or member == 'system.Everyone':
+    if member.startswith("/buckets/") or member == "system.Everyone":
         raise colander.Invalid(node, "'{}' is not a valid user ID.".format(member))
 
 
 class GroupSchema(resource.ResourceSchema):
-    members = colander.SchemaNode(colander.Sequence(),
-                                  colander.SchemaNode(colander.String(),
-                                                      validator=validate_member),
-                                  missing=[])
+    members = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String(), validator=validate_member),
+        missing=[],
+    )
 
 
-@resource.register(name='group',
-                   collection_path='/buckets/{{bucket_id}}/groups',
-                   record_path='/buckets/{{bucket_id}}/groups/{{id}}')
+@resource.register(
+    name="group",
+    collection_path="/buckets/{{bucket_id}}/groups",
+    record_path="/buckets/{{bucket_id}}/groups/{{id}}",
+)
 class Group(resource.ShareableResource):
     schema = GroupSchema
 
     def get_parent_id(self, request):
-        bucket_id = request.matchdict['bucket_id']
-        parent_id = utils.instance_uri(request, 'bucket', id=bucket_id)
+        bucket_id = request.matchdict["bucket_id"]
+        parent_id = utils.instance_uri(request, "bucket", id=bucket_id)
         return parent_id
 
     def process_record(self, new, old=None):
@@ -34,51 +37,49 @@ class Group(resource.ShareableResource):
         new = super().process_record(new, old)
 
         # Remove internal and auto-assigned fields.
-        internal_fields = (self.model.id_field,
-                           self.model.modified_field,
-                           self.model.permissions_field)
-        validate_from_bucket_schema_or_400(new, resource_name="group", request=self.request,
-                                           ignore_fields=internal_fields)
+        internal_fields = (
+            self.model.id_field,
+            self.model.modified_field,
+            self.model.permissions_field,
+        )
+        validate_from_bucket_schema_or_400(
+            new, resource_name="group", request=self.request, ignore_fields=internal_fields
+        )
 
         return new
 
 
-@subscriber(ResourceChanged,
-            for_resources=('group',),
-            for_actions=(ACTIONS.DELETE,))
+@subscriber(ResourceChanged, for_resources=("group",), for_actions=(ACTIONS.DELETE,))
 def on_groups_deleted(event):
     """Some groups were deleted, remove them from users principals.
     """
     permission_backend = event.request.registry.permission
 
     for change in event.impacted_records:
-        group = change['old']
-        bucket_id = event.payload['bucket_id']
-        group_uri = utils.instance_uri(event.request, 'group',
-                                       bucket_id=bucket_id,
-                                       id=group['id'])
+        group = change["old"]
+        bucket_id = event.payload["bucket_id"]
+        group_uri = utils.instance_uri(event.request, "group", bucket_id=bucket_id, id=group["id"])
 
         permission_backend.remove_principal(group_uri)
 
 
-@subscriber(ResourceChanged,
-            for_resources=('group',),
-            for_actions=(ACTIONS.CREATE, ACTIONS.UPDATE))
+@subscriber(
+    ResourceChanged, for_resources=("group",), for_actions=(ACTIONS.CREATE, ACTIONS.UPDATE)
+)
 def on_groups_changed(event):
     """Some groups were changed, update users principals.
     """
     permission_backend = event.request.registry.permission
 
     for change in event.impacted_records:
-        if 'old' in change:
-            existing_record_members = set(change['old'].get('members', []))
+        if "old" in change:
+            existing_record_members = set(change["old"].get("members", []))
         else:
             existing_record_members = set()
 
-        group = change['new']
-        group_uri = '/buckets/{bucket_id}/groups/{id}'.format(id=group['id'],
-                                                              **event.payload)
-        new_record_members = set(group.get('members', []))
+        group = change["new"]
+        group_uri = "/buckets/{bucket_id}/groups/{id}".format(id=group["id"], **event.payload)
+        new_record_members = set(group.get("members", []))
         new_members = new_record_members - existing_record_members
         removed_members = existing_record_members - new_record_members
 

--- a/kinto/views/records.py
+++ b/kinto/views/records.py
@@ -4,43 +4,51 @@ from pyramid.settings import asbool
 from kinto.core import resource, utils
 from kinto.core.errors import raise_invalid
 from kinto.views import object_exists_or_404
-from kinto.schema_validation import (validate_from_bucket_schema_or_400, validate_schema,
-                                     ValidationError, RefResolutionError)
+from kinto.schema_validation import (
+    validate_from_bucket_schema_or_400,
+    validate_schema,
+    ValidationError,
+    RefResolutionError,
+)
 
 
-_parent_path = '/buckets/{{bucket_id}}/collections/{{collection_id}}'
+_parent_path = "/buckets/{{bucket_id}}/collections/{{collection_id}}"
 
 
-@resource.register(name='record',
-                   collection_path=_parent_path + '/records',
-                   record_path=_parent_path + '/records/{{id}}')
+@resource.register(
+    name="record",
+    collection_path=_parent_path + "/records",
+    record_path=_parent_path + "/records/{{id}}",
+)
 class Record(resource.ShareableResource):
 
-    schema_field = 'schema'
+    schema_field = "schema"
 
     def __init__(self, request, **kwargs):
         # Before all, first check that the parent collection exists.
         # Check if already fetched before (in batch).
-        collections = request.bound_data.setdefault('collections', {})
+        collections = request.bound_data.setdefault("collections", {})
         collection_uri = self.get_parent_id(request)
         if collection_uri not in collections:
             # Unknown yet, fetch from storage.
-            bucket_uri = utils.instance_uri(request, 'bucket', id=self.bucket_id)
-            collection = object_exists_or_404(request,
-                                              collection_id='collection',
-                                              parent_id=bucket_uri,
-                                              object_id=self.collection_id)
+            bucket_uri = utils.instance_uri(request, "bucket", id=self.bucket_id)
+            collection = object_exists_or_404(
+                request,
+                collection_id="collection",
+                parent_id=bucket_uri,
+                object_id=self.collection_id,
+            )
             collections[collection_uri] = collection
         self._collection = collections[collection_uri]
 
         super().__init__(request, **kwargs)
 
     def get_parent_id(self, request):
-        self.bucket_id = request.matchdict['bucket_id']
-        self.collection_id = request.matchdict['collection_id']
-        return utils.instance_uri(request, 'collection',
-                                  bucket_id=self.bucket_id,
-                                  id=self.collection_id)
+        self.bucket_id = request.matchdict["bucket_id"]
+        self.collection_id = request.matchdict["collection_id"]
+        return utils.instance_uri(
+            request, "collection", bucket_id=self.bucket_id, id=self.collection_id
+        )
 
     def process_record(self, new, old=None):
         """Validate records against collection or bucket schema, if any."""
@@ -48,34 +56,37 @@ class Record(resource.ShareableResource):
 
         # Is schema validation enabled?
         settings = self.request.registry.settings
-        schema_validation = 'experimental_collection_schema_validation'
+        schema_validation = "experimental_collection_schema_validation"
         if not asbool(settings.get(schema_validation)):
             return new
 
         # Remove internal and auto-assigned fields from schemas and record.
-        internal_fields = (self.model.id_field,
-                           self.model.modified_field,
-                           self.schema_field,
-                           self.model.permissions_field)
+        internal_fields = (
+            self.model.id_field,
+            self.model.modified_field,
+            self.schema_field,
+            self.model.permissions_field,
+        )
 
         # The schema defined on the collection will be validated first.
-        if 'schema' in self._collection:
-            schema = self._collection['schema']
+        if "schema" in self._collection:
+            schema = self._collection["schema"]
 
             try:
                 validate_schema(new, schema, ignore_fields=internal_fields)
             except ValidationError as e:
                 raise_invalid(self.request, name=e.field, description=e.message)
             except RefResolutionError as e:
-                raise_invalid(self.request, name='schema', description=str(e))
+                raise_invalid(self.request, name="schema", description=str(e))
 
             # Assign the schema version to the record.
             schema_timestamp = self._collection[self.model.modified_field]
             new[self.schema_field] = schema_timestamp
 
         # Validate also from the record:schema field defined on the bucket.
-        validate_from_bucket_schema_or_400(new, resource_name="record", request=self.request,
-                                           ignore_fields=internal_fields)
+        validate_from_bucket_schema_or_400(
+            new, resource_name="record", request=self.request, ignore_fields=internal_fields
+        )
 
         return new
 
@@ -102,14 +113,16 @@ class Record(resource.ShareableResource):
         if not is_anonymous:
             return
 
-        cache_expires = self._collection.get('cache_expires')
+        cache_expires = self._collection.get("cache_expires")
         if cache_expires is None:
-            by_collection = '{}.{}.record_cache_expires_seconds'.format(
-                self.bucket_id, self.collection_id)
-            by_bucket = '{}.record_cache_expires_seconds'.format(self.bucket_id)
-            by_collection_legacy = '{}_{}_record_cache_expires_seconds'.format(
-                self.bucket_id, self.collection_id)
-            by_bucket_legacy = '{}_record_cache_expires_seconds'.format(self.bucket_id)
+            by_collection = "{}.{}.record_cache_expires_seconds".format(
+                self.bucket_id, self.collection_id
+            )
+            by_bucket = "{}.record_cache_expires_seconds".format(self.bucket_id)
+            by_collection_legacy = "{}_{}_record_cache_expires_seconds".format(
+                self.bucket_id, self.collection_id
+            )
+            by_bucket_legacy = "{}_record_cache_expires_seconds".format(self.bucket_id)
             settings = self.request.registry.settings
             for s in (by_collection, by_bucket, by_collection_legacy, by_bucket_legacy):
                 cache_expires = settings.get(s)

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,0 +1,2 @@
+therapist==1.5.0
+black==18.9b0

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,2 +1,4 @@
 therapist==1.5.0
 black==18.9b0
+flake8
+setuptools<36

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 99
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/setup.py
+++ b/setup.py
@@ -9,111 +9,90 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def read_file(filename):
     """Open a related file and return its content."""
-    with codecs.open(os.path.join(here, filename), encoding='utf-8') as f:
+    with codecs.open(os.path.join(here, filename), encoding="utf-8") as f:
         content = f.read()
     return content
 
 
-README = read_file('README.rst')
-CHANGELOG = read_file('CHANGELOG.rst')
-CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
+README = read_file("README.rst")
+CHANGELOG = read_file("CHANGELOG.rst")
+CONTRIBUTORS = read_file("CONTRIBUTORS.rst")
 
 REQUIREMENTS = [
-    'bcrypt',
-    'colander >= 1.4.0',
-    'cornice',
-    'cornice_swagger >= 0.5.1',
-    'dockerflow',
-    'jsonschema',
-    'jsonpatch',
-    'logging-color-formatter >= 1.0.1',  # Message interpolations.
-    'python-dateutil',
-    'pyramid >= 1.9.1, < 2.0',
-    'pyramid_multiauth >= 0.8',  # User on policy selected event.
-    'transaction',
+    "bcrypt",
+    "colander >= 1.4.0",
+    "cornice",
+    "cornice_swagger >= 0.5.1",
+    "dockerflow",
+    "jsonschema",
+    "jsonpatch",
+    "logging-color-formatter >= 1.0.1",  # Message interpolations.
+    "python-dateutil",
+    "pyramid >= 1.9.1, < 2.0",
+    "pyramid_multiauth >= 0.8",  # User on policy selected event.
+    "transaction",
     # pyramid_tm changed the location of their tween in 2.x and one of
     # our tests fails on 2.0.
-    'pyramid_tm >= 2.1',
-    'requests',
-    'waitress',
-    'ujson >= 1.35',
+    "pyramid_tm >= 2.1",
+    "requests",
+    "waitress",
+    "ujson >= 1.35",
 ]
 
-POSTGRESQL_REQUIRES = [
-    'SQLAlchemy',
-    'psycopg2 > 2.5',
-    'zope.sqlalchemy',
-]
+POSTGRESQL_REQUIRES = ["SQLAlchemy", "psycopg2 > 2.5", "zope.sqlalchemy"]
 
-REDIS_REQUIRES = [
-    'kinto_redis'
-]
+REDIS_REQUIRES = ["kinto_redis"]
 
-MEMCACHED_REQUIRES = [
-    'python-memcached'
-]
+MEMCACHED_REQUIRES = ["python-memcached"]
 
-SETUP_REQUIRES = [
-    'pytest-runner'
-]
+SETUP_REQUIRES = ["pytest-runner"]
 
-TEST_REQUIREMENTS = [
-    'bravado_core',
-    'pytest',
-    'WebTest'
-]
+TEST_REQUIREMENTS = ["bravado_core", "pytest", "WebTest"]
 
 DEPENDENCY_LINKS = []
 
-MONITORING_REQUIRES = [
-    'raven',
-    'statsd',
-    'newrelic',
-    'werkzeug',
-]
+MONITORING_REQUIRES = ["raven", "statsd", "newrelic", "werkzeug"]
 
 ENTRY_POINTS = {
-    'paste.app_factory': [
-        'main = kinto:main',
-    ],
-    'console_scripts': [
-        'kinto = kinto.__main__:main'
-    ],
+    "paste.app_factory": ["main = kinto:main"],
+    "console_scripts": ["kinto = kinto.__main__:main"],
 }
 
 
-setup(name='kinto',
-      version='11.1.0.dev0',
-      description='Kinto Web Service - Store, Sync, Share, and Self-Host.',
-      long_description='{}\n\n{}\n\n{}'.format(README, CHANGELOG, CONTRIBUTORS),
-      license='Apache License (2.0)',
-      classifiers=[
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Topic :: Internet :: WWW/HTTP',
-          'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
-          'License :: OSI Approved :: Apache Software License'
-      ],
-      keywords='web sync json storage services',
-      author='Mozilla Services',
-      author_email='storage-team@mozilla.com',
-      url='https://github.com/Kinto/kinto',
-      packages=find_packages(),
-      package_data={'': ['*.rst', '*.py', '*.yaml']},
-      include_package_data=True,
-      zip_safe=False,
-      setup_requires=SETUP_REQUIRES,
-      tests_require=TEST_REQUIREMENTS,
-      install_requires=REQUIREMENTS,
-      extras_require={
-          'redis': REDIS_REQUIRES,
-          'memcached': MEMCACHED_REQUIRES,
-          'postgresql': POSTGRESQL_REQUIRES,
-          'monitoring': MONITORING_REQUIRES,
-      },
-      test_suite='tests',
-      dependency_links=DEPENDENCY_LINKS,
-      entry_points=ENTRY_POINTS)
+setup(
+    name="kinto",
+    version="11.1.0.dev0",
+    description="Kinto Web Service - Store, Sync, Share, and Self-Host.",
+    long_description="{}\n\n{}\n\n{}".format(README, CHANGELOG, CONTRIBUTORS),
+    license="Apache License (2.0)",
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+        "License :: OSI Approved :: Apache Software License",
+    ],
+    keywords="web sync json storage services",
+    author="Mozilla Services",
+    author_email="storage-team@mozilla.com",
+    url="https://github.com/Kinto/kinto",
+    packages=find_packages(),
+    package_data={"": ["*.rst", "*.py", "*.yaml"]},
+    include_package_data=True,
+    zip_safe=False,
+    setup_requires=SETUP_REQUIRES,
+    tests_require=TEST_REQUIREMENTS,
+    install_requires=REQUIREMENTS,
+    extras_require={
+        "redis": REDIS_REQUIRES,
+        "memcached": MEMCACHED_REQUIRES,
+        "postgresql": POSTGRESQL_REQUIRES,
+        "monitoring": MONITORING_REQUIRES,
+    },
+    test_suite="tests",
+    dependency_links=DEPENDENCY_LINKS,
+    entry_points=ENTRY_POINTS,
+)

--- a/tests/core/resource/__init__.py
+++ b/tests/core/resource/__init__.py
@@ -19,20 +19,18 @@ class BaseTest(unittest.TestCase):
     def setUp(self):
         self.storage = storage_memory.Storage()
         self.cache = cache_memory.Cache(cache_prefix="", cache_max_size_bytes=1000)
-        self.resource = self.resource_class(request=self.get_request(),
-                                            context=self.get_context())
+        self.resource = self.resource_class(request=self.get_request(), context=self.get_context())
         self.resource.schema = StrictSchema
         self.model = self.resource.model
-        self.patch_known_field = mock.patch.object(self.resource,
-                                                   'is_known_field')
-        self.validated = {'body': {}, 'header': {}, 'querystring': {}}
+        self.patch_known_field = mock.patch.object(self.resource, "is_known_field")
+        self.validated = {"body": {}, "header": {}, "querystring": {}}
         self.resource.request.validated = self.validated
 
     def tearDown(self):
         mock.patch.stopall()
 
-    def get_request(self, resource_name=''):
-        request = DummyRequest(method='GET')
+    def get_request(self, resource_name=""):
+        request = DummyRequest(method="GET")
         request.current_resource_name = resource_name
         request.registry.cache = self.cache
         request.registry.storage = self.storage

--- a/tests/core/resource/test_base.py
+++ b/tests/core/resource/test_base.py
@@ -10,18 +10,19 @@ from . import BaseTest
 
 
 class ResourceTest(BaseTest):
-
     def test_get_parent_id_default_to_prefixed_userid(self):
         request = self.get_request()
         parent_id = self.resource.get_parent_id(request)
-        self.assertEqual(parent_id, 'basicauth:bob')
+        self.assertEqual(parent_id, "basicauth:bob")
 
     def test_raise_if_backend_fails_to_obtain_timestamp(self):
         request = self.get_request()
 
-        with mock.patch.object(request.registry.storage,
-                               'collection_timestamp',
-                               side_effect=storage_exceptions.BackendError):
+        with mock.patch.object(
+            request.registry.storage,
+            "collection_timestamp",
+            side_effect=storage_exceptions.BackendError,
+        ):
             with self.assertRaises(storage_exceptions.BackendError):
                 self.resource_class(request)
 
@@ -30,13 +31,15 @@ class ResourceTest(BaseTest):
 
         excepted_exc = httpexceptions.HTTPServiceUnavailable
 
-        request.registry.settings = {'readonly': 'true'}
-        with mock.patch.object(request.registry.storage,
-                               'collection_timestamp',
-                               side_effect=storage_exceptions.BackendError):
+        request.registry.settings = {"readonly": "true"}
+        with mock.patch.object(
+            request.registry.storage,
+            "collection_timestamp",
+            side_effect=storage_exceptions.BackendError,
+        ):
             with self.assertRaises(excepted_exc) as cm:
                 self.resource_class(request)
-                self.assertIn('writable', cm.exception.message)
+                self.assertIn("writable", cm.exception.message)
 
 
 class ShareableResourceTest(BaseTest):
@@ -51,7 +54,7 @@ class ShareableResourceTest(BaseTest):
     def test_get_parent_id_is_empty(self):
         request = self.get_request()
         parent_id = self.resource.get_parent_id(request)
-        self.assertEqual(parent_id, '')
+        self.assertEqual(parent_id, "")
 
 
 class NewResource(UserResource):
@@ -66,8 +69,8 @@ class ParentIdOverrideResourceTest(BaseTest):
         request = self.get_request()
 
         parent_id = self.resource.get_parent_id(request)
-        self.assertEqual(parent_id, 'overrided')
-        self.assertEqual(self.resource.model.parent_id, 'overrided')
+        self.assertEqual(parent_id, "overrided")
+        self.assertEqual(self.resource.model.parent_id, "overrided")
 
 
 class CustomModelResource(UserResource):

--- a/tests/core/resource/test_cache_expires.py
+++ b/tests/core/resource/test_cache_expires.py
@@ -2,11 +2,11 @@ from . import BaseTest
 
 
 class CacheExpires(BaseTest):
-    setting = 'test_cache_expires_seconds'
+    setting = "test_cache_expires_seconds"
 
     def get_context(self):
         context = super().get_context()
-        context.resource_name = 'test'
+        context.resource_name = "test"
         return context
 
     def get_request(self):
@@ -28,7 +28,7 @@ class CacheExpires(BaseTest):
 
     def test_cache_expires_is_also_on_record_get(self):
         stored = self.model.create_record({})
-        self.resource.record_id = stored['id']
+        self.resource.record_id = stored["id"]
         settings = self.resource.request.registry.settings
         settings[self.setting] = 3
         self.resource.get()

--- a/tests/core/resource/test_events.py
+++ b/tests/core/resource/test_events.py
@@ -5,9 +5,14 @@ from unittest import mock
 from pyramid.config import Configurator
 
 from kinto.core import statsd
-from kinto.core.events import (ResourceChanged, AfterResourceChanged,
-                               ResourceRead, AfterResourceRead, ACTIONS,
-                               notify_resource_event)
+from kinto.core.events import (
+    ResourceChanged,
+    AfterResourceChanged,
+    ResourceRead,
+    AfterResourceRead,
+    ACTIONS,
+    notify_resource_event,
+)
 from kinto.core.storage.exceptions import BackendError
 from kinto.core.testing import unittest
 
@@ -36,7 +41,7 @@ class BaseEventTest(BaseWebTest):
     def setUp(self):
         super().setUp()
         del self.events[:]
-        self.body = {'data': {'name': 'de Paris'}}
+        self.body = {"data": {"name": "de Paris"}}
 
     def tearDown(self):
         del self.events[:]
@@ -61,33 +66,30 @@ class ResourceReadTest(BaseEventTest, unittest.TestCase):
     subscribed = (ResourceRead,)
 
     def test_get_sends_read_event(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers, status=201)
-        record_id = resp.json['data']['id']
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        record_id = resp.json["data"]["id"]
         record_url = self.get_item_url(record_id)
         self.app.get(record_url, headers=self.headers)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.READ.value)
         self.assertEqual(len(self.events[0].read_records), 1)
 
     def test_collection_get_sends_read_event(self):
         self.app.get(self.collection_url, headers=self.headers)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.READ.value)
         self.assertEqual(len(self.events[0].read_records), 0)
 
     def test_post_sends_read_if_id_already_exists(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers, status=201)
-        record = resp.json['data']
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        record = resp.json["data"]
         body = {**self.body}
-        body['data']['id'] = record['id']
+        body["data"]["id"] = record["id"]
 
         # a second post with the same record id
-        self.app.post_json(self.collection_url, body, headers=self.headers,
-                           status=200)
+        self.app.post_json(self.collection_url, body, headers=self.headers, status=200)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'], ACTIONS.READ.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.READ.value)
 
 
 class ResourceChangedTest(BaseEventTest, unittest.TestCase):
@@ -95,141 +97,108 @@ class ResourceChangedTest(BaseEventTest, unittest.TestCase):
     subscribed = (ResourceChanged,)
 
     def test_events_have_custom_representation(self):
-        self.app.post_json(self.collection_url, self.body,
-                           headers=self.headers, status=201)
-        self.assertEqual(repr(self.events[0]),
-                         "<ResourceChanged action=create "
-                         "uri={}>".format(self.collection_url))
+        self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        self.assertEqual(
+            repr(self.events[0]),
+            "<ResourceChanged action=create " "uri={}>".format(self.collection_url),
+        )
 
     def test_post_sends_create_action(self):
-        self.app.post_json(self.collection_url, self.body,
-                           headers=self.headers, status=201)
+        self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
 
     def test_put_sends_create_action(self):
         body = {**self.body}
-        body['data']['id'] = record_id = str(uuid.uuid4())
+        body["data"]["id"] = record_id = str(uuid.uuid4())
         record_url = self.get_item_url(record_id)
-        self.app.put_json(record_url, body,
-                          headers=self.headers, status=201)
+        self.app.put_json(record_url, body, headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
 
     def test_put_event_has_sensible_timestamp(self):
         body = {**self.body}
-        body['data']['id'] = record_id = str(uuid.uuid4())
+        body["data"]["id"] = record_id = str(uuid.uuid4())
         record_url = self.get_item_url(record_id)
-        resp = self.app.put_json(record_url, body,
-                                 headers=self.headers, status=201)
+        resp = self.app.put_json(record_url, body, headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[0].payload['timestamp'],
-                         resp.json['data']['last_modified'])
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload["timestamp"], resp.json["data"]["last_modified"])
 
     def test_not_triggered_on_failed_put(self):
         body = {**self.body}
-        body['data']['id'] = record_id = str(uuid.uuid4())
+        body["data"]["id"] = record_id = str(uuid.uuid4())
         record_url = self.get_item_url(record_id)
         self.app.put_json(record_url, body, headers=self.headers)
-        headers = {**self.headers, 'If-Match': '"12345"'}
+        headers = {**self.headers, "If-Match": '"12345"'}
         self.app.put_json(record_url, body, headers=headers, status=412)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
 
     def test_patch_sends_update_action(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers, status=201)
-        record = resp.json['data']
-        record_url = self.get_item_url(record['id'])
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        record = resp.json["data"]
+        record_url = self.get_item_url(record["id"])
 
-        self.app.patch_json(record_url, self.body, headers=self.headers,
-                            status=200)
+        self.app.patch_json(record_url, self.body, headers=self.headers, status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.UPDATE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload["action"], ACTIONS.UPDATE.value)
 
     def test_put_sends_update_action_if_record_exists(self):
         body = {**self.body}
-        body['data']['id'] = record_id = str(uuid.uuid4())
+        body["data"]["id"] = record_id = str(uuid.uuid4())
         record_url = self.get_item_url(record_id)
-        self.app.put_json(record_url, body,
-                          headers=self.headers, status=201)
+        self.app.put_json(record_url, body, headers=self.headers, status=201)
 
-        body['data']['more'] = 'stuff'
-        self.app.put_json(record_url, body,
-                          headers=self.headers, status=200)
+        body["data"]["more"] = "stuff"
+        self.app.put_json(record_url, body, headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.UPDATE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload["action"], ACTIONS.UPDATE.value)
 
     def test_delete_sends_delete_action(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers, status=201)
-        record = resp.json['data']
-        record_url = self.get_item_url(record['id'])
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        record = resp.json["data"]
+        record_url = self.get_item_url(record["id"])
 
         self.app.delete(record_url, headers=self.headers, status=200)
         self.assertEqual(len(self.events), 2)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.DELETE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload["action"], ACTIONS.DELETE.value)
 
     def test_collection_delete_sends_delete_action(self):
-        self.app.post_json(self.collection_url, self.body,
-                           headers=self.headers, status=201)
-        self.app.post_json(self.collection_url, self.body,
-                           headers=self.headers, status=201)
+        self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
 
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
         self.assertEqual(len(self.events), 3)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[1].payload['action'],
-                         ACTIONS.CREATE.value)
-        self.assertEqual(self.events[2].payload['action'],
-                         ACTIONS.DELETE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[1].payload["action"], ACTIONS.CREATE.value)
+        self.assertEqual(self.events[2].payload["action"], ACTIONS.DELETE.value)
 
     def test_request_fails_if_notify_fails(self):
         with notif_broken(self.app.app, ResourceChanged):
-            self.app.post_json(self.collection_url, self.body,
-                               headers=self.headers, status=500)
+            self.app.post_json(self.collection_url, self.body, headers=self.headers, status=500)
         self.assertEqual(len(self.events), 0)
 
     def test_triggered_on_protected_resource(self):
-        app = self.make_app(settings={
-            'psilo_write_principals': 'system.Authenticated'
-        })
-        app.post_json('/psilos', self.body,
-                      headers=self.headers, status=201)
+        app = self.make_app(settings={"psilo_write_principals": "system.Authenticated"})
+        app.post_json("/psilos", self.body, headers=self.headers, status=201)
         self.assertEqual(len(self.events), 1)
-        self.assertEqual(self.events[0].payload['action'],
-                         ACTIONS.CREATE.value)
+        self.assertEqual(self.events[0].payload["action"], ACTIONS.CREATE.value)
 
     def test_permissions_are_stripped_from_event_on_protected_resource(self):
-        app = self.make_app(settings={
-            'psilo_write_principals': 'system.Authenticated'
-        })
-        resp = app.post_json('/psilos', self.body,
-                             headers=self.headers, status=201)
-        record = resp.json['data']
-        record_url = '/psilos/{}'.format(record['id'])
-        app.patch_json(record_url, {"data": {"name": "De barcelona"}},
-                       headers=self.headers)
+        app = self.make_app(settings={"psilo_write_principals": "system.Authenticated"})
+        resp = app.post_json("/psilos", self.body, headers=self.headers, status=201)
+        record = resp.json["data"]
+        record_url = "/psilos/{}".format(record["id"])
+        app.patch_json(record_url, {"data": {"name": "De barcelona"}}, headers=self.headers)
         impacted_records = self.events[-1].impacted_records
-        self.assertNotIn('__permissions__', impacted_records[0]['new'])
-        self.assertNotIn('__permissions__', impacted_records[0]['old'])
+        self.assertNotIn("__permissions__", impacted_records[0]["new"])
+        self.assertNotIn("__permissions__", impacted_records[0]["old"])
 
 
 class AfterResourceChangedTest(BaseEventTest, unittest.TestCase):
@@ -238,8 +207,7 @@ class AfterResourceChangedTest(BaseEventTest, unittest.TestCase):
 
     def test_request_succeeds_if_notify_fails(self):
         with notif_broken(self.app.app, AfterResourceChanged):
-            self.app.post_json(self.collection_url, self.body,
-                               headers=self.headers)
+            self.app.post_json(self.collection_url, self.body, headers=self.headers)
 
         self.assertEqual(len(self.events), 0)
 
@@ -250,8 +218,7 @@ class AfterResourceReadTest(BaseEventTest, unittest.TestCase):
 
     def test_request_succeeds_if_notify_fails(self):
         with notif_broken(self.app.app, AfterResourceChanged):
-            self.app.post_json(self.collection_url, self.body,
-                               headers=self.headers)
+            self.app.post_json(self.collection_url, self.body, headers=self.headers)
 
         self.assertEqual(len(self.events), 0)
 
@@ -261,67 +228,56 @@ class ImpactedRecordsTest(BaseEventTest, unittest.TestCase):
     subscribed = (ResourceChanged,)
 
     def test_create_has_new_record_and_no_old_in_payload(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers)
-        record = resp.json['data']
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers)
+        record = resp.json["data"]
         impacted_records = self.events[-1].impacted_records
         self.assertEqual(len(impacted_records), 1)
-        self.assertNotIn('old', impacted_records[0])
-        self.assertEqual(impacted_records[0]['new'], record)
+        self.assertNotIn("old", impacted_records[0])
+        self.assertEqual(impacted_records[0]["new"], record)
 
     def test_collection_delete_has_old_and_new_in_payload(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers)
-        record1 = resp.json['data']
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers)
-        record2 = resp.json['data']
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers)
+        record1 = resp.json["data"]
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers)
+        record2 = resp.json["data"]
 
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
         impacted_records = self.events[-1].impacted_records
         self.assertEqual(len(impacted_records), 2)
-        impacted_records = sorted(impacted_records,
-                                  key=lambda x: x['old']['last_modified'])
-        self.assertEqual(impacted_records[0]['old'], record1)
-        self.assertEqual(impacted_records[1]['old'], record2)
-        self.assertEqual(impacted_records[0]['new']['deleted'], True)
-        self.assertEqual(impacted_records[1]['new']['deleted'], True)
-        self.assertEqual(impacted_records[0]['old']['id'],
-                         impacted_records[0]['new']['id'])
-        self.assertEqual(impacted_records[1]['old']['id'],
-                         impacted_records[1]['new']['id'])
-        deleted_ids = {impacted_records[0]['new']['id'],
-                       impacted_records[1]['new']['id']}
-        self.assertEqual(deleted_ids, {record1['id'], record2['id']})
+        impacted_records = sorted(impacted_records, key=lambda x: x["old"]["last_modified"])
+        self.assertEqual(impacted_records[0]["old"], record1)
+        self.assertEqual(impacted_records[1]["old"], record2)
+        self.assertEqual(impacted_records[0]["new"]["deleted"], True)
+        self.assertEqual(impacted_records[1]["new"]["deleted"], True)
+        self.assertEqual(impacted_records[0]["old"]["id"], impacted_records[0]["new"]["id"])
+        self.assertEqual(impacted_records[1]["old"]["id"], impacted_records[1]["new"]["id"])
+        deleted_ids = {impacted_records[0]["new"]["id"], impacted_records[1]["new"]["id"]}
+        self.assertEqual(deleted_ids, {record1["id"], record2["id"]})
 
     def test_update_has_old_and_new_record(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers, status=201)
-        record = resp.json['data']
-        record_url = self.get_item_url(record['id'])
-        self.app.patch_json(record_url, {'data': {'name': 'en boite'}},
-                            headers=self.headers)
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        record = resp.json["data"]
+        record_url = self.get_item_url(record["id"])
+        self.app.patch_json(record_url, {"data": {"name": "en boite"}}, headers=self.headers)
         impacted_records = self.events[-1].impacted_records
         self.assertEqual(len(impacted_records), 1)
-        self.assertEqual(impacted_records[0]['new']['id'], record['id'])
-        self.assertEqual(impacted_records[0]['new']['id'],
-                         impacted_records[0]['old']['id'])
-        self.assertEqual(impacted_records[0]['old']['name'], 'de Paris')
-        self.assertEqual(impacted_records[0]['new']['name'], 'en boite')
+        self.assertEqual(impacted_records[0]["new"]["id"], record["id"])
+        self.assertEqual(impacted_records[0]["new"]["id"], impacted_records[0]["old"]["id"])
+        self.assertEqual(impacted_records[0]["old"]["name"], "de Paris")
+        self.assertEqual(impacted_records[0]["new"]["name"], "en boite")
 
     def test_delete_has_old_and_new_record_in_payload(self):
-        resp = self.app.post_json(self.collection_url, self.body,
-                                  headers=self.headers, status=201)
-        record = resp.json['data']
-        record_url = self.get_item_url(record['id'])
+        resp = self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
+        record = resp.json["data"]
+        record_url = self.get_item_url(record["id"])
         self.app.delete(record_url, headers=self.headers, status=200)
 
         impacted_records = self.events[-1].impacted_records
         self.assertEqual(len(impacted_records), 1)
-        self.assertEqual(impacted_records[0]['old'], record)
-        self.assertEqual(impacted_records[0]['new']['id'], record['id'])
-        self.assertEqual(impacted_records[0]['new']['deleted'], True)
+        self.assertEqual(impacted_records[0]["old"], record)
+        self.assertEqual(impacted_records[0]["new"]["id"], record["id"])
+        self.assertEqual(impacted_records[0]["new"]["deleted"], True)
 
 
 class BatchEventsTest(BaseEventTest, unittest.TestCase):
@@ -332,49 +288,39 @@ class BatchEventsTest(BaseEventTest, unittest.TestCase):
         record_id = str(uuid.uuid4())
         record_url = self.get_item_url(record_id)
         body = {
-            "defaults": {
-                "method": "PUT",
-                "path": record_url
-            },
+            "defaults": {"method": "PUT", "path": record_url},
             "requests": [
-                {"body": {'data': {'name': 'foo'}}},
-                {"body": {'data': {'name': 'bar'}}},
-                {"body": {'data': {'name': 'baz'}}},
-                {"method": "DELETE"}
-            ]
+                {"body": {"data": {"name": "foo"}}},
+                {"body": {"data": {"name": "bar"}}},
+                {"body": {"data": {"name": "baz"}}},
+                {"method": "DELETE"},
+            ],
         }
         self.app.post_json("/batch", body, headers=self.headers)
         self.assertEqual(len(self.events), 3)
 
         create_event = self.events[0]
-        self.assertEqual(create_event.payload['action'], 'create')
+        self.assertEqual(create_event.payload["action"], "create")
         self.assertEqual(len(create_event.impacted_records), 1)
-        self.assertNotIn('old', create_event.impacted_records[0])
+        self.assertNotIn("old", create_event.impacted_records[0])
         update_event = self.events[1]
-        self.assertEqual(update_event.payload['action'], 'update')
+        self.assertEqual(update_event.payload["action"], "update")
         impacted = update_event.impacted_records
         self.assertEqual(len(impacted), 2)
-        self.assertEqual(impacted[0]['old']['name'], 'foo')
-        self.assertEqual(impacted[0]['new']['name'], 'bar')
-        self.assertEqual(impacted[1]['old']['name'], 'bar')
-        self.assertEqual(impacted[1]['new']['name'], 'baz')
+        self.assertEqual(impacted[0]["old"]["name"], "foo")
+        self.assertEqual(impacted[0]["new"]["name"], "bar")
+        self.assertEqual(impacted[1]["old"]["name"], "bar")
+        self.assertEqual(impacted[1]["new"]["name"], "baz")
         delete_event = self.events[2]
-        self.assertEqual(delete_event.payload['action'], 'delete')
+        self.assertEqual(delete_event.payload["action"], "delete")
         self.assertEqual(len(delete_event.impacted_records), 1)
-        self.assertIn('old', delete_event.impacted_records[0])
-        self.assertIn('new', delete_event.impacted_records[0])
+        self.assertIn("old", delete_event.impacted_records[0])
+        self.assertIn("new", delete_event.impacted_records[0])
 
     def test_one_event_is_sent_per_resource(self):
         body = {
-            "defaults": {
-                "method": "POST",
-                "body": self.body,
-            },
-            "requests": [
-                {"path": '/mushrooms'},
-                {"path": '/mushrooms'},
-                {"path": '/psilos'},
-            ]
+            "defaults": {"method": "POST", "body": self.body},
+            "requests": [{"path": "/mushrooms"}, {"path": "/mushrooms"}, {"path": "/psilos"}],
         }
         self.app.post_json("/batch", body, headers=self.headers)
         self.assertEqual(len(self.events), 2)
@@ -383,16 +329,12 @@ class BatchEventsTest(BaseEventTest, unittest.TestCase):
         # /mushrooms is a UserResource (see testapp.views), which means
         # that parent_id depends on the authenticated user.
         body = {
-            "defaults": {
-                "path": '/mushrooms',
-                "method": "POST",
-                "body": self.body
-            },
+            "defaults": {"path": "/mushrooms", "method": "POST", "body": self.body},
             "requests": [
                 {"headers": {"Authorization": "Basic bWF0OjE="}},
                 {"headers": {"Authorization": "Basic dG90bzp0dXR1"}},
                 {"headers": {"Authorization": "Basic bWF0OjE="}},
-            ]
+            ],
         }
         self.app.post_json("/batch", body, headers=self.headers)
         # Two different auth headers, thus two different parent_id:
@@ -400,40 +342,27 @@ class BatchEventsTest(BaseEventTest, unittest.TestCase):
 
     def test_one_event_is_sent_per_action(self):
         body = {
-            "defaults": {
-                "path": '/mushrooms',
-            },
+            "defaults": {"path": "/mushrooms"},
             "requests": [
                 {"method": "POST", "body": self.body},
                 {"method": "DELETE"},
                 {"method": "GET"},
-            ]
+            ],
         }
         self.app.post_json("/batch", body, headers=self.headers)
         self.assertEqual(len(self.events), 3)
 
     def test_events_are_not_sent_if_subrequest_fails(self):
-        patch = mock.patch.object(self.storage,
-                                  'delete_all',
-                                  side_effect=BackendError('boom'))
+        patch = mock.patch.object(self.storage, "delete_all", side_effect=BackendError("boom"))
         patch.start()
         self.addCleanup(patch.stop)
-        request_create = {
-            "method": "POST",
-            "body": self.body,
-        }
-        request_delete_all = {
-            "method": "DELETE",
-            "body": self.body,
-        }
+        request_create = {"method": "POST", "body": self.body}
+        request_delete_all = {"method": "DELETE", "body": self.body}
         body = {
-            "defaults": {
-                "path": self.collection_url
-            },
-            "requests": [request_create, request_delete_all]
+            "defaults": {"path": self.collection_url},
+            "requests": [request_create, request_delete_all],
         }
-        self.app.post_json("/batch", body, headers=self.headers,
-                           status=503)
+        self.app.post_json("/batch", body, headers=self.headers, status=503)
         self.assertEqual(len(self.events), 0)
 
 
@@ -450,67 +379,66 @@ class CascadingEventsTest(BaseEventTest, unittest.TestCase):
             raise ValueError("Too many events {}".format(event.impacted_records))
         # An event without records is impossible.
         assert len(event.impacted_records) == 1
-        if event.impacted_records[0]['new']['name'] == 'de Paris':
-            new_record = {'name': 'de New York'}
+        if event.impacted_records[0]["new"]["name"] == "de Paris":
+            new_record = {"name": "de New York"}
             # Trying to match the Mushroom (i.e. UserResource) parent
             # ID to test event grouping
             parent_id = event.request.prefixed_userid
-            notify_resource_event(event.request, parent_id, event.payload['timestamp'], new_record,
-                                  ACTIONS.CREATE)
+            notify_resource_event(
+                event.request, parent_id, event.payload["timestamp"], new_record, ACTIONS.CREATE
+            )
 
     def test_event_can_trigger_other_event(self):
-        self.app.post_json(self.collection_url, self.body,
-                           headers=self.headers, status=201)
+        self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
         resource_changed_events = [e for e in self.events if isinstance(e, ResourceChanged)]
         self.assertEqual(len(resource_changed_events), 2)
-        self.assertEqual(resource_changed_events[0].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(resource_changed_events[0].payload["action"], ACTIONS.CREATE.value)
         self.assertEqual(len(resource_changed_events[0].impacted_records), 1)
-        self.assertEqual(resource_changed_events[0].impacted_records[0]['new']['name'],
-                         'de Paris')
-        self.assertEqual(resource_changed_events[1].payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(resource_changed_events[0].impacted_records[0]["new"]["name"], "de Paris")
+        self.assertEqual(resource_changed_events[1].payload["action"], ACTIONS.CREATE.value)
         self.assertEqual(len(resource_changed_events[1].impacted_records), 1)
-        self.assertEqual(resource_changed_events[1].impacted_records[0]['new']['name'],
-                         'de New York')
+        self.assertEqual(
+            resource_changed_events[1].impacted_records[0]["new"]["name"], "de New York"
+        )
 
     def test_cascading_events_are_merged(self):
-        self.app.post_json(self.collection_url, self.body,
-                           headers=self.headers, status=201)
+        self.app.post_json(self.collection_url, self.body, headers=self.headers, status=201)
         relevant_events = [e for e in self.events if isinstance(e, AfterResourceChanged)]
         self.assertEqual(len(relevant_events), 1)
         merged_event = relevant_events[0]
-        self.assertEqual(merged_event.payload['action'], ACTIONS.CREATE.value)
+        self.assertEqual(merged_event.payload["action"], ACTIONS.CREATE.value)
         self.assertEqual(len(merged_event.impacted_records), 2)
-        self.assertEqual(merged_event.impacted_records[0]['new']['name'], 'de Paris')
-        self.assertEqual(merged_event.impacted_records[1]['new']['name'], 'de New York')
+        self.assertEqual(merged_event.impacted_records[0]["new"]["name"], "de Paris")
+        self.assertEqual(merged_event.impacted_records[1]["new"]["name"], "de New York")
 
 
 def load_from_config(config, prefix):
     class ClassListener:
         def __call__(self, event):
             pass
+
     return ClassListener()
 
 
 @unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")
 class StatsDTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, *args, **kwargs):
         settings = super().get_app_settings(*args, **kwargs)
         if not statsd.statsd_module:
             return settings
 
-        settings['statsd_url'] = 'udp://localhost:8125'
-        this_module = 'tests.core.resource.test_events'
-        settings['event_listeners'] = 'test'
-        settings['event_listeners.test.use'] = this_module
+        settings["statsd_url"] = "udp://localhost:8125"
+        this_module = "tests.core.resource.test_events"
+        settings["event_listeners"] = "test"
+        settings["event_listeners.test.use"] = this_module
         return settings
 
     def test_statds_tracks_listeners_execution_duration(self):
         statsd_client = self.app.app.registry.statsd._client
-        with mock.patch.object(statsd_client, 'timing') as mocked:
-            self.app.post_json(self.collection_url,
-                               {"data": {"name": "pouet"}},
-                               headers=self.headers)
+        with mock.patch.object(statsd_client, "timing") as mocked:
+            self.app.post_json(
+                self.collection_url, {"data": {"name": "pouet"}}, headers=self.headers
+            )
             timers = set(c[0][0] for c in mocked.call_args_list)
-            self.assertIn('listeners.test', timers)
+            self.assertIn("listeners.test", timers)

--- a/tests/core/resource/test_model.py
+++ b/tests/core/resource/test_model.py
@@ -6,11 +6,11 @@ from . import BaseTest
 class ModelTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.record = self.model.create_record({'field': 'value'})
+        self.record = self.model.create_record({"field": "value"})
 
     def test_list_returns_all_records_in_data(self):
         result = self.resource.collection_get()
-        records = result['data']
+        records = result["data"]
         self.assertEqual(len(records), 1)
         self.assertDictEqual(records[0], self.record)
 
@@ -18,74 +18,75 @@ class ModelTest(BaseTest):
 class CreateTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.resource.request.validated['body'] = {'data': {'field': 'new'}}
+        self.resource.request.validated["body"] = {"data": {"field": "new"}}
 
     def test_new_records_are_linked_to_owner(self):
-        resp = self.resource.collection_post()['data']
-        record_id = resp['id']
+        resp = self.resource.collection_post()["data"]
+        record_id = resp["id"]
         self.model.get_record(record_id)  # not raising
 
     def test_create_record_returns_at_least_id_and_last_modified(self):
-        record = self.resource.collection_post()['data']
+        record = self.resource.collection_post()["data"]
         self.assertIn(self.resource.model.id_field, record)
         self.assertIn(self.resource.model.modified_field, record)
-        self.assertIn('field', record)
+        self.assertIn("field", record)
 
 
 class DeleteModelTest(BaseTest):
     def setUp(self):
         super().setUp()
         self.patch_known_field.start()
-        self.model.create_record({'field': 'a'})
-        self.model.create_record({'field': 'b'})
+        self.model.create_record({"field": "a"})
+        self.model.create_record({"field": "b"})
 
     def test_delete_on_list_removes_all_records(self):
         self.resource.collection_delete()
         result = self.resource.collection_get()
-        records = result['data']
+        records = result["data"]
         self.assertEqual(len(records), 0)
 
     def test_delete_returns_deleted_version_of_records(self):
         result = self.resource.collection_delete()
-        deleted = result['data'][0]
-        self.assertIn('deleted', deleted)
+        deleted = result["data"][0]
+        self.assertIn("deleted", deleted)
 
     def test_delete_supports_collection_filters(self):
-        self.resource.request.validated['querystring'] = {'field': 'a'}
+        self.resource.request.validated["querystring"] = {"field": "a"}
         self.resource.collection_delete()
-        self.resource.request.validated['querystring'] = {}
+        self.resource.request.validated["querystring"] = {}
         result = self.resource.collection_get()
-        records = result['data']
+        records = result["data"]
         self.assertEqual(len(records), 1)
 
 
 class IsolatedModelsTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.resource.request.validated = {'header': {}, 'querystring': {}}
-        self.stored = self.model.create_record({}, parent_id='bob')
-        self.resource.record_id = self.stored['id']
+        self.resource.request.validated = {"header": {}, "querystring": {}}
+        self.stored = self.model.create_record({}, parent_id="bob")
+        self.resource.record_id = self.stored["id"]
 
     def get_request(self):
         request = super().get_request()
-        request.prefixed_userid = 'basicauth:alice'
+        request.prefixed_userid = "basicauth:alice"
         return request
 
     def get_context(self):
         context = super().get_context()
-        context.prefixed_userid = 'basicauth:alice'
+        context.prefixed_userid = "basicauth:alice"
         return context
 
     def test_list_is_filtered_by_user(self):
         resp = self.resource.collection_get()
-        records = resp['data']
+        records = resp["data"]
         self.assertEqual(len(records), 0)
 
     def test_update_record_of_another_user_will_create_it(self):
-        self.resource.request.validated['body'] = {'data': {'some': 'record'}}
+        self.resource.request.validated["body"] = {"data": {"some": "record"}}
         self.resource.put()
-        self.model.get_record(record_id=self.stored['id'],
-                              parent_id='basicauth:alice')  # not raising
+        self.model.get_record(
+            record_id=self.stored["id"], parent_id="basicauth:alice"
+        )  # not raising
 
     def test_cannot_modify_record_of_other_user(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.patch)

--- a/tests/core/resource/test_object_permissions.py
+++ b/tests/core/resource/test_object_permissions.py
@@ -27,221 +27,207 @@ class CollectionPermissionTest(PermissionTest):
         self.result = self.resource.collection_get()
 
     def test_permissions_are_not_provided_in_collection_get(self):
-        self.assertNotIn('permissions', self.result)
+        self.assertNotIn("permissions", self.result)
 
     def test_permissions_are_not_provided_in_collection_delete(self):
         result = self.resource.collection_delete()
-        self.assertNotIn('permissions', result)
+        self.assertNotIn("permissions", result)
 
 
 class ObtainRecordPermissionTest(PermissionTest):
     def setUp(self):
         super().setUp()
         record = self.resource.model.create_record({})
-        record_id = record['id']
-        record_uri = '/articles/{}'.format(record_id)
-        self.permission.add_principal_to_ace(record_uri, 'read', 'basicauth:bob')
-        self.permission.add_principal_to_ace(record_uri, 'read', 'account:readonly')
-        self.permission.add_principal_to_ace(record_uri, 'write', 'basicauth:bob')
+        record_id = record["id"]
+        record_uri = "/articles/{}".format(record_id)
+        self.permission.add_principal_to_ace(record_uri, "read", "basicauth:bob")
+        self.permission.add_principal_to_ace(record_uri, "read", "account:readonly")
+        self.permission.add_principal_to_ace(record_uri, "write", "basicauth:bob")
         self.resource.record_id = record_id
-        self.resource.request.validated['body'] = {'data': {}}
+        self.resource.request.validated["body"] = {"data": {}}
         self.resource.request.path = record_uri
 
     def test_permissions_are_provided_in_record_get(self):
         result = self.resource.get()
-        self.assertIn('permissions', result)
+        self.assertIn("permissions", result)
 
     def test_permissions_are_provided_in_record_put(self):
         result = self.resource.put()
-        self.assertIn('permissions', result)
+        self.assertIn("permissions", result)
 
     def test_permissions_are_provided_in_record_patch(self):
         result = self.resource.patch()
-        self.assertIn('permissions', result)
+        self.assertIn("permissions", result)
 
     def test_permissions_are_not_provided_in_record_delete(self):
         result = self.resource.delete()
-        self.assertNotIn('permissions', result)
+        self.assertNotIn("permissions", result)
 
     def test_permissions_gives_lists_of_principals_per_ace(self):
         result = self.resource.get()
-        permissions = result['permissions']
-        self.assertEqual(sorted(permissions['read']), ['account:readonly', 'basicauth:bob'])
-        self.assertEqual(sorted(permissions['write']), ['basicauth:bob'])
+        permissions = result["permissions"]
+        self.assertEqual(sorted(permissions["read"]), ["account:readonly", "basicauth:bob"])
+        self.assertEqual(sorted(permissions["write"]), ["basicauth:bob"])
 
     def test_permissions_are_hidden_if_user_has_only_read_permission(self):
-        self.resource.model.current_principal = 'account:readonly'
+        self.resource.model.current_principal = "account:readonly"
         self.resource.model.prefixed_principals = []
         result = self.resource.get()
-        self.assertEqual(result['permissions'], {})
+        self.assertEqual(result["permissions"], {})
 
 
 class SpecifyRecordPermissionTest(PermissionTest):
     def setUp(self):
         super().setUp()
         self.record = self.resource.model.create_record({})
-        record_id = self.record['id']
-        self.record_uri = '/articles/{}'.format(record_id)
-        self.permission.add_principal_to_ace(self.record_uri,
-                                             'read',
-                                             'account:readonly')
+        record_id = self.record["id"]
+        self.record_uri = "/articles/{}".format(record_id)
+        self.permission.add_principal_to_ace(self.record_uri, "read", "account:readonly")
         self.resource.record_id = record_id
-        self.resource.request.validated['body'] = {'data': {}}
+        self.resource.request.validated["body"] = {"data": {}}
         self.resource.request.path = self.record_uri
 
     def test_write_permission_is_given_to_creator_on_post(self):
-        self.resource.context.object_uri = '/articles'
-        self.resource.request.method = 'POST'
+        self.resource.context.object_uri = "/articles"
+        self.resource.request.method = "POST"
         result = self.resource.collection_post()
-        self.assertEqual(sorted(result['permissions']['write']),
-                         ['basicauth:bob'])
+        self.assertEqual(sorted(result["permissions"]["write"]), ["basicauth:bob"])
 
     def test_write_permission_is_given_to_put(self):
-        self.resource.request.method = 'PUT'
+        self.resource.request.method = "PUT"
         result = self.resource.put()
-        permissions = result['permissions']
-        self.assertEqual(sorted(permissions['write']), ['basicauth:bob'])
+        permissions = result["permissions"]
+        self.assertEqual(sorted(permissions["write"]), ["basicauth:bob"])
 
     def test_write_permission_is_given_to_anonymous(self):
         request = self.get_request()
         # Simulate an anonymous PUT
-        request.method = 'PUT'
-        request.validated = {**self.resource.request.validated, 'body': {'data': {**self.record}}}
+        request.method = "PUT"
+        request.validated = {**self.resource.request.validated, "body": {"data": {**self.record}}}
         request.prefixed_userid = None
-        request.matchdict = {'id': self.record['id']}
-        resource = self.resource_class(request=request,
-                                       context=self.get_context())
+        request.matchdict = {"id": self.record["id"]}
+        resource = self.resource_class(request=request, context=self.get_context())
         result = resource.put()
-        self.assertIn('system.Everyone', result['permissions']['write'])
+        self.assertIn("system.Everyone", result["permissions"]["write"])
 
     def test_permissions_can_be_specified_in_collection_post(self):
-        perms = {'write': ['jean-louis']}
-        self.resource.request.method = 'POST'
-        self.resource.context.object_uri = '/articles'
-        self.resource.request.validated['body'] = {'data': {}, 'permissions': perms}
+        perms = {"write": ["jean-louis"]}
+        self.resource.request.method = "POST"
+        self.resource.context.object_uri = "/articles"
+        self.resource.request.validated["body"] = {"data": {}, "permissions": perms}
         result = self.resource.collection_post()
-        self.assertEqual(sorted(result['permissions']['write']),
-                         ['basicauth:bob', 'jean-louis'])
+        self.assertEqual(sorted(result["permissions"]["write"]), ["basicauth:bob", "jean-louis"])
 
     def test_permissions_are_replaced_with_put(self):
-        perms = {'write': ['jean-louis']}
-        self.resource.request.validated['body']['permissions'] = perms
-        self.resource.request.method = 'PUT'
+        perms = {"write": ["jean-louis"]}
+        self.resource.request.validated["body"]["permissions"] = perms
+        self.resource.request.method = "PUT"
         result = self.resource.put()
         # In setUp() 'read' was set on this record.
         # PUT had got rid of it:
-        self.assertNotIn('read', result['permissions'])
+        self.assertNotIn("read", result["permissions"])
 
     def test_permissions_are_modified_with_patch(self):
-        perms = {'write': ['jean-louis']}
-        self.resource.request.validated['body'] = {'permissions': perms}
-        self.resource.request.method = 'PATCH'
+        perms = {"write": ["jean-louis"]}
+        self.resource.request.validated["body"] = {"permissions": perms}
+        self.resource.request.method = "PATCH"
         result = self.resource.patch()
-        permissions = result['permissions']
-        self.assertEqual(sorted(permissions['read']), ['account:readonly'])
-        self.assertEqual(sorted(permissions['write']),
-                         ['basicauth:bob', 'jean-louis'])
+        permissions = result["permissions"]
+        self.assertEqual(sorted(permissions["read"]), ["account:readonly"])
+        self.assertEqual(sorted(permissions["write"]), ["basicauth:bob", "jean-louis"])
 
     def test_permissions_can_be_removed_with_patch_but_keep_current_user(self):
-        self.permission.add_principal_to_ace(self.record_uri,
-                                             'write',
-                                             'jean-louis')
+        self.permission.add_principal_to_ace(self.record_uri, "write", "jean-louis")
 
-        perms = {'write': []}
-        self.resource.request.validated['body'] = {'permissions': perms}
-        self.resource.request.method = 'PATCH'
+        perms = {"write": []}
+        self.resource.request.validated["body"] = {"permissions": perms}
+        self.resource.request.method = "PATCH"
         result = self.resource.patch()
-        permissions = result['permissions']
-        self.assertEqual(sorted(permissions['read']), ['account:readonly']),
-        self.assertEqual(sorted(permissions['write']), ['basicauth:bob'])
+        permissions = result["permissions"]
+        self.assertEqual(sorted(permissions["read"]), ["account:readonly"]),
+        self.assertEqual(sorted(permissions["write"]), ["basicauth:bob"])
 
     def test_permissions_can_be_removed_with_patch(self):
-        self.permission.add_principal_to_ace(self.record_uri,
-                                             'write',
-                                             'jean-louis')
+        self.permission.add_principal_to_ace(self.record_uri, "write", "jean-louis")
 
-        perms = {'read': []}
-        self.resource.request.validated['body'] = {'permissions': perms}
-        self.resource.request.method = 'PATCH'
+        perms = {"read": []}
+        self.resource.request.validated["body"] = {"permissions": perms}
+        self.resource.request.method = "PATCH"
         result = self.resource.patch()
-        self.assertNotIn('read', result['permissions'])
-        self.assertEqual(sorted(result['permissions']['write']),
-                         ['basicauth:bob', 'jean-louis'])
+        self.assertNotIn("read", result["permissions"])
+        self.assertEqual(sorted(result["permissions"]["write"]), ["basicauth:bob", "jean-louis"])
 
     def test_412_errors_do_not_put_permission_in_record(self):
-        self.resource.request.validated['header'] = {'If-Match': 1234567}  # invalid
+        self.resource.request.validated["header"] = {"If-Match": 1234567}  # invalid
         try:
             self.resource.put()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertEqual(error.json['details']['existing'],
-                         {'id': self.record['id'],
-                          'last_modified': self.record['last_modified']})
+        self.assertEqual(
+            error.json["details"]["existing"],
+            {"id": self.record["id"], "last_modified": self.record["last_modified"]},
+        )
 
 
 class DeletedRecordPermissionTest(PermissionTest):
     def setUp(self):
         super().setUp()
         record = self.resource.model.create_record({})
-        self.resource.record_id = record_id = record['id']
-        self.record_uri = '/articles/{}'.format(record_id)
+        self.resource.record_id = record_id = record["id"]
+        self.record_uri = "/articles/{}".format(record_id)
         self.resource.request.route_path.return_value = self.record_uri
         self.resource.request.path = self.record_uri
-        self.permission.add_principal_to_ace(self.record_uri,
-                                             'read',
-                                             'fxa:user')
+        self.permission.add_principal_to_ace(self.record_uri, "read", "fxa:user")
 
     def test_permissions_are_deleted_when_record_is_deleted(self):
         self.resource.delete()
-        principals = self.permission.get_object_permission_principals(
-            self.record_uri, 'read')
+        principals = self.permission.get_object_permission_principals(self.record_uri, "read")
         self.assertEqual(len(principals), 0)
 
     def test_permissions_are_deleted_when_collection_is_deleted(self):
         self.resource.context.on_collection = True
         self.resource.collection_delete()
-        principals = self.permission.get_object_permission_principals(
-            self.record_uri, 'read')
+        principals = self.permission.get_object_permission_principals(self.record_uri, "read")
         self.assertEqual(len(principals), 0)
 
 
 class GuestCollectionListTest(PermissionTest):
     def setUp(self):
         super().setUp()
-        record1 = self.resource.model.create_record({'letter': 'a'})
-        record2 = self.resource.model.create_record({'letter': 'b'})
-        record3 = self.resource.model.create_record({'letter': 'c'})
+        record1 = self.resource.model.create_record({"letter": "a"})
+        record2 = self.resource.model.create_record({"letter": "b"})
+        record3 = self.resource.model.create_record({"letter": "c"})
 
-        uri1 = '/articles/{}'.format(record1['id'])
-        uri2 = '/articles/{}'.format(record2['id'])
-        uri3 = '/articles/{}'.format(record3['id'])
+        uri1 = "/articles/{}".format(record1["id"])
+        uri2 = "/articles/{}".format(record2["id"])
+        uri3 = "/articles/{}".format(record3["id"])
 
-        self.permission.add_principal_to_ace(uri1, 'read', 'fxa:user')
-        self.permission.add_principal_to_ace(uri2, 'read', 'group')
-        self.permission.add_principal_to_ace(uri3, 'read', 'jean-louis')
+        self.permission.add_principal_to_ace(uri1, "read", "fxa:user")
+        self.permission.add_principal_to_ace(uri2, "read", "group")
+        self.permission.add_principal_to_ace(uri3, "read", "jean-louis")
 
-        self.resource.context.shared_ids = [record1['id'], record2['id']]
+        self.resource.context.shared_ids = [record1["id"], record2["id"]]
 
     def test_collection_is_filtered_for_current_guest(self):
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 2)
+        self.assertEqual(len(result["data"]), 2)
 
     def test_guest_collection_can_be_filtered(self):
-        self.resource.request.validated['querystring'] = {'letter': 'a'}
-        with mock.patch.object(self.resource, 'is_known_field'):
+        self.resource.request.validated["querystring"] = {"letter": "a"}
+        with mock.patch.object(self.resource, "is_known_field"):
             result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 1)
+        self.assertEqual(len(result["data"]), 1)
 
     def test_guest_collection_is_empty_if_no_record_is_shared(self):
-        self.resource.context.shared_ids = ['tata lili']
+        self.resource.context.shared_ids = ["tata lili"]
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 0)
+        self.assertEqual(len(result["data"]), 0)
 
     def test_permission_backend_is_not_queried_if_not_guest(self):
         self.resource.context.shared_ids = None
         self.resource.request.registry.permission = None  # would fail!
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 3)
+        self.assertEqual(len(result["data"]), 3)
 
     def test_unauthorized_error_if_collection_does_not_exist(self):
         pass
@@ -250,46 +236,46 @@ class GuestCollectionListTest(PermissionTest):
 class GuestCollectionDeleteTest(PermissionTest):
     def setUp(self):
         super().setUp()
-        record1 = self.resource.model.create_record({'letter': 'a'})
-        record2 = self.resource.model.create_record({'letter': 'b'})
-        record3 = self.resource.model.create_record({'letter': 'c'})
-        record4 = self.resource.model.create_record({'letter': 'd'})
+        record1 = self.resource.model.create_record({"letter": "a"})
+        record2 = self.resource.model.create_record({"letter": "b"})
+        record3 = self.resource.model.create_record({"letter": "c"})
+        record4 = self.resource.model.create_record({"letter": "d"})
 
-        uri1 = '/articles/{}'.format(record1['id'])
-        uri2 = '/articles/{}'.format(record2['id'])
-        uri3 = '/articles/{}'.format(record3['id'])
-        uri4 = '/articles/{}'.format(record4['id'])
+        uri1 = "/articles/{}".format(record1["id"])
+        uri2 = "/articles/{}".format(record2["id"])
+        uri3 = "/articles/{}".format(record3["id"])
+        uri4 = "/articles/{}".format(record4["id"])
 
-        self.permission.add_principal_to_ace(uri1, 'read', 'fxa:user')
-        self.permission.add_principal_to_ace(uri2, 'write', 'fxa:user')
-        self.permission.add_principal_to_ace(uri3, 'write', 'group')
-        self.permission.add_principal_to_ace(uri4, 'write', 'jean-louis')
+        self.permission.add_principal_to_ace(uri1, "read", "fxa:user")
+        self.permission.add_principal_to_ace(uri2, "write", "fxa:user")
+        self.permission.add_principal_to_ace(uri3, "write", "group")
+        self.permission.add_principal_to_ace(uri4, "write", "jean-louis")
 
-        self.resource.context.shared_ids = [record2['id'], record3['id']]
-        self.resource.request.method = 'DELETE'
+        self.resource.context.shared_ids = [record2["id"], record3["id"]]
+        self.resource.request.method = "DELETE"
 
     def get_request(self):
         request = super().get_request()
         # RouteFactory must be aware of DELETE to query 'write' permission.
-        request.method = 'DELETE'
+        request.method = "DELETE"
         return request
 
     def test_collection_is_filtered_for_current_guest(self):
-        self.resource.request.path = '/articles'
+        self.resource.request.path = "/articles"
         result = self.resource.collection_delete()
-        self.assertEqual(len(result['data']), 2)
+        self.assertEqual(len(result["data"]), 2)
 
     def test_guest_collection_can_be_filtered(self):
-        self.resource.request.validated['querystring'] = {'letter': 'b'}
-        with mock.patch.object(self.resource, 'is_known_field'):
+        self.resource.request.validated["querystring"] = {"letter": "b"}
+        with mock.patch.object(self.resource, "is_known_field"):
             result = self.resource.collection_delete()
-        self.assertEqual(len(result['data']), 1)
+        self.assertEqual(len(result["data"]), 1)
         records, _ = self.resource.model.get_records()
         self.assertEqual(len(records), 3)
 
     def test_guest_cannot_delete_records_if_not_allowed(self):
-        self.resource.context.shared_ids = ['tata lili']
+        self.resource.context.shared_ids = ["tata lili"]
         result = self.resource.collection_delete()
-        self.assertEqual(len(result['data']), 0)
+        self.assertEqual(len(result["data"]), 0)
         records, _ = self.resource.model.get_records()
         self.assertEqual(len(records), 4)

--- a/tests/core/resource/test_pagination.py
+++ b/tests/core/resource/test_pagination.py
@@ -18,23 +18,19 @@ class BasePaginationTest(BaseTest):
         indices = list(range(20))
         random.shuffle(indices)
         for i in indices:
-            record = {
-                'title': 'MoFo #{0:02}'.format(i),
-                'status': i % 4,
-                'unread': (i % 2 == 0)
-            }
+            record = {"title": "MoFo #{0:02}".format(i), "status": i % 4, "unread": (i % 2 == 0)}
             if i % 3 == 0:
-                record['optional'] = True
+                record["optional"] = True
             self.model.create_record(record)
 
         self.validated = self.resource.request.validated
 
     def _setup_next_page(self):
-        next_page = self.last_response.headers['Next-Page']
+        next_page = self.last_response.headers["Next-Page"]
         url_fragments = urlparse(next_page)
         queryparams = parse_qs(url_fragments.query)
-        self.validated['querystring']['_token'] = queryparams['_token'][0]
-        self.validated['querystring']['_limit'] = int(queryparams['_limit'][0])
+        self.validated["querystring"]["_token"] = queryparams["_token"][0]
+        self.validated["querystring"]["_limit"] = int(queryparams["_limit"][0])
         self.last_response.headers = {}
         return queryparams
 
@@ -42,209 +38,205 @@ class BasePaginationTest(BaseTest):
 class PaginationTest(BasePaginationTest):
     def test_return_data(self):
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 20)
+        self.assertEqual(len(result["data"]), 20)
 
     def test_handle_limit(self):
-        self.validated['querystring'] = {'_limit': 10}
+        self.validated["querystring"] = {"_limit": 10}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 10)
+        self.assertEqual(len(result["data"]), 10)
 
     def test_handle_forced_limit(self):
-        with mock.patch.dict(self.resource.request.registry.settings, [
-                ('paginate_by', 10)]):
+        with mock.patch.dict(self.resource.request.registry.settings, [("paginate_by", 10)]):
             result = self.resource.collection_get()
-            self.assertEqual(len(result['data']), 10)
+            self.assertEqual(len(result["data"]), 10)
 
     def test_forced_limit_has_precedence_over_provided_limit(self):
-        with mock.patch.dict(self.resource.request.registry.settings, [
-                ('paginate_by', 5)]):
-            self.validated['querystring'] = {'_limit': 10}
+        with mock.patch.dict(self.resource.request.registry.settings, [("paginate_by", 5)]):
+            self.validated["querystring"] = {"_limit": 10}
             result = self.resource.collection_get()
-            self.assertEqual(len(result['data']), 5)
+            self.assertEqual(len(result["data"]), 5)
 
     def test_return_total_records_in_headers(self):
-        self.validated['querystring'] = {'_limit': 5}
+        self.validated["querystring"] = {"_limit": 5}
         self.resource.collection_get()
         headers = self.last_response.headers
-        count = headers['Total-Records']
+        count = headers["Total-Records"]
         self.assertEqual(int(count), 20)
 
     def test_return_next_page_url_is_given_in_headers(self):
-        self.validated['querystring'] = {'_limit': 10}
+        self.validated["querystring"] = {"_limit": 10}
         self.resource.collection_get()
-        self.assertIn('Next-Page', self.last_response.headers)
+        self.assertIn("Next-Page", self.last_response.headers)
 
     def test_next_page_url_has_got_querystring(self):
-        self.validated['querystring'] = {'_limit': 10}
+        self.validated["querystring"] = {"_limit": 10}
         self.resource.collection_get()
         queryparams = self._setup_next_page()
-        self.assertIn('_limit', queryparams)
-        self.assertIn('_token', queryparams)
+        self.assertIn("_limit", queryparams)
+        self.assertIn("_token", queryparams)
 
     def test_next_page_url_gives_distinct_records(self):
-        self.validated['querystring'] = {'_limit': 10}
+        self.validated["querystring"] = {"_limit": 10}
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        results_id1 = set([x['id'] for x in results1['data']])
-        results_id2 = set([x['id'] for x in results2['data']])
+        results_id1 = set([x["id"] for x in results1["data"]])
+        results_id2 = set([x["id"] for x in results2["data"]])
         self.assertFalse(results_id1.intersection(results_id2))
 
     def test_next_page_url_gives_distinct_records_with_forced_limit(self):
-        with mock.patch.dict(self.resource.request.registry.settings, [
-                ('paginate_by', 5)]):
+        with mock.patch.dict(self.resource.request.registry.settings, [("paginate_by", 5)]):
             results1 = self.resource.collection_get()
             self._setup_next_page()
             results2 = self.resource.collection_get()
 
-            results_id1 = set([x['id'] for x in results1['data']])
-            results_id2 = set([x['id'] for x in results2['data']])
+            results_id1 = set([x["id"] for x in results1["data"]])
+            results_id2 = set([x["id"] for x in results2["data"]])
             self.assertFalse(results_id1.intersection(results_id2))
 
     def test_twice_the_same_next_page(self):
-        self.validated['querystring'] = {'_limit': 10}
+        self.validated["querystring"] = {"_limit": 10}
         records = self.resource.collection_get()
-        first_ids = [r['id'] for r in records['data']]
+        first_ids = [r["id"] for r in records["data"]]
         records = self.resource.collection_get()
-        second_ids = [r['id'] for r in records['data']]
+        second_ids = [r["id"] for r in records["data"]]
         self.assertEqual(first_ids, second_ids)
 
     def test_stops_giving_next_page_at_the_end_of_first_page(self):
         self.resource.collection_get()
-        self.assertNotIn('Next-Page', self.last_response.headers)
+        self.assertNotIn("Next-Page", self.last_response.headers)
 
     def test_stops_giving_next_page_at_the_end_sets(self):
-        self.validated['querystring'] = {'_limit': 11}
+        self.validated["querystring"] = {"_limit": 11}
         self.resource.collection_get()
         self._setup_next_page()
         self.resource.collection_get()
-        self.assertNotIn('Next-Page', self.last_response.headers)
+        self.assertNotIn("Next-Page", self.last_response.headers)
 
     def test_stops_giving_next_page_at_the_end_sets_on_exact_limit(self):
-        self.validated['querystring'] = {'_limit': 10}
+        self.validated["querystring"] = {"_limit": 10}
         self.resource.collection_get()
         self._setup_next_page()
         self.resource.collection_get()
-        self.assertNotIn('Next-Page', self.last_response.headers)
+        self.assertNotIn("Next-Page", self.last_response.headers)
 
     def test_handle_simple_sorting(self):
-        self.validated['querystring'] = {'_sort': ['-status'], '_limit': 20}
+        self.validated["querystring"] = {"_sort": ["-status"], "_limit": 20}
         expected_results = self.resource.collection_get()
-        self.validated['querystring']['_limit'] = 10
+        self.validated["querystring"]["_limit"] = 10
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['data'],
-                         results1['data'] + results2['data'])
+        self.assertEqual(expected_results["data"], results1["data"] + results2["data"])
 
     def test_handle_multiple_sorting(self):
-        self.validated['querystring'] = {'_sort': ['-status', 'title'], '_limit': 20}
+        self.validated["querystring"] = {"_sort": ["-status", "title"], "_limit": 20}
         expected_results = self.resource.collection_get()
-        self.validated['querystring']['_limit'] = 10
+        self.validated["querystring"]["_limit"] = 10
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['data'],
-                         results1['data'] + results2['data'])
+        self.assertEqual(expected_results["data"], results1["data"] + results2["data"])
 
     def test_handle_filtering_sorting(self):
-        self.validated['querystring'] = {'_sort': ['-status', 'title'], 'status': 2,
-                                         '_limit': 20}
+        self.validated["querystring"] = {"_sort": ["-status", "title"], "status": 2, "_limit": 20}
         expected_results = self.resource.collection_get()
-        self.validated['querystring']['_limit'] = 3
+        self.validated["querystring"]["_limit"] = 3
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['data'],
-                         results1['data'] + results2['data'])
+        self.assertEqual(expected_results["data"], results1["data"] + results2["data"])
 
     def test_handle_sorting_desc(self):
-        self.validated['querystring'] = {'_sort': ['status', '-title'], '_limit': 20}
+        self.validated["querystring"] = {"_sort": ["status", "-title"], "_limit": 20}
         expected_results = self.resource.collection_get()
-        self.validated['querystring']['_limit'] = 10
+        self.validated["querystring"]["_limit"] = 10
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['data'],
-                         results1['data'] + results2['data'])
+        self.assertEqual(expected_results["data"], results1["data"] + results2["data"])
 
     def test_handle_since(self):
-        self.validated['querystring'] = {'_since': 123, '_limit': 20}
+        self.validated["querystring"] = {"_since": 123, "_limit": 20}
         expected_results = self.resource.collection_get()
-        self.validated['querystring']['_limit'] = 10
+        self.validated["querystring"]["_limit"] = 10
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        self.assertEqual(expected_results['data'],
-                         results1['data'] + results2['data'])
+        self.assertEqual(expected_results["data"], results1["data"] + results2["data"])
 
     def test_token_wrong_base64(self):
-        self.validated['querystring'] = {
-            '_since': 123, '_limit': 20, '_token': '123'}
+        self.validated["querystring"] = {"_since": 123, "_limit": 20, "_token": "123"}
         self.assertRaises(HTTPBadRequest, self.resource.collection_get)
 
     def test_token_wrong_json(self):
-        self.validated['querystring'] = {
-            '_since': 123, '_limit': 20,
-            '_token': b64encode('{"toto":'.encode('ascii')).decode('ascii')}
+        self.validated["querystring"] = {
+            "_since": 123,
+            "_limit": 20,
+            "_token": b64encode('{"toto":'.encode("ascii")).decode("ascii"),
+        }
         self.assertRaises(HTTPBadRequest, self.resource.collection_get)
 
     def test_token_wrong_json_fields(self):
         badtoken = '{"toto": {"tutu": 1}}'
-        self.validated['querystring'] = {
-            '_since': 123, '_limit': 20,
-            '_token': b64encode(badtoken.encode('ascii')).decode('ascii')}
+        self.validated["querystring"] = {
+            "_since": 123,
+            "_limit": 20,
+            "_token": b64encode(badtoken.encode("ascii")).decode("ascii"),
+        }
         self.assertRaises(HTTPBadRequest, self.resource.collection_get)
 
     def test_raises_bad_request_if_token_has_bad_data_structure(self):
-        invalid_token = json.dumps([[('last_modified', 0, '>')]])
-        self.validated['querystring'] = {
-            '_since': 123, '_limit': 20,
-            '_token': b64encode(invalid_token.encode('ascii')).decode('ascii')}
+        invalid_token = json.dumps([[("last_modified", 0, ">")]])
+        self.validated["querystring"] = {
+            "_since": 123,
+            "_limit": 20,
+            "_token": b64encode(invalid_token.encode("ascii")).decode("ascii"),
+        }
         self.assertRaises(HTTPBadRequest, self.resource.collection_get)
 
     def test_next_page_url_works_with_optional_fields(self):
-        self.validated['querystring'] = {'_limit': 10, '_sort': ['-optional']}
+        self.validated["querystring"] = {"_limit": 10, "_sort": ["-optional"]}
         results1 = self.resource.collection_get()
         self._setup_next_page()
         results2 = self.resource.collection_get()
-        results_id1 = set([x['id'] for x in results1['data']])
-        results_id2 = set([x['id'] for x in results2['data']])
+        results_id1 = set([x["id"] for x in results1["data"]])
+        results_id2 = set([x["id"] for x in results2["data"]])
         self.assertFalse(results_id1.intersection(results_id2))
 
 
 class PaginatedDeleteTest(BasePaginationTest):
     def test_handle_limit_on_delete(self):
-        self.validated['querystring'] = {'_limit': 3}
+        self.validated["querystring"] = {"_limit": 3}
         result = self.resource.collection_delete()
-        self.assertEqual(len(result['data']), 3)
+        self.assertEqual(len(result["data"]), 3)
 
     def test_paginated_delete(self):
         all_records = self.resource.collection_get()
-        expected_ids = [r['id'] for r in all_records['data']]
+        expected_ids = [r["id"] for r in all_records["data"]]
         # Page 1
-        self.validated['querystring']['_limit'] = 10
+        self.validated["querystring"]["_limit"] = 10
         results1 = self.resource.collection_delete()
-        results1_ids = [r['id'] for r in results1['data']]
+        results1_ids = [r["id"] for r in results1["data"]]
         self._setup_next_page()
         # Page 2
         results2 = self.resource.collection_delete()
-        results2_ids = [r['id'] for r in results2['data']]
+        results2_ids = [r["id"] for r in results2["data"]]
         self.assertEqual(expected_ids, results1_ids + results2_ids)
 
     def test_return_total_records_in_headers_matching_deletable(self):
-        self.validated['querystring'] = {'_limit': 5}
+        self.validated["querystring"] = {"_limit": 5}
         self.resource.collection_delete()
         headers = self.last_response.headers
-        count = headers['Total-Records']
+        count = headers["Total-Records"]
         self.assertEqual(int(count), 20)
 
     def test_paginated_delete_second_to_last_gets_next_header(self):
         self.resource.collection_get()
         get_all_headers = self.last_response.headers
-        count = int(get_all_headers['Total-Records']) - 1
+        count = int(get_all_headers["Total-Records"]) - 1
 
-        self.validated['querystring'] = {'_limit': 1}
+        self.validated["querystring"] = {"_limit": 1}
         headers = []
         for i in range(count):
             self.resource.collection_delete()
@@ -254,12 +246,12 @@ class PaginatedDeleteTest(BasePaginationTest):
         self.resource.collection_delete()
         headers.append(self.last_response.headers)
 
-        self.assertIn('Next-Page', headers[count - 1])
-        self.assertNotIn('Next-Page', headers[count])
+        self.assertIn("Next-Page", headers[count - 1])
+        self.assertNotIn("Next-Page", headers[count])
 
     def test_token_cannot_be_reused_twice(self):
         self.resource.request.method = "DELETE"
-        self.validated['querystring']['_limit'] = 3
+        self.validated["querystring"]["_limit"] = 3
         self.resource.collection_delete()
         self._setup_next_page()
         self.resource.collection_delete()
@@ -272,89 +264,72 @@ class BuildPaginationTokenTest(BaseTest):
         super().setUp()
         self.patch_known_field.start()
         self.record = {
-            'id': 1, 'status': 2, 'unread': True,
-            'last_modified': 1234, 'title': 'Title',
-            'nested': {'subvalue': 42},
-            'nested.other': {'subvalue': 43},
+            "id": 1,
+            "status": 2,
+            "unread": True,
+            "last_modified": 1234,
+            "title": "Title",
+            "nested": {"subvalue": 42},
+            "nested.other": {"subvalue": 43},
         }
 
     def test_token_contains_current_offset(self):
-        token = self.resource._build_pagination_token([('last_modified', -1)],
-                                                      self.record,
-                                                      42)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['offset'], 42)
+        token = self.resource._build_pagination_token([("last_modified", -1)], self.record, 42)
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(tokeninfo["offset"], 42)
 
     def test_no_sorting_default_to_modified_field(self):
-        token = self.resource._build_pagination_token([('last_modified', -1)],
-                                                      self.record,
-                                                      42)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertDictEqual(tokeninfo['last_record'],
-                             {"last_modified": 1234})
+        token = self.resource._build_pagination_token([("last_modified", -1)], self.record, 42)
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertDictEqual(tokeninfo["last_record"], {"last_modified": 1234})
 
     def test_sorting_handle_both_rules(self):
-        token = self.resource._build_pagination_token([
-            ('status', -1),
-            ('last_modified', -1)
-        ], self.record, 34)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertDictEqual(tokeninfo['last_record'],
-                             {"last_modified": 1234, "status": 2})
+        token = self.resource._build_pagination_token(
+            [("status", -1), ("last_modified", -1)], self.record, 34
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertDictEqual(tokeninfo["last_record"], {"last_modified": 1234, "status": 2})
 
     def test_sorting_handle_ordering_direction(self):
-        token = self.resource._build_pagination_token([
-            ('status', 1),
-            ('last_modified', 1)
-        ], self.record, 32)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['last_record'],
-                         {"last_modified": 1234, "status": 2})
+        token = self.resource._build_pagination_token(
+            [("status", 1), ("last_modified", 1)], self.record, 32
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(tokeninfo["last_record"], {"last_modified": 1234, "status": 2})
 
     def test_multiple_sorting_keep_all(self):
-        token = self.resource._build_pagination_token([
-            ('status', 1),
-            ('title', -1),
-            ('last_modified', -1)
-        ], self.record, 31)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['last_record'],
-                         {"last_modified": 1234, "status": 2,
-                          'title': 'Title'})
+        token = self.resource._build_pagination_token(
+            [("status", 1), ("title", -1), ("last_modified", -1)], self.record, 31
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(
+            tokeninfo["last_record"], {"last_modified": 1234, "status": 2, "title": "Title"}
+        )
 
     def test_sorting_on_nested_field(self):
-        token = self.resource._build_pagination_token([
-            ('nested.subvalue', -1),
-            ('title', 1),
-        ], self.record, 88)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['last_record'],
-                         {'title': 'Title', 'nested.subvalue': 42})
+        token = self.resource._build_pagination_token(
+            [("nested.subvalue", -1), ("title", 1)], self.record, 88
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(tokeninfo["last_record"], {"title": "Title", "nested.subvalue": 42})
 
     def test_disambiguate_fieldname_containing_dots(self):
-        token = self.resource._build_pagination_token([
-            ('nested.other.subvalue', -1),
-            ('title', 1),
-        ], self.record, 88)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['last_record'],
-                         {'title': 'Title', 'nested.other.subvalue': 43})
+        token = self.resource._build_pagination_token(
+            [("nested.other.subvalue", -1), ("title", 1)], self.record, 88
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(tokeninfo["last_record"], {"title": "Title", "nested.other.subvalue": 43})
 
     def test_strip_malformed_sort_field(self):
-        token = self.resource._build_pagination_token([
-            ('non.existent', -1),
-            ('title', 1),
-        ], self.record, 88)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['last_record'],
-                         {'title': 'Title'})
+        token = self.resource._build_pagination_token(
+            [("non.existent", -1), ("title", 1)], self.record, 88
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(tokeninfo["last_record"], {"title": "Title"})
 
     def test_can_build_while_sorting_on_missing_field(self):
-        token = self.resource._build_pagination_token([
-            ('unknown', 1),
-            ('title', -1),
-            ('last_modified', -1)
-        ], self.record, 31)
-        tokeninfo = json.loads(b64decode(token).decode('ascii'))
-        self.assertEqual(tokeninfo['last_record'],
-                         {"last_modified": 1234, "title": "Title"})
+        token = self.resource._build_pagination_token(
+            [("unknown", 1), ("title", -1), ("last_modified", -1)], self.record, 31
+        )
+        tokeninfo = json.loads(b64decode(token).decode("ascii"))
+        self.assertEqual(tokeninfo["last_record"], {"last_modified": 1234, "title": "Title"})

--- a/tests/core/resource/test_partial_response.py
+++ b/tests/core/resource/test_partial_response.py
@@ -8,88 +8,83 @@ from . import BaseTest
 class PartialResponseBase(BaseTest):
     def setUp(self):
         super().setUp()
-        self.resource._get_known_fields = lambda: ['field', 'other', 'orig']
+        self.resource._get_known_fields = lambda: ["field", "other", "orig"]
         self.record = self.model.create_record(
             {
-                'field': 'value',
-                'other': 'val',
-                'orig': {
-                    'foo': 'food',
-                    'bar': 'baz',
-                    'nested': {
-                        'size': 12546,
-                        'hash': '0x1254',
-                        'mime': 'image/png',
-                    }
-                }
-            })
-        self.resource.record_id = self.record['id']
+                "field": "value",
+                "other": "val",
+                "orig": {
+                    "foo": "food",
+                    "bar": "baz",
+                    "nested": {"size": 12546, "hash": "0x1254", "mime": "image/png"},
+                },
+            }
+        )
+        self.resource.record_id = self.record["id"]
         self.resource.request = self.get_request()
         self.resource.request.validated = self.validated
-        self.validated['querystring'] = {}
+        self.validated["querystring"] = {}
 
 
 class PartialFieldsTest(PartialResponseBase):
-
     def test_fields_parameter_do_projection_on_get(self):
-        self.validated['querystring']['_fields'] = ['field']
+        self.validated["querystring"]["_fields"] = ["field"]
         record = self.resource.get()
-        self.assertIn('field', record['data'])
-        self.assertNotIn('other', record['data'])
+        self.assertIn("field", record["data"])
+        self.assertNotIn("other", record["data"])
 
     def test_fields_parameter_do_projection_on_get_all(self):
-        self.validated['querystring']['_fields'] = ['field']
-        record = self.resource.collection_get()['data'][0]
-        self.assertIn('field', record)
-        self.assertNotIn('other', record)
+        self.validated["querystring"]["_fields"] = ["field"]
+        record = self.resource.collection_get()["data"][0]
+        self.assertIn("field", record)
+        self.assertNotIn("other", record)
 
     def test_fail_if_fields_parameter_is_invalid(self):
-        self.validated['querystring']['_fields'] = 'invalid_field'
+        self.validated["querystring"]["_fields"] = "invalid_field"
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.get)
-        self.assertRaises(
-            httpexceptions.HTTPBadRequest, self.resource.collection_get)
+        self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.collection_get)
 
     def test_can_have_multiple_fields(self):
-        self.validated['querystring']['_fields'] = ['field', 'other']
+        self.validated["querystring"]["_fields"] = ["field", "other"]
         record = self.resource.get()
-        self.assertIn('field', record['data'])
-        self.assertIn('other', record['data'])
+        self.assertIn("field", record["data"])
+        self.assertIn("other", record["data"])
 
     def test_id_and_last_modified_are_not_filtered(self):
-        self.validated['querystring']['_fields'] = ['field']
+        self.validated["querystring"]["_fields"] = ["field"]
         record = self.resource.get()
-        self.assertIn('id', record['data'])
-        self.assertIn('last_modified', record['data'])
+        self.assertIn("id", record["data"])
+        self.assertIn("last_modified", record["data"])
 
     def test_nested_parameter_can_be_filtered(self):
-        self.validated['querystring']['_fields'] = ['orig.foo']
+        self.validated["querystring"]["_fields"] = ["orig.foo"]
         record = self.resource.get()
-        self.assertIn('orig', record['data'])
-        self.assertIn('foo', record['data']['orig'])
-        self.assertNotIn('other', record['data'])
-        self.assertNotIn('bar', record['data']['orig'])
-        self.assertNotIn('nested', record['data']['orig'])
+        self.assertIn("orig", record["data"])
+        self.assertIn("foo", record["data"]["orig"])
+        self.assertNotIn("other", record["data"])
+        self.assertNotIn("bar", record["data"]["orig"])
+        self.assertNotIn("nested", record["data"]["orig"])
 
     def test_nested_parameter_can_be_filtered_on_multiple_levels(self):
-        self.validated['querystring']['_fields'] = ['orig.nested.size']
+        self.validated["querystring"]["_fields"] = ["orig.nested.size"]
         record = self.resource.get()
-        self.assertIn('nested', record['data']['orig'])
-        self.assertIn('size', record['data']['orig']['nested'])
-        self.assertNotIn('hash', record['data']['orig']['nested'])
-        self.assertNotIn('mime', record['data']['orig']['nested'])
+        self.assertIn("nested", record["data"]["orig"])
+        self.assertIn("size", record["data"]["orig"]["nested"])
+        self.assertNotIn("hash", record["data"]["orig"]["nested"])
+        self.assertNotIn("mime", record["data"]["orig"]["nested"])
 
     def test_can_filter_on_several_nested_fields(self):
-        self.validated['querystring']['_fields'] = ['orig.nested.size', 'orig.nested.hash']
+        self.validated["querystring"]["_fields"] = ["orig.nested.size", "orig.nested.hash"]
         record = self.resource.get()
-        self.assertIn('size', record['data']['orig']['nested'])
-        self.assertIn('hash', record['data']['orig']['nested'])
-        self.assertNotIn('mime', record['data']['orig']['nested'])
+        self.assertIn("size", record["data"]["orig"]["nested"])
+        self.assertIn("hash", record["data"]["orig"]["nested"])
+        self.assertNotIn("mime", record["data"]["orig"]["nested"])
 
 
 class PermissionTest(PartialResponseBase):
     resource_class = ShareableResource
 
     def test_permissions_are_not_displayed(self):
-        self.validated['querystring']['_fields'] = ['field']
+        self.validated["querystring"]["_fields"] = ["field"]
         result = self.resource.get()
-        self.assertNotIn('permissions', result)
+        self.assertNotIn("permissions", result)

--- a/tests/core/resource/test_preconditions.py
+++ b/tests/core/resource/test_preconditions.py
@@ -10,16 +10,15 @@ class NotModifiedTest(BaseTest):
         super().setUp()
         self.stored = self.model.create_record({})
 
-        self.resource = self.resource_class(request=self.get_request(),
-                                            context=self.get_context())
+        self.resource = self.resource_class(request=self.get_request(), context=self.get_context())
         self.resource.request.validated = {**self.validated}
         self.resource.collection_get()
         self.validated = self.resource.request.validated
-        current = self.last_response.headers['ETag'][1:-1]
-        self.validated['header']['If-None-Match'] = int(current)
+        current = self.last_response.headers["ETag"][1:-1]
+        self.validated["header"]["If-None-Match"] = int(current)
 
     def test_collection_returns_200_if_change_meanwhile(self):
-        self.validated['header']['If-None-Match'] = 42
+        self.validated["header"]["If-None-Match"] = 42
         self.resource.collection_get()  # Not raising.
 
     def test_collection_returns_304_if_no_change_meanwhile(self):
@@ -28,27 +27,27 @@ class NotModifiedTest(BaseTest):
         except httpexceptions.HTTPNotModified as e:
             error = e
         self.assertEqual(error.code, 304)
-        self.assertIsNotNone(error.headers.get('ETag'))
-        self.assertIsNotNone(error.headers.get('Last-Modified'))
+        self.assertIsNotNone(error.headers.get("ETag"))
+        self.assertIsNotNone(error.headers.get("Last-Modified"))
 
     def test_single_record_returns_304_if_no_change_meanwhile(self):
-        self.resource.record_id = self.stored['id']
+        self.resource.record_id = self.stored["id"]
         try:
             self.resource.get()
         except httpexceptions.HTTPNotModified as e:
             error = e
         self.assertEqual(error.code, 304)
-        self.assertIsNotNone(error.headers.get('ETag'))
-        self.assertIsNotNone(error.headers.get('Last-Modified'))
+        self.assertIsNotNone(error.headers.get("ETag"))
+        self.assertIsNotNone(error.headers.get("Last-Modified"))
 
     def test_single_record_last_modified_is_returned(self):
         self.resource.timestamp = 0
-        self.resource.record_id = self.stored['id']
+        self.resource.record_id = self.stored["id"]
         try:
             self.resource.get()
         except httpexceptions.HTTPNotModified as e:
             error = e
-        self.assertNotIn('1970', error.headers['Last-Modified'])
+        self.assertNotIn("1970", error.headers["Last-Modified"])
 
 
 class ModifiedMeanwhileTest(BaseTest):
@@ -58,38 +57,40 @@ class ModifiedMeanwhileTest(BaseTest):
         # Create a record using model (will have an incremented last_modified)
         self.stored = self.model.create_record({})
         # Update the record we just created (will set last_modified with the server ETag)
-        self.resource.record_id = self.stored['id']
+        self.resource.record_id = self.stored["id"]
         self.resource.put()
         # Update our record with last_modified provided by the server
-        self.stored['last_modified'] = int(self.last_response.headers['ETag'][1:-1])
+        self.stored["last_modified"] = int(self.last_response.headers["ETag"][1:-1])
 
         self.validated = self.resource.request.validated
-        self.current = int(self.last_response.headers['ETag'][1:-1])
+        self.current = int(self.last_response.headers["ETag"][1:-1])
         previous = self.current - 10
-        self.validated['header']['If-Match'] = previous
+        self.validated["header"]["If-Match"] = previous
 
     def test_preconditions_errors_are_json_formatted(self):
         try:
             self.resource.collection_get()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertEqual(error.json, {
-            'errno': ERRORS.MODIFIED_MEANWHILE.value,
-            'message': 'Resource was modified meanwhile',
-            'code': 412,
-            'error': 'Precondition Failed'})
+        self.assertEqual(
+            error.json,
+            {
+                "errno": ERRORS.MODIFIED_MEANWHILE.value,
+                "message": "Resource was modified meanwhile",
+                "code": 412,
+                "error": "Precondition Failed",
+            },
+        )
 
     def test_collection_returns_412_if_changed_meanwhile(self):
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_get)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_get)
 
     def test_collection_returns_412_if_if_match_is_superior(self):
-        self.validated['header']['If-Match'] = self.current + 10
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_get)
+        self.validated["header"]["If-Match"] = self.current + 10
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_get)
 
     def test_collection_returns_200_if_if_match_is_equal(self):
-        self.validated['header']['If-Match'] = self.current
+        self.validated["header"]["If-Match"] = self.current
         self.resource.collection_get()
 
     def test_412_errors_on_collection_do_not_provide_existing_record(self):
@@ -97,186 +98,161 @@ class ModifiedMeanwhileTest(BaseTest):
             self.resource.collection_get()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertNotIn('existing', error.json.get('details', {}))
+        self.assertNotIn("existing", error.json.get("details", {}))
 
     def test_412_on_collection_has_last_modified_timestamp(self):
         try:
             self.resource.collection_get()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertIsNotNone(error.headers.get('ETag'))
-        self.assertIsNotNone(error.headers.get('Last-Modified'))
+        self.assertIsNotNone(error.headers.get("ETag"))
+        self.assertIsNotNone(error.headers.get("Last-Modified"))
 
     def test_412_errors_on_record_provide_existing_data(self):
         try:
             self.resource.put()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertDictEqual(error.json['details']['existing'],
-                             self.stored)
+        self.assertDictEqual(error.json["details"]["existing"], self.stored)
 
     def test_single_record_returns_412_if_changed_meanwhile(self):
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.get)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.get)
 
     def test_412_on_single_record_has_last_modified_timestamp(self):
         try:
             self.resource.get()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertIsNotNone(error.headers.get('ETag'))
-        self.assertIsNotNone(error.headers.get('Last-Modified'))
+        self.assertIsNotNone(error.headers.get("ETag"))
+        self.assertIsNotNone(error.headers.get("Last-Modified"))
 
     def test_create_returns_412_if_changed_meanwhile(self):
-        self.validated['body'] = {'data': {'field': 'new'}}
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_post)
+        self.validated["body"] = {"data": {"field": "new"}}
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_post)
 
     def test_put_returns_412_if_changed_meanwhile(self):
         self.model.delete_record(self.stored)
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_put_returns_412_if_changed_and_none_match_present(self):
-        self.validated['body'] = {'data': {'field': 'new'}}
-        self.validated['header']['If-None-Match'] = 42
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.validated["body"] = {"data": {"field": "new"}}
+        self.validated["header"]["If-None-Match"] = 42
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_put_returns_last_modified_if_changed_meanwhile(self):
         self.resource.timestamp = 0
-        self.resource.record_id = self.stored['id']
+        self.resource.record_id = self.stored["id"]
         try:
             self.resource.put()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertNotIn('1970', error.headers['Last-Modified'])
+        self.assertNotIn("1970", error.headers["Last-Modified"])
 
     def test_put_returns_412_if_deleted_meanwhile(self):
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_put_if_none_match_star_fails_if_record_exists(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_get_if_none_match_star_fails_if_record_exists(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.get)
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.get)
 
     def test_put_if_none_match_star_succeeds_if_record_does_not_exist(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.validated['body'] = {'data': {'field': 'new'}}
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.validated["body"] = {"data": {"field": "new"}}
         self.resource.record_id = self.resource.model.id_generator()
         self.resource.put()  # not raising.
 
     def test_put_if_none_match_star_succeeds_if_tombstone_exists(self):
         self.model.delete_record(self.stored)
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.validated['body'] = {'data': {'field': 'new'}}
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.validated["body"] = {"data": {"field": "new"}}
         self.resource.put()  # not raising.
 
     def test_post_if_none_match_star_fails_if_record_exists(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.resource.request.json = {
-            'data': {
-                'id': self.stored['id'],
-                'field': 'new'}}
-        self.validated['body'] = self.resource.request.json
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_post)
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.resource.request.json = {"data": {"id": self.stored["id"], "field": "new"}}
+        self.validated["body"] = self.resource.request.json
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_post)
 
     def test_post_if_none_match_star_succeeds_if_record_does_not_exist(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.validated['body'] = {
-            'data': {
-                'id': self.resource.model.id_generator(),
-                'field': 'new'}}
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.validated["body"] = {
+            "data": {"id": self.resource.model.id_generator(), "field": "new"}
+        }
         self.resource.collection_post()  # not raising.
 
     def test_get_if_none_match_star_fails_on_collections(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_get)
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_get)
 
     def test_delete_if_none_match_star_fails_on_collections(self):
-        self.validated['header'].pop('If-Match')
-        self.validated['header']['If-None-Match'] = '*'
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_delete)
+        self.validated["header"].pop("If-Match")
+        self.validated["header"]["If-None-Match"] = "*"
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_delete)
 
     def test_get_if_match_star_succeeds_if_record_exists(self):
-        self.validated['header']['If-Match'] = '*'
-        self.resource.record_id = self.stored['id']
+        self.validated["header"]["If-Match"] = "*"
+        self.resource.record_id = self.stored["id"]
         self.resource.get()
 
     def test_post_if_match_star_succeeds_if_record_exists(self):
-        self.validated['header']['If-Match'] = '*'
-        self.resource.request.json = {
-            'data': {
-                'id': self.stored['id'],
-                'field': 'new'}}
-        self.validated['body'] = self.resource.request.json
+        self.validated["header"]["If-Match"] = "*"
+        self.resource.request.json = {"data": {"id": self.stored["id"], "field": "new"}}
+        self.validated["body"] = self.resource.request.json
         self.resource.collection_post()
 
     def test_put_if_match_star_succeeds_if_record_exists(self):
-        self.validated['header']['If-Match'] = '*'
+        self.validated["header"]["If-Match"] = "*"
         self.resource.put()
 
     def test_patch_if_match_star_succeeds_if_record_exists(self):
-        self.validated['header']['If-Match'] = '*'
-        self.resource.request.json = {
-            'data': {
-                'id': self.stored['id'],
-                'field': 'new'}}
-        self.validated['body'] = self.resource.request.json
+        self.validated["header"]["If-Match"] = "*"
+        self.resource.request.json = {"data": {"id": self.stored["id"], "field": "new"}}
+        self.validated["body"] = self.resource.request.json
         self.resource.patch()
 
     def test_delete_if_match_star_succeeds_if_record_exists(self):
-        self.validated['header']['If-Match'] = '*'
+        self.validated["header"]["If-Match"] = "*"
         self.resource.delete()
 
     def test_put_if_match_star_fails_if_record_does_not_exist(self):
-        self.validated['header']['If-Match'] = '*'
-        self.resource.request.json = {'data': {'field': 'new'}}
-        self.validated['body'] = self.resource.request.json
+        self.validated["header"]["If-Match"] = "*"
+        self.resource.request.json = {"data": {"field": "new"}}
+        self.validated["body"] = self.resource.request.json
         self.resource.record_id = self.resource.model.id_generator()
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_put_if_match_current_fails_if_record_does_not_exist(self):
-        self.validated['header']['If-Match'] = self.current  # wouldn't raise on existing
-        self.resource.request.json = {'data': {'field': 'new'}}
-        self.validated['body'] = self.resource.request.json
+        self.validated["header"]["If-Match"] = self.current  # wouldn't raise on existing
+        self.resource.request.json = {"data": {"field": "new"}}
+        self.validated["body"] = self.resource.request.json
         self.resource.record_id = self.resource.model.id_generator()
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_put_if_fails_if_if_match_is_superior(self):
-        self.validated['header']['If-Match'] += self.current + 10
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.put)
+        self.validated["header"]["If-Match"] += self.current + 10
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.put)
 
     def test_get_if_match_star_suceed_on_collections(self):
-        self.validated['header']['If-Match'] = '*'
+        self.validated["header"]["If-Match"] = "*"
         self.resource.collection_get()
 
     def test_delete_if_match_star_suceed_on_collections(self):
-        self.validated['header']['If-Match'] = '*'
+        self.validated["header"]["If-Match"] = "*"
         self.resource.collection_delete()
 
     def test_patch_returns_412_if_changed_meanwhile(self):
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.patch)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.patch)
 
     def test_patch_returns_last_modified_if_changed_meanwhile(self):
         self.resource.timestamp = 0
@@ -284,12 +260,10 @@ class ModifiedMeanwhileTest(BaseTest):
             self.resource.patch()
         except httpexceptions.HTTPPreconditionFailed as e:
             error = e
-        self.assertNotIn('1970', error.headers['Last-Modified'])
+        self.assertNotIn("1970", error.headers["Last-Modified"])
 
     def test_delete_returns_412_if_changed_meanwhile(self):
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.delete)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.delete)
 
     def test_delete_all_returns_412_if_changed_meanwhile(self):
-        self.assertRaises(httpexceptions.HTTPPreconditionFailed,
-                          self.resource.collection_delete)
+        self.assertRaises(httpexceptions.HTTPPreconditionFailed, self.resource.collection_delete)

--- a/tests/core/resource/test_record.py
+++ b/tests/core/resource/test_record.py
@@ -12,118 +12,108 @@ from . import BaseTest
 
 class GetTest(BaseTest):
     def test_get_record_returns_all_fields(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
-        result = self.resource.get()['data']
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
+        result = self.resource.get()["data"]
         self.assertIn(self.resource.model.id_field, result)
         self.assertIn(self.resource.model.modified_field, result)
-        self.assertIn('field', result)
+        self.assertIn("field", result)
 
     def test_etag_is_provided(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
         self.resource.get()
-        self.assertIn('ETag', self.last_response.headers)
+        self.assertIn("ETag", self.last_response.headers)
 
     def test_etag_contains_record_timestamp(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
         # Create another one, bump collection timestamp.
-        self.model.create_record({'field': 'value'})
+        self.model.create_record({"field": "value"})
         self.resource.get()
-        expected = '"{}"'.format(record['last_modified'])
-        self.assertEqual(expected, self.last_response.headers['ETag'])
+        expected = '"{}"'.format(record["last_modified"])
+        self.assertEqual(expected, self.last_response.headers["ETag"])
 
 
 class PutTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.record = self.model.create_record({'field': 'old'})
-        self.resource.record_id = self.record['id']
+        self.record = self.model.create_record({"field": "old"})
+        self.resource.record_id = self.record["id"]
 
     def test_etag_is_provided(self):
-        self.validated['body'] = {'data': {'field': 'new'}}
+        self.validated["body"] = {"data": {"field": "new"}}
         self.resource.put()
-        self.assertIn('ETag', self.last_response.headers)
+        self.assertIn("ETag", self.last_response.headers)
 
     def test_etag_contains_record_new_timestamp(self):
-        self.validated['body'] = {'data': {'field': 'new'}}
-        new = self.resource.put()['data']
-        expected = '"{}"'.format(new['last_modified'])
-        self.assertEqual(expected, self.last_response.headers['ETag'])
+        self.validated["body"] = {"data": {"field": "new"}}
+        new = self.resource.put()["data"]
+        expected = '"{}"'.format(new["last_modified"])
+        self.assertEqual(expected, self.last_response.headers["ETag"])
 
     def test_returns_201_if_created(self):
         self.resource.record_id = self.resource.model.id_generator()
-        self.validated['body'] = {'data': {'field': 'new'}}
+        self.validated["body"] = {"data": {"field": "new"}}
         self.resource.put()
         self.assertEqual(self.last_response.status_code, 201)
 
     def test_relies_on_collection_create(self):
         self.resource.record_id = self.resource.model.id_generator()
-        self.validated['body'] = {'data': {'field': 'new'}}
-        with mock.patch.object(self.model, 'create_record') as patched:
+        self.validated["body"] = {"data": {"field": "new"}}
+        with mock.patch.object(self.model, "create_record") as patched:
             self.resource.put()
             self.assertEqual(patched.call_count, 1)
 
     def test_relies_on_collection_create_even_when_previously_deleted(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
-        self.resource.delete()['data']
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
+        self.resource.delete()["data"]
 
-        self.validated['body'] = {'data': {'field': 'new'}}
-        with mock.patch.object(self.model, 'create_record') as patched:
+        self.validated["body"] = {"data": {"field": "new"}}
+        with mock.patch.object(self.model, "create_record") as patched:
             self.resource.put()
             self.assertEqual(patched.call_count, 1)
 
     def test_replace_record_returns_updated_fields(self):
-        self.validated['body'] = {'data': {'field': 'new'}}
-        result = self.resource.put()['data']
-        self.assertEqual(self.record['id'], result['id'])
-        self.assertNotEqual(self.record['last_modified'],
-                            result['last_modified'])
-        self.assertNotEqual(self.record['field'], 'new')
+        self.validated["body"] = {"data": {"field": "new"}}
+        result = self.resource.put()["data"]
+        self.assertEqual(self.record["id"], result["id"])
+        self.assertNotEqual(self.record["last_modified"], result["last_modified"])
+        self.assertNotEqual(self.record["field"], "new")
 
     def test_last_modified_is_kept_if_present(self):
-        new_last_modified = self.record['last_modified'] + 20
-        self.validated['body'] = {'data': {
-            'field': 'new',
-            'last_modified': new_last_modified}
-        }
-        result = self.resource.put()['data']
-        self.assertEqual(result['last_modified'], new_last_modified)
+        new_last_modified = self.record["last_modified"] + 20
+        self.validated["body"] = {"data": {"field": "new", "last_modified": new_last_modified}}
+        result = self.resource.put()["data"]
+        self.assertEqual(result["last_modified"], new_last_modified)
 
     def test_last_modified_is_dropped_if_same_as_previous(self):
-        self.validated['body'] = {'data': {
-            'field': 'new',
-            'last_modified': self.record['last_modified']}
+        self.validated["body"] = {
+            "data": {"field": "new", "last_modified": self.record["last_modified"]}
         }
-        result = self.resource.put()['data']
-        self.assertGreater(result['last_modified'],
-                           self.record['last_modified'])
+        result = self.resource.put()["data"]
+        self.assertGreater(result["last_modified"], self.record["last_modified"])
 
     def test_last_modified_is_dropped_if_lesser_than_existing(self):
-        new_last_modified = self.record['last_modified'] - 20
-        self.validated['body'] = {'data': {
-            'field': 'new',
-            'last_modified': new_last_modified}
-        }
-        result = self.resource.put()['data']
-        self.assertNotEqual(result['last_modified'],
-                            self.record['last_modified'])
+        new_last_modified = self.record["last_modified"] - 20
+        self.validated["body"] = {"data": {"field": "new", "last_modified": new_last_modified}}
+        result = self.resource.put()["data"]
+        self.assertNotEqual(result["last_modified"], self.record["last_modified"])
 
     def test_cannot_replace_with_different_id(self):
-        self.validated['body'] = {'data': {'id': 'abc'}}
+        self.validated["body"] = {"data": {"id": "abc"}}
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.put)
 
     def test_last_modified_is_overwritten_on_replace(self):
-        self.validated['body'] = {'data': {'last_modified': 123}}
-        result = self.resource.put()['data']
-        self.assertNotEqual(result['last_modified'], 123)
+        self.validated["body"] = {"data": {"last_modified": 123}}
+        result = self.resource.put()["data"]
+        self.assertNotEqual(result["last_modified"], 123)
 
     def test_storage_is_not_used_if_context_provides_current_record(self):
-        self.resource.context.current_record = {'id': 'hola'}
-        self.validated['body'] = {'data': {}}
-        with mock.patch.object(self.resource.model, 'get_record') as get:
+        self.resource.context.current_record = {"id": "hola"}
+        self.validated["body"] = {"data": {}}
+        with mock.patch.object(self.resource.model, "get_record") as get:
             self.resource.put()
             self.assertFalse(get.called)
 
@@ -136,71 +126,70 @@ class PutTest(BaseTest):
 
 class DeleteTest(BaseTest):
     def test_delete_record_returns_last_timestamp(self):
-        record = {'field': 'value'}
+        record = {"field": "value"}
         record = {**self.model.create_record(record)}
-        self.resource.record_id = record['id']
-        result = self.resource.delete()['data']
-        self.assertNotEqual(result['last_modified'], record['last_modified'])
+        self.resource.record_id = record["id"]
+        result = self.resource.delete()["data"]
+        self.assertNotEqual(result["last_modified"], record["last_modified"])
 
     def test_etag_is_provided(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
         self.resource.delete()
-        self.assertIn('ETag', self.last_response.headers)
+        self.assertIn("ETag", self.last_response.headers)
 
     def test_etag_contains_deleted_timestamp(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
         deleted = self.resource.delete()
-        expected = '"{}"'.format(deleted['data']['last_modified'])
-        self.assertEqual(expected, self.last_response.headers['ETag'])
+        expected = '"{}"'.format(deleted["data"]["last_modified"])
+        self.assertEqual(expected, self.last_response.headers["ETag"])
 
     def test_delete_record_returns_stripped_record(self):
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
-        result = self.resource.delete()['data']
-        self.assertEqual(result['id'], record['id'])
-        self.assertNotIn('field', result)
-        self.assertIn('last_modified', result)
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
+        result = self.resource.delete()["data"]
+        self.assertEqual(result["id"], record["id"])
+        self.assertNotIn("field", result)
+        self.assertIn("last_modified", result)
 
     def test_delete_uses_last_modified_from_querystring(self):
-        record = self.model.create_record({'field': 'value'})
+        record = self.model.create_record({"field": "value"})
         last_modified = record[self.model.modified_field] + 20
-        self.resource.record_id = record['id']
-        self.validated['querystring']['last_modified'] = last_modified
-        result = self.resource.delete()['data']
+        self.resource.record_id = record["id"]
+        self.validated["querystring"]["last_modified"] = last_modified
+        result = self.resource.delete()["data"]
         self.validated = self.validated
         self.assertEqual(result[self.model.modified_field], last_modified)
-        self.validated['querystring'] = {
-            '_since': 0, 'deleted': True}
+        self.validated["querystring"] = {"_since": 0, "deleted": True}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 1)
-        retrieved = result['data'][0]
+        self.assertEqual(len(result["data"]), 1)
+        retrieved = result["data"][0]
         self.assertEqual(retrieved[self.model.modified_field], last_modified)
 
     def test_delete_ignores_last_modified_if_equal(self):
-        record = self.model.create_record({'field': 'value'})
+        record = self.model.create_record({"field": "value"})
         last_modified = record[self.model.modified_field]
-        self.resource.record_id = record['id']
-        self.validated['querystring']['last_modified'] = last_modified
-        result = self.resource.delete()['data']
+        self.resource.record_id = record["id"]
+        self.validated["querystring"]["last_modified"] = last_modified
+        result = self.resource.delete()["data"]
         self.assertGreater(result[self.model.modified_field], last_modified)
 
     def test_delete_ignores_last_modified_if_less(self):
-        record = self.model.create_record({'field': 'value'})
+        record = self.model.create_record({"field": "value"})
         last_modified = record[self.model.modified_field] - 20
-        self.resource.record_id = record['id']
-        self.validated['querystring']['last_modified'] = last_modified
-        result = self.resource.delete()['data']
+        self.resource.record_id = record["id"]
+        self.validated["querystring"]["last_modified"] = last_modified
+        result = self.resource.delete()["data"]
         self.assertGreater(result[self.model.modified_field], last_modified)
 
     def test_delete_returns_404_if_backend_throws(self):
         def raise_recordnotfound(*args, **kwargs):
             raise storage_exceptions.RecordNotFoundError
 
-        record = self.model.create_record({'field': 'value'})
-        self.resource.record_id = record['id']
-        with mock.patch.object(self.model, 'delete_record', side_effect=raise_recordnotfound):
+        record = self.model.create_record({"field": "value"})
+        self.resource.record_id = record["id"]
+        with mock.patch.object(self.model, "delete_record", side_effect=raise_recordnotfound):
             self.assertRaises(httpexceptions.HTTPNotFound, self.resource.delete)
 
 
@@ -208,8 +197,8 @@ class PatchTest(BaseTest):
     def setUp(self):
         super().setUp()
         self.stored = self.model.create_record({})
-        self.resource.record_id = self.stored['id']
-        self.validated['body'] = {'data': {'position': 10}}
+        self.resource.record_id = self.stored["id"]
+        self.validated["body"] = {"data": {"position": 10}}
 
         class ArticleSchema(ResourceSchema):
             unread = colander.SchemaNode(colander.Boolean(), missing=colander.drop)
@@ -217,87 +206,82 @@ class PatchTest(BaseTest):
 
         self.resource.schema = ArticleSchema
 
-        self.result = self.resource.patch()['data']
+        self.result = self.resource.patch()["data"]
 
     def test_etag_is_provided(self):
-        self.assertIn('ETag', self.last_response.headers)
+        self.assertIn("ETag", self.last_response.headers)
 
     def test_etag_contains_record_new_timestamp(self):
-        expected = '"{}"'.format(self.result['last_modified'])
-        self.assertEqual(expected, self.last_response.headers['ETag'])
+        expected = '"{}"'.format(self.result["last_modified"])
+        self.assertEqual(expected, self.last_response.headers["ETag"])
 
     def test_etag_contains_old_timestamp_if_no_field_changed(self):
-        self.validated['body'] = {'data': {'position': 10}}
-        self.resource.patch()['data']
-        expected = '"{}"'.format(self.result['last_modified'])
-        self.assertEqual(expected, self.last_response.headers['ETag'])
+        self.validated["body"] = {"data": {"position": 10}}
+        self.resource.patch()["data"]
+        expected = '"{}"'.format(self.result["last_modified"])
+        self.assertEqual(expected, self.last_response.headers["ETag"])
 
     def test_modify_record_updates_timestamp(self):
-        before = self.stored['last_modified']
-        after = self.result['last_modified']
+        before = self.stored["last_modified"]
+        after = self.result["last_modified"]
         self.assertNotEquals(after, before)
 
     def test_patch_record_returns_updated_fields(self):
-        self.assertEqual(self.stored['id'], self.result['id'])
-        self.assertEqual(self.result['position'], 10)
+        self.assertEqual(self.stored["id"], self.result["id"])
+        self.assertEqual(self.result["position"], 10)
 
     def test_record_timestamp_is_not_updated_if_none_for_missing_field(self):
-        self.validated['body'] = {'data': {'polo': None}}
-        result = self.resource.patch()['data']
-        self.assertEqual(self.result['last_modified'],
-                         result['last_modified'])
+        self.validated["body"] = {"data": {"polo": None}}
+        result = self.resource.patch()["data"]
+        self.assertEqual(self.result["last_modified"], result["last_modified"])
 
     def test_record_timestamp_is_not_updated_if_no_field_changed(self):
-        self.validated['body'] = {'data': {'position': 10}}
-        result = self.resource.patch()['data']
-        self.assertEqual(self.result['last_modified'],
-                         result['last_modified'])
+        self.validated["body"] = {"data": {"position": 10}}
+        result = self.resource.patch()["data"]
+        self.assertEqual(self.result["last_modified"], result["last_modified"])
 
     def test_collection_timestamp_is_not_updated_if_no_field_changed(self):
-        self.validated['body'] = {'data': {'position': 10}}
+        self.validated["body"] = {"data": {"position": 10}}
         self.resource.patch()
-        self.resource = self.resource_class(request=self.get_request(),
-                                            context=self.get_context())
+        self.resource = self.resource_class(request=self.get_request(), context=self.get_context())
         self.resource.request.validated = self.validated
-        self.resource.collection_get()['data']
-        last_modified = int(self.last_response.headers['ETag'][1:-1])
-        self.assertEqual(self.result['last_modified'], last_modified)
+        self.resource.collection_get()["data"]
+        last_modified = int(self.last_response.headers["ETag"][1:-1])
+        self.assertEqual(self.result["last_modified"], last_modified)
 
     def test_timestamp_is_not_updated_if_no_change_after_preprocessed(self):
-        with mock.patch.object(self.resource, 'process_record') as mocked:
+        with mock.patch.object(self.resource, "process_record") as mocked:
             mocked.return_value = self.result
-            self.validated['body'] = {'data': {'position': 20}}
-            result = self.resource.patch()['data']
-            self.assertEqual(self.result['last_modified'], result['last_modified'])
+            self.validated["body"] = {"data": {"position": 20}}
+            result = self.resource.patch()["data"]
+            self.assertEqual(self.result["last_modified"], result["last_modified"])
 
     def test_returns_changed_fields_among_provided_if_behaviour_is_diff(self):
-        self.validated['body'] = {'data': {'unread': True, 'position': 15}}
-        self.validated['header'] = {
-            'Response-Behavior': 'diff'
-        }
-        with mock.patch.object(self.resource.model, 'update_record',
-                               return_value={'unread': True, 'position': 0}):
-            result = self.resource.patch()['data']
-        self.assertDictEqual(result, {'position': 0})
+        self.validated["body"] = {"data": {"unread": True, "position": 15}}
+        self.validated["header"] = {"Response-Behavior": "diff"}
+        with mock.patch.object(
+            self.resource.model, "update_record", return_value={"unread": True, "position": 0}
+        ):
+            result = self.resource.patch()["data"]
+        self.assertDictEqual(result, {"position": 0})
 
     def test_returns_changed_fields_if_behaviour_is_light(self):
-        self.validated['body'] = {'data': {'unread': True, 'position': 15}}
-        self.validated['header'] = {
-            'Response-Behavior': 'light'
-        }
-        with mock.patch.object(self.resource.model, 'update_record',
-                               return_value={'unread': True, 'position': 0}):
-            result = self.resource.patch()['data']
-        self.assertDictEqual(result, {'unread': True, 'position': 0})
+        self.validated["body"] = {"data": {"unread": True, "position": 15}}
+        self.validated["header"] = {"Response-Behavior": "light"}
+        with mock.patch.object(
+            self.resource.model, "update_record", return_value={"unread": True, "position": 0}
+        ):
+            result = self.resource.patch()["data"]
+        self.assertDictEqual(result, {"unread": True, "position": 0})
 
 
 class MergePatchTest(BaseTest):
     def setUp(self):
         super().setUp()
         self.stored = self.model.create_record({})
-        self.resource.record_id = self.stored['id']
+        self.resource.record_id = self.stored["id"]
         self.headers = self.resource.request.headers
-        self.headers['Content-Type'] = 'application/merge-patch+json'
+        self.headers["Content-Type"] = "application/merge-patch+json"
         self.resource._is_merge_patch = True
 
         class ArticleSchema(ResourceSchema):
@@ -307,189 +291,173 @@ class MergePatchTest(BaseTest):
         self.resource.schema = ArticleSchema
 
     def test_merge_patch_updates_attributes_recursively(self):
-        self.validated['body'] = {'data': {'a': {'b': 'bbb',
-                                                 'c': 'ccc'}}}
+        self.validated["body"] = {"data": {"a": {"b": "bbb", "c": "ccc"}}}
         self.resource.patch()
-        self.validated['body'] = {'data': {'a': {'b': 'aaa',
-                                                 'c': None}}}
-        result = self.resource.patch()['data']
-        self.assertEqual(result['a']['b'], 'aaa')
+        self.validated["body"] = {"data": {"a": {"b": "aaa", "c": None}}}
+        result = self.resource.patch()["data"]
+        self.assertEqual(result["a"]["b"], "aaa")
 
     def test_merge_patch_removes_attribute_if_none(self):
-        self.validated['body'] = {'data': {'field': 'aaa'}}
+        self.validated["body"] = {"data": {"field": "aaa"}}
         self.resource.patch()
-        self.validated['body'] = {'data': {'field': None}}
-        result = self.resource.patch()['data']
-        self.assertNotIn('field', result)
-        result = self.resource.get()['data']
-        self.assertNotIn('field', result)
+        self.validated["body"] = {"data": {"field": None}}
+        result = self.resource.patch()["data"]
+        self.assertNotIn("field", result)
+        result = self.resource.get()["data"]
+        self.assertNotIn("field", result)
 
     def test_merge_patch_removes_attributes_recursively_if_none(self):
-        self.validated['body'] = {'data': {'a': {'b': 'aaa'}}}
+        self.validated["body"] = {"data": {"a": {"b": "aaa"}}}
         self.resource.patch()
-        self.validated['body'] = {'data': {'a': {'b': None}}}
-        result = self.resource.patch()['data']
-        self.assertIn('a', result)
-        self.assertNotIn('b', result['a'])
-        self.validated['body'] = {'data': {'aa': {'bb': {'cc': None}}}}
-        result = self.resource.patch()['data']
-        self.assertIn('aa', result)
-        self.assertIn('bb', result['aa'])
-        self.assertNotIn('cc', result['aa']['bb'])
+        self.validated["body"] = {"data": {"a": {"b": None}}}
+        result = self.resource.patch()["data"]
+        self.assertIn("a", result)
+        self.assertNotIn("b", result["a"])
+        self.validated["body"] = {"data": {"aa": {"bb": {"cc": None}}}}
+        result = self.resource.patch()["data"]
+        self.assertIn("aa", result)
+        self.assertIn("bb", result["aa"])
+        self.assertNotIn("cc", result["aa"]["bb"])
 
     def test_merge_patch_doesnt_remove_attribute_if_false(self):
-        self.validated['body'] = {'data': {'field': 0}}
-        result = self.resource.patch()['data']
-        self.assertIn('field', result)
-        self.validated['body'] = {'data': {'field': False}}
-        result = self.resource.patch()['data']
-        self.assertIn('field', result)
-        self.validated['body'] = {'data': {'field': {}}}
-        result = self.resource.patch()['data']
-        self.assertIn('field', result)
+        self.validated["body"] = {"data": {"field": 0}}
+        result = self.resource.patch()["data"]
+        self.assertIn("field", result)
+        self.validated["body"] = {"data": {"field": False}}
+        result = self.resource.patch()["data"]
+        self.assertIn("field", result)
+        self.validated["body"] = {"data": {"field": {}}}
+        result = self.resource.patch()["data"]
+        self.assertIn("field", result)
 
     def test_patch_doesnt_remove_attribute_if_not_merge_header(self):
-        self.headers['Content-Type'] = 'application/json'
+        self.headers["Content-Type"] = "application/json"
         self.resource._is_merge_patch = False
-        self.validated['body'] = {'data': {'field': 'aaa'}}
+        self.validated["body"] = {"data": {"field": "aaa"}}
         self.resource.patch()
-        self.validated['body'] = {'data': {'field': None}}
-        result = self.resource.patch()['data']
-        self.assertIn('field', result)
-        result = self.resource.get()['data']
-        self.assertIn('field', result)
+        self.validated["body"] = {"data": {"field": None}}
+        result = self.resource.patch()["data"]
+        self.assertIn("field", result)
+        result = self.resource.get()["data"]
+        self.assertIn("field", result)
 
     def test_merge_patch_doesnt_remove_previously_inserted_nones(self):
-        self.headers['Content-Type'] = 'application/json'
+        self.headers["Content-Type"] = "application/json"
         self.resource._is_merge_patch = False
-        self.validated['body'] = {'data': {'field': 'aaa'}}
-        result = self.resource.patch()['data']
-        self.validated['body'] = {'data': {'field': None}}
-        result = self.resource.patch()['data']
-        self.assertIn('field', result)
-        self.headers['Content-Type'] = 'application/merge-patch+json'
-        self.validated['body'] = {'data': {'position': 10}}
-        result = self.resource.patch()['data']
-        self.assertIn('field', result)
+        self.validated["body"] = {"data": {"field": "aaa"}}
+        result = self.resource.patch()["data"]
+        self.validated["body"] = {"data": {"field": None}}
+        result = self.resource.patch()["data"]
+        self.assertIn("field", result)
+        self.headers["Content-Type"] = "application/merge-patch+json"
+        self.validated["body"] = {"data": {"position": 10}}
+        result = self.resource.patch()["data"]
+        self.assertIn("field", result)
 
 
 class JsonPatchTest(BaseTest):
     def setUp(self):
         super().setUp()
         self.stored = self.model.create_record({})
-        self.resource.record_id = self.stored['id']
-        self.validated['body'] = {'data': {'a': 'aaa', 'b': ['bb', 'bbb'], 'd': []}}
+        self.resource.record_id = self.stored["id"]
+        self.validated["body"] = {"data": {"a": "aaa", "b": ["bb", "bbb"], "d": []}}
         self.resource.schema = ResourceSchema
-        self.result = self.resource.patch()['data']
+        self.result = self.resource.patch()["data"]
         header = self.resource.request.headers
-        header['Content-Type'] = 'application/json-patch+json'
+        header["Content-Type"] = "application/json-patch+json"
         self.resource._is_json_patch = True
 
     def test_json_patch_add(self):
-        self.validated['body'] = [
-            {'op': 'add', 'path': '/data/c', 'value': 'ccc'},
-            {'op': 'add', 'path': '/data/b/1', 'value': 'ddd'},
-            {'op': 'add', 'path': '/data/b/-', 'value': 'eee'},
+        self.validated["body"] = [
+            {"op": "add", "path": "/data/c", "value": "ccc"},
+            {"op": "add", "path": "/data/b/1", "value": "ddd"},
+            {"op": "add", "path": "/data/b/-", "value": "eee"},
         ]
-        result = self.resource.patch()['data']
-        self.assertEqual(result['c'], 'ccc')
-        self.assertEqual(result['b'][0], 'bb')
-        self.assertEqual(result['b'][1], 'ddd')
-        self.assertEqual(result['b'][2], 'bbb')
-        self.assertEqual(result['b'][3], 'eee')
-        self.assertEqual(len(result['b']), 4)
+        result = self.resource.patch()["data"]
+        self.assertEqual(result["c"], "ccc")
+        self.assertEqual(result["b"][0], "bb")
+        self.assertEqual(result["b"][1], "ddd")
+        self.assertEqual(result["b"][2], "bbb")
+        self.assertEqual(result["b"][3], "eee")
+        self.assertEqual(len(result["b"]), 4)
 
     def test_json_patch_remove(self):
-        self.validated['body'] = [
-            {'op': 'remove', 'path': '/data/a'},
-            {'op': 'remove', 'path': '/data/b/0'},
+        self.validated["body"] = [
+            {"op": "remove", "path": "/data/a"},
+            {"op": "remove", "path": "/data/b/0"},
         ]
-        result = self.resource.patch()['data']
-        self.assertNotIn('a', result)
-        self.assertEqual(len(result['b']), 1)
-        self.assertEqual(result['b'][0], 'bbb')
+        result = self.resource.patch()["data"]
+        self.assertNotIn("a", result)
+        self.assertEqual(len(result["b"]), 1)
+        self.assertEqual(result["b"][0], "bbb")
 
     def test_json_patch_test_success(self):
-        self.validated['body'] = [
-            {'op': 'test', 'path': '/data/a', 'value': 'aaa'},
-        ]
-        self.resource.patch()['data']
+        self.validated["body"] = [{"op": "test", "path": "/data/a", "value": "aaa"}]
+        self.resource.patch()["data"]
 
     def test_json_patch_test_failure(self):
-        self.validated['body'] = [
-            {'op': 'test', 'path': '/data/a', 'value': 'bbb'},
-        ]
+        self.validated["body"] = [{"op": "test", "path": "/data/a", "value": "bbb"}]
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.patch)
 
     def test_json_patch_move(self):
-        self.validated['body'] = [
-            {'op': 'move', 'from': '/data/a', 'path': '/data/c'},
-            {'op': 'move', 'from': '/data/b/1', 'path': '/data/d/0'},
-            {'op': 'move', 'from': '/data/b/0', 'path': '/data/e'},
+        self.validated["body"] = [
+            {"op": "move", "from": "/data/a", "path": "/data/c"},
+            {"op": "move", "from": "/data/b/1", "path": "/data/d/0"},
+            {"op": "move", "from": "/data/b/0", "path": "/data/e"},
         ]
-        result = self.resource.patch()['data']
-        self.assertNotIn('a', result)
-        self.assertEqual(result['c'], 'aaa')
-        self.assertEqual(len(result['b']), 0)
-        self.assertEqual(result['d'][0], 'bbb')
-        self.assertEqual(result['e'], 'bb')
+        result = self.resource.patch()["data"]
+        self.assertNotIn("a", result)
+        self.assertEqual(result["c"], "aaa")
+        self.assertEqual(len(result["b"]), 0)
+        self.assertEqual(result["d"][0], "bbb")
+        self.assertEqual(result["e"], "bb")
 
     def test_json_patch_copy(self):
-        self.validated['body'] = [
-            {'op': 'copy', 'from': '/data/a', 'path': '/data/c'},
-            {'op': 'copy', 'from': '/data/b/1', 'path': '/data/d/0'},
-            {'op': 'copy', 'from': '/data/d/0', 'path': '/data/e'},
+        self.validated["body"] = [
+            {"op": "copy", "from": "/data/a", "path": "/data/c"},
+            {"op": "copy", "from": "/data/b/1", "path": "/data/d/0"},
+            {"op": "copy", "from": "/data/d/0", "path": "/data/e"},
         ]
-        result = self.resource.patch()['data']
-        self.assertEqual(result['a'], 'aaa')
-        self.assertEqual(result['c'], 'aaa')
-        self.assertEqual(len(result['b']), 2)
-        self.assertEqual(result['d'][0], 'bbb')
-        self.assertEqual(result['e'], 'bbb')
+        result = self.resource.patch()["data"]
+        self.assertEqual(result["a"], "aaa")
+        self.assertEqual(result["c"], "aaa")
+        self.assertEqual(len(result["b"]), 2)
+        self.assertEqual(result["d"][0], "bbb")
+        self.assertEqual(result["e"], "bbb")
 
     def test_json_patch_replace(self):
-        self.validated['body'] = [
-            {'op': 'replace', 'path': '/data/a', 'value': 'bbb'},
-            {'op': 'replace', 'path': '/data/b/0', 'value': 'aaa'},
+        self.validated["body"] = [
+            {"op": "replace", "path": "/data/a", "value": "bbb"},
+            {"op": "replace", "path": "/data/b/0", "value": "aaa"},
         ]
-        result = self.resource.patch()['data']
-        self.assertEqual(result['a'], 'bbb')
-        self.assertEqual(result['b'][0], 'aaa')
+        result = self.resource.patch()["data"]
+        self.assertEqual(result["a"], "bbb")
+        self.assertEqual(result["b"][0], "aaa")
 
     def test_json_patch_raises_400_on_invalid_path(self):
-        self.validated['body'] = [
-            {'op': 'remove', 'path': '/data/f'},
-        ]
+        self.validated["body"] = [{"op": "remove", "path": "/data/f"}]
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.patch)
-        self.validated['body'] = [
-            {'op': 'move', 'from': '/data/f', 'path': '/data/what'},
-        ]
+        self.validated["body"] = [{"op": "move", "from": "/data/f", "path": "/data/what"}]
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.patch)
-        self.validated['body'] = [
-            {'op': 'copy', 'from': '/data/what', 'path': '/data/f'},
-        ]
+        self.validated["body"] = [{"op": "copy", "from": "/data/what", "path": "/data/f"}]
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.patch)
-        self.validated['body'] = [
-            {'op': 'replace', 'path': '/data/c', 'value': 'ccc'},
-        ]
+        self.validated["body"] = [{"op": "replace", "path": "/data/c", "value": "ccc"}]
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.patch)
 
     def test_json_patch_format_not_accepted_without_header(self):
         header = self.resource.request.headers
-        header['Content-Type'] = 'application/json'
+        header["Content-Type"] = "application/json"
         self.resource._is_json_patch = False
-        self.validated['body'] = [
-            {'op': 'add', 'from': '/data/a', 'value': 'aaa'},
-        ]
+        self.validated["body"] = [{"op": "add", "from": "/data/a", "value": "aaa"}]
         self.assertRaises(AttributeError, self.resource.patch)
 
 
 class UnknownRecordTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.unknown_id = '1cea99eb-5e3d-44ad-a53a-2fb68473b538'
+        self.unknown_id = "1cea99eb-5e3d-44ad-a53a-2fb68473b538"
         self.resource.record_id = self.unknown_id
-        self.validated['body'] = {'data': {'field': 'new'}}
+        self.validated["body"] = {"data": {"field": "new"}}
 
     def test_get_record_unknown_raises_404(self):
         self.assertRaises(httpexceptions.HTTPNotFound, self.resource.get)
@@ -508,7 +476,7 @@ class UnknownRecordTest(BaseTest):
 class InvalidIdTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.resource.record_id = 'a*b'
+        self.resource.record_id = "a*b"
 
     def test_get_with_invalid_id_raises_400(self):
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.get)
@@ -526,9 +494,9 @@ class InvalidIdTest(BaseTest):
 class ReadonlyFieldsTest(BaseTest):
     def setUp(self):
         super().setUp()
-        self.stored = self.model.create_record({'age': 32})
-        self.resource.schema.Options.readonly_fields = ('age',)
-        self.resource.record_id = self.stored['id']
+        self.stored = self.model.create_record({"age": 32})
+        self.resource.schema.Options.readonly_fields = ("age",)
+        self.resource.record_id = self.stored["id"]
 
     def assertReadonlyError(self, field):
         error = None
@@ -536,19 +504,23 @@ class ReadonlyFieldsTest(BaseTest):
             self.resource.patch()
         except httpexceptions.HTTPBadRequest as e:
             error = e
-        self.assertEqual(error.json, {
-            'errno': ERRORS.INVALID_PARAMETERS.value,
-            'message': 'Cannot modify {0}'.format(field),
-            'code': 400,
-            'error': 'Invalid parameters',
-            'details': [{'description': 'Cannot modify age',
-                         'location': 'body',
-                         'name': 'age'}]})
+        self.assertEqual(
+            error.json,
+            {
+                "errno": ERRORS.INVALID_PARAMETERS.value,
+                "message": "Cannot modify {0}".format(field),
+                "code": 400,
+                "error": "Invalid parameters",
+                "details": [
+                    {"description": "Cannot modify age", "location": "body", "name": "age"}
+                ],
+            },
+        )
 
     def test_can_specify_readonly_fields_if_not_changed(self):
-        self.validated['body'] = {'data': {'age': self.stored['age']}}
+        self.validated["body"] = {"data": {"age": self.stored["age"]}}
         self.resource.patch()  # not raising
 
     def test_cannot_modify_readonly_field(self):
-        self.validated['body'] = {'data': {'age': 16}}
-        self.assertReadonlyError('age')
+        self.validated["body"] = {"data": {"age": 16}}
+        self.assertReadonlyError("age")

--- a/tests/core/resource/test_schema.py
+++ b/tests/core/resource/test_schema.py
@@ -7,33 +7,35 @@ from kinto.core.resource import schema
 
 
 class DepracatedSchemasTest(unittest.TestCase):
-
     def test_resource_timestamp_is_depracated(self):
-        with mock.patch('kinto.core.resource.schema.warnings') as mocked:
+        with mock.patch("kinto.core.resource.schema.warnings") as mocked:
             schema.TimeStamp()
-            message = ("`kinto.core.resource.schema.TimeStamp` is deprecated, "
-                       "use `kinto.core.schema.TimeStamp` instead.")
+            message = (
+                "`kinto.core.resource.schema.TimeStamp` is deprecated, "
+                "use `kinto.core.schema.TimeStamp` instead."
+            )
             mocked.warn.assert_called_with(message, DeprecationWarning)
 
     def test_resource_URL_is_depracated(self):
-        with mock.patch('kinto.core.resource.schema.warnings') as mocked:
+        with mock.patch("kinto.core.resource.schema.warnings") as mocked:
             schema.URL()
-            message = ("`kinto.core.resource.schema.URL` is deprecated, "
-                       "use `kinto.core.schema.URL` instead.")
+            message = (
+                "`kinto.core.resource.schema.URL` is deprecated, "
+                "use `kinto.core.schema.URL` instead."
+            )
             mocked.warn.assert_called_with(message, DeprecationWarning)
 
 
 class ResourceSchemaTest(unittest.TestCase):
-
     def test_preserves_unknown_fields_when_specified(self):
         class PreserveSchema(schema.ResourceSchema):
             class Options:
                 preserve_unknown = True
 
         schema_instance = PreserveSchema()
-        deserialized = schema_instance.deserialize({'foo': 'bar'})
-        self.assertIn('foo', deserialized)
-        self.assertEqual(deserialized['foo'], 'bar')
+        deserialized = schema_instance.deserialize({"foo": "bar"})
+        self.assertIn("foo", deserialized)
+        self.assertEqual(deserialized["foo"], "bar")
 
     def test_ignore_unknwon_fields_when_specified(self):
         class PreserveSchema(schema.ResourceSchema):
@@ -41,13 +43,13 @@ class ResourceSchemaTest(unittest.TestCase):
                 preserve_unknown = False
 
         schema_instance = PreserveSchema()
-        deserialized = schema_instance.deserialize({'foo': 'bar'})
-        self.assertNotIn('foo', deserialized)
+        deserialized = schema_instance.deserialize({"foo": "bar"})
+        self.assertNotIn("foo", deserialized)
 
     def test_accepts_unknown_fields_by_default(self):
         schema_instance = schema.ResourceSchema()
-        deserialized = schema_instance.deserialize({'foo': 'bar'})
-        self.assertIn('foo', deserialized)
+        deserialized = schema_instance.deserialize({"foo": "bar"})
+        self.assertIn("foo", deserialized)
 
     def test_options_parameters_use_default_value_when_subclassed(self):
         class PreserveSchema(schema.ResourceSchema):
@@ -55,17 +57,16 @@ class ResourceSchemaTest(unittest.TestCase):
                 pass
 
         schema_instance = PreserveSchema()
-        deserialized = schema_instance.deserialize({'foo': 'bar'})
-        self.assertIn('foo', deserialized)
+        deserialized = schema_instance.deserialize({"foo": "bar"})
+        self.assertIn("foo", deserialized)
 
 
 class PermissionsSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.PermissionsSchema()
 
     def test_works_with_any_permission_name_by_default(self):
-        perms = {'can_cook': ['mat']}
+        perms = {"can_cook": ["mat"]}
         deserialized = self.schema.deserialize(perms)
         self.assertEqual(deserialized, perms)
 
@@ -75,58 +76,48 @@ class PermissionsSchemaTest(unittest.TestCase):
         self.assertEqual(deserialized, perms)
 
     def test_works_with_empty_list_of_principals(self):
-        perms = {'can_cook': []}
+        perms = {"can_cook": []}
         deserialized = self.schema.deserialize(perms)
         self.assertEqual(deserialized, perms)
 
     def test_works_with_empty_none_permissions(self):
-        perms = {'can_cook': None}
+        perms = {"can_cook": None}
         deserialized = self.schema.deserialize(perms)
         self.assertEqual(deserialized, perms)
 
     def test_raises_invalid_if_not_a_mapping(self):
-        perms = ['gab']
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          perms)
+        perms = ["gab"]
+        self.assertRaises(colander.Invalid, self.schema.deserialize, perms)
 
     def test_raises_invalid_if_permission_is_unknown(self):
-        self.schema.known_perms = ('can_sleep',)
-        perms = {'can_work': ['mat']}
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          perms)
+        self.schema.known_perms = ("can_sleep",)
+        perms = {"can_work": ["mat"]}
+        self.assertRaises(colander.Invalid, self.schema.deserialize, perms)
 
     def test_raises_invalid_if_not_list(self):
-        perms = {'can_cook': 3.14}
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          perms)
+        perms = {"can_cook": 3.14}
+        self.assertRaises(colander.Invalid, self.schema.deserialize, perms)
 
     def test_raises_invalid_if_not_list_of_strings(self):
-        perms = {'can_cook': ['pi', 3.14]}
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          perms)
+        perms = {"can_cook": ["pi", 3.14]}
+        self.assertRaises(colander.Invalid, self.schema.deserialize, perms)
 
 
 class HeaderFieldSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.HeaderField(colander.String())
 
     def test_decode_unicode(self):
-        value = '\xe7 is not a c'
-        deserialized = self.schema.deserialize(value.encode('utf-8'))
+        value = "\xe7 is not a c"
+        deserialized = self.schema.deserialize(value.encode("utf-8"))
         self.assertEqual(deserialized, value)
 
     def test_bad_unicode_raises_invalid(self):
-        value = b'utf8 \xe9'
+        value = b"utf8 \xe9"
         self.assertRaises(colander.Invalid, self.schema.deserialize, value)
 
 
 class QueryFieldSchemaTest(unittest.TestCase):
-
     def test_deserialize_integer_between_quotes(self):
         self.schema = schema.QueryField(colander.Integer())
         deserialized = self.schema.deserialize("123")
@@ -134,14 +125,13 @@ class QueryFieldSchemaTest(unittest.TestCase):
 
 
 class FieldListSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.FieldList()
 
     def test_deserialize_as_list(self):
-        value = 'foo,-bar,123'
+        value = "foo,-bar,123"
         deserialized = self.schema.deserialize(value)
-        self.assertEqual(deserialized, ['foo', '-bar', '123'])
+        self.assertEqual(deserialized, ["foo", "-bar", "123"])
 
     def test_handle_drop(self):
         value = colander.null
@@ -149,19 +139,16 @@ class FieldListSchemaTest(unittest.TestCase):
         self.assertEqual(deserialized, colander.drop)
 
     def test_handle_empty(self):
-        value = ''
+        value = ""
         deserialized = self.schema.deserialize(value)
         self.assertEqual(deserialized, [])
 
     def test_raises_invalid_if_not_string(self):
         value = 123
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          value)
+        self.assertRaises(colander.Invalid, self.schema.deserialize, value)
 
 
 class HeaderQuotedIntegerSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.HeaderQuotedInteger()
 
@@ -171,99 +158,89 @@ class HeaderQuotedIntegerSchemaTest(unittest.TestCase):
         self.assertEqual(deserialized, 123)
 
     def test_deserialize_any(self):
-        value = '*'
+        value = "*"
         deserialized = self.schema.deserialize(value)
-        self.assertEqual(deserialized, '*')
+        self.assertEqual(deserialized, "*")
 
     def test_unquoted_raises_invalid(self):
-        value = '123'
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          value)
+        value = "123"
+        self.assertRaises(colander.Invalid, self.schema.deserialize, value)
 
     def test_integer_raises_invalid(self):
         value = 123
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          value)
+        self.assertRaises(colander.Invalid, self.schema.deserialize, value)
 
     def test_invalid_quoted_raises_invalid(self):
-        value = 'foo'
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          value)
+        value = "foo"
+        self.assertRaises(colander.Invalid, self.schema.deserialize, value)
 
     def test_empty_raises_invalid(self):
         value = '""'
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          value)
+        self.assertRaises(colander.Invalid, self.schema.deserialize, value)
 
 
 class RecordSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.RecordSchema()
 
     def test_binds_data(self):
         bound = self.schema.bind(data=schema.ResourceSchema())
-        value = {'data': {'foo': 'bar'}}
+        value = {"data": {"foo": "bar"}}
         deserialized = bound.deserialize(value)
         self.assertEqual(deserialized, value)
 
     def test_binds_permissions(self):
-        permissions = schema.PermissionsSchema(permissions=('sleep', ))
+        permissions = schema.PermissionsSchema(permissions=("sleep",))
         bound = self.schema.bind(permissions=permissions)
-        value = {'permissions': {'sleep': []}}
+        value = {"permissions": {"sleep": []}}
         deserialized = bound.deserialize(value)
         self.assertEqual(deserialized, value)
 
     def test_allow_binding_perms_after_data(self):
         bound = self.schema.bind(data=schema.ResourceSchema())
-        permissions = schema.PermissionsSchema(permissions=('sleep', ))
+        permissions = schema.PermissionsSchema(permissions=("sleep",))
         bound = bound.bind(permissions=permissions)
-        value = {'data': {'foo': 'bar'}, 'permissions': {'sleep': []}}
+        value = {"data": {"foo": "bar"}, "permissions": {"sleep": []}}
         deserialized = bound.deserialize(value)
         self.assertEqual(deserialized, value)
 
     def test_doesnt_allow_permissions_unless_bound(self):
         bound = self.schema.bind(data=schema.ResourceSchema())
-        value = {'permissions': {'sleep': []}}
+        value = {"permissions": {"sleep": []}}
         self.assertRaises(colander.UnsupportedFields, bound.deserialize, value)
 
 
 class RequestSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.RequestSchema()
 
     def test_header_supports_binding(self):
-        header = colander.MappingSchema(missing={'foo': 'bar'})
+        header = colander.MappingSchema(missing={"foo": "bar"})
         bound = self.schema.bind(header=header)
         deserialized = bound.deserialize({})
-        self.assertEqual(deserialized['header'], {'foo': 'bar'})
+        self.assertEqual(deserialized["header"], {"foo": "bar"})
 
     def test_querystring_supports_binding(self):
-        querystring = colander.MappingSchema(missing={'foo': 'bar'})
+        querystring = colander.MappingSchema(missing={"foo": "bar"})
         bound = self.schema.bind(querystring=querystring)
         deserialized = bound.deserialize({})
-        self.assertEqual(deserialized['querystring'], {'foo': 'bar'})
+        self.assertEqual(deserialized["querystring"], {"foo": "bar"})
 
     def test_default_header_if_not_bound(self):
         bound = self.schema.bind()
-        self.assertEqual(type(bound['header']), schema.HeaderSchema)
+        self.assertEqual(type(bound["header"]), schema.HeaderSchema)
 
     def test_default_querystring_if_not_bound(self):
         bound = self.schema.bind()
-        self.assertEqual(type(bound['querystring']), schema.QuerySchema)
+        self.assertEqual(type(bound["querystring"]), schema.QuerySchema)
 
     def test_header_preserve_unknown_fields(self):
-        value = {'header': {'foo': 'bar'}}
+        value = {"header": {"foo": "bar"}}
         deserialized = self.schema.bind().deserialize(value)
         self.assertEqual(deserialized, value)
 
     def test_querystring_preserve_unknown_fields(self):
-        value = {'querystring': {'foo': 'bar'}}
+        value = {"querystring": {"foo": "bar"}}
         deserialized = self.schema.bind().deserialize(value)
         self.assertEqual(deserialized, value)
 
@@ -273,169 +250,164 @@ class RequestSchemaTest(unittest.TestCase):
 
 
 class PayloadRequestSchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.PayloadRequestSchema()
 
     def test_body_supports_binding(self):
-        body = colander.MappingSchema(missing={'foo': 'bar'})
+        body = colander.MappingSchema(missing={"foo": "bar"})
         bound = self.schema.bind(body=body)
         deserialized = bound.deserialize({})
-        self.assertEqual(deserialized['body'], {'foo': 'bar'})
+        self.assertEqual(deserialized["body"], {"foo": "bar"})
 
     def test_body_supports_binding_after_other_binds(self):
-        querystring = colander.MappingSchema(missing={'foo': 'bar'})
+        querystring = colander.MappingSchema(missing={"foo": "bar"})
         bound = self.schema.bind(querystring=querystring)
-        body = colander.MappingSchema(missing={'foo': 'beer'})
+        body = colander.MappingSchema(missing={"foo": "beer"})
         bound = bound.bind(body=body)
         deserialized = bound.deserialize({})
-        self.assertEqual(deserialized['querystring'], {'foo': 'bar'})
-        self.assertEqual(deserialized['body'], {'foo': 'beer'})
+        self.assertEqual(deserialized["querystring"], {"foo": "bar"})
+        self.assertEqual(deserialized["body"], {"foo": "beer"})
 
 
 class CollectionQuerySchemaTest(unittest.TestCase):
-
     def setUp(self):
         self.schema = schema.CollectionQuerySchema()
         self.querystring = {
-            '_limit': '2',
-            '_sort': 'toto,tata',
-            '_token': 'abc',
-            '_since': '1234',
-            '_to': '7890',
-            '_before': '4567',
-            'id': 'toot',
-            'last_modified': '9874',
-            'in_age': '15,16,17',
-            'exclude_id': '45aea306-cf9c-44d3-fbe0e5bb3ef6,2400fc9b-1db6-473d-818b68431545',
-            'contains_comma_int': '3,4',
-            'contains_any_comma_strings': 'red,blue',
-            'contains_any_object': '{"id": 1234}',
-            'contains_user.name': '["Ethan","Remy"]',
-            'contains_any_user.height': '[165, 200]',
-            'contains_aliases': '[{"ls": "ll -a"}, {"rimraf": "rm -rf"}]',
+            "_limit": "2",
+            "_sort": "toto,tata",
+            "_token": "abc",
+            "_since": "1234",
+            "_to": "7890",
+            "_before": "4567",
+            "id": "toot",
+            "last_modified": "9874",
+            "in_age": "15,16,17",
+            "exclude_id": "45aea306-cf9c-44d3-fbe0e5bb3ef6,2400fc9b-1db6-473d-818b68431545",
+            "contains_comma_int": "3,4",
+            "contains_any_comma_strings": "red,blue",
+            "contains_any_object": '{"id": 1234}',
+            "contains_user.name": '["Ethan","Remy"]',
+            "contains_any_user.height": "[165, 200]",
+            "contains_aliases": '[{"ls": "ll -a"}, {"rimraf": "rm -rf"}]',
         }
 
     def test_decode_valid_querystring(self):
         self.maxDiff = None
         deserialized = self.schema.deserialize(self.querystring)
-        self.assertEqual(deserialized, {
-            '_limit': 2,
-            '_sort': ['toto', 'tata'],
-            '_token': 'abc',
-            '_since': 1234,
-            '_to': 7890,
-            '_before': 4567,
-            'id': 'toot',
-            'last_modified': 9874,
-            'contains_comma_int': ['3,4'],
-            'contains_any_comma_strings': ['red,blue'],
-            'contains_any_object': [{"id": 1234}],
-            'contains_any_user.height': [165, 200],
-            'contains_user.name': ['Ethan', 'Remy'],
-            'contains_aliases': [{'ls': 'll -a'}, {'rimraf': 'rm -rf'}],
-            'in_age': [15, 16, 17],
-            'exclude_id': ['45aea306-cf9c-44d3-fbe0e5bb3ef6',
-                           '2400fc9b-1db6-473d-818b68431545'],
-        })
+        self.assertEqual(
+            deserialized,
+            {
+                "_limit": 2,
+                "_sort": ["toto", "tata"],
+                "_token": "abc",
+                "_since": 1234,
+                "_to": 7890,
+                "_before": 4567,
+                "id": "toot",
+                "last_modified": 9874,
+                "contains_comma_int": ["3,4"],
+                "contains_any_comma_strings": ["red,blue"],
+                "contains_any_object": [{"id": 1234}],
+                "contains_any_user.height": [165, 200],
+                "contains_user.name": ["Ethan", "Remy"],
+                "contains_aliases": [{"ls": "ll -a"}, {"rimraf": "rm -rf"}],
+                "in_age": [15, 16, 17],
+                "exclude_id": [
+                    "45aea306-cf9c-44d3-fbe0e5bb3ef6",
+                    "2400fc9b-1db6-473d-818b68431545",
+                ],
+            },
+        )
 
     def test_raises_invalid_for_to_big_integer_in_limit(self):
         querystring = self.querystring.copy()
-        querystring['_limit'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        querystring["_limit"] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_since(self):
         querystring = self.querystring.copy()
-        querystring['_since'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        querystring["_since"] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_to(self):
         querystring = self.querystring.copy()
-        querystring['_to'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        querystring["_to"] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_before(self):
         querystring = self.querystring.copy()
-        querystring['_before'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        querystring["_before"] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_to_big_integer_in_last_modified(self):
         querystring = self.querystring.copy()
-        querystring['last_modified'] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
+        querystring["last_modified"] = schema.POSTGRESQL_MAX_INTEGER_VALUE + 1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_negative_integer_in_limit(self):
         querystring = self.querystring.copy()
-        querystring['_limit'] = -1
+        querystring["_limit"] = -1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_negative_integer_in_since(self):
         querystring = self.querystring.copy()
-        querystring['_since'] = -1
+        querystring["_since"] = -1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_negative_integer_in_to(self):
         querystring = self.querystring.copy()
-        querystring['_to'] = -1
+        querystring["_to"] = -1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_negative_integer_in_before(self):
         querystring = self.querystring.copy()
-        querystring['_before'] = -1
+        querystring["_before"] = -1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
     def test_raises_invalid_for_negative_integer_in_last_modified(self):
         querystring = self.querystring.copy()
-        querystring['last_modified'] = -1
+        querystring["last_modified"] = -1
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
 
 class ResourceReponsesTest(unittest.TestCase):
-
     def setUp(self):
         self.handler = schema.ResourceReponses()
-        self.resource = colander.MappingSchema(title='fake')
+        self.resource = colander.MappingSchema(title="fake")
         self.record = schema.RecordSchema().bind(data=self.resource)
 
     def test_get_and_bind_assign_resource_schema_to_records(self):
-        responses = self.handler.get_and_bind('record', 'get',
-                                              record=self.record)
-        ok_response = responses['200']
-        self.assertEqual(self.record['data'], ok_response['body']['data'])
+        responses = self.handler.get_and_bind("record", "get", record=self.record)
+        ok_response = responses["200"]
+        self.assertEqual(self.record["data"], ok_response["body"]["data"])
 
     def test_get_and_bind_assign_resource_schema_to_collections(self):
-        responses = self.handler.get_and_bind('collection', 'get',
-                                              record=self.record)
-        ok_response = responses['200']
+        responses = self.handler.get_and_bind("collection", "get", record=self.record)
+        ok_response = responses["200"]
         # XXX: Data is repeated because it's a colander sequence type index
-        self.assertEqual(self.record['data'], ok_response['body']['data']['data'])
+        self.assertEqual(self.record["data"], ok_response["body"]["data"]["data"])
 
     def test_responses_doesnt_have_permissions_if_not_bound(self):
-        responses = self.handler.get_and_bind('record', 'get',
-                                              record=self.record)
-        ok_response = responses['200']
-        self.assertNotIn('permissions', ok_response['body'])
+        responses = self.handler.get_and_bind("record", "get", record=self.record)
+        ok_response = responses["200"]
+        self.assertNotIn("permissions", ok_response["body"])
 
 
 class ShareableResourceReponsesTest(unittest.TestCase):
-
     def setUp(self):
         self.handler = schema.ShareableResourseResponses()
-        self.resource = colander.MappingSchema(title='fake')
-        self.permissions = colander.MappingSchema(title='bla')
-        self.record = schema.RecordSchema().bind(data=self.resource,
-                                                 permissions=self.permissions)
+        self.resource = colander.MappingSchema(title="fake")
+        self.permissions = colander.MappingSchema(title="bla")
+        self.record = schema.RecordSchema().bind(data=self.resource, permissions=self.permissions)
 
     def test_shareable_responses_doesnt_update_resource_responses(self):
         resource_handler = schema.ResourceReponses()
-        shareable_responses = self.handler.get_and_bind('record', 'get')
-        resource_responses = resource_handler.get_and_bind('record', 'get')
-        self.assertIn('401', shareable_responses)
-        self.assertNotIn('401', resource_responses)
+        shareable_responses = self.handler.get_and_bind("record", "get")
+        resource_responses = resource_handler.get_and_bind("record", "get")
+        self.assertIn("401", shareable_responses)
+        self.assertNotIn("401", resource_responses)
 
     def test_get_and_bind_assign_permission_schema_to_records(self):
-        responses = self.handler.get_and_bind('record', 'get',
-                                              record=self.record)
-        ok_response = responses['200']
-        self.assertEqual(self.record['permissions'],
-                         ok_response['body']['permissions'])
+        responses = self.handler.get_and_bind("record", "get", record=self.record)
+        ok_response = responses["200"]
+        self.assertEqual(self.record["permissions"], ok_response["body"]["permissions"])

--- a/tests/core/resource/test_sort.py
+++ b/tests/core/resource/test_sort.py
@@ -16,105 +16,107 @@ class SortingTest(BaseTest):
         random.shuffle(indices)
 
         for i in indices:
-            record = {
-                'title': 'MoFo #{0:02}'.format(i),
-                'status': i % 4,
-                'unread': (i % 2 == 0)
-            }
+            record = {"title": "MoFo #{0:02}".format(i), "status": i % 4, "unread": (i % 2 == 0)}
             self.model.create_record(record)
 
     def test_sort_works_with_empty_list(self):
-        self.resource.model.parent_id = 'alice'
-        self.resource.request.validated['querystring'] = {'_sort': ['unread']}
+        self.resource.model.parent_id = "alice"
+        self.resource.request.validated["querystring"] = {"_sort": ["unread"]}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 0)
+        self.assertEqual(len(result["data"]), 0)
 
     def test_sort_on_unknown_attribute_raises_error(self):
         self.patch_known_field.stop()
-        self.resource.request.validated['querystring'] = {'_sort': ['foo']}
-        self.assertRaises(httpexceptions.HTTPBadRequest,
-                          self.resource.collection_get)
+        self.resource.request.validated["querystring"] = {"_sort": ["foo"]}
+        self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.collection_get)
 
     def test_filter_errors_are_json_formatted(self):
         self.patch_known_field.stop()
-        self.resource.request.validated['querystring'] = {'_sort': ['foo']}
+        self.resource.request.validated["querystring"] = {"_sort": ["foo"]}
         try:
             self.resource.collection_get()
         except httpexceptions.HTTPBadRequest as e:
             error = e
-        self.assertEqual(error.json, {
-            'errno': ERRORS.INVALID_PARAMETERS.value,
-            'message': "querystring: Unknown sort field 'foo'",
-            'code': 400,
-            'error': 'Invalid parameters',
-            'details': [{'description': "Unknown sort field 'foo'",
-                         'location': 'querystring',
-                         'name': None}]})
+        self.assertEqual(
+            error.json,
+            {
+                "errno": ERRORS.INVALID_PARAMETERS.value,
+                "message": "querystring: Unknown sort field 'foo'",
+                "code": 400,
+                "error": "Invalid parameters",
+                "details": [
+                    {
+                        "description": "Unknown sort field 'foo'",
+                        "location": "querystring",
+                        "name": None,
+                    }
+                ],
+            },
+        )
 
     def test_sort_on_last_modified_is_supported(self):
         self.patch_known_field.stop()
-        self.resource.request.validated['querystring'] = {'_sort': ['-last_modified']}
+        self.resource.request.validated["querystring"] = {"_sort": ["-last_modified"]}
         result = self.resource.collection_get()
         tstamp = self.model.timestamp()
-        self.assertEqual(result['data'][0]['last_modified'], tstamp)
+        self.assertEqual(result["data"][0]["last_modified"], tstamp)
 
     def test_single_basic_sort_by_attribute(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['title']}
+        self.resource.request.validated["querystring"] = {"_sort": ["title"]}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 20)
-        self.assertEqual(result['data'][0]['title'], 'MoFo #00')
-        self.assertEqual(result['data'][-1]['title'], 'MoFo #19')
+        self.assertEqual(len(result["data"]), 20)
+        self.assertEqual(result["data"][0]["title"], "MoFo #00")
+        self.assertEqual(result["data"][-1]["title"], "MoFo #19")
 
     def test_single_basic_sort_by_attribute_reversed(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['-title']}
+        self.resource.request.validated["querystring"] = {"_sort": ["-title"]}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 20)
-        self.assertEqual(result['data'][0]['title'], 'MoFo #19')
-        self.assertEqual(result['data'][-1]['title'], 'MoFo #00')
+        self.assertEqual(len(result["data"]), 20)
+        self.assertEqual(result["data"][0]["title"], "MoFo #19")
+        self.assertEqual(result["data"][-1]["title"], "MoFo #00")
 
     def test_multiple_sort(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['status', 'title']}
+        self.resource.request.validated["querystring"] = {"_sort": ["status", "title"]}
         result = self.resource.collection_get()
-        self.assertEqual(result['data'][0]['status'], 0)
-        self.assertEqual(result['data'][0]['title'], 'MoFo #00')
-        self.assertEqual(result['data'][1]['status'], 0)
-        self.assertEqual(result['data'][1]['title'], 'MoFo #04')
-        self.assertEqual(result['data'][-2]['status'], 3)
-        self.assertEqual(result['data'][-2]['title'], 'MoFo #15')
-        self.assertEqual(result['data'][-1]['status'], 3)
-        self.assertEqual(result['data'][-1]['title'], 'MoFo #19')
+        self.assertEqual(result["data"][0]["status"], 0)
+        self.assertEqual(result["data"][0]["title"], "MoFo #00")
+        self.assertEqual(result["data"][1]["status"], 0)
+        self.assertEqual(result["data"][1]["title"], "MoFo #04")
+        self.assertEqual(result["data"][-2]["status"], 3)
+        self.assertEqual(result["data"][-2]["title"], "MoFo #15")
+        self.assertEqual(result["data"][-1]["status"], 3)
+        self.assertEqual(result["data"][-1]["title"], "MoFo #19")
 
     def test_multiple_sort_with_order(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['status', '-title']}
+        self.resource.request.validated["querystring"] = {"_sort": ["status", "-title"]}
         result = self.resource.collection_get()
-        self.assertEqual(result['data'][0]['status'], 0)
-        self.assertEqual(result['data'][0]['title'], 'MoFo #16')
-        self.assertEqual(result['data'][1]['status'], 0)
-        self.assertEqual(result['data'][1]['title'], 'MoFo #12')
-        self.assertEqual(result['data'][-2]['status'], 3)
-        self.assertEqual(result['data'][-2]['title'], 'MoFo #07')
-        self.assertEqual(result['data'][-1]['status'], 3)
-        self.assertEqual(result['data'][-1]['title'], 'MoFo #03')
+        self.assertEqual(result["data"][0]["status"], 0)
+        self.assertEqual(result["data"][0]["title"], "MoFo #16")
+        self.assertEqual(result["data"][1]["status"], 0)
+        self.assertEqual(result["data"][1]["title"], "MoFo #12")
+        self.assertEqual(result["data"][-2]["status"], 3)
+        self.assertEqual(result["data"][-2]["title"], "MoFo #07")
+        self.assertEqual(result["data"][-1]["status"], 3)
+        self.assertEqual(result["data"][-1]["title"], "MoFo #03")
 
     def test_boolean_sort_brings_true_last(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['unread']}
+        self.resource.request.validated["querystring"] = {"_sort": ["unread"]}
         result = self.resource.collection_get()
-        self.assertEqual(result['data'][0]['unread'], False)
-        self.assertEqual(result['data'][-1]['unread'], True)
+        self.assertEqual(result["data"][0]["unread"], False)
+        self.assertEqual(result["data"][-1]["unread"], True)
 
     def test_default_sort_is_last_modified_desc_by_default(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['']}
+        self.resource.request.validated["querystring"] = {"_sort": [""]}
         result = self.resource.collection_get()
         tstamp = self.model.timestamp()
-        self.assertEqual(result['data'][0]['last_modified'], tstamp)
+        self.assertEqual(result["data"][0]["last_modified"], tstamp)
 
     def test_default_sort_is_last_modified_records_have_same_status(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['status']}
+        self.resource.request.validated["querystring"] = {"_sort": ["status"]}
         result = self.resource.collection_get()
-        self.assertEqual(result['data'][0]['status'], 0)
-        self.assertEqual(result['data'][1]['status'], 0)
-        self.assertGreater(result['data'][0]['last_modified'],
-                           result['data'][1]['last_modified'])
+        self.assertEqual(result["data"][0]["status"], 0)
+        self.assertEqual(result["data"][1]["status"], 0)
+        self.assertGreater(result["data"][0]["last_modified"], result["data"][1]["last_modified"])
 
 
 class SubobjectSortingTest(BaseTest):
@@ -126,20 +128,17 @@ class SubobjectSortingTest(BaseTest):
         random.shuffle(indices)
 
         for i in indices:
-            record = {
-                'party': {'candidate': 'Marie', 'voters': i},
-                'location': 'Creuse'
-            }
+            record = {"party": {"candidate": "Marie", "voters": i}, "location": "Creuse"}
             self.model.create_record(record)
 
     def test_records_can_be_sorted_by_subobjects(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['party.voters']}
+        self.resource.request.validated["querystring"] = {"_sort": ["party.voters"]}
         result = self.resource.collection_get()
-        values = [item['party']['voters'] for item in result['data']]
+        values = [item["party"]["voters"] for item in result["data"]]
         self.assertEqual(sorted(values), values)
 
     def test_subobjects_sorting_is_ignored_if_not_object(self):
-        self.resource.request.validated['querystring'] = {'_sort': ['location.city']}
+        self.resource.request.validated["querystring"] = {"_sort": ["location.city"]}
         result = self.resource.collection_get()
-        values = [item['party']['voters'] for item in result['data']]
+        values = [item["party"]["voters"] for item in result["data"]]
         self.assertNotEqual(sorted(values), values)

--- a/tests/core/resource/test_sync.py
+++ b/tests/core/resource/test_sync.py
@@ -8,119 +8,116 @@ from . import BaseTest
 
 
 class SinceModifiedTest(ThreadMixin, BaseTest):
-
     def setUp(self):
         super().setUp()
-        self.validated['body'] = {'data': {}}
+        self.validated["body"] = {"data": {}}
 
-        with mock.patch.object(self.model.storage,
-                               'bump_and_store_timestamp') as msec_mocked:
+        with mock.patch.object(self.model.storage, "bump_and_store_timestamp") as msec_mocked:
             for i in range(6):
                 msec_mocked.return_value = i
                 self.resource.collection_post()
 
     def test_filter_with_since_is_exclusive(self):
-        self.validated['querystring'] = {'_since': 3}
+        self.validated["querystring"] = {"_since": 3}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 2)
+        self.assertEqual(len(result["data"]), 2)
 
     def test_filter_with__to_is_exclusive(self):
-        self.validated['querystring'] = {'_to': 3}
+        self.validated["querystring"] = {"_to": 3}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 3)
+        self.assertEqual(len(result["data"]), 3)
 
     def test_filter_with__before_is_exclusive(self):
-        self.validated['querystring'] = {'_before': 3}
+        self.validated["querystring"] = {"_before": 3}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 3)
+        self.assertEqual(len(result["data"]), 3)
 
     def test_filter_with__to_return_an_alert_header(self):
-        self.validated['querystring'] = {'_to': 3}
+        self.validated["querystring"] = {"_to": 3}
         self.resource.collection_get()
-        self.assertIn('Alert', self.resource.request.response.headers)
-        alert = self.resource.request.response.headers['Alert']
+        self.assertIn("Alert", self.resource.request.response.headers)
+        alert = self.resource.request.response.headers["Alert"]
         self.assertDictEqual(
             json.loads(alert),
             {
-                'code': 'soft-eol',
-                'message': ('_to is now deprecated, '
-                            'you should use _before instead'),
-                'url': ('https://kinto.readthedocs.io/en/2.4.0/api/resource'
-                        '.html#list-of-available-url-parameters')
-            })
+                "code": "soft-eol",
+                "message": ("_to is now deprecated, " "you should use _before instead"),
+                "url": (
+                    "https://kinto.readthedocs.io/en/2.4.0/api/resource"
+                    ".html#list-of-available-url-parameters"
+                ),
+            },
+        )
 
     def test_get_timestamp_header_is_equal_to_last_modification(self):
-        result = self.resource.collection_post()['data']
-        modification = result['last_modified']
-        self.resource = self.resource_class(request=self.get_request(),
-                                            context=self.get_context())
+        result = self.resource.collection_post()["data"]
+        modification = result["last_modified"]
+        self.resource = self.resource_class(request=self.get_request(), context=self.get_context())
         self.resource.request.validated = self.validated
         self.resource.collection_get()
-        header = int(self.last_response.headers['ETag'][1:-1])
+        header = int(self.last_response.headers["ETag"][1:-1])
         self.assertEqual(header, modification)
 
     def test_delete_timestamp_header_is_equal_to_last_deleted(self):
-        self.resource.collection_post()['data']
-        self.resource = self.resource_class(request=self.get_request(),
-                                            context=self.get_context())
+        self.resource.collection_post()["data"]
+        self.resource = self.resource_class(request=self.get_request(), context=self.get_context())
         self.resource.request.validated = self.validated
         result = self.resource.collection_delete()
-        modification = max([record['last_modified'] for record in result['data']])
-        header = int(self.last_response.headers['ETag'][1:-1])
+        modification = max([record["last_modified"] for record in result["data"]])
+        header = int(self.last_response.headers["ETag"][1:-1])
         self.assertEqual(header, modification)
 
     def test_post_timestamp_header_is_equal_to_creation(self):
-        result = self.resource.collection_post()['data']
-        modification = result['last_modified']
-        header = int(self.last_response.headers['ETag'][1:-1])
+        result = self.resource.collection_post()["data"]
+        modification = result["last_modified"]
+        header = int(self.last_response.headers["ETag"][1:-1])
         self.assertEqual(header, modification)
 
     def test_filter_with_since_accepts_numeric_value(self):
-        self.validated['querystring'] = {'_since': 6}
+        self.validated["querystring"] = {"_since": 6}
         self.resource.collection_post()
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 1)
+        self.assertEqual(len(result["data"]), 1)
 
     def test_filter_from_last_modified_is_exclusive(self):
-        result = self.resource.collection_post()['data']
-        current = result['last_modified']
+        result = self.resource.collection_post()["data"]
+        current = result["last_modified"]
 
-        self.validated['querystring'] = {'_since': current}
+        self.validated["querystring"] = {"_since": current}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 0)
+        self.assertEqual(len(result["data"]), 0)
 
     def test_filter_with_last_modified_includes_deleted_data(self):
         self.resource.collection_post()
-        result = self.resource.collection_post()['data']
-        current = result['last_modified']
+        result = self.resource.collection_post()["data"]
+        current = result["last_modified"]
 
-        self.resource.record_id = result['id']
+        self.resource.record_id = result["id"]
         self.resource.delete()
 
-        self.validated['querystring'] = {'_since': current}
+        self.validated["querystring"] = {"_since": current}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 1)
-        self.assertTrue(result['data'][0]['deleted'])
+        self.assertEqual(len(result["data"]), 1)
+        self.assertTrue(result["data"][0]["deleted"])
 
     def test_filter_from_last_header_value_is_exclusive(self):
         self.resource.collection_get()
-        current = int(self.last_response.headers['ETag'][1:-1])
+        current = int(self.last_response.headers["ETag"][1:-1])
 
-        self.validated['querystring'] = {'_since': current}
+        self.validated["querystring"] = {"_since": current}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 0)
+        self.assertEqual(len(result["data"]), 0)
 
     def test_filter_works_with_empty_list(self):
-        self.resource.model.parent_id = 'alice'
-        self.validated['querystring'] = {'_since': 3}
+        self.resource.model.parent_id = "alice"
+        self.validated["querystring"] = {"_since": 3}
         result = self.resource.collection_get()
-        self.assertEqual(len(result['data']), 0)
+        self.assertEqual(len(result["data"]), 0)
 
     def test_timestamp_are_always_identical_on_read(self):
-
         def read_timestamp():
             self.resource.collection_get()
-            return int(self.last_response.headers['ETag'][1:-1])
+            return int(self.last_response.headers["ETag"][1:-1])
 
         before = read_timestamp()
         now = read_timestamp()
@@ -129,10 +126,9 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
         self.assertEqual(now, after)
 
     def test_timestamp_are_always_incremented_on_creation(self):
-
         def read_timestamp():
-            record = self.resource.collection_post()['data']
-            return record['last_modified']
+            record = self.resource.collection_post()["data"]
+            return record["last_modified"]
 
         before = read_timestamp()
         now = read_timestamp()
@@ -147,14 +143,13 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
             """Simulate a overhead while reading on storage."""
 
             def delayed_get(*args, **kwargs):
-                time.sleep(.100)  # 100 msec
+                time.sleep(0.100)  # 100 msec
                 return [], 0
 
-            with mock.patch.object(self.model.storage,
-                                   'get_all', delayed_get):
+            with mock.patch.object(self.model.storage, "get_all", delayed_get):
                 self.resource.collection_get()
-                fetch_at = self.last_response.headers['ETag'][1:-1]
-                timestamps['fetch'] = int(fetch_at)
+                fetch_at = self.last_response.headers["ETag"][1:-1]
+                timestamps["fetch"] = int(fetch_at)
 
         # Create a real record with no patched timestamp
         self.resource.collection_post()
@@ -164,18 +159,17 @@ class SinceModifiedTest(ThreadMixin, BaseTest):
         thread.start()
 
         # Create record while other is fetching
-        time.sleep(.020)  # 20 msec
+        time.sleep(0.020)  # 20 msec
         # Instantiate a new resource/request to avoid shared references with
         # the other one running in a thread:
-        resource = self.resource_class(request=self.get_request(),
-                                       context=self.get_context())
+        resource = self.resource_class(request=self.get_request(), context=self.get_context())
         resource.request.validated = self.validated
-        resource.request.validated['body'] = {'data': {}}
-        record = resource.collection_post()['data']
-        timestamps['post'] = record['last_modified']
+        resource.request.validated["body"] = {"data": {}}
+        record = resource.collection_post()["data"]
+        timestamps["post"] = record["last_modified"]
 
         # Wait for the fetch to finish
         thread.join()
 
         # Make sure fetch timestamp is below (for next fetch)
-        self.assertGreater(timestamps['post'], timestamps['fetch'])
+        self.assertGreater(timestamps["post"], timestamps["fetch"])

--- a/tests/core/resource/test_views.py
+++ b/tests/core/resource/test_views.py
@@ -9,35 +9,33 @@ from kinto.core.testing import unittest, FormattedErrorMixin
 from ..support import BaseWebTest
 
 
-MINIMALIST_RECORD = {'name': 'Champignon'}
+MINIMALIST_RECORD = {"name": "Champignon"}
 
 
 class UserResourcePermissionTest(BaseWebTest, unittest.TestCase):
-    authorization_policy = 'kinto.core.authorization.AuthorizationPolicy'
+    authorization_policy = "kinto.core.authorization.AuthorizationPolicy"
 
     def test_views_require_authentication(self):
         self.app.get(self.collection_url, status=401)
-        body = {'data': MINIMALIST_RECORD}
+        body = {"data": MINIMALIST_RECORD}
         self.app.post_json(self.collection_url, body, status=401)
-        record_url = self.get_item_url('abc')
+        record_url = self.get_item_url("abc")
         self.app.get(record_url, status=401)
         self.app.put_json(record_url, body, status=401)
         self.app.patch_json(record_url, body, status=401)
         self.app.delete(record_url, status=401)
 
     def test_collection_operations_are_authorized_if_authenticated(self):
-        body = {'data': MINIMALIST_RECORD}
+        body = {"data": MINIMALIST_RECORD}
         self.app.get(self.collection_url, headers=self.headers, status=200)
-        self.app.post_json(self.collection_url, body,
-                           headers=self.headers, status=201)
+        self.app.post_json(self.collection_url, body, headers=self.headers, status=201)
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
     def test_record_operations_are_authorized_if_authenticated(self):
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers, status=201)
-        record = resp.json['data']
-        record_url = self.get_item_url(record['id'])
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers, status=201)
+        record = resp.json["data"]
+        record_url = self.get_item_url(record["id"])
         unknown_url = self.get_item_url(uuid.uuid4())
 
         self.app.get(record_url, headers=self.headers, status=200)
@@ -48,9 +46,9 @@ class UserResourcePermissionTest(BaseWebTest, unittest.TestCase):
 
 
 class AuthzAuthnTest(BaseWebTest, unittest.TestCase):
-    authorization_policy = 'kinto.core.authorization.AuthorizationPolicy'
+    authorization_policy = "kinto.core.authorization.AuthorizationPolicy"
     # Shareable resource.
-    collection_url = '/toadstools'
+    collection_url = "/toadstools"
 
     def add_permission(self, object_id, permission, principal=None):
         if not principal:
@@ -60,103 +58,90 @@ class AuthzAuthnTest(BaseWebTest, unittest.TestCase):
 
 class ShareableResourcePermissionTest(AuthzAuthnTest):
     def setUp(self):
-        self.add_permission(self.collection_url, 'toadstool:create')
+        self.add_permission(self.collection_url, "toadstool:create")
 
     def test_permissions_are_associated_to_object_uri_without_prefix(self):
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers']}}
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers)
-        object_uri = self.get_item_url(resp.json['data']['id'])
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["group:readers"]}}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        object_uri = self.get_item_url(resp.json["data"]["id"])
         backend = self.permission
-        stored_perms = backend.get_object_permission_principals(object_uri,
-                                                                'read')
-        self.assertEqual(stored_perms, {'group:readers'})
+        stored_perms = backend.get_object_permission_principals(object_uri, "read")
+        self.assertEqual(stored_perms, {"group:readers"})
 
     def test_permissions_are_not_modified_if_not_specified(self):
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers']}}
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers)
-        object_uri = self.get_item_url(resp.json['data']['id'])
-        body.pop('permissions')
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["group:readers"]}}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        object_uri = self.get_item_url(resp.json["data"]["id"])
+        body.pop("permissions")
 
-        self.add_permission(object_uri, 'write')
+        self.add_permission(object_uri, "write")
         resp = self.app.put_json(object_uri, body, headers=self.headers)
-        self.assertEqual(resp.json['permissions']['read'], ['group:readers'])
+        self.assertEqual(resp.json["permissions"]["read"], ["group:readers"])
 
     def test_data_is_always_required_when_schema_has_required_fields(self):
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers']}}
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers)
-        object_uri = self.get_item_url(resp.json['data']['id'])
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["group:readers"]}}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        object_uri = self.get_item_url(resp.json["data"]["id"])
 
-        body.pop('data')
-        resp = self.app.put_json(object_uri, body, headers=self.headers,
-                                 status=400)
+        body.pop("data")
+        resp = self.app.put_json(object_uri, body, headers=self.headers, status=400)
 
     def test_data_is_not_required_when_schema_has_no_required_fields(self):
-        self.add_permission('/psilos', 'psilo:create')
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers']}}
-        resp = self.app.post_json('/psilos', body,
-                                  headers=self.headers)
-        object_uri = '/psilos/{}'.format(resp.json['data']['id'])
+        self.add_permission("/psilos", "psilo:create")
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["group:readers"]}}
+        resp = self.app.post_json("/psilos", body, headers=self.headers)
+        object_uri = "/psilos/{}".format(resp.json["data"]["id"])
 
-        body.pop('data')
+        body.pop("data")
         resp = self.app.put_json(object_uri, body, headers=self.headers)
-        self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
+        self.assertEqual(resp.json["data"]["name"], MINIMALIST_RECORD["name"])
 
     def test_data_are_not_modified_if_not_specified_on_schemaless(self):
-        self.add_permission('/spores', 'spore:create')
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers']}}
-        resp = self.app.post_json('/spores', body,
-                                  headers=self.headers)
-        object_uri = '/spores/{}'.format(resp.json['data']['id'])
-        self.add_permission(object_uri, 'write')
+        self.add_permission("/spores", "spore:create")
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["group:readers"]}}
+        resp = self.app.post_json("/spores", body, headers=self.headers)
+        object_uri = "/spores/{}".format(resp.json["data"]["id"])
+        self.add_permission(object_uri, "write")
 
-        body.pop('data')
+        body.pop("data")
         resp = self.app.put_json(object_uri, body, headers=self.headers)
 
-        self.assertEqual(resp.json['data']['name'], MINIMALIST_RECORD['name'])
+        self.assertEqual(resp.json["data"]["name"], MINIMALIST_RECORD["name"])
 
     def test_permissions_can_be_modified_using_patch(self):
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers']}}
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers)
-        body = {'permissions': {'read': ['fxa:user']}}
-        uri = self.get_item_url(resp.json['data']['id'])
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["group:readers"]}}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        body = {"permissions": {"read": ["fxa:user"]}}
+        uri = self.get_item_url(resp.json["data"]["id"])
         resp = self.app.patch_json(uri, body, headers=self.headers)
-        principals = resp.json['permissions']['read']
-        self.assertEqual(sorted(principals), ['fxa:user'])
+        principals = resp.json["permissions"]["read"]
+        self.assertEqual(sorted(principals), ["fxa:user"])
 
     def test_unknown_permissions_are_not_accepted(self):
         self.maxDiff = None
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['group:readers'],
-                                'unknown': ['jacques']}}
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers, status=400)
+        body = {
+            "data": MINIMALIST_RECORD,
+            "permissions": {"read": ["group:readers"], "unknown": ["jacques"]},
+        }
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers, status=400)
         self.assertEqual(
-            resp.json['message'],
-            'permissions in body: "unknown" is not one of read, write')
+            resp.json["message"], 'permissions in body: "unknown" is not one of read, write'
+        )
 
 
 class CollectionAuthzGrantedTest(AuthzAuthnTest):
     def test_collection_get_is_granted_when_authorized(self):
-        self.add_permission(self.collection_url, 'read')
+        self.add_permission(self.collection_url, "read")
         self.app.get(self.collection_url, headers=self.headers, status=200)
 
     def test_collection_post_is_granted_when_authorized(self):
-        self.add_permission(self.collection_url, 'toadstool:create')
-        self.app.post_json(self.collection_url, {'data': MINIMALIST_RECORD},
-                           headers=self.headers, status=201)
+        self.add_permission(self.collection_url, "toadstool:create")
+        self.app.post_json(
+            self.collection_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=201
+        )
 
     def test_collection_delete_is_granted_when_authorized(self):
-        self.add_permission(self.collection_url, 'write')
+        self.add_permission(self.collection_url, "write")
         self.app.delete(self.collection_url, headers=self.headers, status=200)
 
 
@@ -164,15 +149,16 @@ class CollectionAuthzDeniedTest(AuthzAuthnTest):
     def test_views_require_authentication(self):
         self.app.get(self.collection_url, status=401)
 
-        body = {'data': MINIMALIST_RECORD}
+        body = {"data": MINIMALIST_RECORD}
         self.app.post_json(self.collection_url, body, status=401)
 
     def test_collection_get_is_denied_when_not_authorized(self):
         self.app.get(self.collection_url, headers=self.headers, status=403)
 
     def test_collection_post_is_denied_when_not_authorized(self):
-        self.app.post_json(self.collection_url, {'data': MINIMALIST_RECORD},
-                           headers=self.headers, status=403)
+        self.app.post_json(
+            self.collection_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=403
+        )
 
     def test_collection_delete_is_denied_when_not_authorized(self):
         self.app.delete(self.collection_url, headers=self.headers, status=403)
@@ -181,70 +167,75 @@ class CollectionAuthzDeniedTest(AuthzAuthnTest):
 class RecordAuthzGrantedTest(AuthzAuthnTest):
     def setUp(self):
         super().setUp()
-        self.add_permission(self.collection_url, 'toadstool:create')
+        self.add_permission(self.collection_url, "toadstool:create")
 
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': MINIMALIST_RECORD},
-                                  headers=self.headers)
-        self.record = resp.json['data']
+        resp = self.app.post_json(
+            self.collection_url, {"data": MINIMALIST_RECORD}, headers=self.headers
+        )
+        self.record = resp.json["data"]
         self.record_url = self.get_item_url()
         self.unknown_record_url = self.get_item_url(uuid.uuid4())
 
     def test_record_get_is_granted_when_authorized(self):
-        self.add_permission(self.record_url, 'read')
+        self.add_permission(self.record_url, "read")
         self.app.get(self.record_url, headers=self.headers, status=200)
 
     def test_record_patch_is_granted_when_authorized(self):
-        self.add_permission(self.record_url, 'write')
-        self.app.patch_json(self.record_url, {'data': MINIMALIST_RECORD},
-                            headers=self.headers, status=200)
+        self.add_permission(self.record_url, "write")
+        self.app.patch_json(
+            self.record_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=200
+        )
 
     def test_record_delete_is_granted_when_authorized(self):
-        self.add_permission(self.record_url, 'write')
+        self.add_permission(self.record_url, "write")
         self.app.delete(self.record_url, headers=self.headers, status=200)
 
     def test_record_put_on_existing_record_is_granted_when_authorized(self):
-        self.add_permission(self.record_url, 'write')
-        self.app.put_json(self.record_url, {'data': MINIMALIST_RECORD},
-                          headers=self.headers, status=200)
+        self.add_permission(self.record_url, "write")
+        self.app.put_json(
+            self.record_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=200
+        )
 
     def test_record_put_on_unexisting_record_is_granted_when_authorized(self):
-        self.add_permission(self.collection_url, 'toadstool:create')
-        self.app.put_json(self.unknown_record_url, {'data': MINIMALIST_RECORD},
-                          headers=self.headers, status=201)
+        self.add_permission(self.collection_url, "toadstool:create")
+        self.app.put_json(
+            self.unknown_record_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=201
+        )
 
 
 class RecordAuthzDeniedTest(AuthzAuthnTest):
     def setUp(self):
         super().setUp()
         # Add permission to create a sample record.
-        self.add_permission(self.collection_url, 'toadstool:create')
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': MINIMALIST_RECORD},
-                                  headers=self.headers)
-        self.record = resp.json['data']
+        self.add_permission(self.collection_url, "toadstool:create")
+        resp = self.app.post_json(
+            self.collection_url, {"data": MINIMALIST_RECORD}, headers=self.headers
+        )
+        self.record = resp.json["data"]
         self.record_url = self.get_item_url()
         self.unknown_record_url = self.get_item_url(uuid.uuid4())
         # Remove every permissions.
         self.permission.flush()
 
     def test_views_require_authentication(self):
-        url = self.get_item_url('abc')
+        url = self.get_item_url("abc")
         self.app.get(url, status=401)
-        self.app.put_json(url, {'data': MINIMALIST_RECORD}, status=401)
-        self.app.patch_json(url, {'data': MINIMALIST_RECORD}, status=401)
+        self.app.put_json(url, {"data": MINIMALIST_RECORD}, status=401)
+        self.app.patch_json(url, {"data": MINIMALIST_RECORD}, status=401)
         self.app.delete(url, status=401)
 
     def test_record_get_is_denied_when_not_authorized(self):
         self.app.get(self.record_url, headers=self.headers, status=403)
 
     def test_record_patch_is_denied_when_not_authorized(self):
-        self.app.patch_json(self.record_url, {'data': MINIMALIST_RECORD},
-                            headers=self.headers, status=403)
+        self.app.patch_json(
+            self.record_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=403
+        )
 
     def test_record_put_is_denied_when_not_authorized(self):
-        self.app.put_json(self.record_url, {'data': MINIMALIST_RECORD},
-                          headers=self.headers, status=403)
+        self.app.put_json(
+            self.record_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=403
+        )
 
     def test_record_delete_is_denied_when_not_authorized(self):
         self.app.delete(self.record_url, headers=self.headers, status=403)
@@ -252,224 +243,201 @@ class RecordAuthzDeniedTest(AuthzAuthnTest):
     def test_record_put_on_unexisting_record_is_rejected_if_write_perm(self):
         object_id = self.collection_url
         self.permission.remove_principal_from_ace(
-            object_id, 'toadstool:create', self.principal)  # Added in setUp.
+            object_id, "toadstool:create", self.principal
+        )  # Added in setUp.
 
-        self.permission.add_principal_to_ace(
-            object_id, 'write', self.principal)
-        self.app.put_json(self.unknown_record_url, {'data': MINIMALIST_RECORD},
-                          headers=self.headers, status=403)
+        self.permission.add_principal_to_ace(object_id, "write", self.principal)
+        self.app.put_json(
+            self.unknown_record_url, {"data": MINIMALIST_RECORD}, headers=self.headers, status=403
+        )
 
 
 class RecordAuthzGrantedOnCollectionTest(AuthzAuthnTest):
     def setUp(self):
         super().setUp()
-        self.add_permission(self.collection_url, 'toadstool:create')
+        self.add_permission(self.collection_url, "toadstool:create")
 
-        self.guest_headers = {**self.headers, 'Authorization': "Basic bmF0aW06"}
-        resp = self.app.get('/', headers=self.guest_headers)
-        self.guest_id = resp.json['user']['id']
+        self.guest_headers = {**self.headers, "Authorization": "Basic bmF0aW06"}
+        resp = self.app.get("/", headers=self.guest_headers)
+        self.guest_id = resp.json["user"]["id"]
 
         body = {
-            'data': MINIMALIST_RECORD,
-            'permissions': {
-                'write': [self.guest_id],
-                'read': [self.guest_id]
-            }
+            "data": MINIMALIST_RECORD,
+            "permissions": {"write": [self.guest_id], "read": [self.guest_id]},
         }
-        resp = self.app.post_json(self.collection_url, body,
-                                  headers=self.headers)
-        self.record = resp.json['data']
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        self.record = resp.json["data"]
         self.record_url = self.get_item_url()
 
         # Add another private record
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': MINIMALIST_RECORD,
-                                   'permissions': {"read": [self.principal]}},
-                                  headers=self.headers)
+        resp = self.app.post_json(
+            self.collection_url,
+            {"data": MINIMALIST_RECORD, "permissions": {"read": [self.principal]}},
+            headers=self.headers,
+        )
 
     def test_guest_can_access_the_record(self):
         self.app.get(self.record_url, headers=self.guest_headers, status=200)
 
     def test_guest_can_see_the_record_in_the_list_of_records(self):
-        resp = self.app.get(self.collection_url, headers=self.guest_headers,
-                            status=200)
-        self.assertEqual(len(resp.json['data']), 1)
+        resp = self.app.get(self.collection_url, headers=self.guest_headers, status=200)
+        self.assertEqual(len(resp.json["data"]), 1)
 
     def test_guest_can_remove_its_records_from_the_list_of_records(self):
-        resp = self.app.delete(self.collection_url, headers=self.guest_headers,
-                               status=200)
-        self.assertEqual(len(resp.json['data']), 1)
-        resp = self.app.get(self.collection_url, headers=self.headers,
-                            status=200)
-        self.assertEqual(len(resp.json['data']), 1)
+        resp = self.app.delete(self.collection_url, headers=self.guest_headers, status=200)
+        self.assertEqual(len(resp.json["data"]), 1)
+        resp = self.app.get(self.collection_url, headers=self.headers, status=200)
+        self.assertEqual(len(resp.json["data"]), 1)
 
 
 class StrictSchemaTest(BaseWebTest, unittest.TestCase):
-    collection_url = '/moistures'
+    collection_url = "/moistures"
 
     def test_accept_empty_body(self):
-        resp = self.app.post(self.collection_url,
-                             headers=self.headers)
-        self.assertIn('id', resp.json['data'])
-        resp = self.app.put(self.get_item_url(uuid.uuid4()),
-                            headers=self.headers)
-        self.assertIn('id', resp.json['data'])
+        resp = self.app.post(self.collection_url, headers=self.headers)
+        self.assertIn("id", resp.json["data"])
+        resp = self.app.put(self.get_item_url(uuid.uuid4()), headers=self.headers)
+        self.assertIn("id", resp.json["data"])
 
     def test_data_can_be_specified(self):
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': {}},
-                                  headers=self.headers)
-        self.assertIn('id', resp.json['data'])
+        resp = self.app.post_json(self.collection_url, {"data": {}}, headers=self.headers)
+        self.assertIn("id", resp.json["data"])
 
     def test_data_fields_are_ignored(self):
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': {'icq': '9427392'}},
-                                  headers=self.headers)
-        self.assertNotIn('icq', resp.json['data'])
+        resp = self.app.post_json(
+            self.collection_url, {"data": {"icq": "9427392"}}, headers=self.headers
+        )
+        self.assertNotIn("icq", resp.json["data"])
 
 
 class OptionalSchemaTest(BaseWebTest, unittest.TestCase):
-    collection_url = '/psilos'
+    collection_url = "/psilos"
 
     def test_accept_empty_body(self):
-        resp = self.app.post(self.collection_url,
-                             headers=self.headers)
-        self.assertIn('id', resp.json['data'])
-        resp = self.app.put(self.get_item_url(uuid.uuid4()),
-                            headers=self.headers)
-        self.assertIn('id', resp.json['data'])
+        resp = self.app.post(self.collection_url, headers=self.headers)
+        self.assertIn("id", resp.json["data"])
+        resp = self.app.put(self.get_item_url(uuid.uuid4()), headers=self.headers)
+        self.assertIn("id", resp.json["data"])
 
     def test_data_can_be_specified(self):
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': {}},
-                                  headers=self.headers)
-        self.assertIn('id', resp.json['data'])
+        resp = self.app.post_json(self.collection_url, {"data": {}}, headers=self.headers)
+        self.assertIn("id", resp.json["data"])
 
     def test_known_fields_are_saved(self):
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': {'edible': False}},
-                                  headers=self.headers)
-        self.assertIn('edible', resp.json['data'])
+        resp = self.app.post_json(
+            self.collection_url, {"data": {"edible": False}}, headers=self.headers
+        )
+        self.assertIn("edible", resp.json["data"])
 
 
 class InvalidRecordTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url,
-                                  body,
-                                  headers=self.headers)
-        self.record = resp.json['data']
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        self.record = resp.json["data"]
 
-        self.invalid_record = {'data': {'name': 42}}
+        self.invalid_record = {"data": {"name": 42}}
 
     def test_invalid_record_returns_json_formatted_error(self):
-        resp = self.app.post_json(self.collection_url,
-                                  self.invalid_record,
-                                  headers=self.headers,
-                                  status=400)
+        resp = self.app.post_json(
+            self.collection_url, self.invalid_record, headers=self.headers, status=400
+        )
         # XXX: weird resp.json['message']
-        self.assertDictEqual(resp.json, {
-            'errno': ERRORS.INVALID_PARAMETERS.value,
-            'message': "data.name in body: 42 is not a string: {'name': ''}",
-            'code': 400,
-            'error': 'Invalid parameters',
-            'details': [{'description': "42 is not a string: {'name': ''}",
-                         'location': 'body',
-                         'name': 'data.name'}]})
+        self.assertDictEqual(
+            resp.json,
+            {
+                "errno": ERRORS.INVALID_PARAMETERS.value,
+                "message": "data.name in body: 42 is not a string: {'name': ''}",
+                "code": 400,
+                "error": "Invalid parameters",
+                "details": [
+                    {
+                        "description": "42 is not a string: {'name': ''}",
+                        "location": "body",
+                        "name": "data.name",
+                    }
+                ],
+            },
+        )
 
     def test_empty_body_returns_400(self):
-        resp = self.app.post(self.collection_url,
-                             '',
-                             headers=self.headers,
-                             status=400)
-        self.assertEqual(resp.json['message'], 'data in body: Required')
+        resp = self.app.post(self.collection_url, "", headers=self.headers, status=400)
+        self.assertEqual(resp.json["message"], "data in body: Required")
 
     def test_unknown_attribute_returns_400(self):
-        resp = self.app.post(self.collection_url,
-                             '{"data": {"name": "ML"}, "datta": {}}',
-                             headers=self.headers,
-                             status=400)
-        self.assertIn('Unrecognized keys in mapping', resp.json['message'])
-        self.assertIn('datta', resp.json['message'])
+        resp = self.app.post(
+            self.collection_url,
+            '{"data": {"name": "ML"}, "datta": {}}',
+            headers=self.headers,
+            status=400,
+        )
+        self.assertIn("Unrecognized keys in mapping", resp.json["message"])
+        self.assertIn("datta", resp.json["message"])
 
     def test_create_invalid_record_returns_400(self):
-        self.app.post_json(self.collection_url,
-                           self.invalid_record,
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            self.collection_url, self.invalid_record, headers=self.headers, status=400
+        )
 
     def test_modify_with_invalid_record_returns_400(self):
-        self.app.patch_json(self.get_item_url(),
-                            self.invalid_record,
-                            headers=self.headers,
-                            status=400)
+        self.app.patch_json(
+            self.get_item_url(), self.invalid_record, headers=self.headers, status=400
+        )
 
     def test_modify_with_unknown_attribute_returns_400(self):
-        self.app.patch_json(self.get_item_url(),
-                            {"datta": {}},
-                            headers=self.headers,
-                            status=400)
+        self.app.patch_json(self.get_item_url(), {"datta": {}}, headers=self.headers, status=400)
 
     def test_replace_with_invalid_record_returns_400(self):
-        self.app.put_json(self.get_item_url(),
-                          self.invalid_record,
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(
+            self.get_item_url(), self.invalid_record, headers=self.headers, status=400
+        )
 
     def test_id_is_validated_on_post(self):
-        record = {**MINIMALIST_RECORD, 'id': 3.14}
-        self.app.post_json(self.collection_url,
-                           {'data': record},
-                           headers=self.headers,
-                           status=400)
+        record = {**MINIMALIST_RECORD, "id": 3.14}
+        self.app.post_json(self.collection_url, {"data": record}, headers=self.headers, status=400)
 
-        with mock.patch.object(self.app.app.registry.id_generators[''],
-                               'match', return_value=True):
-            self.app.post_json(self.collection_url,
-                               {'data': record},
-                               headers=self.headers,
-                               status=400)
+        with mock.patch.object(
+            self.app.app.registry.id_generators[""], "match", return_value=True
+        ):
+            self.app.post_json(
+                self.collection_url, {"data": record}, headers=self.headers, status=400
+            )
 
     def test_id_is_preserved_on_post(self):
-        record = {**MINIMALIST_RECORD, 'id': '472be9ec-26fe-461b-8282-9c4e4b207ab3'}
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': record},
-                                  headers=self.headers)
-        self.assertEqual(resp.json['data']['id'], record['id'])
+        record = {**MINIMALIST_RECORD, "id": "472be9ec-26fe-461b-8282-9c4e4b207ab3"}
+        resp = self.app.post_json(self.collection_url, {"data": record}, headers=self.headers)
+        self.assertEqual(resp.json["data"]["id"], record["id"])
 
     def test_200_is_returned_if_id_matches_existing_record(self):
-        record = {**MINIMALIST_RECORD, 'id': self.record['id']}
-        self.app.post_json(self.collection_url,
-                           {'data': record},
-                           headers=self.headers,
-                           status=200)
+        record = {**MINIMALIST_RECORD, "id": self.record["id"]}
+        self.app.post_json(self.collection_url, {"data": record}, headers=self.headers, status=200)
 
     def test_invalid_accept_header_on_collections_returns_406(self):
-        headers = {**self.headers, 'Accept': 'text/plain'}
-        resp = self.app.post(self.collection_url, '', headers=headers, status=406)
-        self.assertEqual(resp.json['code'], 406)
+        headers = {**self.headers, "Accept": "text/plain"}
+        resp = self.app.post(self.collection_url, "", headers=headers, status=406)
+        self.assertEqual(resp.json["code"], 406)
         message = "Accept header should be one of ['application/json']"
-        self.assertEqual(resp.json['message'], message)
+        self.assertEqual(resp.json["message"], message)
 
     def test_invalid_content_type_header_on_collections_returns_415(self):
-        headers = {**self.headers, 'Content-Type': 'text/plain'}
-        resp = self.app.post(self.collection_url, '', headers=headers, status=415)
-        self.assertEqual(resp.json['code'], 415)
+        headers = {**self.headers, "Content-Type": "text/plain"}
+        resp = self.app.post(self.collection_url, "", headers=headers, status=415)
+        self.assertEqual(resp.json["code"], 415)
         message = "Content-Type header should be one of ['application/json']"
-        self.assertEqual(resp.json['message'], message)
+        self.assertEqual(resp.json["message"], message)
 
     def test_invalid_accept_header_on_record_returns_406(self):
-        headers = {**self.headers, 'Accept': 'text/plain'}
+        headers = {**self.headers, "Accept": "text/plain"}
         resp = self.app.get(self.get_item_url(), headers=headers, status=406)
-        self.assertEqual(resp.json['code'], 406)
+        self.assertEqual(resp.json["code"], 406)
         message = "Accept header should be one of ['application/json']"
-        self.assertEqual(resp.json['message'], message)
+        self.assertEqual(resp.json["message"], message)
 
     def test_invalid_content_type_header_on_record_returns_415(self):
-        headers = {**self.headers, 'Content-Type': 'text/plain'}
-        resp = self.app.patch_json(self.get_item_url(), '', headers=headers, status=415)
-        self.assertEqual(resp.json['code'], 415)
+        headers = {**self.headers, "Content-Type": "text/plain"}
+        resp = self.app.patch_json(self.get_item_url(), "", headers=headers, status=415)
+        self.assertEqual(resp.json["code"], 415)
         messages = (
             "Content-Type header should be one of [",
             "'application/json-patch+json'",
@@ -477,41 +445,34 @@ class InvalidRecordTest(BaseWebTest, unittest.TestCase):
             "'application/json'",
             ", ",
             "'application/merge-patch+json'",
-            "]")
+            "]",
+        )
         for message in messages:
-            self.assertIn(message, resp.json['message'])
-        self.assertEqual(len("".join(messages)), len(resp.json['message']))
+            self.assertIn(message, resp.json["message"])
+        self.assertEqual(len("".join(messages)), len(resp.json["message"]))
 
 
 class IgnoredFieldsTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url,
-                                  body,
-                                  headers=self.headers)
-        self.record = resp.json['data']
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        self.record = resp.json["data"]
 
     def test_last_modified_is_not_validated_and_overwritten(self):
-        record = {**MINIMALIST_RECORD, 'last_modified': 'abc'}
-        resp = self.app.post_json(self.collection_url,
-                                  {'data': record},
-                                  headers=self.headers)
-        self.assertNotEqual(resp.json['data']['last_modified'], 'abc')
+        record = {**MINIMALIST_RECORD, "last_modified": "abc"}
+        resp = self.app.post_json(self.collection_url, {"data": record}, headers=self.headers)
+        self.assertNotEqual(resp.json["data"]["last_modified"], "abc")
 
     def test_modify_works_with_invalid_last_modified(self):
-        body = {'data': {'last_modified': 'abc'}}
-        resp = self.app.patch_json(self.get_item_url(),
-                                   body,
-                                   headers=self.headers)
-        self.assertNotEqual(resp.json['data']['last_modified'], 'abc')
+        body = {"data": {"last_modified": "abc"}}
+        resp = self.app.patch_json(self.get_item_url(), body, headers=self.headers)
+        self.assertNotEqual(resp.json["data"]["last_modified"], "abc")
 
     def test_replace_works_with_invalid_last_modified(self):
-        record = {**MINIMALIST_RECORD, 'last_modified': 'abc'}
-        resp = self.app.put_json(self.get_item_url(),
-                                 {'data': record},
-                                 headers=self.headers)
-        self.assertNotEqual(resp.json['data']['last_modified'], 'abc')
+        record = {**MINIMALIST_RECORD, "last_modified": "abc"}
+        resp = self.app.put_json(self.get_item_url(), {"data": record}, headers=self.headers)
+        self.assertNotEqual(resp.json["data"]["last_modified"], "abc")
 
 
 class InvalidBodyTest(BaseWebTest, unittest.TestCase):
@@ -520,166 +481,147 @@ class InvalidBodyTest(BaseWebTest, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url,
-                                  body,
-                                  headers=self.headers)
-        self.record = resp.json['data']
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        self.record = resp.json["data"]
 
     def test_invalid_body_returns_json_formatted_error(self):
         self.maxDiff = None
-        resp = self.app.post(self.collection_url,
-                             self.invalid_body,
-                             headers=self.headers,
-                             status=400)
-        error_msg = ("Invalid JSON: Expecting property name enclosed in "
-                     "double quotes: line 1 column 2 (char 1)")
-        self.assertDictEqual(resp.json, {
-            'errno': ERRORS.INVALID_PARAMETERS.value,
-            'message': error_msg,
-            'code': 400,
-            'error': 'Invalid parameters',
-            'details': [
-                {'description': error_msg,
-                 'location': 'body',
-                 'name': ''},
-                {'description': 'Required',
-                 'location': 'body',
-                 'name': ''}]})
+        resp = self.app.post(
+            self.collection_url, self.invalid_body, headers=self.headers, status=400
+        )
+        error_msg = (
+            "Invalid JSON: Expecting property name enclosed in "
+            "double quotes: line 1 column 2 (char 1)"
+        )
+        self.assertDictEqual(
+            resp.json,
+            {
+                "errno": ERRORS.INVALID_PARAMETERS.value,
+                "message": error_msg,
+                "code": 400,
+                "error": "Invalid parameters",
+                "details": [
+                    {"description": error_msg, "location": "body", "name": ""},
+                    {"description": "Required", "location": "body", "name": ""},
+                ],
+            },
+        )
 
     def test_create_invalid_body_returns_400(self):
-        self.app.post(self.collection_url,
-                      self.invalid_body,
-                      headers=self.headers,
-                      status=400)
+        self.app.post(self.collection_url, self.invalid_body, headers=self.headers, status=400)
 
     def test_modify_with_invalid_body_returns_400(self):
-        self.app.patch(self.get_item_url(),
-                       self.invalid_body,
-                       headers=self.headers,
-                       status=400)
+        self.app.patch(self.get_item_url(), self.invalid_body, headers=self.headers, status=400)
 
     def test_replace_with_invalid_body_returns_400(self):
-        self.app.put(self.get_item_url(),
-                     self.invalid_body,
-                     headers=self.headers,
-                     status=400)
+        self.app.put(self.get_item_url(), self.invalid_body, headers=self.headers, status=400)
 
     def test_invalid_uft8_returns_400(self):
         body = '{"foo": "\\u0d1"}'
-        resp = self.app.post(self.collection_url,
-                             body,
-                             headers=self.headers,
-                             status=400)
-        self.assertIn('Invalid \\uXXXX escape: line 1', resp.json['message'])
+        resp = self.app.post(self.collection_url, body, headers=self.headers, status=400)
+        self.assertIn("Invalid \\uXXXX escape: line 1", resp.json["message"])
 
     def test_modify_with_invalid_uft8_returns_400(self):
         body = '{"foo": "\\u0d1"}'
-        resp = self.app.patch(self.get_item_url(),
-                              body,
-                              headers=self.headers,
-                              status=400)
-        self.assertIn('Invalid \\uXXXX escape', resp.json['message'])
+        resp = self.app.patch(self.get_item_url(), body, headers=self.headers, status=400)
+        self.assertIn("Invalid \\uXXXX escape", resp.json["message"])
 
     def test_modify_with_empty_body_returns_400(self):
-        self.app.patch(self.get_item_url(),
-                       headers=self.headers,
-                       status=400)
+        self.app.patch(self.get_item_url(), headers=self.headers, status=400)
 
     def test_modify_shareable_resource_with_empty_body_returns_400(self):
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json('/toadstools',
-                                  body,
-                                  headers=self.headers)
-        record = resp.json['data']
-        item_url = '/toadstools/{}'.format(record['id'])
-        self.app.patch(item_url,
-                       headers=self.headers,
-                       status=400)
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json("/toadstools", body, headers=self.headers)
+        record = resp.json["data"]
+        item_url = "/toadstools/{}".format(record["id"])
+        self.app.patch(item_url, headers=self.headers, status=400)
 
 
 class InvalidPermissionsTest(BaseWebTest, unittest.TestCase):
-    collection_url = '/toadstools'
+    collection_url = "/toadstools"
 
     def setUp(self):
         super().setUp()
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url,
-                                  body,
-                                  headers=self.headers)
-        self.record = resp.json['data']
-        self.invalid_body = {'data': MINIMALIST_RECORD,
-                             'permissions': {'read': 'book'}}  # book not list
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
+        self.record = resp.json["data"]
+        self.invalid_body = {
+            "data": MINIMALIST_RECORD,
+            "permissions": {"read": "book"},
+        }  # book not list
 
     def test_permissions_are_not_accepted_on_normal_resources(self):
-        body = {'data': MINIMALIST_RECORD,
-                'permissions': {'read': ['book']}}
-        resp = self.app.post_json('/mushrooms', body, headers=self.headers,
-                                  status=400)
-        self.assertIn('Unrecognized keys in mapping', resp.json['message'])
-        self.assertIn('permissions', resp.json['message'])
+        body = {"data": MINIMALIST_RECORD, "permissions": {"read": ["book"]}}
+        resp = self.app.post_json("/mushrooms", body, headers=self.headers, status=400)
+        self.assertIn("Unrecognized keys in mapping", resp.json["message"])
+        self.assertIn("permissions", resp.json["message"])
 
     def test_create_invalid_body_returns_400(self):
-        self.app.post_json(self.collection_url,
-                           self.invalid_body,
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            self.collection_url, self.invalid_body, headers=self.headers, status=400
+        )
 
     def test_modify_with_invalid_permissions_returns_400(self):
-        self.app.patch_json(self.get_item_url(),
-                            self.invalid_body,
-                            headers=self.headers,
-                            status=400)
+        self.app.patch_json(
+            self.get_item_url(), self.invalid_body, headers=self.headers, status=400
+        )
 
     def test_invalid_body_returns_json_formatted_error(self):
-        resp = self.app.post_json(self.collection_url,
-                                  self.invalid_body,
-                                  headers=self.headers,
-                                  status=400)
-        self.assertDictEqual(resp.json, {
-            'errno': ERRORS.INVALID_PARAMETERS.value,
-            'message': 'permissions.read in body: "book" is not iterable',
-            'code': 400,
-            'error': 'Invalid parameters',
-            'details': [
-                {'description': '"book" is not iterable',
-                 'location': 'body',
-                 'name': 'permissions.read'}]})
+        resp = self.app.post_json(
+            self.collection_url, self.invalid_body, headers=self.headers, status=400
+        )
+        self.assertDictEqual(
+            resp.json,
+            {
+                "errno": ERRORS.INVALID_PARAMETERS.value,
+                "message": 'permissions.read in body: "book" is not iterable',
+                "code": 400,
+                "error": "Invalid parameters",
+                "details": [
+                    {
+                        "description": '"book" is not iterable',
+                        "location": "body",
+                        "name": "permissions.read",
+                    }
+                ],
+            },
+        )
 
 
 class CacheControlTest(BaseWebTest, unittest.TestCase):
-    collection_url = '/toadstools'
+    collection_url = "/toadstools"
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['toadstool_cache_expires_seconds'] = 3600
-        settings['toadstool_read_principals'] = 'system.Everyone'
-        settings['psilo_cache_expires_seconds'] = 0
-        settings['moisture_read_principals'] = 'system.Everyone'
+        settings["toadstool_cache_expires_seconds"] = 3600
+        settings["toadstool_read_principals"] = "system.Everyone"
+        settings["psilo_cache_expires_seconds"] = 0
+        settings["moisture_read_principals"] = "system.Everyone"
         return settings
 
     def test_cache_control_headers_are_set_if_anonymous(self):
         resp = self.app.get(self.collection_url)
-        self.assertIn('Expires', resp.headers)
-        self.assertIn('Cache-Control', resp.headers)
+        self.assertIn("Expires", resp.headers)
+        self.assertIn("Cache-Control", resp.headers)
 
     def test_cache_control_headers_are_not_set_if_authenticated(self):
         resp = self.app.get(self.collection_url, headers=self.headers)
-        self.assertIn('no-cache', resp.headers['Cache-Control'])
-        self.assertIn('no-store', resp.headers['Cache-Control'])
-        self.assertNotIn('Expires', resp.headers)
+        self.assertIn("no-cache", resp.headers["Cache-Control"])
+        self.assertIn("no-store", resp.headers["Cache-Control"])
+        self.assertNotIn("Expires", resp.headers)
 
     def test_cache_control_headers_set_no_cache_if_zero(self):
-        resp = self.app.get('/psilos')
-        self.assertIn('Cache-Control', resp.headers)
+        resp = self.app.get("/psilos")
+        self.assertIn("Cache-Control", resp.headers)
         # Check that not set by Pyramid.cache_expires()
-        self.assertNotIn('Expires', resp.headers)
+        self.assertNotIn("Expires", resp.headers)
 
     def test_cache_control_provides_no_cache_by_default(self):
-        resp = self.app.get('/moistures')
-        self.assertIn('no-cache', resp.headers['Cache-Control'])
-        self.assertNotIn('Expires', resp.headers)
+        resp = self.app.get("/moistures")
+        self.assertIn("no-cache", resp.headers["Cache-Control"])
+        self.assertNotIn("Expires", resp.headers)
 
 
 class StorageErrorTest(BaseWebTest, unittest.TestCase):
@@ -687,25 +629,19 @@ class StorageErrorTest(BaseWebTest, unittest.TestCase):
         super().__init__(*args, **kwargs)
         self.error = storage_exceptions.BackendError(ValueError())
         self.storage_error_patcher = mock.patch(
-            'kinto.core.storage.memory.Storage.create',
-            side_effect=self.error)
+            "kinto.core.storage.memory.Storage.create", side_effect=self.error
+        )
 
     def test_backend_errors_are_served_as_503(self):
-        body = {'data': MINIMALIST_RECORD}
+        body = {"data": MINIMALIST_RECORD}
         with self.storage_error_patcher:
-            self.app.post_json(self.collection_url,
-                               body,
-                               headers=self.headers,
-                               status=503)
+            self.app.post_json(self.collection_url, body, headers=self.headers, status=503)
 
     def test_backend_errors_original_error_is_logged(self):
-        body = {'data': MINIMALIST_RECORD}
-        with mock.patch('kinto.core.views.errors.logger.critical') as mocked:
+        body = {"data": MINIMALIST_RECORD}
+        with mock.patch("kinto.core.views.errors.logger.critical") as mocked:
             with self.storage_error_patcher:
-                self.app.post_json(self.collection_url,
-                                   body,
-                                   headers=self.headers,
-                                   status=503)
+                self.app.post_json(self.collection_url, body, headers=self.headers, status=503)
                 self.assertTrue(mocked.called)
                 self.assertEqual(type(mocked.call_args[0][0]), ValueError)
 
@@ -716,75 +652,81 @@ class PaginationNextURLTest(BaseWebTest, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        body = {'data': MINIMALIST_RECORD}
-        self.app.post_json(self.collection_url,
-                           body,
-                           headers=self.headers)
-        self.app.post_json(self.collection_url,
-                           body,
-                           headers=self.headers)
+        body = {"data": MINIMALIST_RECORD}
+        self.app.post_json(self.collection_url, body, headers=self.headers)
+        self.app.post_json(self.collection_url, body, headers=self.headers)
 
     def test_next_page_url_has_got_port_number_if_different_than_80(self):
-        resp = self.app.get(self.collection_url + '?_limit=1',
-                            extra_environ={'HTTP_HOST': 'localhost:8000'},
-                            headers=self.headers)
-        self.assertIn(':8000', resp.headers['Next-Page'])
+        resp = self.app.get(
+            self.collection_url + "?_limit=1",
+            extra_environ={"HTTP_HOST": "localhost:8000"},
+            headers=self.headers,
+        )
+        self.assertIn(":8000", resp.headers["Next-Page"])
 
     def test_next_page_url_has_not_port_number_if_80(self):
-        resp = self.app.get(self.collection_url + '?_limit=1',
-                            extra_environ={'HTTP_HOST': 'localhost:80'},
-                            headers=self.headers)
-        self.assertNotIn(':80', resp.headers['Next-Page'])
+        resp = self.app.get(
+            self.collection_url + "?_limit=1",
+            extra_environ={"HTTP_HOST": "localhost:80"},
+            headers=self.headers,
+        )
+        self.assertNotIn(":80", resp.headers["Next-Page"])
 
     def test_next_page_url_relies_on_pyramid_url_system(self):
-        resp = self.app.get(self.collection_url + '?_limit=1',
-                            extra_environ={'wsgi.url_scheme': 'https'},
-                            headers=self.headers)
-        self.assertIn('https://', resp.headers['Next-Page'])
+        resp = self.app.get(
+            self.collection_url + "?_limit=1",
+            extra_environ={"wsgi.url_scheme": "https"},
+            headers=self.headers,
+        )
+        self.assertIn("https://", resp.headers["Next-Page"])
 
     def test_next_page_url_relies_on_headers_information(self):
-        headers = {**self.headers, 'Host': 'https://server.name:443'}
-        resp = self.app.get(self.collection_url + '?_limit=1',
-                            headers=headers)
-        self.assertIn('https://server.name:443', resp.headers['Next-Page'])
+        headers = {**self.headers, "Host": "https://server.name:443"}
+        resp = self.app.get(self.collection_url + "?_limit=1", headers=headers)
+        self.assertIn("https://server.name:443", resp.headers["Next-Page"])
 
 
 class SchemaLessPartialResponseTest(BaseWebTest, unittest.TestCase):
     """Extra tests for :mod:`tests.core.resource.test_partial_response`
     """
-    collection_url = '/spores'
+
+    collection_url = "/spores"
 
     def setUp(self):
         super().setUp()
-        body = {'data': {'size': 42, 'category': 'some-cat', 'owner': 'loco'}}
-        resp = self.app.post_json(self.collection_url,
-                                  body,
-                                  headers=self.headers)
+        body = {"data": {"size": 42, "category": "some-cat", "owner": "loco"}}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers)
         self.record = resp.json
 
     def test_unspecified_fields_are_excluded(self):
-        resp = self.app.get(self.collection_url + '?_fields=size,category')
-        result = resp.json['data'][0]
-        self.assertNotIn('owner', result)
+        resp = self.app.get(self.collection_url + "?_fields=size,category")
+        result = resp.json["data"][0]
+        self.assertNotIn("owner", result)
 
     def test_specified_fields_are_included(self):
-        resp = self.app.get(self.collection_url + '?_fields=size,category')
-        result = resp.json['data'][0]
-        self.assertIn('size', result)
-        self.assertIn('category', result)
+        resp = self.app.get(self.collection_url + "?_fields=size,category")
+        result = resp.json["data"][0]
+        self.assertIn("size", result)
+        self.assertIn("category", result)
 
     def test_unknown_fields_are_ignored(self):
-        resp = self.app.get(self.collection_url + '?_fields=nationality')
-        result = resp.json['data'][0]
-        self.assertNotIn('nationality', result)
+        resp = self.app.get(self.collection_url + "?_fields=nationality")
+        result = resp.json["data"][0]
+        self.assertNotIn("nationality", result)
 
 
 class UnicodeDecodeErrorTest(BaseWebTest, FormattedErrorMixin, unittest.TestCase):
-    collection_url = '/spores'
+    collection_url = "/spores"
 
     def test_wrong_filter_encoding_raise_a_400_bad_request(self):
-        resp = self.app.get(self.collection_url + '?foo\xe2\xfc\xa7bar',
-                            headers=self.headers, status=400)
-        self.assertFormattedError(resp, 400, ERRORS.INVALID_PARAMETERS, "Bad Request",
-                                  "A request with an incorrect encoding in the querystring was"
-                                  "received. Please make sure your requests are encoded in UTF-8")
+        resp = self.app.get(
+            self.collection_url + "?foo\xe2\xfc\xa7bar", headers=self.headers, status=400
+        )
+        self.assertFormattedError(
+            resp,
+            400,
+            ERRORS.INVALID_PARAMETERS,
+            "Bad Request",
+            "A request with an incorrect encoding in the querystring was"
+            "received. Please make sure your requests are encoded in UTF-8",
+        )

--- a/tests/core/resource/test_views_cors.py
+++ b/tests/core/resource/test_views_cors.py
@@ -7,202 +7,202 @@ from kinto.core.testing import unittest
 from ..support import BaseWebTest
 
 
-MINIMALIST_RECORD = {'name': 'Champignon'}
+MINIMALIST_RECORD = {"name": "Champignon"}
 
 
 class CORSOriginHeadersTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.headers['Origin'] = 'notmyidea.org'
+        cls.headers["Origin"] = "notmyidea.org"
 
     def setUp(self):
         super().setUp()
-        body = {'data': MINIMALIST_RECORD}
-        response = self.app.post_json(self.collection_url,
-                                      body,
-                                      headers=self.headers,
-                                      status=201)
-        self.record = response.json['data']
+        body = {"data": MINIMALIST_RECORD}
+        response = self.app.post_json(self.collection_url, body, headers=self.headers, status=201)
+        self.record = response.json["data"]
 
     def test_can_be_configured_from_settings(self):
-        app = self.make_app({'cors_origins': '*.daybed.io'})
-        headers = {**self.headers, 'Origin': 'demo.daybed.io'}
+        app = self.make_app({"cors_origins": "*.daybed.io"})
+        headers = {**self.headers, "Origin": "demo.daybed.io"}
         resp = app.get(self.collection_url, headers=headers)
-        self.assertEqual(resp.headers['Access-Control-Allow-Origin'],
-                         'demo.daybed.io')
+        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "demo.daybed.io")
 
     def test_present_on_hello(self):
-        response = self.app.get('/',
-                                headers=self.headers,
-                                status=200)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        response = self.app.get("/", headers=self.headers, status=200)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_single_record(self):
-        response = self.app.get(self.get_item_url(),
-                                headers=self.headers)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        response = self.app.get(self.get_item_url(), headers=self.headers)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_deletion(self):
-        response = self.app.delete(self.get_item_url(),
-                                   headers=self.headers)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        response = self.app.delete(self.get_item_url(), headers=self.headers)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_unknown_url(self):
-        response = self.app.get('/unknown',
-                                headers=self.headers,
-                                status=404)
-        self.assertEqual(response.headers['Access-Control-Allow-Origin'],
-                         'notmyidea.org')
+        response = self.app.get("/unknown", headers=self.headers, status=404)
+        self.assertEqual(response.headers["Access-Control-Allow-Origin"], "notmyidea.org")
 
     def test_not_present_on_unknown_url_if_setting_does_not_match(self):
-        with mock.patch.dict(self.app.app.registry.settings,
-                             [('cors_origins', 'daybed.io')]):
-            response = self.app.get('/unknown',
-                                    headers=self.headers,
-                                    status=404)
-            self.assertNotIn('Access-Control-Allow-Origin', response.headers)
+        with mock.patch.dict(self.app.app.registry.settings, [("cors_origins", "daybed.io")]):
+            response = self.app.get("/unknown", headers=self.headers, status=404)
+            self.assertNotIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_unknown_record(self):
-        url = self.get_item_url('1cea99eb-5e3d-44ad-a53a-2fb68473b538')
-        response = self.app.get(url,
-                                headers=self.headers,
-                                status=404)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        url = self.get_item_url("1cea99eb-5e3d-44ad-a53a-2fb68473b538")
+        response = self.app.get(url, headers=self.headers, status=404)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_invalid_record_update(self):
-        body = {'data': {'name': 42}}
-        response = self.app.patch_json(self.get_item_url(),
-                                       body,
-                                       headers=self.headers,
-                                       status=400)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        body = {"data": {"name": 42}}
+        response = self.app.patch_json(self.get_item_url(), body, headers=self.headers, status=400)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_successful_creation(self):
-        body = {'data': MINIMALIST_RECORD}
-        response = self.app.post_json(self.collection_url,
-                                      body,
-                                      headers=self.headers,
-                                      status=201)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        body = {"data": MINIMALIST_RECORD}
+        response = self.app.post_json(self.collection_url, body, headers=self.headers, status=201)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_invalid_record_creation(self):
-        body = {'name': 42}
-        response = self.app.post_json(self.collection_url,
-                                      body,
-                                      headers=self.headers,
-                                      status=400)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        body = {"name": 42}
+        response = self.app.post_json(self.collection_url, body, headers=self.headers, status=400)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_readonly_update(self):
-        with mock.patch('tests.core.testapp.views.MushroomSchema.is_readonly',
-                        return_value=True):
-            body = {'data': {'name': 'Amanite'}}
-            response = self.app.patch_json(self.get_item_url(),
-                                           body,
-                                           headers=self.headers,
-                                           status=400)
-        self.assertEqual(response.json['message'], 'Cannot modify name')
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        with mock.patch("tests.core.testapp.views.MushroomSchema.is_readonly", return_value=True):
+            body = {"data": {"name": "Amanite"}}
+            response = self.app.patch_json(
+                self.get_item_url(), body, headers=self.headers, status=400
+            )
+        self.assertEqual(response.json["message"], "Cannot modify name")
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_unauthorized(self):
         headers = {**self.headers}
-        headers.pop('Authorization', None)
-        body = {'data': MINIMALIST_RECORD}
-        response = self.app.post_json(self.collection_url,
-                                      body,
-                                      headers=headers,
-                                      status=401)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        headers.pop("Authorization", None)
+        body = {"data": MINIMALIST_RECORD}
+        response = self.app.post_json(self.collection_url, body, headers=headers, status=401)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_internal_error(self):
-        with mock.patch('kinto.core.resource.UserResource._extract_filters',
-                        side_effect=ValueError):
-            response = self.app.get('/mushrooms',
-                                    headers=self.headers, status=500)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        with mock.patch(
+            "kinto.core.resource.UserResource._extract_filters", side_effect=ValueError
+        ):
+            response = self.app.get("/mushrooms", headers=self.headers, status=500)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
     def test_present_on_http_error(self):
-        with mock.patch('kinto.core.resource.UserResource._extract_filters',
-                        side_effect=httpexceptions.HTTPPaymentRequired):
-            response = self.app.get('/mushrooms',
-                                    headers=self.headers, status=402)
-        self.assertIn('Access-Control-Allow-Origin', response.headers)
+        with mock.patch(
+            "kinto.core.resource.UserResource._extract_filters",
+            side_effect=httpexceptions.HTTPPaymentRequired,
+        ):
+            response = self.app.get("/mushrooms", headers=self.headers, status=402)
+        self.assertIn("Access-Control-Allow-Origin", response.headers)
 
 
 class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
-    def assert_expose_headers(self, method, path, allowed_headers, body=None,
-                              status=None):
-        headers = {**self.headers, 'Origin': 'lolnet.org'}
+    def assert_expose_headers(self, method, path, allowed_headers, body=None, status=None):
+        headers = {**self.headers, "Origin": "lolnet.org"}
         http_method = getattr(self.app, method.lower())
         kwargs = dict(headers=headers)
         if status:
-            kwargs['status'] = status
+            kwargs["status"] = status
         response = http_method(path, body, **kwargs)
-        exposed_headers = response.headers['Access-Control-Expose-Headers']
-        exposed_headers = [x.strip() for x in exposed_headers.split(',')]
+        exposed_headers = response.headers["Access-Control-Expose-Headers"]
+        exposed_headers = [x.strip() for x in exposed_headers.split(",")]
         self.assertEqual(sorted(allowed_headers), sorted(exposed_headers))
         return response
 
     def test_collection_get_exposes_every_possible_header(self):
-        self.assert_expose_headers('GET', self.collection_url, [
-            'Alert', 'Backoff', 'ETag', 'Last-Modified', 'Next-Page',
-            'Retry-After', 'Total-Records', 'Content-Length',
-            'Cache-Control', 'Expires', 'Pragma'])
+        self.assert_expose_headers(
+            "GET",
+            self.collection_url,
+            [
+                "Alert",
+                "Backoff",
+                "ETag",
+                "Last-Modified",
+                "Next-Page",
+                "Retry-After",
+                "Total-Records",
+                "Content-Length",
+                "Cache-Control",
+                "Expires",
+                "Pragma",
+            ],
+        )
 
     def test_hello_endpoint_exposes_only_minimal_set_of_headers(self):
-        self.assert_expose_headers('GET', '/', [
-            'Alert', 'Backoff', 'Retry-After', 'Content-Length'])
+        self.assert_expose_headers(
+            "GET", "/", ["Alert", "Backoff", "Retry-After", "Content-Length"]
+        )
 
     def test_record_get_exposes_only_used_headers(self):
-        body = {'data': MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url,
-                                  body,
-                                  headers=self.headers,
-                                  status=201)
-        record_url = self.get_item_url(resp.json['data']['id'])
-        self.assert_expose_headers('GET', record_url, [
-            'Alert', 'Backoff', 'ETag', 'Retry-After',
-            'Last-Modified', 'Content-Length',
-            'Cache-Control', 'Expires', 'Pragma'])
+        body = {"data": MINIMALIST_RECORD}
+        resp = self.app.post_json(self.collection_url, body, headers=self.headers, status=201)
+        record_url = self.get_item_url(resp.json["data"]["id"])
+        self.assert_expose_headers(
+            "GET",
+            record_url,
+            [
+                "Alert",
+                "Backoff",
+                "ETag",
+                "Retry-After",
+                "Last-Modified",
+                "Content-Length",
+                "Cache-Control",
+                "Expires",
+                "Pragma",
+            ],
+        )
 
     def test_record_post_exposes_only_minimal_set_of_headers(self):
-        body = {'data': MINIMALIST_RECORD}
-        self.assert_expose_headers('POST_JSON', '/mushrooms', [
-            'Alert', 'Backoff', 'Retry-After', 'Content-Length'], body=body)
+        body = {"data": MINIMALIST_RECORD}
+        self.assert_expose_headers(
+            "POST_JSON",
+            "/mushrooms",
+            ["Alert", "Backoff", "Retry-After", "Content-Length"],
+            body=body,
+        )
 
     def test_present_on_bad_id_400_errors(self):
-        body = {'data': {'name': 'Amanite'}}
-        self.assert_expose_headers('PUT_JSON', '/mushrooms/wrong=ids', [
-            'Alert', 'Backoff', 'Retry-After', 'Content-Length'],
-            body=body, status=400)
+        body = {"data": {"name": "Amanite"}}
+        self.assert_expose_headers(
+            "PUT_JSON",
+            "/mushrooms/wrong=ids",
+            ["Alert", "Backoff", "Retry-After", "Content-Length"],
+            body=body,
+            status=400,
+        )
 
     def test_present_on_unknown_url(self):
-        self.assert_expose_headers('PUT_JSON', '/unknown', [
-            'Alert', 'Backoff', 'Retry-After', 'Content-Length'], status=404)
+        self.assert_expose_headers(
+            "PUT_JSON",
+            "/unknown",
+            ["Alert", "Backoff", "Retry-After", "Content-Length"],
+            status=404,
+        )
 
 
 class CORSMaxAgeTest(BaseWebTest, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.headers.update({
-            'Origin': 'lolnet.org',
-            'Access-Control-Request-Method': 'GET'
-        })
+        cls.headers.update({"Origin": "lolnet.org", "Access-Control-Request-Method": "GET"})
 
     def test_cors_max_age_is_3600_seconds_by_default(self):
         app = self.make_app()
-        resp = app.options('/', headers=self.headers)
-        self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 3600)
+        resp = app.options("/", headers=self.headers)
+        self.assertEqual(int(resp.headers["Access-Control-Max-Age"]), 3600)
 
     def test_cors_max_age_can_be_specified_in_settings(self):
-        app = self.make_app({'cors_max_age_seconds': '42'})
-        resp = app.options('/', headers=self.headers)
-        self.assertEqual(int(resp.headers['Access-Control-Max-Age']), 42)
+        app = self.make_app({"cors_max_age_seconds": "42"})
+        resp = app.options("/", headers=self.headers)
+        self.assertEqual(int(resp.headers["Access-Control-Max-Age"]), 42)
 
     def test_cors_max_age_is_disabled_if_unset(self):
-        app = self.make_app({'cors_max_age_seconds': ''})
-        resp = app.options('/', headers=self.headers)
-        self.assertNotIn('Access-Control-Max-Age', resp.headers)
+        app = self.make_app({"cors_max_age_seconds": ""})
+        resp = app.options("/", headers=self.headers)
+        self.assertNotIn("Access-Control-Max-Age", resp.headers)

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -13,11 +13,12 @@ from kinto.core.testing import unittest
 
 class FakeViewSet(ViewSet):
     """Fake viewset class used for tests."""
+
     collection_path = "/{resource_name}"
     record_path = "/{resource_name}/{{id}}"
 
-    collection_methods = ('GET',)
-    record_methods = ('PUT',)
+    collection_methods = ("GET",)
+    record_methods = ("PUT",)
 
     def __init__(self):
         self.collection_arguments = self.arguments
@@ -32,169 +33,147 @@ class FakeViewSet(ViewSet):
 
 class FakeResource:
     """Fake resource class used for tests"""
+
     name = "fake"
 
     def __init__(self):
         # Create fake views which are in fact mock sentinels.
         # {type}_{method} will map to the sentinel with the same name.
-        for endpoint_type in ('collection', 'record'):
-            for method in ('get', 'put', 'patch', 'delete'):
-                if endpoint_type == 'record':
+        for endpoint_type in ("collection", "record"):
+            for method in ("get", "put", "patch", "delete"):
+                if endpoint_type == "record":
                     view_name = method
                 else:
-                    view_name = '_'.join((endpoint_type, method))
+                    view_name = "_".join((endpoint_type, method))
                 setattr(self, view_name, getattr(mock.sentinel, view_name))
 
 
 class ViewSetTest(unittest.TestCase):
-
     def test_arguments_are_merged_on_initialization(self):
         viewset = ViewSet(collection_path=mock.sentinel.collection_path)
-        self.assertEqual(viewset.collection_path,
-                         mock.sentinel.collection_path)
+        self.assertEqual(viewset.collection_path, mock.sentinel.collection_path)
 
     def test_default_arguments_are_copied_before_being_returned(self):
         original_arguments = {}
-        viewset = ViewSet(
-            collection_get_arguments=original_arguments)
+        viewset = ViewSet(collection_get_arguments=original_arguments)
         viewset.responses = mock.MagicMock()
-        arguments = viewset.collection_arguments(mock.MagicMock(), 'GET')
+        arguments = viewset.collection_arguments(mock.MagicMock(), "GET")
         self.assertEqual(original_arguments, {})
         self.assertNotEquals(original_arguments, arguments)
 
     def test_permission_private_is_set_by_default(self):
         viewset = ViewSet()
         viewset.responses = mock.MagicMock()
-        args = viewset.collection_arguments(mock.MagicMock(), 'GET')
-        self.assertEqual(args['permission'], 'private')
+        args = viewset.collection_arguments(mock.MagicMock(), "GET")
+        self.assertEqual(args["permission"], "private")
 
     def test_schema_is_added_when_method_matches(self):
         viewset = ViewSet()
         viewset.responses = mock.MagicMock()
         resource = mock.MagicMock()
-        arguments = viewset.collection_arguments(resource, 'GET')
-        self.assertIn('schema', arguments)
+        arguments = viewset.collection_arguments(resource, "GET")
+        self.assertIn("schema", arguments)
 
     def test_schema_is_added_when_uppercase_method_matches(self):
-        viewset = ViewSet(
-            collection_methods=('GET', 'DELETE')
-        )
+        viewset = ViewSet(collection_methods=("GET", "DELETE"))
         viewset.responses = mock.MagicMock()
-        arguments = viewset.collection_arguments(mock.MagicMock(), 'get')
-        self.assertIn('schema', arguments)
+        arguments = viewset.collection_arguments(mock.MagicMock(), "get")
+        self.assertIn("schema", arguments)
 
-    @mock.patch('kinto.core.resource.viewset.RequestSchema')
+    @mock.patch("kinto.core.resource.viewset.RequestSchema")
     def test_a_default_schema_is_added_when_method_doesnt_match(self, mocked):
         viewset = ViewSet()
         resource = mock.MagicMock()
         viewset.responses = mock.MagicMock()
         mocked.Mapping.return_value = mock.sentinel.default_schema
 
-        arguments = viewset.collection_arguments(resource, 'GET')
-        self.assertNotEqual(arguments['schema'], resource.schema)
+        arguments = viewset.collection_arguments(resource, "GET")
+        self.assertNotEqual(arguments["schema"], resource.schema)
 
         mocked.assert_called_with()
 
-    @mock.patch('kinto.core.resource.viewset.RequestSchema')
+    @mock.patch("kinto.core.resource.viewset.RequestSchema")
     def test_class_parameters_are_used_for_collection_arguments(self, mocked):
-        default_arguments = {
-            'cors_headers': mock.sentinel.cors_headers,
-        }
+        default_arguments = {"cors_headers": mock.sentinel.cors_headers}
 
-        default_get_arguments = {
-            'accept': mock.sentinel.accept,
-        }
+        default_get_arguments = {"accept": mock.sentinel.accept}
 
-        default_collection_arguments = {
-            'cors_origins': mock.sentinel.cors_origins,
-        }
+        default_collection_arguments = {"cors_origins": mock.sentinel.cors_origins}
 
-        collection_get_arguments = {
-            'error_handler': mock.sentinel.error_handler
-        }
+        collection_get_arguments = {"error_handler": mock.sentinel.error_handler}
 
         viewset = ViewSet(
             default_arguments=default_arguments,
             default_get_arguments=default_get_arguments,
             default_collection_arguments=default_collection_arguments,
-            collection_get_arguments=collection_get_arguments
+            collection_get_arguments=collection_get_arguments,
         )
 
         viewset.responses = mock.MagicMock()
-        arguments = viewset.collection_arguments(mock.MagicMock(), 'get')
+        arguments = viewset.collection_arguments(mock.MagicMock(), "get")
 
         self.assertDictEqual(
             arguments,
             {
-                'schema': mocked().bind(),
-                'accept': mock.sentinel.accept,
-                'cors_headers': mock.sentinel.cors_headers,
-                'cors_origins': mock.sentinel.cors_origins,
-                'error_handler': mock.sentinel.error_handler,
-                'validators': [colander_validator],
-                'response_schemas': viewset.responses.get_and_bind()
-            }
+                "schema": mocked().bind(),
+                "accept": mock.sentinel.accept,
+                "cors_headers": mock.sentinel.cors_headers,
+                "cors_origins": mock.sentinel.cors_origins,
+                "error_handler": mock.sentinel.error_handler,
+                "validators": [colander_validator],
+                "response_schemas": viewset.responses.get_and_bind(),
+            },
         )
 
-    @mock.patch('kinto.core.resource.viewset.RequestSchema')
+    @mock.patch("kinto.core.resource.viewset.RequestSchema")
     def test_default_arguments_are_used_for_record_arguments(self, mocked):
-        default_arguments = {
-            'cors_headers': mock.sentinel.cors_headers,
-        }
+        default_arguments = {"cors_headers": mock.sentinel.cors_headers}
 
-        default_get_arguments = {
-            'accept': mock.sentinel.accept,
-        }
+        default_get_arguments = {"accept": mock.sentinel.accept}
 
-        default_record_arguments = {
-            'cors_origins': mock.sentinel.record_cors_origins,
-        }
+        default_record_arguments = {"cors_origins": mock.sentinel.record_cors_origins}
 
-        record_get_arguments = {
-            'error_handler': mock.sentinel.error_handler
-        }
+        record_get_arguments = {"error_handler": mock.sentinel.error_handler}
 
         viewset = ViewSet(
             default_arguments=default_arguments,
             default_get_arguments=default_get_arguments,
             default_record_arguments=default_record_arguments,
-            record_get_arguments=record_get_arguments
+            record_get_arguments=record_get_arguments,
         )
 
         viewset.responses = mock.MagicMock()
-        arguments = viewset.record_arguments(mock.MagicMock(), 'get')
+        arguments = viewset.record_arguments(mock.MagicMock(), "get")
 
         self.assertDictEqual(
             arguments,
             {
-                'schema': mocked().bind(),
-                'accept': mock.sentinel.accept,
-                'cors_headers': mock.sentinel.cors_headers,
-                'cors_origins': mock.sentinel.record_cors_origins,
-                'error_handler': mock.sentinel.error_handler,
-                'validators': [colander_validator],
-                'response_schemas': viewset.responses.get_and_bind()
-            }
+                "schema": mocked().bind(),
+                "accept": mock.sentinel.accept,
+                "cors_headers": mock.sentinel.cors_headers,
+                "cors_origins": mock.sentinel.record_cors_origins,
+                "error_handler": mock.sentinel.error_handler,
+                "validators": [colander_validator],
+                "response_schemas": viewset.responses.get_and_bind(),
+            },
         )
 
-    @mock.patch('kinto.core.resource.viewset.RequestSchema')
+    @mock.patch("kinto.core.resource.viewset.RequestSchema")
     def test_class_parameters_overwrite_each_others(self, mocked):
         # Some class parameters should overwrite each others.
         # The more specifics should prevail over the more generics.
         # Items annoted with a "<<" are the one that should prevail.
         default_arguments = {
-            'cors_origins': mock.sentinel.default_cors_origins,
-            'error_handler': mock.sentinel.default_error_handler,
-            'cors_headers': mock.sentinel.default_cors_headers,  # <<
+            "cors_origins": mock.sentinel.default_cors_origins,
+            "error_handler": mock.sentinel.default_error_handler,
+            "cors_headers": mock.sentinel.default_cors_headers,  # <<
         }
         default_record_arguments = {
-            'cors_origins': mock.sentinel.default_record_cors_origin,
-            'error_handler': mock.sentinel.default_record_error_handler,  # <<
+            "cors_origins": mock.sentinel.default_record_cors_origin,
+            "error_handler": mock.sentinel.default_record_error_handler,  # <<
         }
 
-        record_get_arguments = {
-            'cors_origins': mock.sentinel.record_get_cors_origin,  # <<
-        }
+        record_get_arguments = {"cors_origins": mock.sentinel.record_get_cors_origin}  # <<
 
         viewset = ViewSet(
             default_arguments=default_arguments,
@@ -203,166 +182,129 @@ class ViewSetTest(unittest.TestCase):
         )
 
         viewset.responses = mock.MagicMock()
-        arguments = viewset.record_arguments(mock.MagicMock(), 'get')
+        arguments = viewset.record_arguments(mock.MagicMock(), "get")
 
         self.assertDictEqual(
             arguments,
             {
-                'schema': mocked().bind(),
-                'cors_headers': mock.sentinel.default_cors_headers,
-                'error_handler': mock.sentinel.default_record_error_handler,
-                'cors_origins': mock.sentinel.record_get_cors_origin,
-                'validators': [colander_validator],
-                'response_schemas': viewset.responses.get_and_bind()
-            }
+                "schema": mocked().bind(),
+                "cors_headers": mock.sentinel.default_cors_headers,
+                "error_handler": mock.sentinel.default_record_error_handler,
+                "cors_origins": mock.sentinel.record_get_cors_origin,
+                "validators": [colander_validator],
+                "response_schemas": viewset.responses.get_and_bind(),
+            },
         )
 
-    @mock.patch('kinto.core.resource.viewset.RequestSchema')
+    @mock.patch("kinto.core.resource.viewset.RequestSchema")
     def test_service_arguments_arent_inherited_by_record_arguments(self, mocked):
-        service_arguments = {
-            'description': 'The little book of calm',
-        }
+        service_arguments = {"description": "The little book of calm"}
 
-        default_arguments = {
-            'cors_headers': mock.sentinel.cors_headers,
-        }
+        default_arguments = {"cors_headers": mock.sentinel.cors_headers}
         viewset = ViewSet(
             default_arguments=default_arguments,
             service_arguments=service_arguments,
             default_record_arguments={},
-            record_get_arguments={}
+            record_get_arguments={},
         )
 
         viewset.responses = mock.MagicMock()
-        arguments = viewset.record_arguments(mock.MagicMock(), 'get')
+        arguments = viewset.record_arguments(mock.MagicMock(), "get")
 
         self.assertDictEqual(
             arguments,
             {
-                'schema': mocked().bind(),
-                'cors_headers': mock.sentinel.cors_headers,
-                'validators': [colander_validator],
-                'response_schemas': viewset.responses.get_and_bind()
-            }
+                "schema": mocked().bind(),
+                "cors_headers": mock.sentinel.cors_headers,
+                "validators": [colander_validator],
+                "response_schemas": viewset.responses.get_and_bind(),
+            },
         )
 
     def test_get_service_name_returns_the_viewset_name_if_defined(self):
-        viewset = ViewSet(name='fakename')
-        self.assertEqual(viewset.get_service_name('record', mock.MagicMock),
-                         'fakename-record')
+        viewset = ViewSet(name="fakename")
+        self.assertEqual(viewset.get_service_name("record", mock.MagicMock), "fakename-record")
 
     def test_get_service_name_returns_resource_att_if_not_callable(self):
         viewset = ViewSet()
         resource = mock.MagicMock()
-        resource.name = 'fakename'
-        self.assertEqual(viewset.get_service_name('record', resource),
-                         'fakename-record')
+        resource.name = "fakename"
+        self.assertEqual(viewset.get_service_name("record", resource), "fakename-record")
 
     def test_get_service_name_doesnt_use_callable_as_a_name(self):
         viewset = ViewSet()
         resource = mock.MagicMock()
-        resource.name = lambda x: 'should not be called'
+        resource.name = lambda x: "should not be called"
         resource.__name__ = "FakeName"
-        self.assertEqual(
-            viewset.get_service_name('record', resource),
-            'fakename-record')
+        self.assertEqual(viewset.get_service_name("record", resource), "fakename-record")
 
     def test_get_service_arguments_has_no_factory_by_default(self):
         viewset = ViewSet()
         service_arguments = viewset.get_service_arguments()
-        self.assertNotIn('factory', service_arguments)
+        self.assertNotIn("factory", service_arguments)
 
     def test_is_endpoint_enabled_returns_true_if_unknown(self):
         viewset = ViewSet()
         config = {}
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'get',
-                                                 config)
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "get", config)
         self.assertTrue(is_enabled)
 
     def test_is_endpoint_enabled_returns_false_if_disabled(self):
         viewset = ViewSet()
-        config = {
-            'record_fake_get_enabled': False
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'get',
-                                                 config)
+        config = {"record_fake_get_enabled": False}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "get", config)
         self.assertFalse(is_enabled)
 
     def test_is_endpoint_enabled_returns_true_if_enabled(self):
         viewset = ViewSet()
-        config = {
-            'record_fake_get_enabled': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'get',
-                                                 config)
+        config = {"record_fake_get_enabled": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "get", config)
         self.assertTrue(is_enabled)
 
     def test_is_endpoint_enabled_returns_false_for_put_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'put',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "put", config)
         self.assertFalse(is_enabled)
 
     def test_is_endpoint_enabled_returns_false_for_post_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'post',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "post", config)
         self.assertFalse(is_enabled)
 
     def test_is_endpoint_enabled_returns_false_for_patch_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'patch',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "patch", config)
         self.assertFalse(is_enabled)
 
     def test_is_endpoint_enabled_returns_false_for_delete_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'delete',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "delete", config)
         self.assertFalse(is_enabled)
 
     def test_is_endpoint_enabled_returns_true_for_get_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'get',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "get", config)
         self.assertTrue(is_enabled)
 
     def test_is_endpoint_enabled_returns_true_for_options_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'options',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "options", config)
         self.assertTrue(is_enabled)
 
     def test_is_endpoint_enabled_returns_true_for_head_if_readonly(self):
         viewset = ViewSet()
-        config = {
-            'readonly': True
-        }
-        is_enabled = viewset.is_endpoint_enabled('record', 'fake', 'head',
-                                                 config)
+        config = {"readonly": True}
+        is_enabled = viewset.is_endpoint_enabled("record", "fake", "head", config)
         self.assertTrue(is_enabled)
 
 
 class TestViewsetBindedSchemas(unittest.TestCase):
-
     def setUp(self):
         self.viewset = ViewSet()
         self.viewset.responses = mock.MagicMock()
@@ -370,98 +312,92 @@ class TestViewsetBindedSchemas(unittest.TestCase):
 
     def test_request_schemas_have_header_and_querystring(self):
         self.viewset = ViewSet(
-            default_get_arguments={},
-            default_record_arguments={},
-            record_get_arguments={}
+            default_get_arguments={}, default_record_arguments={}, record_get_arguments={}
         )
-        arguments = self.viewset.record_arguments(self.resource, 'GET')
-        schema = arguments['schema']
-        self.assertIn('querystring', schema)
-        self.assertIn('header', schema)
+        arguments = self.viewset.record_arguments(self.resource, "GET")
+        schema = arguments["schema"]
+        self.assertIn("querystring", schema)
+        self.assertIn("header", schema)
 
     def test_payload_request_schemas_have_a_body(self):
-        arguments = self.viewset.record_arguments(self.resource, 'PUT')
-        schema = arguments['schema']
-        self.assertIn('body', schema)
+        arguments = self.viewset.record_arguments(self.resource, "PUT")
+        schema = arguments["schema"]
+        self.assertIn("body", schema)
 
     def test_collection_deserialize_sort(self):
-        arguments = self.viewset.collection_arguments(self.resource, 'DELETE')
-        schema = arguments['schema']
-        value = {'querystring': {'_sort': 'foo,-bar'}}
+        arguments = self.viewset.collection_arguments(self.resource, "DELETE")
+        schema = arguments["schema"]
+        value = {"querystring": {"_sort": "foo,-bar"}}
         deserialized = schema.deserialize(value)
-        expected = {'querystring': {'_sort': ['foo', '-bar']}}
+        expected = {"querystring": {"_sort": ["foo", "-bar"]}}
         self.assertEqual(deserialized, expected)
 
     def test_get_collection_deserialize_fields(self):
-        arguments = self.viewset.collection_arguments(self.resource, 'GET')
-        schema = arguments['schema']
-        value = {'querystring': {'_fields': 'foo,bar'}}
+        arguments = self.viewset.collection_arguments(self.resource, "GET")
+        schema = arguments["schema"]
+        value = {"querystring": {"_fields": "foo,bar"}}
         deserialized = schema.deserialize(value)
-        expected = {'querystring': {'_fields': ['foo', 'bar']}}
+        expected = {"querystring": {"_fields": ["foo", "bar"]}}
         self.assertEqual(deserialized, expected)
 
     def test_get_record_deserialize_fields(self):
-        arguments = self.viewset.record_arguments(self.resource, 'GET')
-        schema = arguments['schema']
-        value = {'querystring': {'_fields': 'foo,bar'}}
+        arguments = self.viewset.record_arguments(self.resource, "GET")
+        schema = arguments["schema"]
+        value = {"querystring": {"_fields": "foo,bar"}}
         deserialized = schema.deserialize(value)
-        expected = {'querystring': {'_fields': ['foo', 'bar']}}
+        expected = {"querystring": {"_fields": ["foo", "bar"]}}
         self.assertEqual(deserialized, expected)
 
     def test_patch_record_validate_response_behavior(self):
-        arguments = self.viewset.collection_arguments(self.resource, 'PATCH')
-        schema = arguments['schema']
-        invalid = {'header': {'Response-Behavior': 'impolite'}}
+        arguments = self.viewset.collection_arguments(self.resource, "PATCH")
+        schema = arguments["schema"]
+        invalid = {"header": {"Response-Behavior": "impolite"}}
         self.assertRaises(colander.Invalid, schema.deserialize, invalid)
 
 
 class TestViewsetSchemasTest(unittest.TestCase):
-
     def test_partial_schema_ignores_unknown(self):
         schema = PartialSchema()
-        result = schema.deserialize({'foo': 'bar'})
+        result = schema.deserialize({"foo": "bar"})
         self.assertEqual(result, {})
 
     def test_strict_schema_raise_on_unknown(self):
         schema = StrictSchema()
-        self.assertRaises(colander.Invalid, schema.deserialize, {'foo': 'bar'})
+        self.assertRaises(colander.Invalid, schema.deserialize, {"foo": "bar"})
 
 
 class ShareableViewSetTest(unittest.TestCase):
-
     def test_permission_dynamic_is_set_by_default(self):
         viewset = ShareableViewSet()
         viewset.responses = mock.MagicMock()
         resource = mock.MagicMock()
-        args = viewset.collection_arguments(resource, 'GET')
-        self.assertEqual(args['permission'], 'dynamic')
+        args = viewset.collection_arguments(resource, "GET")
+        self.assertEqual(args["permission"], "dynamic")
 
     def test_get_service_arguments_has_default_factory(self):
         viewset = ShareableViewSet()
         args = viewset.get_service_arguments()
-        self.assertEqual(args['factory'], authorization.RouteFactory)
+        self.assertEqual(args["factory"], authorization.RouteFactory)
 
     def test_mapping_is_deprecated(self):
         viewset = ShareableViewSet()
         viewset.responses = mock.MagicMock()
         resource = mock.MagicMock()
         resource.mapping = mock.MagicMock()
-        with mock.patch('kinto.core.resource.viewset.warnings') as mocked:
-            viewset.collection_arguments(resource, 'GET')
+        with mock.patch("kinto.core.resource.viewset.warnings") as mocked:
+            viewset.collection_arguments(resource, "GET")
             msg = "Resource `mapping` is deprecated, use `schema`"
             mocked.warn.assert_called_with(msg, DeprecationWarning)
 
 
 class RegisterTest(unittest.TestCase):
-
     def setUp(self):
         self.resource = FakeResource
         self.viewset = FakeViewSet()
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_register_fails_if_no_storage_backend_is_configured(self, *args):
-        venusian_callback = register_resource(
-            self.resource, viewset=self.viewset)
+        venusian_callback = register_resource(self.resource, viewset=self.viewset)
         context = mock.MagicMock()
         config = testing.setUp(settings=DEFAULT_SETTINGS)
         context.config.with_package.return_value = config
@@ -469,26 +405,24 @@ class RegisterTest(unittest.TestCase):
             venusian_callback(context, None, None)
         except exceptions.ConfigurationError as e:
             error = e
-        self.assertIn('storage backend is missing', str(error))
+        self.assertIn("storage backend is missing", str(error))
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_viewset_is_updated_if_provided(self, service_class):
-        additional_params = {'foo': 'bar'}
-        register_resource(self.resource, viewset=self.viewset,
-                          **additional_params)
+        additional_params = {"foo": "bar"}
+        register_resource(self.resource, viewset=self.viewset, **additional_params)
         self.viewset.update.assert_called_with(**additional_params)
 
     def test_resource_default_viewset_is_used_if_not_provided(self):
         resource = FakeResource
         resource.default_viewset = mock.Mock()
-        additional_params = {'foo': 'bar'}
+        additional_params = {"foo": "bar"}
         register_resource(resource, **additional_params)
         resource.default_viewset.assert_called_with(**additional_params)
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_collection_views_are_registered_in_cornice(self, service_class):
-        venusian_callback = register_resource(
-            self.resource, viewset=self.viewset)
+        venusian_callback = register_resource(self.resource, viewset=self.viewset)
 
         config = mock.MagicMock()
         config.registry.settings = DEFAULT_SETTINGS
@@ -497,15 +431,14 @@ class RegisterTest(unittest.TestCase):
         context.config.with_package.return_value = config
         venusian_callback(context, None, None)
 
-        service_class.assert_any_call('fake-collection', '/fake', depth=1,
-                                      **self.viewset.get_service_arguments())
-        service_class().add_view.assert_any_call(
-            'GET', 'collection_get', klass=self.resource)
+        service_class.assert_any_call(
+            "fake-collection", "/fake", depth=1, **self.viewset.get_service_arguments()
+        )
+        service_class().add_view.assert_any_call("GET", "collection_get", klass=self.resource)
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_record_views_are_registered_in_cornice(self, service_class):
-        venusian_callback = register_resource(
-            self.resource, viewset=self.viewset)
+        venusian_callback = register_resource(self.resource, viewset=self.viewset)
 
         config = mock.MagicMock()
         config.registry.settings = DEFAULT_SETTINGS
@@ -514,20 +447,17 @@ class RegisterTest(unittest.TestCase):
         context.config.with_package.return_value = config
         venusian_callback(context, None, None)
 
-        service_class.assert_any_call('fake-record', '/fake/{id}', depth=1,
-                                      **self.viewset.get_service_arguments())
-        service_class().add_view.assert_any_call(
-            'PUT', 'put', klass=self.resource)
+        service_class.assert_any_call(
+            "fake-record", "/fake/{id}", depth=1, **self.viewset.get_service_arguments()
+        )
+        service_class().add_view.assert_any_call("PUT", "put", klass=self.resource)
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_collection_methods_are_skipped_if_not_enabled(self, service_cls):
-        venusian_callback = register_resource(
-            self.resource, viewset=self.viewset)
+        venusian_callback = register_resource(self.resource, viewset=self.viewset)
 
         context = mock.MagicMock()
-        context.registry.settings = {
-            'record_fake_put_enabled': False
-        }
+        context.registry.settings = {"record_fake_put_enabled": False}
         context.config.with_package.return_value = context
         venusian_callback(context, None, None)
 
@@ -535,38 +465,34 @@ class RegisterTest(unittest.TestCase):
         # 3 calls: two registering the service classes,
         # one for the collection_get
         self.assertEqual(len(service_cls.mock_calls), 3)
-        service_cls.assert_any_call('fake-collection', '/fake', depth=1,
-                                    **self.viewset.get_service_arguments())
-        service_cls().add_view.assert_any_call(
-            'GET', 'collection_get', klass=self.resource)
+        service_cls.assert_any_call(
+            "fake-collection", "/fake", depth=1, **self.viewset.get_service_arguments()
+        )
+        service_cls().add_view.assert_any_call("GET", "collection_get", klass=self.resource)
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_record_methods_are_skipped_if_not_enabled(self, service_class):
-        venusian_callback = register_resource(
-            self.resource, viewset=self.viewset)
+        venusian_callback = register_resource(self.resource, viewset=self.viewset)
 
         context = mock.MagicMock()
         context.config.with_package.return_value = context
-        context.registry.settings = {
-            'collection_fake_get_enabled': False
-        }
+        context.registry.settings = {"collection_fake_get_enabled": False}
         venusian_callback(context, None, None)
 
         # Only the collection views should have been added.
         # 3 calls: two registering the service classes,
         # one for the collection_get
         self.assertEqual(len(service_class.mock_calls), 3)
-        service_class.assert_any_call('fake-record', '/fake/{id}', depth=1,
-                                      **self.viewset.get_service_arguments())
-        service_class().add_view.assert_any_call(
-            'PUT', 'put', klass=self.resource)
+        service_class.assert_any_call(
+            "fake-record", "/fake/{id}", depth=1, **self.viewset.get_service_arguments()
+        )
+        service_class().add_view.assert_any_call("PUT", "put", klass=self.resource)
 
-    @mock.patch('kinto.core.resource.Service')
+    @mock.patch("kinto.core.resource.Service")
     def test_endpoint_is_skipped_if_record_path_is_none(self, service_cls):
         self.viewset.record_path = None
 
-        venusian_callback = register_resource(self.resource,
-                                              viewset=self.viewset)
+        venusian_callback = register_resource(self.resource, viewset=self.viewset)
         config = mock.MagicMock()
         config.registry.settings = DEFAULT_SETTINGS
         context = mock.MagicMock()
@@ -574,5 +500,5 @@ class RegisterTest(unittest.TestCase):
         venusian_callback(context, None, None)
 
         paths = [call[1][1] for call in service_cls.mock_calls]
-        self.assertIn('/fake', paths)
-        self.assertNotIn('/fake/{id}', paths)
+        self.assertIn("/fake", paths)
+        self.assertNotIn("/fake/{id}", paths)

--- a/tests/core/support.py
+++ b/tests/core/support.py
@@ -13,8 +13,7 @@ from .testapp import main as testapp
 
 
 # This is the principal a connected user should have (in the tests).
-USER_PRINCIPAL = 'basicauth:8a931a10fc88ab2f6d1cc02a07d3a81b5d4768f6f13e85c5' \
-                 'd8d4180419acb1b4'
+USER_PRINCIPAL = "basicauth:8a931a10fc88ab2f6d1cc02a07d3a81b5d4768f6f13e85c5" "d8d4180419acb1b4"
 
 
 class BaseWebTest(testing.BaseWebTest):
@@ -26,32 +25,31 @@ class BaseWebTest(testing.BaseWebTest):
     entry_point = testapp
     principal = USER_PRINCIPAL
 
-    authorization_policy = 'tests.core.support.AllowAuthorizationPolicy'
-    collection_url = '/mushrooms'
+    authorization_policy = "tests.core.support.AllowAuthorizationPolicy"
+    collection_url = "/mushrooms"
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.headers.update(testing.get_user_headers('mat'))
+        cls.headers.update(testing.get_user_headers("mat"))
 
     @classmethod
     def get_app_settings(cls, extras=None):
         if extras is None:
             extras = {}
-        extras.setdefault('project_name', 'myapp')
-        extras.setdefault('project_version', '0.0.1')
-        extras.setdefault('http_api_version', '0.1')
-        extras.setdefault('project_docs', 'https://kinto.readthedocs.io/')
-        extras.setdefault('multiauth.policies', 'basicauth')
-        extras.setdefault('multiauth.authorization_policy',
-                          cls.authorization_policy)
+        extras.setdefault("project_name", "myapp")
+        extras.setdefault("project_version", "0.0.1")
+        extras.setdefault("http_api_version", "0.1")
+        extras.setdefault("project_docs", "https://kinto.readthedocs.io/")
+        extras.setdefault("multiauth.policies", "basicauth")
+        extras.setdefault("multiauth.authorization_policy", cls.authorization_policy)
         return super().get_app_settings(extras)
 
     def get_item_url(self, id=None):
         """Return the URL of the item using self.item_url."""
         if id is None:
-            id = self.record['id']
-        return '{}/{}'.format(self.collection_url, id)
+            id = self.record["id"]
+        return "{}/{}".format(self.collection_url, id)
 
 
 @implementer(IAuthorizationPolicy)
@@ -74,21 +72,20 @@ def authorize(permits=True, authz_class=None):
     in :param:permits.
     """
     if authz_class is None:
-        authz_class = 'tests.core.support.AllowAuthorizationPolicy'
+        authz_class = "tests.core.support.AllowAuthorizationPolicy"
 
     def wrapper(f):
         @functools.wraps(f)
         def wrapped(*args, **kwargs):
-            with mock.patch(
-                    '{}.permits'.format(authz_class),
-                    return_value=permits):
+            with mock.patch("{}.permits".format(authz_class), return_value=permits):
                 return f(*args, **kwargs)
+
         return wrapped
+
     return wrapper
 
 
 class PostgreSQLTest(BaseWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
@@ -96,41 +93,34 @@ class PostgreSQLTest(BaseWebTest):
             from .test_storage import PostgreSQLStorageTest
             from .test_cache import PostgreSQLCacheTest
             from .test_permission import PostgreSQLPermissionTest
+
             settings.update(**PostgreSQLStorageTest.settings)
             settings.update(**PostgreSQLCacheTest.settings)
             settings.update(**PostgreSQLPermissionTest.settings)
-            settings.pop('storage_poolclass', None)
-            settings.pop('cache_poolclass', None)
-            settings.pop('permission_poolclass', None)
+            settings.pop("storage_poolclass", None)
+            settings.pop("cache_poolclass", None)
+            settings.pop("permission_poolclass", None)
         return settings
 
     def run_failing_batch(self):
-        patch = mock.patch.object(
-            self.storage,
-            'delete_all',
-            side_effect=BackendError('boom'))
+        patch = mock.patch.object(self.storage, "delete_all", side_effect=BackendError("boom"))
         self.addCleanup(patch.stop)
         patch.start()
         request_create = {
-            'method': 'POST',
-            'path': '/mushrooms',
-            'body': {'data': {'name': 'Amanite'}}
+            "method": "POST",
+            "path": "/mushrooms",
+            "body": {"data": {"name": "Amanite"}},
         }
-        request_delete = {
-            'method': 'DELETE',
-            'path': '/mushrooms'
-        }
-        body = {'requests': [request_create, request_create, request_delete]}
-        self.app.post_json('/batch', body, headers=self.headers, status=503)
+        request_delete = {"method": "DELETE", "path": "/mushrooms"}
+        body = {"requests": [request_create, request_create, request_delete]}
+        self.app.post_json("/batch", body, headers=self.headers, status=503)
 
     def run_failing_post(self):
         patch = mock.patch.object(
-            self.permission,
-            'add_principal_to_ace',
-            side_effect=BackendError('boom'))
+            self.permission, "add_principal_to_ace", side_effect=BackendError("boom")
+        )
         self.addCleanup(patch.stop)
         patch.start()
-        self.app.post_json('/psilos',
-                           {'data': {'name': 'Amanite'}},
-                           headers=self.headers,
-                           status=503)
+        self.app.post_json(
+            "/psilos", {"data": {"name": "Amanite"}}, headers=self.headers, status=503
+        )

--- a/tests/core/test_authentication.py
+++ b/tests/core/test_authentication.py
@@ -9,84 +9,88 @@ from .support import BaseWebTest
 
 
 class AuthenticationPoliciesTest(BaseWebTest, unittest.TestCase):
-
     def test_basic_auth_is_accepted_by_default(self):
         self.app.get(self.collection_url, headers=self.headers, status=200)
         # Check that the capability is exposed on the homepage.
-        resp = self.app.get('/')
-        assert 'basicauth' in resp.json['capabilities']
+        resp = self.app.get("/")
+        assert "basicauth" in resp.json["capabilities"]
 
     def test_basic_auth_is_accepted_if_enabled_in_settings(self):
-        app = self.make_app({'multiauth.policies': 'basicauth'})
+        app = self.make_app({"multiauth.policies": "basicauth"})
         app.get(self.collection_url, headers=self.headers, status=200)
         # Check that the capability is exposed on the homepage.
-        resp = app.get('/')
-        assert 'basicauth' in resp.json['capabilities']
+        resp = app.get("/")
+        assert "basicauth" in resp.json["capabilities"]
 
     def test_basic_auth_is_declined_if_disabled_in_settings(self):
-        app = self.make_app({
-            'multiauth.policies': 'dummy',
-            'multiauth.policy.dummy.use': ('pyramid.authentication.'
-                                           'RepozeWho1AuthenticationPolicy')})
+        app = self.make_app(
+            {
+                "multiauth.policies": "dummy",
+                "multiauth.policy.dummy.use": (
+                    "pyramid.authentication." "RepozeWho1AuthenticationPolicy"
+                ),
+            }
+        )
         app.get(self.collection_url, headers=self.headers, status=401)
         # Check that the capability is exposed on the homepage.
-        resp = app.get('/')
-        assert 'basicauth' not in resp.json['capabilities']
+        resp = app.get("/")
+        assert "basicauth" not in resp.json["capabilities"]
 
-    @mock.patch('kinto.core.authentication.BasicAuthAuthenticationPolicy')
+    @mock.patch("kinto.core.authentication.BasicAuthAuthenticationPolicy")
     def test_policy_name_is_used(self, basicAuth):
         basicAuth.return_value.name = "foobar"
-        app = self.make_app({
-            'multiauth.policies': 'dummy',
-            'multiauth.policy.dummy.use': ('kinto.core.authentication.'
-                                           'BasicAuthAuthenticationPolicy')})
+        app = self.make_app(
+            {
+                "multiauth.policies": "dummy",
+                "multiauth.policy.dummy.use": (
+                    "kinto.core.authentication." "BasicAuthAuthenticationPolicy"
+                ),
+            }
+        )
         # Check that the policy uses its name rather than the settings prefix
-        resp = app.get('/')
-        assert resp.json['user']['id'].startswith('foobar:')
+        resp = app.get("/")
+        assert resp.json["user"]["id"].startswith("foobar:")
 
     def test_views_are_forbidden_if_unknown_auth_method(self):
-        app = self.make_app({'multiauth.policies': 'basicauth'})
-        self.headers['Authorization'] = 'Carrier'
+        app = self.make_app({"multiauth.policies": "basicauth"})
+        self.headers["Authorization"] = "Carrier"
         app.get(self.collection_url, headers=self.headers, status=401)
-        self.headers['Authorization'] = 'Carrier pigeon'
+        self.headers["Authorization"] = "Carrier pigeon"
         app.get(self.collection_url, headers=self.headers, status=401)
 
     def test_principals_are_fetched_from_permission_backend(self):
-        patch = mock.patch(('tests.core.support.'
-                            'AllowAuthorizationPolicy.permits'))
+        patch = mock.patch(("tests.core.support." "AllowAuthorizationPolicy.permits"))
         self.addCleanup(patch.stop)
         mocked = patch.start()
 
-        self.permission.add_user_principal(self.principal, 'group:admin')
+        self.permission.add_user_principal(self.principal, "group:admin")
         self.app.get(self.collection_url, headers=self.headers)
 
         _, principals, _ = mocked.call_args[0]
-        self.assertIn('group:admin', principals)
+        self.assertIn("group:admin", principals)
 
     def test_user_principals_are_cached_per_user(self):
-        patch = mock.patch.object(self.permission, 'get_user_principals',
-                                  wraps=self.permission.get_user_principals)
+        patch = mock.patch.object(
+            self.permission, "get_user_principals", wraps=self.permission.get_user_principals
+        )
         self.addCleanup(patch.stop)
         mocked = patch.start()
         batch = {
-            "defaults": {
-                "headers": self.headers,
-                "path": "/mushrooms"
-            },
+            "defaults": {"headers": self.headers, "path": "/mushrooms"},
             "requests": [
                 {},
                 {},
                 {},
                 {"headers": {"Authorization": "Basic Ym9iOg=="}},
                 {"headers": {"Authorization": "Basic bWF0Og=="}},
-            ]
+            ],
         }
-        self.app.post_json('/batch', batch)
+        self.app.post_json("/batch", batch)
         self.assertEqual(mocked.call_count, 3)
 
     def test_basicauth_hash_is_computed_only_once(self):
         # hmac_digest() is used in Basic Authentication only.
-        patch = mock.patch('kinto.core.utils.hmac_digest', return_value='abcdef')
+        patch = mock.patch("kinto.core.utils.hmac_digest", return_value="abcdef")
         self.addCleanup(patch.stop)
         mocked = patch.start()
         body = {"data": {"name": "haha"}}
@@ -99,38 +103,38 @@ class BasicAuthenticationPolicyTest(unittest.TestCase):
     def setUp(self):
         self.policy = authentication.BasicAuthAuthenticationPolicy()
         self.request = DummyRequest()
-        self.request.headers['Authorization'] = 'Basic bWF0Og=='
+        self.request.headers["Authorization"] = "Basic bWF0Og=="
 
-    @mock.patch('kinto.core.utils.hmac_digest')
+    @mock.patch("kinto.core.utils.hmac_digest")
     def test_userid_is_hashed(self, mocked):
-        mocked.return_value = 'yeah'
+        mocked.return_value = "yeah"
         user_id = self.policy.unauthenticated_userid(self.request)
-        self.assertIn('yeah', user_id)
+        self.assertIn("yeah", user_id)
 
     def test_userid_is_built_using_password(self):
-        auth_password = utils.encode64('user:secret1', encoding='ascii')
-        self.request.headers['Authorization'] = 'Basic {}'.format(auth_password)
+        auth_password = utils.encode64("user:secret1", encoding="ascii")
+        self.request.headers["Authorization"] = "Basic {}".format(auth_password)
         user_id1 = self.policy.unauthenticated_userid(self.request)
 
-        auth_password = utils.encode64('user:secret2', encoding='ascii')
-        self.request.headers['Authorization'] = 'Basic {}'.format(auth_password)
+        auth_password = utils.encode64("user:secret2", encoding="ascii")
+        self.request.headers["Authorization"] = "Basic {}".format(auth_password)
         user_id2 = self.policy.unauthenticated_userid(self.request)
 
         self.assertNotEqual(user_id1, user_id2)
 
     def test_views_are_forbidden_if_basic_is_wrong(self):
-        self.request.headers['Authorization'] = 'Basic abc'
+        self.request.headers["Authorization"] = "Basic abc"
         user_id = self.policy.unauthenticated_userid(self.request)
         self.assertIsNone(user_id)
 
     def test_returns_none_if_username_is_empty(self):
-        auth_password = utils.encode64(':secret', encoding='ascii')
-        self.request.headers['Authorization'] = 'Basic {}'.format(auth_password)
+        auth_password = utils.encode64(":secret", encoding="ascii")
+        self.request.headers["Authorization"] = "Basic {}".format(auth_password)
         user_id = self.policy.unauthenticated_userid(self.request)
         self.assertIsNone(user_id)
 
     def test_providing_empty_password_is_supported(self):
-        auth_password = utils.encode64('secret:', encoding='ascii')
-        self.request.headers['Authorization'] = 'Basic {}'.format(auth_password)
+        auth_password = utils.encode64("secret:", encoding="ascii")
+        self.request.headers["Authorization"] = "Basic {}".format(auth_password)
         user_id = self.policy.unauthenticated_userid(self.request)
         self.assertIsNotNone(user_id)

--- a/tests/core/test_authorization.py
+++ b/tests/core/test_authorization.py
@@ -9,22 +9,19 @@ from kinto.core.testing import DummyRequest, unittest
 
 
 class RouteFactoryTest(unittest.TestCase):
-
     def setUp(self):
         self.record_uri = "/foo/bar"
 
-    def assert_request_resolves_to(self, method, permission, uri=None,
-                                   record_not_found=False):
+    def assert_request_resolves_to(self, method, permission, uri=None, record_not_found=False):
         if uri is None:
             uri = self.record_uri
 
-        with mock.patch('kinto.core.utils.current_service') as current_service:
+        with mock.patch("kinto.core.utils.current_service") as current_service:
             # Patch current service.
             resource = mock.MagicMock()
             resource.record_id = 1
             if record_not_found:
-                resource.model.get_record.side_effect = \
-                    storage_exceptions.RecordNotFoundError
+                resource.model.get_record.side_effect = storage_exceptions.RecordNotFoundError
             else:
                 resource.model.get_record.return_value = 1
             current_service().resource.return_value = resource
@@ -49,34 +46,33 @@ class RouteFactoryTest(unittest.TestCase):
         self.assert_request_resolves_to("delete", "write")
 
     def test_http_put_unexisting_record_resolves_in_a_create_permission(self):
-        with mock.patch('kinto.core.utils.current_service') as current_service:
+        with mock.patch("kinto.core.utils.current_service") as current_service:
             # Patch current service.
             resource = mock.MagicMock()
             resource.record_id = 1
-            resource.model.get_record.side_effect = \
-                storage_exceptions.RecordNotFoundError
+            resource.model.get_record.side_effect = storage_exceptions.RecordNotFoundError
             current_service().resource.return_value = resource
-            current_service().collection_path = '/buckets/{bucket_id}'
+            current_service().collection_path = "/buckets/{bucket_id}"
             # Do the actual call.
-            request = DummyRequest(method='put')
-            request.upath_info = '/buckets/abc/collections/1'
-            request.matchdict = {'bucket_id': 'abc'}
+            request = DummyRequest(method="put")
+            request.upath_info = "/buckets/abc/collections/1"
+            request.matchdict = {"bucket_id": "abc"}
             context = RouteFactory(request)
 
-            self.assertEqual(context.required_permission, 'create')
+            self.assertEqual(context.required_permission, "create")
 
     def test_http_put_existing_record_resolves_in_a_write_permission(self):
         self.assert_request_resolves_to("put", "write")
 
     def test_http_put_sets_current_record_attribute(self):
-        with mock.patch('kinto.core.utils.current_service') as current_service:
+        with mock.patch("kinto.core.utils.current_service") as current_service:
             # Patch current service.
             resource = mock.MagicMock()
             resource.record_id = 1
             resource.model.get_record.return_value = mock.sentinel.record
             current_service().resource.return_value = resource
             # Do the actual call.
-            request = DummyRequest(method='put')
+            request = DummyRequest(method="put")
             context = RouteFactory(request)
             self.assertEqual(context.current_record, mock.sentinel.record)
 
@@ -84,9 +80,9 @@ class RouteFactoryTest(unittest.TestCase):
         self.assert_request_resolves_to("patch", "write")
 
     def test_attributes_are_none_with_blank_requests(self):
-        request = Request.blank(path='/')
+        request = Request.blank(path="/")
         request.registry = mock.Mock(settings={})
-        request.authn_type = 'fxa'
+        request.authn_type = "fxa"
         request.prefixed_userid = property(utils.prefixed_userid)
         context = RouteFactory(request)
         self.assertIsNone(context.required_permission)
@@ -95,10 +91,10 @@ class RouteFactoryTest(unittest.TestCase):
 
     def test_attributes_are_none_with_non_resource_requests(self):
         basic_service = object()
-        request = Request.blank(path='/')
+        request = Request.blank(path="/")
         request.prefixed_userid = property(utils.prefixed_userid)
-        request.matched_route = mock.Mock(pattern='foo')
-        request.registry = mock.Mock(cornice_services={'foo': basic_service})
+        request.matched_route = mock.Mock(pattern="foo")
+        request.registry = mock.Mock(cornice_services={"foo": basic_service})
         request.registry.settings = {}
 
         context = RouteFactory(request)
@@ -108,58 +104,56 @@ class RouteFactoryTest(unittest.TestCase):
 
     def test_fetch_shared_records_uses_pattern_if_on_collection(self):
         request = DummyRequest()
-        request.route_path.return_value = '/v1/buckets/%2A'
+        request.route_path.return_value = "/v1/buckets/%2A"
         service = mock.MagicMock()
-        service.type = 'collection'
-        with mock.patch('kinto.core.authorization.utils.current_service') as m:
+        service.type = "collection"
+        with mock.patch("kinto.core.authorization.utils.current_service") as m:
             m.return_value = service
             context = RouteFactory(request)
         self.assertTrue(context.on_collection)
 
-        context.fetch_shared_records('read', ['userid'], None)
+        context.fetch_shared_records("read", ["userid"], None)
 
         request.registry.permission.get_accessible_objects.assert_called_with(
-            ['userid'],
-            [('/buckets/*', 'read')],
-            with_children=False)
+            ["userid"], [("/buckets/*", "read")], with_children=False
+        )
 
     def test_fetch_shared_records_uses_get_bound_permission_callback(self):
         request = DummyRequest()
         service = mock.MagicMock()
-        request.route_path.return_value = '/v1/buckets/%2A'
-        service.type = 'collection'
-        with mock.patch('kinto.core.authorization.utils.current_service') as m:
+        request.route_path.return_value = "/v1/buckets/%2A"
+        service.type = "collection"
+        with mock.patch("kinto.core.authorization.utils.current_service") as m:
             m.return_value = service
             context = RouteFactory(request)
         self.assertTrue(context.on_collection)
 
         # Define a callback where write means read:
         def get_bound_perms(obj_id, perm):
-            return [(obj_id, 'write'), (obj_id, 'read')]
+            return [(obj_id, "write"), (obj_id, "read")]
 
-        context.fetch_shared_records('read', ['userid'], get_bound_perms)
+        context.fetch_shared_records("read", ["userid"], get_bound_perms)
 
         request.registry.permission.get_accessible_objects.assert_called_with(
-            ['userid'],
-            [('/buckets/*', 'write'), ('/buckets/*', 'read')],
-            with_children=False)
+            ["userid"], [("/buckets/*", "write"), ("/buckets/*", "read")], with_children=False
+        )
 
     def test_fetch_shared_records_sets_shared_ids_from_results(self):
         request = DummyRequest()
         context = RouteFactory(request)
         request.registry.permission.get_accessible_objects.return_value = {
-            '/obj/1': ['read', 'write'],
-            '/obj/3': ['obj:create']
+            "/obj/1": ["read", "write"],
+            "/obj/3": ["obj:create"],
         }
-        context.fetch_shared_records('read', ['userid'], None)
-        self.assertEqual(sorted(context.shared_ids), ['1', '3'])
+        context.fetch_shared_records("read", ["userid"], None)
+        self.assertEqual(sorted(context.shared_ids), ["1", "3"])
 
     def test_fetch_shared_records_sets_shared_ids_if_empty(self):
         request = DummyRequest()
         context = RouteFactory(request)
         request.registry.permission.get_accessible_objects.return_value = {}
 
-        context.fetch_shared_records('read', ['userid'], None)
+        context.fetch_shared_records("read", ["userid"], None)
 
         self.assertEqual(context.shared_ids, [])
 
@@ -168,82 +162,81 @@ class AuthorizationPolicyTest(unittest.TestCase):
     def setUp(self):
         self.authz = AuthorizationPolicy()
         self.context = mock.MagicMock()
-        self.context.permission_object_id = '/articles/43/comments/2'
-        self.context.required_permission = 'read'
+        self.context.permission_object_id = "/articles/43/comments/2"
+        self.context.required_permission = "read"
         self.principals = ["portier:yourself"]
         self.context.get_prefixed_principals.return_value = self.principals
-        self.permission = 'dynamic'
+        self.permission = "dynamic"
 
     def test_permits_does_not_refer_to_context_if_permission_is_private(self):
-        self.assertFalse(self.authz.permits(None, [], 'private'))
+        self.assertFalse(self.authz.permits(None, [], "private"))
 
     def test_permits_return_if_authenticated_when_permission_is_private(self):
-        self.assertTrue(self.authz.permits(None,
-                                           ['system.Authenticated'],
-                                           'private'))
+        self.assertTrue(self.authz.permits(None, ["system.Authenticated"], "private"))
 
     def test_permits_logs_authz_failures(self):
         self.context.on_collection = False
         self.context.check_permission.return_value = False
-        with mock.patch('kinto.core.authorization.logger') as mocked:
-            self.authz.permits(self.context, self.principals, 'dynamic')
-        userid = 'portier:yourself'
-        object_id = '/articles/43/comments/2'
-        perm = 'read'
-        mocked.warn.assert_called_with('Permission %r on %r not granted to %r.',
-                                       perm, object_id, userid,
-                                       extra=dict(perm=perm, uri=object_id, userid=userid))
+        with mock.patch("kinto.core.authorization.logger") as mocked:
+            self.authz.permits(self.context, self.principals, "dynamic")
+        userid = "portier:yourself"
+        object_id = "/articles/43/comments/2"
+        perm = "read"
+        mocked.warn.assert_called_with(
+            "Permission %r on %r not granted to %r.",
+            perm,
+            object_id,
+            userid,
+            extra=dict(perm=perm, uri=object_id, userid=userid),
+        )
 
     def test_permits_refers_to_context_to_check_permissions(self):
         self.context.check_permission.return_value = True
-        allowed = self.authz.permits(self.context, self.principals, 'dynamic')
+        allowed = self.authz.permits(self.context, self.principals, "dynamic")
         self.assertTrue(allowed)
 
     def test_permits_refers_to_context_to_check_permission_principals(self):
         self.context.check_permission.return_value = False
-        allowed = self.authz.permits(
-            self.context, self.principals, 'dynamic')
+        allowed = self.authz.permits(self.context, self.principals, "dynamic")
         self.assertTrue(allowed)
 
     def test_permits_reads_the_context_when_permission_is_dynamic(self):
-        self.authz.permits(self.context, self.principals, 'dynamic')
+        self.authz.permits(self.context, self.principals, "dynamic")
         self.context.check_permission.assert_called_with(
-            self.principals,
-            [(self.context.permission_object_id, 'read')])
+            self.principals, [(self.context.permission_object_id, "read")]
+        )
 
     def test_permits_uses_get_bound_permissions_if_defined(self):
         self.authz.get_bound_permissions = lambda o, p: mock.sentinel.callback
-        self.authz.permits(self.context, self.principals, 'dynamic')
-        self.context.check_permission.assert_called_with(
-            self.principals,
-            mock.sentinel.callback)
+        self.authz.permits(self.context, self.principals, "dynamic")
+        self.context.check_permission.assert_called_with(self.principals, mock.sentinel.callback)
 
     def test_permits_calls_get_bound_permissions_with_context_info(self):
         self.authz.get_bound_permissions = mock.Mock(return_value=[])
-        self.authz.permits(self.context, self.principals, 'dynamic')
+        self.authz.permits(self.context, self.principals, "dynamic")
         self.authz.get_bound_permissions.assert_called_with(
-            self.context.permission_object_id,
-            'read')
+            self.context.permission_object_id, "read"
+        )
 
     def test_permits_consider_permission_when_not_dynamic(self):
-        self.authz.permits(self.context, self.principals, 'foobar')
+        self.authz.permits(self.context, self.principals, "foobar")
         self.context.check_permission.assert_called_with(
-            self.principals,
-            [(self.context.permission_object_id, 'foobar')])
+            self.principals, [(self.context.permission_object_id, "foobar")]
+        )
 
     def test_permits_prepend_obj_type_to_permission_on_create(self):
-        self.context.required_permission = 'create'
-        self.context.resource_name = 'record'
-        self.authz.permits(self.context, self.principals, 'dynamic')
+        self.context.required_permission = "create"
+        self.context.resource_name = "record"
+        self.authz.permits(self.context, self.principals, "dynamic")
         self.context.check_permission.assert_called_with(
-            self.principals,
-            [(self.context.permission_object_id, 'record:create')])
+            self.principals, [(self.context.permission_object_id, "record:create")]
+        )
 
     def test_permits_takes_route_factory_allowed_principals_into_account(self):
-        self.context.resource_name = 'record'
-        self.context.required_permission = 'create'
-        self.context._settings = {'record_create_principals': 'fxa:user'}
-        allowed = self.authz.permits(self.context, self.principals, 'dynamic')
+        self.context.resource_name = "record"
+        self.context.required_permission = "create"
+        self.context._settings = {"record_create_principals": "fxa:user"}
+        allowed = self.authz.permits(self.context, self.principals, "dynamic")
         self.context._check_permission.assert_not_called()
         self.assertTrue(allowed)
 
@@ -252,74 +245,75 @@ class GuestAuthorizationPolicyTest(unittest.TestCase):
     def setUp(self):
         self.authz = AuthorizationPolicy()
         self.authz.get_bound_permissions = lambda o, p: []
-        self.request = DummyRequest(method='GET')
+        self.request = DummyRequest(method="GET")
         self.context = RouteFactory(self.request)
         self.context.on_collection = True
         self.context.check_permission = mock.Mock(return_value=False)
 
     def test_permits_returns_true_if_collection_and_shared_records(self):
-        self.context.fetch_shared_records = mock.MagicMock(return_value=[
-            'record1', 'record2'])
-        allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
+        self.context.fetch_shared_records = mock.MagicMock(return_value=["record1", "record2"])
+        allowed = self.authz.permits(self.context, ["userid"], "dynamic")
         # Note: we use the list of principals from request.prefixed_principals
         self.context.fetch_shared_records.assert_called_with(
-            'read',
-            ['basicauth:bob', 'system.Everyone', 'system.Authenticated'],
-            self.authz.get_bound_permissions)
+            "read",
+            ["basicauth:bob", "system.Everyone", "system.Authenticated"],
+            self.authz.get_bound_permissions,
+        )
         self.assertTrue(allowed)
 
     def test_permits_does_not_return_true_if_not_collection(self):
         self.context.on_collection = False
-        allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
+        allowed = self.authz.permits(self.context, ["userid"], "dynamic")
         self.assertFalse(allowed)
 
     def test_permits_does_not_return_true_if_not_list_operation(self):
-        self.context.required_permission = 'create'
-        allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
+        self.context.required_permission = "create"
+        allowed = self.authz.permits(self.context, ["userid"], "dynamic")
         self.assertFalse(allowed)
-        allowed = self.authz.permits(self.context, ['userid'], 'create')
+        allowed = self.authz.permits(self.context, ["userid"], "create")
         self.assertFalse(allowed)
 
     def test_permits_returns_false_if_collection_is_unknown(self):
         self.context.fetch_shared_records = mock.MagicMock(return_value=None)
-        allowed = self.authz.permits(self.context, ['userid'], 'dynamic')
+        allowed = self.authz.permits(self.context, ["userid"], "dynamic")
         # Note: we use the list of principals from request.prefixed_principals
         self.context.fetch_shared_records.assert_called_with(
-            'read',
-            ['basicauth:bob', 'system.Everyone', 'system.Authenticated'],
-            self.authz.get_bound_permissions)
+            "read",
+            ["basicauth:bob", "system.Everyone", "system.Authenticated"],
+            self.authz.get_bound_permissions,
+        )
         self.assertFalse(allowed)
 
     def test_perm_object_id_is_naive_if_no_record_path_exists(self):
         def route_path(service_name, **kwargs):
             # Simulate a resource that has no record_path (only list).
-            if service_name == 'article-record':
+            if service_name == "article-record":
                 raise KeyError
-            return '/comments/sub/{id}'.format_map(kwargs)
+            return "/comments/sub/{id}".format_map(kwargs)
 
         self.request.route_path.side_effect = route_path
 
-        self.request.path = '/comments'
-        self.context.resource_name = 'comment'
-        obj_id = self.context.get_permission_object_id(self.request, '*')
-        self.assertEqual(obj_id, '/comments/sub/*')
+        self.request.path = "/comments"
+        self.context.resource_name = "comment"
+        obj_id = self.context.get_permission_object_id(self.request, "*")
+        self.assertEqual(obj_id, "/comments/sub/*")
 
-        self.request.path = '/articles'
-        self.context.resource_name = 'article'
-        obj_id = self.context.get_permission_object_id(self.request, '*')
-        self.assertEqual(obj_id, '/articles/*')
+        self.request.path = "/articles"
+        self.context.resource_name = "article"
+        obj_id = self.context.get_permission_object_id(self.request, "*")
+        self.assertEqual(obj_id, "/articles/*")
 
 
 class GroupFinderTest(unittest.TestCase):
     def setUp(self):
-        self.request = DummyRequest(method='GET')
+        self.request = DummyRequest(method="GET")
 
     def test_uses_prefixed_as_userid(self):
-        self.request.prefixed_userid = 'basic:bob'
-        groupfinder('bob', self.request)
-        self.request.registry.permission.get_user_principals.assert_called_with('basic:bob')
+        self.request.prefixed_userid = "basic:bob"
+        groupfinder("bob", self.request)
+        self.request.registry.permission.get_user_principals.assert_called_with("basic:bob")
 
     def test_uses_provided_id_if_no_prefixed_userid(self):
         self.request.prefixed_userid = None
-        groupfinder('bob', self.request)
-        self.request.registry.permission.get_user_principals.assert_called_with('bob')
+        groupfinder("bob", self.request)
+        self.request.registry.permission.get_user_principals.assert_called_with("bob")

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -3,25 +3,29 @@ import unittest
 from unittest import mock
 
 from kinto.core.utils import sqlalchemy, memcache
-from kinto.core.cache import (CacheBase, memory as memory_backend, memcached as memcached_backend,
-                              postgresql as postgresql_backend)
+from kinto.core.cache import (
+    CacheBase,
+    memory as memory_backend,
+    memcached as memcached_backend,
+    postgresql as postgresql_backend,
+)
 from kinto.core.cache.testing import CacheTest
 from kinto.core.testing import skip_if_no_postgresql, skip_if_no_memcached
 
 
 class CacheBaseTest(unittest.TestCase):
     def setUp(self):
-        self.cache = CacheBase(cache_prefix='')
+        self.cache = CacheBase(cache_prefix="")
 
     def test_mandatory_overrides(self):
         calls = [
             (self.cache.initialize_schema,),
             (self.cache.flush,),
-            (self.cache.ttl, ''),
-            (self.cache.expire, '', ''),
-            (self.cache.get, ''),
-            (self.cache.set, '', '', 42),
-            (self.cache.delete, ''),
+            (self.cache.ttl, ""),
+            (self.cache.expire, "", ""),
+            (self.cache.get, ""),
+            (self.cache.set, "", "", 42),
+            (self.cache.delete, ""),
         ]
         for call in calls:
             self.assertRaises(NotImplementedError, *call)
@@ -29,10 +33,7 @@ class CacheBaseTest(unittest.TestCase):
 
 class MemoryCacheTest(CacheTest, unittest.TestCase):
     backend = memory_backend
-    settings = {
-        'cache_prefix': '',
-        'cache_max_size_bytes': 7000
-    }
+    settings = {"cache_prefix": "", "cache_max_size_bytes": 7000}
 
     def get_backend_prefix(self, prefix):
         backend_prefix = CacheTest.get_backend_prefix(self, prefix)
@@ -53,63 +54,59 @@ class MemoryCacheTest(CacheTest, unittest.TestCase):
         pass
 
     def test_clean_expired_expires_items(self):
-        self.cache.set('foobar', 'toto', 0.01)
-        assert 'foobar' in self.cache._store
-        assert 'foobar' in self.cache._ttl
-        assert 'foobar' in self.cache._created_at
+        self.cache.set("foobar", "toto", 0.01)
+        assert "foobar" in self.cache._store
+        assert "foobar" in self.cache._ttl
+        assert "foobar" in self.cache._created_at
         time.sleep(0.02)
         retrieved = self.cache._clean_expired()
-        assert 'foobar' not in self.cache._store
-        assert 'foobar' not in self.cache._ttl
-        assert 'foobar' not in self.cache._created_at
+        assert "foobar" not in self.cache._store
+        assert "foobar" not in self.cache._ttl
+        assert "foobar" not in self.cache._created_at
         self.assertIsNone(retrieved)
 
     def test_add_over_quota_clean_oversized_items(self):
         for x in range(100):
             # Each entry is 70 bytes
-            self.cache.set('foo{0:03d}'.format(x), 'toto', 42)
+            self.cache.set("foo{0:03d}".format(x), "toto", 42)
             time.sleep(0.001)
-        assert self.cache.get('foo000') == 'toto'
+        assert self.cache.get("foo000") == "toto"
         # This should delete the 2 first entries
-        self.cache.set('foobar', 'tata', 42)
+        self.cache.set("foobar", "tata", 42)
         assert self.cache._quota == 7000 - 70 * 20
-        assert self.cache.get('foo000') is None
-        assert self.cache.get('foobar') == 'tata'
+        assert self.cache.get("foo000") is None
+        assert self.cache.get("foobar") == "tata"
 
     def test_size_quota_can_be_set_to_zero(self):
         before = self.cache.max_size_bytes
         self.cache.max_size_bytes = 0
-        self.cache.set('foobar', 'tata', 42)
+        self.cache.set("foobar", "tata", 42)
         self.cache.max_size_bytes = before
-        assert self.cache.get('foobar') == 'tata'
+        assert self.cache.get("foobar") == "tata"
 
 
 @skip_if_no_memcached
 class MemcachedCacheTest(CacheTest, unittest.TestCase):
     backend = memcached_backend
-    settings = {
-        'cache_prefix': '',
-        'cache_hosts': '127.0.0.1:11211',
-    }
+    settings = {"cache_prefix": "", "cache_hosts": "127.0.0.1:11211"}
 
     def setUp(self):
         super().setUp()
         self.client_error_patcher = mock.patch.object(
-            self.cache._client.servers[0],
-            'connect',
-            side_effect=memcache.Client.MemcachedKeyError)
+            self.cache._client.servers[0], "connect", side_effect=memcache.Client.MemcachedKeyError
+        )
 
     def test_set_with_ttl_expires_the_value(self):
-        self.cache.set('foobar', 'toto', 1)
+        self.cache.set("foobar", "toto", 1)
         time.sleep(1.1)
-        retrieved = self.cache.get('foobar')
+        retrieved = self.cache.get("foobar")
         self.assertIsNone(retrieved)
 
     def test_expire_expires_the_value(self):
-        self.cache.set('foobar', 'toto', 42)
-        self.cache.expire('foobar', 1)
+        self.cache.set("foobar", "toto", 42)
+        self.cache.expire("foobar", 1)
         time.sleep(1.1)
-        retrieved = self.cache.get('foobar')
+        retrieved = self.cache.get("foobar")
         self.assertIsNone(retrieved)
 
 
@@ -117,15 +114,14 @@ class MemcachedCacheTest(CacheTest, unittest.TestCase):
 class PostgreSQLCacheTest(CacheTest, unittest.TestCase):
     backend = postgresql_backend
     settings = {
-        'cache_backend': 'kinto.core.cache.postgresql',
-        'cache_pool_size': 10,
-        'cache_url': 'postgres://postgres:postgres@localhost:5432/testdb',
-        'cache_prefix': ''
+        "cache_backend": "kinto.core.cache.postgresql",
+        "cache_pool_size": 10,
+        "cache_url": "postgres://postgres:postgres@localhost:5432/testdb",
+        "cache_prefix": "",
     }
 
     def setUp(self):
         super().setUp()
         self.client_error_patcher = mock.patch.object(
-            self.cache.client,
-            'session_factory',
-            side_effect=sqlalchemy.exc.SQLAlchemyError)
+            self.cache.client, "session_factory", side_effect=sqlalchemy.exc.SQLAlchemyError
+        )

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -37,9 +37,9 @@ def test_cache_forever_doesnt_care_about_arguments():
     request2 = mock.MagicMock()
     request2.response = StringIO()
 
-    response1 = demo2(request1, 'Henri').getvalue()
-    response2 = demo2(request2, 'Paul').getvalue()
-    assert response1 == response2 == 'demo2: Henri'
+    response1 = demo2(request1, "Henri").getvalue()
+    response2 = demo2(request2, "Paul").getvalue()
+    assert response1 == response2 == "demo2: Henri"
 
 
 def test_each_function_is_cached_separately_for_the_life_of_the_process():
@@ -52,8 +52,8 @@ def test_each_function_is_cached_separately_for_the_life_of_the_process():
     response2 = demo2(request2).getvalue()
 
     assert response1 != response2
-    assert response1 == 'demo1'
-    assert response2 == 'demo2: Henri'
+    assert response1 == "demo1"
+    assert response2 == "demo2: Henri"
 
 
 def test_should_not_cache_responses():

--- a/tests/core/test_deprecation.py
+++ b/tests/core/test_deprecation.py
@@ -9,49 +9,63 @@ from .support import BaseWebTest
 
 
 class DeprecationTest(BaseWebTest, unittest.TestCase):
-
     def test_do_not_return_alert_if_no_eos(self):
-        response = self.app.get('/')
-        self.assertNotIn('Alert', response.headers)
+        response = self.app.get("/")
+        self.assertNotIn("Alert", response.headers)
 
     def test_returns_alert_if_eos_in_the_future(self):
         # Set an end of service date in the future.
         tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
-        with mock.patch.dict(self.app.app.registry.settings, [
-                             ('eos', tomorrow.isoformat()),
-                             ('eos_url', 'http://eos-url'),
-                             ('eos_message',
-                              'This service will soon be decommissioned')]):
-            response = self.app.get('/')
+        with mock.patch.dict(
+            self.app.app.registry.settings,
+            [
+                ("eos", tomorrow.isoformat()),
+                ("eos_url", "http://eos-url"),
+                ("eos_message", "This service will soon be decommissioned"),
+            ],
+        ):
+            response = self.app.get("/")
 
             # Requests should work as usual and contain an
             # Alert header, with the service end of life information.
-            self.assertIn('Alert', response.headers)
-            self.assertDictEqual(json.loads(response.headers['Alert']), {
-                'code': 'soft-eol',
-                'url': 'http://eos-url',
-                'message': 'This service will soon be decommissioned'
-            })
+            self.assertIn("Alert", response.headers)
+            self.assertDictEqual(
+                json.loads(response.headers["Alert"]),
+                {
+                    "code": "soft-eol",
+                    "url": "http://eos-url",
+                    "message": "This service will soon be decommissioned",
+                },
+            )
 
     def test_returns_410_if_eos_in_the_past(self):
         # Set an end of service date in the past.
         yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
-        with mock.patch.dict(self.app.app.registry.settings, [
-                             ('eos', yesterday.isoformat()),
-                             ('eos_url', 'http://eos-url'),
-                             ('eos_message',
-                              'This service had been decommissioned')]):
-            response = self.app.get('/', status=410)
-            self.assertIn('Alert', response.headers)
-            self.assertDictEqual(json.loads(response.headers['Alert']), {
-                'code': 'hard-eol',
-                'url': 'http://eos-url',
-                'message': 'This service had been decommissioned'
-            })
-            self.assertDictEqual(response.json, {
-                "errno": ERRORS.SERVICE_DEPRECATED.value,
-                "message": "The service you are trying to connect no longer "
-                           "exists at this location.",
-                "code": 410,
-                "error": "Gone"
-            })
+        with mock.patch.dict(
+            self.app.app.registry.settings,
+            [
+                ("eos", yesterday.isoformat()),
+                ("eos_url", "http://eos-url"),
+                ("eos_message", "This service had been decommissioned"),
+            ],
+        ):
+            response = self.app.get("/", status=410)
+            self.assertIn("Alert", response.headers)
+            self.assertDictEqual(
+                json.loads(response.headers["Alert"]),
+                {
+                    "code": "hard-eol",
+                    "url": "http://eos-url",
+                    "message": "This service had been decommissioned",
+                },
+            )
+            self.assertDictEqual(
+                response.json,
+                {
+                    "errno": ERRORS.SERVICE_DEPRECATED.value,
+                    "message": "The service you are trying to connect no longer "
+                    "exists at this location.",
+                    "code": 410,
+                    "error": "Gone",
+                },
+            )

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -6,38 +6,30 @@ from kinto.core.testing import DummyRequest
 
 
 class SendAlertTest(unittest.TestCase):
-
     def verify_alert_header(self, request, expected):
-        self.assertIn('Alert', request.response.headers)
-        alert = request.response.headers['Alert']
-        self.assertDictEqual(json.loads(alert),
-                             expected)
+        self.assertIn("Alert", request.response.headers)
+        alert = request.response.headers["Alert"]
+        self.assertDictEqual(json.loads(alert), expected)
 
     def test_send_alert_default_to_project_url(self):
         request = DummyRequest()
-        request.registry.settings['project_docs'] = 'docs_url'
-        send_alert(request, 'Message')
-        self.verify_alert_header(request, {
-            'code': 'soft-eol',
-            'message': 'Message',
-            'url': 'docs_url'
-        })
+        request.registry.settings["project_docs"] = "docs_url"
+        send_alert(request, "Message")
+        self.verify_alert_header(
+            request, {"code": "soft-eol", "message": "Message", "url": "docs_url"}
+        )
 
     def test_send_alert_url_can_be_specified(self):
         request = DummyRequest()
-        send_alert(request, 'Message', 'error_url')
-        self.verify_alert_header(request, {
-            'code': 'soft-eol',
-            'message': 'Message',
-            'url': 'error_url'
-        })
+        send_alert(request, "Message", "error_url")
+        self.verify_alert_header(
+            request, {"code": "soft-eol", "message": "Message", "url": "error_url"}
+        )
 
     def test_send_alert_code_can_be_specified(self):
         request = DummyRequest()
-        request.registry.settings['project_docs'] = 'docs_url'
-        send_alert(request, 'Message', code='hard-eol')
-        self.verify_alert_header(request, {
-            'code': 'hard-eol',
-            'message': 'Message',
-            'url': 'docs_url'
-        })
+        request.registry.settings["project_docs"] = "docs_url"
+        send_alert(request, "Message", code="hard-eol")
+        self.verify_alert_header(
+            request, {"code": "hard-eol", "message": "Message", "url": "docs_url"}
+        )

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -18,267 +18,241 @@ class InitializationTest(unittest.TestCase):
 
     def test_uses_the_version_for_prefix(self):
         config = Configurator()
-        kinto.core.initialize(config, '0.0.1', 'name')
-        self.assertEqual(config.route_prefix, 'v0')
+        kinto.core.initialize(config, "0.0.1", "name")
+        self.assertEqual(config.route_prefix, "v0")
 
     def test_set_the_project_version_if_specified(self):
         config = Configurator()
-        kinto.core.initialize(config, '0.0.1', 'name')
-        self.assertEqual(config.registry.settings['project_version'], '0.0.1')
+        kinto.core.initialize(config, "0.0.1", "name")
+        self.assertEqual(config.registry.settings["project_version"], "0.0.1")
 
     def test_project_version_uses_setting_if_specified(self):
-        config = Configurator(settings={'name.project_version': '1.0.0'})
-        kinto.core.initialize(config, '0.0.1', 'name')
-        self.assertEqual(config.registry.settings['project_version'], '1.0.0')
+        config = Configurator(settings={"name.project_version": "1.0.0"})
+        kinto.core.initialize(config, "0.0.1", "name")
+        self.assertEqual(config.registry.settings["project_version"], "1.0.0")
 
     def test_http_api_version_relies_on_project_version_by_default(self):
         config = Configurator()
-        kinto.core.initialize(config, '0.1.0', 'name')
-        self.assertEqual(config.registry.settings['http_api_version'], '0.1')
+        kinto.core.initialize(config, "0.1.0", "name")
+        self.assertEqual(config.registry.settings["http_api_version"], "0.1")
 
     def test_http_api_version_uses_setting_if_specified(self):
-        config = Configurator(settings={'name.http_api_version': '1.3'})
-        kinto.core.initialize(config, '0.0.1', 'name')
-        self.assertEqual(config.registry.settings['http_api_version'], '1.3')
+        config = Configurator(settings={"name.http_api_version": "1.3"})
+        kinto.core.initialize(config, "0.0.1", "name")
+        self.assertEqual(config.registry.settings["http_api_version"], "1.3")
 
     def test_warns_if_settings_prefix_is_empty(self):
-        config = Configurator(settings={'kinto.settings_prefix': ''})
-        with mock.patch('kinto.core.initialization.warnings.warn') as mocked:
-            kinto.core.initialize(config, '0.0.1')
-            error_msg = 'No value specified for `settings_prefix`'
+        config = Configurator(settings={"kinto.settings_prefix": ""})
+        with mock.patch("kinto.core.initialization.warnings.warn") as mocked:
+            kinto.core.initialize(config, "0.0.1")
+            error_msg = "No value specified for `settings_prefix`"
             mocked.assert_any_call(error_msg)
 
     def test_warns_if_settings_prefix_is_missing(self):
         config = Configurator()
-        with mock.patch('kinto.core.initialization.warnings.warn') as mocked:
-            kinto.core.initialize(config, '0.0.1')
-            error_msg = 'No value specified for `settings_prefix`'
+        with mock.patch("kinto.core.initialization.warnings.warn") as mocked:
+            kinto.core.initialize(config, "0.0.1")
+            error_msg = "No value specified for `settings_prefix`"
             mocked.assert_any_call(error_msg)
 
     def test_set_the_settings_prefix_if_specified(self):
         config = Configurator()
-        kinto.core.initialize(config, '0.0.1', 'kinto')
-        self.assertEqual(config.registry.settings['settings_prefix'],
-                         'kinto')
+        kinto.core.initialize(config, "0.0.1", "kinto")
+        self.assertEqual(config.registry.settings["settings_prefix"], "kinto")
 
     def test_set_the_settings_prefix_from_settings_even_if_specified(self):
-        config = Configurator(settings={'kinto.settings_prefix': 'kinto'})
-        kinto.core.initialize(config, '0.0.1', 'readinglist')
-        self.assertEqual(config.registry.settings['settings_prefix'],
-                         'kinto')
+        config = Configurator(settings={"kinto.settings_prefix": "kinto"})
+        kinto.core.initialize(config, "0.0.1", "readinglist")
+        self.assertEqual(config.registry.settings["settings_prefix"], "kinto")
 
     def test_warns_if_not_https(self):
-        with mock.patch('kinto.core.initialization.warnings.warn') as mocked:
-            config = Configurator(settings={'settings_prefix': 'kinto',
-                                            'kinto.http_scheme': 'https'})
-            kinto.core.initialize(config, '0.0.1')
+        with mock.patch("kinto.core.initialization.warnings.warn") as mocked:
+            config = Configurator(
+                settings={"settings_prefix": "kinto", "kinto.http_scheme": "https"}
+            )
+            kinto.core.initialize(config, "0.0.1")
             self.assertFalse(mocked.called)
 
-            config = Configurator(settings={'kinto.http_scheme': 'http'})
-            kinto.core.initialize(config, '0.0.1')
-            error_msg = 'HTTPS is not enabled'
+            config = Configurator(settings={"kinto.http_scheme": "http"})
+            kinto.core.initialize(config, "0.0.1")
+            error_msg = "HTTPS is not enabled"
             mocked.assert_any_call(error_msg)
 
     def test_default_settings_are_overriden_if_specified_in_initialize(self):
         config = Configurator()
-        defaults = {'paginate_by': 102}
-        kinto.core.initialize(config, '0.0.1', 'prefix', default_settings=defaults)
-        self.assertEqual(config.registry.settings['paginate_by'], 102)
+        defaults = {"paginate_by": 102}
+        kinto.core.initialize(config, "0.0.1", "prefix", default_settings=defaults)
+        self.assertEqual(config.registry.settings["paginate_by"], 102)
 
     def test_default_settings_are_overriden_by_application(self):
-        config = Configurator(settings={'prefix.paginate_by': 10})
-        kinto.core.initialize(config, '0.0.1', 'prefix')
-        self.assertEqual(config.registry.settings['paginate_by'], 10)
+        config = Configurator(settings={"prefix.paginate_by": 10})
+        kinto.core.initialize(config, "0.0.1", "prefix")
+        self.assertEqual(config.registry.settings["paginate_by"], 10)
 
     def test_specified_default_settings_are_overriden_by_application(self):
-        config = Configurator(settings={'settings_prefix.paginate_by': 5})
-        defaults = {'settings_prefix.paginate_by': 10}
-        kinto.core.initialize(config, '0.0.1', 'settings_prefix',
-                              default_settings=defaults)
-        self.assertEqual(config.registry.settings['paginate_by'], 5)
+        config = Configurator(settings={"settings_prefix.paginate_by": 5})
+        defaults = {"settings_prefix.paginate_by": 10}
+        kinto.core.initialize(config, "0.0.1", "settings_prefix", default_settings=defaults)
+        self.assertEqual(config.registry.settings["paginate_by"], 5)
 
     def test_backends_are_not_instantiated_by_default(self):
         config = Configurator(settings={**kinto.core.DEFAULT_SETTINGS})
-        kinto.core.initialize(config, '0.0.1', 'settings_prefix')
-        self.assertFalse(hasattr(config.registry, 'storage'))
-        self.assertFalse(hasattr(config.registry, 'cache'))
-        self.assertFalse(hasattr(config.registry, 'permission'))
+        kinto.core.initialize(config, "0.0.1", "settings_prefix")
+        self.assertFalse(hasattr(config.registry, "storage"))
+        self.assertFalse(hasattr(config.registry, "cache"))
+        self.assertFalse(hasattr(config.registry, "permission"))
 
     def test_backends_type_is_checked_when_instantiated(self):
         def config_fails(settings):
             config = Configurator(settings=settings)
             with self.assertRaises(ConfigurationError):
-                kinto.core.initialize(config, '0.0.1', 'settings_prefix')
+                kinto.core.initialize(config, "0.0.1", "settings_prefix")
 
-        config_fails({'settings_prefix.storage_backend': 'kinto.core.cache.memory'})
-        config_fails({'settings_prefix.cache_backend': 'kinto.core.storage.memory'})
-        config_fails({'settings_prefix.permission_backend': 'kinto.core.storage.memory'})
+        config_fails({"settings_prefix.storage_backend": "kinto.core.cache.memory"})
+        config_fails({"settings_prefix.cache_backend": "kinto.core.storage.memory"})
+        config_fails({"settings_prefix.permission_backend": "kinto.core.storage.memory"})
 
     def test_environment_values_override_configuration(self):
         import os
 
-        envkey = 'KINTO_SETTINGS_PREFIX'
-        os.environ[envkey] = 'abc'
+        envkey = "KINTO_SETTINGS_PREFIX"
+        os.environ[envkey] = "abc"
 
-        config = Configurator(settings={'kinto.settings_prefix': 'kinto'})
-        kinto.core.initialize(config, '0.0.1')
+        config = Configurator(settings={"kinto.settings_prefix": "kinto"})
+        kinto.core.initialize(config, "0.0.1")
 
         os.environ.pop(envkey)
 
-        prefix_used = config.registry.settings['settings_prefix']
-        self.assertEqual(prefix_used, 'abc')
+        prefix_used = config.registry.settings["settings_prefix"]
+        self.assertEqual(prefix_used, "abc")
 
 
 class ProjectSettingsTest(unittest.TestCase):
     def settings(self, provided):
         config = Configurator(settings=provided)
-        kinto.core.initialize(config, '1.0', 'kinto')
+        kinto.core.initialize(config, "1.0", "kinto")
         return config.get_settings()
 
     def test_uses_unprefixed_name(self):
-        settings = {
-            'paginate_by': 3.14
-        }
-        self.assertEqual(self.settings(settings)['paginate_by'], 3.14)
+        settings = {"paginate_by": 3.14}
+        self.assertEqual(self.settings(settings)["paginate_by"], 3.14)
 
     def test_uses_settings_prefix(self):
-        settings = {
-            'kinto.paginate_by': 42,
-        }
-        self.assertEqual(self.settings(settings)['paginate_by'], 42)
+        settings = {"kinto.paginate_by": 42}
+        self.assertEqual(self.settings(settings)["paginate_by"], 42)
 
     def test_does_raise_valueerror_if_multiple_entries_are_equal(self):
-        settings = {
-            'paginate_by': 42,
-            'kinto.paginate_by': 42,
-        }
+        settings = {"paginate_by": 42, "kinto.paginate_by": 42}
         self.settings(settings)  # Not raising.
 
     def test_does_raise_valueerror_if_entries_are_not_hashable(self):
-        settings = {
-            'events.listeners': ['Rémy', 42],
-        }
+        settings = {"events.listeners": ["Rémy", 42]}
         self.settings(settings)  # Not raising.
 
     def test_raises_valueerror_if_different_multiple_entries(self):
-        settings = {
-            'paginate_by': 42,
-            'kinto.paginate_by': 3.14,
-        }
+        settings = {"paginate_by": 42, "kinto.paginate_by": 3.14}
         with self.assertRaises(ValueError):
             self.settings(settings)
 
     def test_environment_can_specify_settings_prefix(self):
         import os
 
-        envkey = 'KINTO_STORAGE_BACKEND'
-        os.environ[envkey] = 'kinto_redis.storage'
-        settings = {
-            'kinto.storage_backend': 'kinto.core.storage.memory',
-        }
-        value = self.settings(settings)['storage_backend']
+        envkey = "KINTO_STORAGE_BACKEND"
+        os.environ[envkey] = "kinto_redis.storage"
+        settings = {"kinto.storage_backend": "kinto.core.storage.memory"}
+        value = self.settings(settings)["storage_backend"]
         os.environ.pop(envkey)
-        self.assertEqual(value, 'kinto_redis.storage')
+        self.assertEqual(value, "kinto_redis.storage")
 
 
 class ApplicationWrapperTest(unittest.TestCase):
-
-    @unittest.skipIf(initialization.newrelic is None,
-                     "newrelic is not installed.")
-    @mock.patch('kinto.core.initialization.newrelic.agent')
+    @unittest.skipIf(initialization.newrelic is None, "newrelic is not installed.")
+    @mock.patch("kinto.core.initialization.newrelic.agent")
     def test_newrelic_is_included_if_defined(self, mocked_newrelic):
-        settings = {
-            'newrelic_config': '/foo/bar.ini',
-            'newrelic_env': 'test'
-        }
-        mocked_newrelic.WSGIApplicationWrapper.return_value = 'wrappedApp'
+        settings = {"newrelic_config": "/foo/bar.ini", "newrelic_env": "test"}
+        mocked_newrelic.WSGIApplicationWrapper.return_value = "wrappedApp"
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
-        mocked_newrelic.initialize.assert_called_with('/foo/bar.ini', 'test')
-        self.assertEqual(app, 'wrappedApp')
+        mocked_newrelic.initialize.assert_called_with("/foo/bar.ini", "test")
+        self.assertEqual(app, "wrappedApp")
 
-    @unittest.skipIf(initialization.newrelic is None,
-                     "newrelic is not installed.")
-    @mock.patch('kinto.core.initialization.newrelic.agent')
+    @unittest.skipIf(initialization.newrelic is None, "newrelic is not installed.")
+    @mock.patch("kinto.core.initialization.newrelic.agent")
     def test_newrelic_is_not_included_if_set_to_false(self, mocked_newrelic):
-        settings = {'newrelic_config': False}
+        settings = {"newrelic_config": False}
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
         mocked_newrelic.initialize.assert_not_called()
         self.assertEqual(app, mock.sentinel.app)
 
-    @mock.patch('kinto.core.initialization.ProfilerMiddleware')
+    @mock.patch("kinto.core.initialization.ProfilerMiddleware")
     def test_profiler_is_not_installed_if_set_to_false(self, mocked_profiler):
-        settings = {'profiler_enabled': False}
+        settings = {"profiler_enabled": False}
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
         mocked_profiler.initialize.assert_not_called()
         self.assertEqual(app, mock.sentinel.app)
 
-    @mock.patch('kinto.core.initialization.ProfilerMiddleware')
+    @mock.patch("kinto.core.initialization.ProfilerMiddleware")
     def test_profiler_is_installed_if_set_to_true(self, mocked_profiler):
-        settings = {
-            'profiler_enabled': True,
-            'profiler_dir': '/tmp/path'
-        }
-        mocked_profiler.return_value = 'wrappedApp'
+        settings = {"profiler_enabled": True, "profiler_dir": "/tmp/path"}
+        mocked_profiler.return_value = "wrappedApp"
         app = kinto.core.install_middlewares(mock.sentinel.app, settings)
 
         mocked_profiler.assert_called_with(
-            mock.sentinel.app,
-            restrictions='*kinto.core*',
-            profile_dir='/tmp/path')
+            mock.sentinel.app, restrictions="*kinto.core*", profile_dir="/tmp/path"
+        )
 
-        self.assertEqual(app, 'wrappedApp')
+        self.assertEqual(app, "wrappedApp")
 
     def test_load_default_settings_handle_prefix_attributes(self):
         config = mock.MagicMock()
 
-        settings = {'settings_prefix': 'myapp'}
+        settings = {"settings_prefix": "myapp"}
 
         config.get_settings.return_value = settings
         initialization.load_default_settings(
-            config, {'multiauth.policies': 'basicauth',
-                     'myapp.http_scheme': 'https',
-                     'myapp.http_host': 'localhost:8888'})
+            config,
+            {
+                "multiauth.policies": "basicauth",
+                "myapp.http_scheme": "https",
+                "myapp.http_host": "localhost:8888",
+            },
+        )
 
-        self.assertIn('multiauth.policies', settings)
-        self.assertNotIn('policies', settings)
-        self.assertEqual(settings['multiauth.policies'], 'basicauth')
+        self.assertIn("multiauth.policies", settings)
+        self.assertNotIn("policies", settings)
+        self.assertEqual(settings["multiauth.policies"], "basicauth")
 
-        self.assertIn('http_scheme', settings)
-        self.assertNotIn('kinto.http_scheme', settings)
-        self.assertEqual(settings['http_scheme'], 'https')
+        self.assertIn("http_scheme", settings)
+        self.assertNotIn("kinto.http_scheme", settings)
+        self.assertEqual(settings["http_scheme"], "https")
 
-        self.assertIn('http_host', settings)
-        self.assertNotIn('myapp.http_host', settings)
-        self.assertEqual(settings['http_host'], 'localhost:8888')
+        self.assertIn("http_host", settings)
+        self.assertNotIn("myapp.http_host", settings)
+        self.assertEqual(settings["http_host"], "localhost:8888")
 
 
 class StatsDConfigurationTest(unittest.TestCase):
     def setUp(self):
         settings = {
             **kinto.core.DEFAULT_SETTINGS,
-            'statsd_url': 'udp://host:8080',
-            'multiauth.policies': 'basicauth',
+            "statsd_url": "udp://host:8080",
+            "multiauth.policies": "basicauth",
         }
         self.config = Configurator(settings=settings)
         self.config.registry.storage = {}
         self.config.registry.cache = {}
         self.config.registry.permission = {}
 
-        patch = mock.patch('kinto.core.statsd.load_from_config')
+        patch = mock.patch("kinto.core.statsd.load_from_config")
         self.mocked = patch.start()
         self.addCleanup(patch.stop)
 
     def test_statsd_isnt_called_if_statsd_url_is_not_set(self):
-        self.config.add_settings({
-            'statsd_url': None
-        })
+        self.config.add_settings({"statsd_url": None})
         initialization.setup_statsd(self.config)
         self.mocked.assert_not_called()
 
     def test_statsd_is_set_to_none_if_statsd_url_not_set(self):
-        self.config.add_settings({
-            'statsd_url': None
-        })
+        self.config.add_settings({"statsd_url": None})
         initialization.setup_statsd(self.config)
         self.assertEqual(self.config.registry.statsd, None)
 
@@ -293,69 +267,69 @@ class StatsDConfigurationTest(unittest.TestCase):
 
     def test_statsd_is_set_on_cache(self):
         c = initialization.setup_statsd(self.config)
-        c.watch_execution_time.assert_any_call({}, prefix='backend')
+        c.watch_execution_time.assert_any_call({}, prefix="backend")
 
     def test_statsd_is_set_on_storage(self):
         c = initialization.setup_statsd(self.config)
-        c.watch_execution_time.assert_any_call({}, prefix='backend')
+        c.watch_execution_time.assert_any_call({}, prefix="backend")
 
     def test_statsd_is_set_on_permission(self):
         c = initialization.setup_statsd(self.config)
-        c.watch_execution_time.assert_any_call({}, prefix='backend')
+        c.watch_execution_time.assert_any_call({}, prefix="backend")
 
     def test_statsd_is_set_on_authentication(self):
         c = initialization.setup_statsd(self.config)
-        c.watch_execution_time.assert_any_call(None, prefix='authentication')
+        c.watch_execution_time.assert_any_call(None, prefix="authentication")
 
     def test_statsd_counts_nothing_on_anonymous_requests(self):
-        kinto.core.initialize(self.config, '0.0.1', 'settings_prefix')
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())
-        app.get('/')
+        app.get("/")
         self.assertFalse(self.mocked.count.called)
 
     def test_statsd_counts_views_and_methods(self):
-        kinto.core.initialize(self.config, '0.0.1', 'settings_prefix')
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())
-        app.get('/v0/__heartbeat__')
-        self.mocked().count.assert_any_call('view.heartbeat.GET')
+        app.get("/v0/__heartbeat__")
+        self.mocked().count.assert_any_call("view.heartbeat.GET")
 
     def test_statsd_counts_unknown_urls(self):
-        kinto.core.initialize(self.config, '0.0.1', 'settings_prefix')
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())
-        app.get('/v0/coucou', status=404)
+        app.get("/v0/coucou", status=404)
         self.assertFalse(self.mocked.count.called)
 
-    @mock.patch('kinto.core.utils.hmac_digest')
+    @mock.patch("kinto.core.utils.hmac_digest")
     def test_statsd_counts_unique_users(self, digest_mocked):
-        digest_mocked.return_value = 'mat'
-        kinto.core.initialize(self.config, '0.0.1', 'settings_prefix')
+        digest_mocked.return_value = "mat"
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())
-        headers = {'Authorization': 'Basic bWF0Og=='}
-        app.get('/v0/', headers=headers)
-        self.mocked().count.assert_any_call('users', unique='basicauth.mat')
+        headers = {"Authorization": "Basic bWF0Og=="}
+        app.get("/v0/", headers=headers)
+        self.mocked().count.assert_any_call("users", unique="basicauth.mat")
 
     def test_statsd_counts_authentication_types(self):
-        kinto.core.initialize(self.config, '0.0.1', 'settings_prefix')
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())
-        headers = {'Authorization': 'Basic bWF0Og=='}
-        app.get('/v0/', headers=headers)
-        self.mocked().count.assert_any_call('authn_type.basicauth')
+        headers = {"Authorization": "Basic bWF0Og=="}
+        app.get("/v0/", headers=headers)
+        self.mocked().count.assert_any_call("authn_type.basicauth")
 
 
 class RequestsConfigurationTest(unittest.TestCase):
     def _get_app(self, settings={}):
         app_settings = {
-            'storage_backend': 'kinto.core.storage.memory',
-            'cache_backend': 'kinto_redis.cache',
+            "storage_backend": "kinto.core.storage.memory",
+            "cache_backend": "kinto_redis.cache",
         }
         app_settings.update(**settings)
         config = Configurator(settings=app_settings)
-        kinto.core.initialize(config, '0.0.1', 'name')
+        kinto.core.initialize(config, "0.0.1", "name")
         return webtest.TestApp(config.make_wsgi_app())
 
     def test_requests_have_a_bound_data_attribute(self):
         config = Configurator()
-        kinto.core.initialize(config, '0.0.1', 'name')
+        kinto.core.initialize(config, "0.0.1", "name")
 
         def on_new_request(event):
             data = event.request.bound_data
@@ -364,11 +338,11 @@ class RequestsConfigurationTest(unittest.TestCase):
 
         config.add_subscriber(on_new_request, NewRequest)
         app = webtest.TestApp(config.make_wsgi_app())
-        app.get('/v0/')
+        app.get("/v0/")
 
     def test_subrequests_share_parent_bound_data(self):
         config = Configurator()
-        kinto.core.initialize(config, '0.0.1', 'name')
+        kinto.core.initialize(config, "0.0.1", "name")
 
         bound_datas = set()
 
@@ -377,84 +351,76 @@ class RequestsConfigurationTest(unittest.TestCase):
 
         config.add_subscriber(on_new_request, NewRequest)
         app = webtest.TestApp(config.make_wsgi_app())
-        app.post_json('/v0/batch', {'requests': [{'path': '/'}]})
+        app.post_json("/v0/batch", {"requests": [{"path": "/"}]})
         self.assertEqual(len(bound_datas), 1)
 
     def test_by_default_relies_on_pyramid_application_url(self):
         app = self._get_app()
-        resp = app.get('/v0/')
-        self.assertEqual(resp.json['url'], 'http://localhost/v0/')
+        resp = app.get("/v0/")
+        self.assertEqual(resp.json["url"], "http://localhost/v0/")
 
     def test_by_default_relies_on_incoming_headers(self):
         app = self._get_app()
-        resp = app.get('/v0/', headers={'Host': 'server:8888'})
-        self.assertEqual(resp.json['url'], 'http://server:8888/v0/')
+        resp = app.get("/v0/", headers={"Host": "server:8888"})
+        self.assertEqual(resp.json["url"], "http://server:8888/v0/")
 
     def test_by_default_relies_on_wsgi_environment(self):
         app = self._get_app()
-        environ = {
-            'wsgi.url_scheme': 'https',
-            'HTTP_HOST': 'server:44311'
-        }
-        resp = app.get('/v0/', extra_environ=environ)
-        self.assertEqual(resp.json['url'], 'https://server:44311/v0/')
+        environ = {"wsgi.url_scheme": "https", "HTTP_HOST": "server:44311"}
+        resp = app.get("/v0/", extra_environ=environ)
+        self.assertEqual(resp.json["url"], "https://server:44311/v0/")
 
     def test_http_scheme_overrides_the_wsgi_environment(self):
-        app = self._get_app({'http_scheme': 'http2'})
-        environ = {
-            'wsgi.url_scheme': 'https'
-        }
-        resp = app.get('/v0/', extra_environ=environ)
-        self.assertEqual(resp.json['url'], 'http2://localhost:80/v0/')
+        app = self._get_app({"http_scheme": "http2"})
+        environ = {"wsgi.url_scheme": "https"}
+        resp = app.get("/v0/", extra_environ=environ)
+        self.assertEqual(resp.json["url"], "http2://localhost:80/v0/")
 
     def test_http_host_overrides_the_wsgi_environment(self):
-        app = self._get_app({'http_host': 'server'})
-        environ = {
-            'HTTP_HOST': 'elb:44311'
-        }
-        resp = app.get('/v0/', extra_environ=environ)
-        self.assertEqual(resp.json['url'], 'http://server/v0/')
+        app = self._get_app({"http_host": "server"})
+        environ = {"HTTP_HOST": "elb:44311"}
+        resp = app.get("/v0/", extra_environ=environ)
+        self.assertEqual(resp.json["url"], "http://server/v0/")
 
     def test_http_host_overrides_the_request_headers(self):
-        app = self._get_app({'http_host': 'server'})
-        resp = app.get('/v0/', headers={'Host': 'elb:8888'})
-        self.assertEqual(resp.json['url'], 'http://server/v0/')
+        app = self._get_app({"http_host": "server"})
+        resp = app.get("/v0/", headers={"Host": "elb:8888"})
+        self.assertEqual(resp.json["url"], "http://server/v0/")
 
 
 class PluginsTest(unittest.TestCase):
     def test_kinto_core_includes_are_included_manually(self):
         config = Configurator(settings={**kinto.core.DEFAULT_SETTINGS})
-        config.add_settings({'includes': 'elastic history'})
-        config.route_prefix = 'v2'
+        config.add_settings({"includes": "elastic history"})
+        config.route_prefix = "v2"
 
-        with mock.patch.object(config, 'include'):
-            with mock.patch.object(config, 'scan'):
+        with mock.patch.object(config, "include"):
+            with mock.patch.object(config, "scan"):
                 kinto.core.includeme(config)
 
-                config.include.assert_any_call('elastic')
-                config.include.assert_any_call('history')
+                config.include.assert_any_call("elastic")
+                config.include.assert_any_call("history")
 
     def make_app(self):
         config = Configurator(settings={**kinto.core.DEFAULT_SETTINGS})
-        config.add_settings({
-            'permission_backend': 'kinto.core.permission.memory',
-            'includes': 'tests.core.testplugin',
-            'multiauth.policies': 'basicauth',
-        })
-        kinto.core.initialize(config, '0.0.1', 'name')
+        config.add_settings(
+            {
+                "permission_backend": "kinto.core.permission.memory",
+                "includes": "tests.core.testplugin",
+                "multiauth.policies": "basicauth",
+            }
+        )
+        kinto.core.initialize(config, "0.0.1", "name")
         return webtest.TestApp(config.make_wsgi_app())
 
     def test_plugin_can_define_protected_views(self):
         app = self.make_app()
-        app.post('/v0/attachment', status=401)
-        headers = {'Authorization': 'Basic bWF0OjE='}
-        app.post('/v0/attachment', headers=headers, status=403)
+        app.post("/v0/attachment", status=401)
+        headers = {"Authorization": "Basic bWF0OjE="}
+        app.post("/v0/attachment", headers=headers, status=403)
 
     def test_plugin_benefits_from_cors_setup(self):
         app = self.make_app()
-        headers = {
-            'Origin': 'lolnet.org',
-            'Access-Control-Request-Method': 'POST'
-        }
-        resp = app.options('/v0/attachment', headers=headers, status=200)
-        self.assertIn('Access-Control-Allow-Origin', resp.headers)
+        headers = {"Origin": "lolnet.org", "Access-Control-Request-Method": "POST"}
+        resp = app.options("/v0/attachment", headers=headers, status=200)
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)

--- a/tests/core/test_listeners.py
+++ b/tests/core/test_listeners.py
@@ -15,7 +15,7 @@ UID = str(uuid.uuid4())
 
 class ViewSet:
     def get_name(*args, **kw):
-        return 'collection'
+        return "collection"
 
 
 class Service:
@@ -23,28 +23,26 @@ class Service:
 
 
 class Match:
-    cornice_services = {'watev': Service()}
-    pattern = 'watev'
+    cornice_services = {"watev": Service()}
+    pattern = "watev"
 
 
 class Request:
-    path = '/1/bucket/collection/'
-    prefixed_userid = 'tarek'
-    matchdict = {'id': UID}
+    path = "/1/bucket/collection/"
+    prefixed_userid = "tarek"
+    matchdict = {"id": UID}
     registry = matched_route = Match()
-    current_resource_name = 'bucket'
+    current_resource_name = "bucket"
 
 
 class ListenerSetupTest(unittest.TestCase):
     def setUp(self):
-        demo_patch = mock.patch('tests.core.listeners.load_from_config')
+        demo_patch = mock.patch("tests.core.listeners.load_from_config")
         self.addCleanup(demo_patch.stop)
         self.demo_mocked = demo_patch.start()
 
     def make_app(self, extra_settings={}):
-        settings = {
-            'event_listeners': 'tests.core.listeners',
-        }
+        settings = {"event_listeners": "tests.core.listeners"}
         settings.update(**extra_settings)
         config = testing.setUp(settings=settings)
         config.commit()
@@ -52,93 +50,98 @@ class ListenerSetupTest(unittest.TestCase):
         return config
 
     def test_listener_module_is_specified_via_settings(self):
-        self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-        })
+        self.make_app(
+            {"event_listeners": "demo", "event_listeners.demo.use": "tests.core.listeners"}
+        )
         self.assertTrue(self.demo_mocked.called)
 
     def test_listener_module_can_be_specified_via_listeners_list(self):
-        self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-        })
+        self.make_app(
+            {"event_listeners": "demo", "event_listeners.demo.use": "tests.core.listeners"}
+        )
         self.assertTrue(self.demo_mocked.called)
 
     def test_callback_called_when_action_is_not_filtered(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-        })
-        ev = ResourceChanged({'action': ACTIONS.CREATE.value}, [], Request())
+        config = self.make_app(
+            {"event_listeners": "demo", "event_listeners.demo.use": "tests.core.listeners"}
+        )
+        ev = ResourceChanged({"action": ACTIONS.CREATE.value}, [], Request())
         config.registry.notify(ev)
 
         self.assertTrue(self.demo_mocked.return_value.called)
 
     def test_callback_is_not_called_when_action_is_filtered(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-            'event_listeners.demo.actions': 'delete',
-        })
-        ev = ResourceChanged({'action': ACTIONS.CREATE.value}, [], Request())
+        config = self.make_app(
+            {
+                "event_listeners": "demo",
+                "event_listeners.demo.use": "tests.core.listeners",
+                "event_listeners.demo.actions": "delete",
+            }
+        )
+        ev = ResourceChanged({"action": ACTIONS.CREATE.value}, [], Request())
         config.registry.notify(ev)
 
         self.assertFalse(self.demo_mocked.return_value.called)
 
     def test_callback_called_when_resource_is_not_filtered(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-        })
-        event = ResourceChanged({'action': ACTIONS.CREATE.value,
-                                 'resource_name': 'mushroom'}, [], Request())
+        config = self.make_app(
+            {"event_listeners": "demo", "event_listeners.demo.use": "tests.core.listeners"}
+        )
+        event = ResourceChanged(
+            {"action": ACTIONS.CREATE.value, "resource_name": "mushroom"}, [], Request()
+        )
         config.registry.notify(event)
 
         self.assertTrue(self.demo_mocked.return_value.called)
 
     def test_callback_is_not_called_when_resource_is_filtered(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-            'event_listeners.demo.resources': 'toad',
-        })
-        event = ResourceChanged({'action': ACTIONS.CREATE.value,
-                                 'resource_name': 'mushroom'}, [], Request())
+        config = self.make_app(
+            {
+                "event_listeners": "demo",
+                "event_listeners.demo.use": "tests.core.listeners",
+                "event_listeners.demo.resources": "toad",
+            }
+        )
+        event = ResourceChanged(
+            {"action": ACTIONS.CREATE.value, "resource_name": "mushroom"}, [], Request()
+        )
         config.registry.notify(event)
 
         self.assertFalse(self.demo_mocked.return_value.called)
 
     def test_callback_is_not_called_on_read_by_default(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-        })
-        event = ResourceRead({'action': ACTIONS.READ.value}, [], Request())
+        config = self.make_app(
+            {"event_listeners": "demo", "event_listeners.demo.use": "tests.core.listeners"}
+        )
+        event = ResourceRead({"action": ACTIONS.READ.value}, [], Request())
         config.registry.notify(event)
 
         self.assertFalse(self.demo_mocked.return_value.called)
 
     def test_callback_is_called_on_read_if_specified(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-            'event_listeners.demo.actions': 'read',
-        })
-        event = ResourceRead({'action': ACTIONS.READ.value}, [], Request())
+        config = self.make_app(
+            {
+                "event_listeners": "demo",
+                "event_listeners.demo.use": "tests.core.listeners",
+                "event_listeners.demo.actions": "read",
+            }
+        )
+        event = ResourceRead({"action": ACTIONS.READ.value}, [], Request())
         config.registry.notify(event)
 
         self.assertTrue(self.demo_mocked.return_value.called)
 
     def test_same_callback_is_called_for_read_and_write_specified(self):
-        config = self.make_app({
-            'event_listeners': 'demo',
-            'event_listeners.demo.use': 'tests.core.listeners',
-            'event_listeners.demo.actions': 'read create delete',
-        })
-        ev = ResourceRead({'action': ACTIONS.READ.value}, [], Request())
+        config = self.make_app(
+            {
+                "event_listeners": "demo",
+                "event_listeners.demo.use": "tests.core.listeners",
+                "event_listeners.demo.actions": "read create delete",
+            }
+        )
+        ev = ResourceRead({"action": ACTIONS.READ.value}, [], Request())
         config.registry.notify(ev)
-        ev = ResourceChanged({'action': ACTIONS.CREATE.value}, [], Request())
+        ev = ResourceChanged({"action": ACTIONS.CREATE.value}, [], Request())
         config.registry.notify(ev)
 
         self.assertEqual(self.demo_mocked.return_value.call_count, 2)
@@ -155,32 +158,35 @@ class ListenerSetupTest(unittest.TestCase):
         }
         os.environ.update(**environ)
 
-        config = self.make_app({
-            # With real/full initialization, these should not be necessary:
-            'settings_prefix': 'kinto',
-            'event_listeners': 'kvstore'
-        })
+        config = self.make_app(
+            {
+                # With real/full initialization, these should not be necessary:
+                "settings_prefix": "kinto",
+                "event_listeners": "kvstore",
+            }
+        )
 
         # Listener is instantiated.
         self.assertTrue(self.demo_mocked.called)
 
         # Action filtering is read from ENV.
-        event = ResourceChanged({'action': ACTIONS.DELETE.value,
-                                 'resource_name': 'toad'}, [], Request())
+        event = ResourceChanged(
+            {"action": ACTIONS.DELETE.value, "resource_name": "toad"}, [], Request()
+        )
         config.registry.notify(event)
         self.assertTrue(self.demo_mocked.return_value.called)
 
         self.demo_mocked.reset_mock()
 
         # Action filtering is read from ENV.
-        event = ResourceChanged({'action': ACTIONS.CREATE.value},
-                                [], Request())
+        event = ResourceChanged({"action": ACTIONS.CREATE.value}, [], Request())
         config.registry.notify(event)
         self.assertFalse(self.demo_mocked.return_value.called)
 
         # Resource filtering is read from ENV.
-        event = ResourceChanged({'action': ACTIONS.CREATE.value,
-                                 'resource_name': 'mushroom'}, [], Request())
+        event = ResourceChanged(
+            {"action": ACTIONS.CREATE.value, "resource_name": "mushroom"}, [], Request()
+        )
         config.registry.notify(event)
         self.assertFalse(self.demo_mocked.return_value.called)
 
@@ -190,7 +196,6 @@ class ListenerSetupTest(unittest.TestCase):
 
 
 class ListenerBaseTest(unittest.TestCase):
-
     def test_not_implemented(self):
         # make sure we can't use the base listener
         listener = ListenerBase()

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -17,117 +17,120 @@ class RequestSummaryTest(BaseWebTest, unittest.TestCase):
         config.registry.settings = DEFAULT_SETTINGS
         initialization.setup_logging(config)
 
-        patch = mock.patch('kinto.core.initialization.summary_logger')
+        patch = mock.patch("kinto.core.initialization.summary_logger")
         self.mocked = patch.start()
         self.addCleanup(patch.stop)
 
     def logger_context(self):
         args, kwargs = self.mocked.info.call_args_list[-1]
-        return kwargs['extra']
+        return kwargs["extra"]
 
     def test_standard_info_is_bound(self):
-        headers = {
-            'User-Agent': 'Smith',
-            **self.headers
-        }
-        self.app.get('/', headers=headers)
+        headers = {"User-Agent": "Smith", **self.headers}
+        self.app.get("/", headers=headers)
         event_dict = self.logger_context()
-        self.assertEqual(event_dict['path'], '/v0/')
-        self.assertEqual(event_dict['method'], 'GET')
-        self.assertEqual(event_dict['code'], 200)
-        self.assertEqual(event_dict['agent'], 'Smith')
-        self.assertIsNotNone(event_dict['uid'])
-        self.assertIsNotNone(event_dict['time'])
-        self.assertIsNotNone(event_dict['t'])
-        self.assertEqual(event_dict['errno'], 0)
-        self.assertNotIn('lang', event_dict)
-        self.assertNotIn('headers', event_dict)
-        self.assertNotIn('body', event_dict)
+        self.assertEqual(event_dict["path"], "/v0/")
+        self.assertEqual(event_dict["method"], "GET")
+        self.assertEqual(event_dict["code"], 200)
+        self.assertEqual(event_dict["agent"], "Smith")
+        self.assertIsNotNone(event_dict["uid"])
+        self.assertIsNotNone(event_dict["time"])
+        self.assertIsNotNone(event_dict["t"])
+        self.assertEqual(event_dict["errno"], 0)
+        self.assertNotIn("lang", event_dict)
+        self.assertNotIn("headers", event_dict)
+        self.assertNotIn("body", event_dict)
 
     def test_userid_is_none_when_anonymous(self):
-        self.app.get('/')
+        self.app.get("/")
         event_dict = self.logger_context()
-        self.assertNotIn('uid', event_dict)
+        self.assertNotIn("uid", event_dict)
 
     def test_lang_is_not_none_when_provided(self):
-        self.app.get('/', headers={'Accept-Language': 'fr-FR'})
+        self.app.get("/", headers={"Accept-Language": "fr-FR"})
         event_dict = self.logger_context()
-        self.assertEqual(event_dict['lang'], 'fr-FR')
+        self.assertEqual(event_dict["lang"], "fr-FR")
 
     def test_agent_is_not_none_when_provided(self):
-        self.app.get('/', headers={'User-Agent': 'webtest/x.y.z'})
+        self.app.get("/", headers={"User-Agent": "webtest/x.y.z"})
         event_dict = self.logger_context()
-        self.assertEqual(event_dict['agent'], 'webtest/x.y.z')
+        self.assertEqual(event_dict["agent"], "webtest/x.y.z")
 
     def test_errno_is_specified_on_error(self):
-        self.app.get('/unknown', status=404)
+        self.app.get("/unknown", status=404)
         event_dict = self.logger_context()
-        self.assertEqual(event_dict['errno'], 111)
+        self.assertEqual(event_dict["errno"], 111)
 
     def test_basic_authn_type_is_bound(self):
-        app = self.make_app({'multiauth.policies': 'basicauth'})
-        app.get('/mushrooms', headers={'Authorization': 'Basic bWF0OjE='})
+        app = self.make_app({"multiauth.policies": "basicauth"})
+        app.get("/mushrooms", headers={"Authorization": "Basic bWF0OjE="})
         event_dict = self.logger_context()
-        self.assertEqual(event_dict['authn_type'], 'basicauth')
+        self.assertEqual(event_dict["authn_type"], "basicauth")
 
     def test_headers_and_body_when_level_is_debug(self):
         self.mocked.level = logging.DEBUG
         body = b'{"boom": 1}'
-        self.app.post('/batch', body, headers=self.headers, status=400)
+        self.app.post("/batch", body, headers=self.headers, status=400)
         event_dict = self.logger_context()
-        self.assertEqual(event_dict['headers'], {
-            'Authorization': 'Basic bWF0OnNlY3JldA==',
-            'Content-Length': '11',
-            'Content-Type': 'application/json',
-            'Host': 'localhost:80'})
-        self.assertEqual(event_dict['body'], body)
+        self.assertEqual(
+            event_dict["headers"],
+            {
+                "Authorization": "Basic bWF0OnNlY3JldA==",
+                "Content-Length": "11",
+                "Content-Type": "application/json",
+                "Host": "localhost:80",
+            },
+        )
+        self.assertEqual(event_dict["body"], body)
 
         self.maxDiff = None
 
-        responseBody = event_dict['response']['body']
-        self.assertEqual(json.loads(responseBody.decode('utf-8'))['error'], 'Invalid parameters')
-        responseHeaders = event_dict['response']['headers']
-        self.assertEqual(sorted(responseHeaders.keys()), [
-            'Access-Control-Expose-Headers',
-            'Content-Length',
-            'Content-Type',
-            'X-Content-Type-Options'])
+        responseBody = event_dict["response"]["body"]
+        self.assertEqual(json.loads(responseBody.decode("utf-8"))["error"], "Invalid parameters")
+        responseHeaders = event_dict["response"]["headers"]
+        self.assertEqual(
+            sorted(responseHeaders.keys()),
+            [
+                "Access-Control-Expose-Headers",
+                "Content-Length",
+                "Content-Type",
+                "X-Content-Type-Options",
+            ],
+        )
 
 
 class BatchSubrequestTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        patch = mock.patch('kinto.core.views.batch.subrequest_logger')
+        patch = mock.patch("kinto.core.views.batch.subrequest_logger")
         self.subrequest_mocked = patch.start()
         self.addCleanup(patch.stop)
 
-        patch = mock.patch('kinto.core.initialization.summary_logger')
+        patch = mock.patch("kinto.core.initialization.summary_logger")
         self.summary_mocked = patch.start()
         self.addCleanup(patch.stop)
 
-        headers = {**self.headers, 'User-Agent': 'readinglist'}
+        headers = {**self.headers, "User-Agent": "readinglist"}
         body = {
-            'requests': [{
-                'path': '/unknown',
-                'headers': {'User-Agent': 'foo'}
-            }, {
-                'path': '/unknown2'
-            }]
+            "requests": [
+                {"path": "/unknown", "headers": {"User-Agent": "foo"}},
+                {"path": "/unknown2"},
+            ]
         }
-        self.app.post_json('/batch', body, headers=headers)
+        self.app.post_json("/batch", body, headers=headers)
 
     def test_batch_global_request_is_preserved(self):
         args, kwargs = self.summary_mocked.info.call_args_list[-1]
-        extra = kwargs['extra']
-        self.assertEqual(extra['code'], 200)
-        self.assertEqual(extra['path'], '/v0/batch')
-        self.assertEqual(extra['agent'], 'readinglist')
+        extra = kwargs["extra"]
+        self.assertEqual(extra["code"], 200)
+        self.assertEqual(extra["path"], "/v0/batch")
+        self.assertEqual(extra["agent"], "readinglist")
 
     def test_batch_size_is_bound(self):
         args, kwargs = self.summary_mocked.info.call_args_list[-1]
-        extra = kwargs['extra']
-        self.assertEqual(extra['batch_size'], 2)
+        extra = kwargs["extra"]
+        self.assertEqual(extra["batch_size"], 2)
 
     def test_subrequests_are_not_logged_as_request_summary(self):
         self.assertEqual(self.summary_mocked.info.call_count, 1)
@@ -135,21 +138,21 @@ class BatchSubrequestTest(BaseWebTest, unittest.TestCase):
     def test_subrequests_are_logged_as_subrequest_summary(self):
         self.assertEqual(self.subrequest_mocked.info.call_count, 2)
         args, kwargs = self.subrequest_mocked.info.call_args_list[-1]
-        extra = kwargs['extra']
-        self.assertEqual(extra['path'], '/v0/unknown2')
+        extra = kwargs["extra"]
+        self.assertEqual(extra["path"], "/v0/unknown2")
         args, kwargs = self.subrequest_mocked.info.call_args_list[-2]
-        extra = kwargs['extra']
-        self.assertEqual(extra['path'], '/v0/unknown')
+        extra = kwargs["extra"]
+        self.assertEqual(extra["path"], "/v0/unknown")
 
 
 class JsonFormatterTest(unittest.TestCase):
     def test_logger_name(self):
-        JsonLogFormatter.init_from_settings({'project_name': 'kintowe'})
+        JsonLogFormatter.init_from_settings({"project_name": "kintowe"})
         f = JsonLogFormatter()
-        record = logging.LogRecord('app.log', logging.DEBUG, '', 0, 'coucou', (), None)
+        record = logging.LogRecord("app.log", logging.DEBUG, "", 0, "coucou", (), None)
         result = f.format(record)
         logged = json.loads(result)
-        self.assertEqual(logged['Logger'], 'kintowe')
-        self.assertEqual(logged['Type'], 'app.log')
+        self.assertEqual(logged["Logger"], "kintowe")
+        self.assertEqual(logged["Type"], "app.log")
         # See https://github.com/mozilla/mozilla-cloud-services-logger/issues/2
-        self.assertEqual(logged['Fields']['msg'], 'coucou')
+        self.assertEqual(logged["Fields"]["msg"], "coucou")

--- a/tests/core/test_openapi.py
+++ b/tests/core/test_openapi.py
@@ -8,7 +8,6 @@ from .support import BaseWebTest
 
 
 class OpenAPITest(BaseWebTest, unittest.TestCase):
-
     def setUp(self):
         super(OpenAPITest, self).setUp()
         self.request = mock.MagicMock()
@@ -17,36 +16,39 @@ class OpenAPITest(BaseWebTest, unittest.TestCase):
         self.api_doc = self.generator.generate()
 
     def test_assign_base_path(self):
-        self.assertEqual(self.api_doc['basePath'], "/{}".format(self.api_prefix))
+        self.assertEqual(self.api_doc["basePath"], "/{}".format(self.api_prefix))
 
     def test_default_security_generator(self):
-        self.assertEqual(self.api_doc['paths']['/']['get']['security'], [])
-        self.assertEqual(self.api_doc['paths']['/mushrooms']['get']['security'],
-                         [{'basicauth': []}])
+        self.assertEqual(self.api_doc["paths"]["/"]["get"]["security"], [])
+        self.assertEqual(
+            self.api_doc["paths"]["/mushrooms"]["get"]["security"], [{"basicauth": []}]
+        )
 
     def test_security_extensions(self):
         method = {
             "type": "oauth2",
             "authorizationUrl": "https://oauth-stable.dev.lcip.org/v1",
             "flow": "implicit",
-            "scopes": {"kinto": "Kinto user scope."}
+            "scopes": {"kinto": "Kinto user scope."},
         }
 
         self.generator.expose_authentication_method("fxa", method)
         api_doc = self.generator.generate()
 
-        self.assertEqual(api_doc['securityDefinitions']['fxa'], method)
-        self.assertCountEqual(api_doc['paths']['/mushrooms']['get']['security'],
-                              [{'basicauth': []}, {'fxa': ['kinto']}])
+        self.assertEqual(api_doc["securityDefinitions"]["fxa"], method)
+        self.assertCountEqual(
+            api_doc["paths"]["/mushrooms"]["get"]["security"],
+            [{"basicauth": []}, {"fxa": ["kinto"]}],
+        )
 
     def test_default_tags(self):
-        self.assertEqual(self.api_doc['paths']['/mushrooms']['get']['tags'],
-                         ['Mushrooms'])
-        self.assertEqual(self.api_doc['paths']['/mushrooms/{id}']['get']['tags'],
-                         ['Mushrooms'])
+        self.assertEqual(self.api_doc["paths"]["/mushrooms"]["get"]["tags"], ["Mushrooms"])
+        self.assertEqual(self.api_doc["paths"]["/mushrooms/{id}"]["get"]["tags"], ["Mushrooms"])
 
     def test_default_operation_ids(self):
-        self.assertEqual(self.api_doc['paths']['/mushrooms']['get']['operationId'],
-                         'get_mushrooms')
-        self.assertEqual(self.api_doc['paths']['/mushrooms/{id}']['get']['operationId'],
-                         'get_mushroom')
+        self.assertEqual(
+            self.api_doc["paths"]["/mushrooms"]["get"]["operationId"], "get_mushrooms"
+        )
+        self.assertEqual(
+            self.api_doc["paths"]["/mushrooms/{id}"]["get"]["operationId"], "get_mushroom"
+        )

--- a/tests/core/test_permission.py
+++ b/tests/core/test_permission.py
@@ -2,8 +2,11 @@ import unittest
 from unittest import mock
 
 from kinto.core.utils import sqlalchemy
-from kinto.core.permission import (PermissionBase, memory as memory_backend,
-                                   postgresql as postgresql_backend)
+from kinto.core.permission import (
+    PermissionBase,
+    memory as memory_backend,
+    postgresql as postgresql_backend,
+)
 from kinto.core.permission.testing import PermissionTest
 from kinto.core.testing import skip_if_no_postgresql
 
@@ -16,17 +19,17 @@ class PermissionBaseTest(unittest.TestCase):
         calls = [
             (self.permission.initialize_schema,),
             (self.permission.flush,),
-            (self.permission.add_user_principal, '', ''),
-            (self.permission.remove_user_principal, '', ''),
-            (self.permission.remove_principal, ''),
-            (self.permission.get_user_principals, ''),
-            (self.permission.add_principal_to_ace, '', '', ''),
-            (self.permission.remove_principal_from_ace, '', '', ''),
-            (self.permission.get_object_permission_principals, '', ''),
-            (self.permission.get_objects_permissions, ''),
-            (self.permission.replace_object_permissions, '', {}),
-            (self.permission.delete_object_permissions, ''),
-            (self.permission.get_accessible_objects, [], ''),
+            (self.permission.add_user_principal, "", ""),
+            (self.permission.remove_user_principal, "", ""),
+            (self.permission.remove_principal, ""),
+            (self.permission.get_user_principals, ""),
+            (self.permission.add_principal_to_ace, "", "", ""),
+            (self.permission.remove_principal_from_ace, "", "", ""),
+            (self.permission.get_object_permission_principals, "", ""),
+            (self.permission.get_objects_permissions, ""),
+            (self.permission.replace_object_permissions, "", {}),
+            (self.permission.delete_object_permissions, ""),
+            (self.permission.get_accessible_objects, [], ""),
             (self.permission.get_authorized_principals, []),
         ]
         for call in calls:
@@ -50,14 +53,17 @@ class MemoryPermissionTest(PermissionTest, unittest.TestCase):
 class PostgreSQLPermissionTest(PermissionTest, unittest.TestCase):
     backend = postgresql_backend
     settings = {
-        'permission_backend': 'kinto.core.permission.postgresql',
-        'permission_pool_size': 10,
-        'permission_url': 'postgres://postgres:postgres@localhost:5432/testdb'
+        "permission_backend": "kinto.core.permission.postgresql",
+        "permission_pool_size": 10,
+        "permission_url": "postgres://postgres:postgres@localhost:5432/testdb",
     }
 
     def setUp(self):
         super().setUp()
-        self.client_error_patcher = [mock.patch.object(
-            self.permission.client,
-            'session_factory',
-            side_effect=sqlalchemy.exc.SQLAlchemyError)]
+        self.client_error_patcher = [
+            mock.patch.object(
+                self.permission.client,
+                "session_factory",
+                side_effect=sqlalchemy.exc.SQLAlchemyError,
+            )
+        ]

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -8,7 +8,7 @@ from kinto.core import schema
 
 class TimeStampTest(unittest.TestCase):
     def setUp(self):
-        patch = mock.patch('kinto.core.schema.msec_time')
+        patch = mock.patch("kinto.core.schema.msec_time")
         self.time_mocked = patch.start()
         self.time_mocked.return_value = 666
         self.addCleanup(patch.stop)
@@ -26,12 +26,10 @@ class TimeStampTest(unittest.TestCase):
 
 class URLTest(unittest.TestCase):
     def test_supports_full_url(self):
-        url = 'https://user:pass@myserver:9999/feeling.html#anchor'
+        url = "https://user:pass@myserver:9999/feeling.html#anchor"
         deserialized = schema.URL().deserialize(url)
         self.assertEqual(deserialized, url)
 
     def test_raises_invalid_if_no_scheme(self):
-        url = 'myserver/feeling.html#anchor'
-        self.assertRaises(colander.Invalid,
-                          schema.URL().deserialize,
-                          url)
+        url = "myserver/feeling.html#anchor"
+        self.assertRaises(colander.Invalid, schema.URL().deserialize, url)

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -10,7 +10,7 @@ class InitSchemaTest(unittest.TestCase):
         self.registry = mock.MagicMock()
 
     def test_migrate_calls_initialize_schema_on_backends(self):
-        scripts.migrate({'registry': self.registry})
+        scripts.migrate({"registry": self.registry})
         self.assertTrue(self.registry.storage.initialize_schema.called)
         self.assertTrue(self.registry.cache.initialize_schema.called)
         self.assertTrue(self.registry.permission.initialize_schema.called)
@@ -19,21 +19,24 @@ class InitSchemaTest(unittest.TestCase):
         class FakeRegistry:
             settings = dict()
             storage = mock.MagicMock()
+
         registry = FakeRegistry()
-        scripts.migrate({'registry': registry})
+        scripts.migrate({"registry": registry})
         self.assertTrue(registry.storage.initialize_schema.called)
 
     def test_migrate_in_read_only_display_an_error(self):
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            self.registry.settings = {'readonly': 'true'}
-            scripts.migrate({'registry': self.registry})
-            mocked.error.assert_any_call('Cannot migrate the storage backend '
-                                         'while in readonly mode.')
-            mocked.error.assert_any_call('Cannot migrate the permission '
-                                         'backend while in readonly mode.')
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            self.registry.settings = {"readonly": "true"}
+            scripts.migrate({"registry": self.registry})
+            mocked.error.assert_any_call(
+                "Cannot migrate the storage backend " "while in readonly mode."
+            )
+            mocked.error.assert_any_call(
+                "Cannot migrate the permission " "backend while in readonly mode."
+            )
 
     def test_migrate_in_dry_run_mode(self):
-        scripts.migrate({'registry': self.registry}, dry_run=True)
+        scripts.migrate({"registry": self.registry}, dry_run=True)
         reg = self.registry
         reg.storage.initialize_schema.assert_called_with(dry_run=True)
         reg.cache.initialize_schema.assert_called_with(dry_run=True)
@@ -45,107 +48,104 @@ class DeleteCollectionTest(unittest.TestCase):
         self.registry = mock.MagicMock()
 
     def test_delete_collection_in_read_only_display_an_error(self):
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            self.registry.settings = {'readonly': 'true'}
-            code = scripts.delete_collection({'registry': self.registry},
-                                             'test_bucket',
-                                             'test_collection')
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            self.registry.settings = {"readonly": "true"}
+            code = scripts.delete_collection(
+                {"registry": self.registry}, "test_bucket", "test_collection"
+            )
             assert code == 31
-            mocked.error.assert_any_call('Cannot delete the collection while '
-                                         'in readonly mode.')
+            mocked.error.assert_any_call("Cannot delete the collection while " "in readonly mode.")
 
     def test_delete_collection_remove_collection_records(self):
-        self.registry.storage.delete_all.return_value = [
-            {"id": "1234"}, {"id": "5678"}
-        ]
+        self.registry.storage.delete_all.return_value = [{"id": "1234"}, {"id": "5678"}]
 
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            scripts.delete_collection({'registry': self.registry},
-                                      'test_bucket',
-                                      'test_collection')
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            scripts.delete_collection(
+                {"registry": self.registry}, "test_bucket", "test_collection"
+            )
 
         self.registry.storage.delete_all.assert_called_with(
-            collection_id='record',
-            parent_id='/buckets/test_bucket/collections/test_collection',
-            with_deleted=False)
+            collection_id="record",
+            parent_id="/buckets/test_bucket/collections/test_collection",
+            with_deleted=False,
+        )
         self.registry.storage.delete.assert_called_with(
-            collection_id='collection',
-            parent_id='/buckets/test_bucket',
-            object_id='test_collection',
-            with_deleted=False)
+            collection_id="collection",
+            parent_id="/buckets/test_bucket",
+            object_id="test_collection",
+            with_deleted=False,
+        )
         self.registry.permission.delete_object_permissions.assert_called_with(
-            '/buckets/test_bucket/collections/test_collection',
-            '/buckets/test_bucket/collections/test_collection/records/1234',
-            '/buckets/test_bucket/collections/test_collection/records/5678')
+            "/buckets/test_bucket/collections/test_collection",
+            "/buckets/test_bucket/collections/test_collection/records/1234",
+            "/buckets/test_bucket/collections/test_collection/records/5678",
+        )
 
-        mocked.info.assert_any_call('2 record(s) were deleted.')
+        mocked.info.assert_any_call("2 record(s) were deleted.")
         mocked.info.assert_any_call(
-            "'/buckets/test_bucket/collections/test_collection' "
-            "collection object was deleted.")
+            "'/buckets/test_bucket/collections/test_collection' " "collection object was deleted."
+        )
 
     def test_delete_collection_tell_when_no_records_where_found(self):
         self.registry.storage.delete_all.return_value = []
 
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            scripts.delete_collection({'registry': self.registry},
-                                      'test_bucket',
-                                      'test_collection')
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            scripts.delete_collection(
+                {"registry": self.registry}, "test_bucket", "test_collection"
+            )
 
         mocked.info.assert_any_call(
-            "No records found for "
-            "'/buckets/test_bucket/collections/test_collection'.")
+            "No records found for " "'/buckets/test_bucket/collections/test_collection'."
+        )
         mocked.info.assert_any_call(
-            "'/buckets/test_bucket/collections/test_collection' "
-            "collection object was deleted.")
+            "'/buckets/test_bucket/collections/test_collection' " "collection object was deleted."
+        )
         mocked.info.assert_any_call("Related permissions were deleted.")
 
     def test_delete_collection_raise_if_the_bucket_does_not_exist(self):
         self.registry.storage.get.side_effect = RecordNotFoundError
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            resp = scripts.delete_collection({'registry': self.registry},
-                                             'test_bucket',
-                                             'test_collection')
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            resp = scripts.delete_collection(
+                {"registry": self.registry}, "test_bucket", "test_collection"
+            )
         assert resp == 32
-        mocked.error.assert_called_with(
-            "Bucket '/buckets/test_bucket' does not exist.")
+        mocked.error.assert_called_with("Bucket '/buckets/test_bucket' does not exist.")
 
     def test_delete_collection_raise_if_the_collection_does_not_exist(self):
-        self.registry.storage.get.side_effect = ['', RecordNotFoundError]
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            resp = scripts.delete_collection({'registry': self.registry},
-                                             'test_bucket',
-                                             'test_collection')
+        self.registry.storage.get.side_effect = ["", RecordNotFoundError]
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            resp = scripts.delete_collection(
+                {"registry": self.registry}, "test_bucket", "test_collection"
+            )
         assert resp == 33
         mocked.error.assert_called_with(
-            "Collection '/buckets/test_bucket/collections/test_collection' "
-            "does not exist.")
+            "Collection '/buckets/test_bucket/collections/test_collection' " "does not exist."
+        )
 
 
 class RebuildQuotasTest(unittest.TestCase):
     def setUp(self):
         self.registry = mock.MagicMock()
-        self.registry.settings = {
-            "includes": "kinto.plugins.quotas",
-        }
+        self.registry.settings = {"includes": "kinto.plugins.quotas"}
 
     def test_rebuild_quotas_in_read_only_display_an_error(self):
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            self.registry.settings['readonly'] = 'true'
-            code = scripts.rebuild_quotas({'registry': self.registry})
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            self.registry.settings["readonly"] = "true"
+            code = scripts.rebuild_quotas({"registry": self.registry})
             assert code == 41
-            mocked.error.assert_any_call('Cannot rebuild quotas while '
-                                         'in readonly mode.')
+            mocked.error.assert_any_call("Cannot rebuild quotas while " "in readonly mode.")
 
     def test_rebuild_quotas_when_not_included_display_an_error(self):
-        with mock.patch('kinto.core.scripts.logger') as mocked:
-            self.registry.settings['includes'] = ''
-            code = scripts.rebuild_quotas({'registry': self.registry})
+        with mock.patch("kinto.core.scripts.logger") as mocked:
+            self.registry.settings["includes"] = ""
+            code = scripts.rebuild_quotas({"registry": self.registry})
             assert code == 42
-            mocked.error.assert_any_call('Cannot rebuild quotas when '
-                                         'quotas plugin is not installed.')
+            mocked.error.assert_any_call(
+                "Cannot rebuild quotas when " "quotas plugin is not installed."
+            )
 
     def test_rebuild_quotas_calls_quotas_script(self):
-        with mock.patch('kinto.core.scripts.quotas.rebuild_quotas') as mocked:
-            code = scripts.rebuild_quotas({'registry': self.registry})
+        with mock.patch("kinto.core.scripts.quotas.rebuild_quotas") as mocked:
+            code = scripts.rebuild_quotas({"registry": self.registry})
             assert code == 0
             mocked.assert_called_with(self.registry.storage, dry_run=False)

--- a/tests/core/test_statsd.py
+++ b/tests/core/test_statsd.py
@@ -34,25 +34,20 @@ class StatsDMissing(unittest.TestCase):
 
 @skip_if_no_statsd
 class StatsdClientTest(unittest.TestCase):
-    settings = {
-        'statsd_url': 'udp://foo:1234',
-        'statsd_prefix': 'prefix',
-        'project_name': '',
-    }
+    settings = {"statsd_url": "udp://foo:1234", "statsd_prefix": "prefix", "project_name": ""}
 
     def setUp(self):
-        self.client = statsd.Client('localhost', 1234, 'prefix')
+        self.client = statsd.Client("localhost", 1234, "prefix")
         self.test_object = TestedClass()
 
-        with mock.patch.object(self.client, '_client') as mocked_client:
-            self.client.watch_execution_time(self.test_object, prefix='test')
+        with mock.patch.object(self.client, "_client") as mocked_client:
+            self.client.watch_execution_time(self.test_object, prefix="test")
             self.mocked_client = mocked_client
 
     def test_public_methods_generates_statsd_calls(self):
         self.test_object.test_method()
 
-        self.mocked_client.timer.assert_called_with(
-            'test.testedclass.test_method')
+        self.mocked_client.timer.assert_called_with("test.testedclass.test_method")
 
     def test_private_methods_does_not_generates_statsd_calls(self):
         self.mocked_client.reset_mock()
@@ -60,65 +55,61 @@ class StatsdClientTest(unittest.TestCase):
         self.assertFalse(self.mocked_client.timer.called)
 
     def test_count_increments_the_counter_for_key(self):
-        with mock.patch.object(self.client, '_client') as mocked_client:
-            self.client.count('click')
-            mocked_client.incr.assert_called_with('click', count=1)
+        with mock.patch.object(self.client, "_client") as mocked_client:
+            self.client.count("click")
+            mocked_client.incr.assert_called_with("click", count=1)
 
     def test_count_with_unique_uses_sets_for_key(self):
-        with mock.patch.object(self.client, '_client') as mocked_client:
-            self.client.count('click', unique='menu')
-            mocked_client.set.assert_called_with('click', 'menu')
+        with mock.patch.object(self.client, "_client") as mocked_client:
+            self.client.count("click", unique="menu")
+            mocked_client.set.assert_called_with("click", "menu")
 
-    @mock.patch('kinto.core.statsd.statsd_module')
+    @mock.patch("kinto.core.statsd.statsd_module")
     def test_load_from_config(self, module_mock):
         config = testing.setUp()
         config.registry.settings = self.settings
         statsd.load_from_config(config)
-        module_mock.StatsClient.assert_called_with('foo', 1234,
-                                                   prefix='prefix')
+        module_mock.StatsClient.assert_called_with("foo", 1234, prefix="prefix")
 
-    @mock.patch('kinto.core.statsd.statsd_module')
+    @mock.patch("kinto.core.statsd.statsd_module")
     def test_load_from_config_uses_project_name_if_defined(self, module_mock):
         config = testing.setUp()
-        config.registry.settings = {**self.settings, 'project_name': 'projectname'}
+        config.registry.settings = {**self.settings, "project_name": "projectname"}
         statsd.load_from_config(config)
-        module_mock.StatsClient.assert_called_with('foo', 1234,
-                                                   prefix='projectname')
+        module_mock.StatsClient.assert_called_with("foo", 1234, prefix="projectname")
 
     def test_statsd_count_handle_unconfigured_statsd_client(self):
         request = mock.MagicMock()
         request.registry.statsd = None
-        statsd.statsd_count(request, 'toto')  # Doesn't raise
+        statsd.statsd_count(request, "toto")  # Doesn't raise
 
     def test_statsd_count_call_the_client_if_configured(self):
         request = mock.MagicMock()
         request.registry.statsd = self.mocked_client
-        statsd.statsd_count(request, 'toto')
-        self.mocked_client.count.assert_called_with('toto')
+        statsd.statsd_count(request, "toto")
+        self.mocked_client.count.assert_called_with("toto")
 
 
 @skip_if_no_statsd
 class TimingTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, *args, **kwargs):
         settings = super().get_app_settings(*args, **kwargs)
         if not statsd.statsd_module:
             return settings
 
-        settings['statsd_url'] = 'udp://localhost:8125'
+        settings["statsd_url"] = "udp://localhost:8125"
         return settings
 
     def test_statds_tracks_listeners_execution_duration(self):
         statsd_client = self.app.app.registry.statsd._client
-        with mock.patch.object(statsd_client, 'timing') as mocked:
-            self.app.get('/', headers=self.headers)
+        with mock.patch.object(statsd_client, "timing") as mocked:
+            self.app.get("/", headers=self.headers)
             self.assertTrue(mocked.called)
 
     def test_statds_tracks_authentication_policies(self):
         statsd_client = self.app.app.registry.statsd._client
-        with mock.patch.object(statsd_client, 'timing') as mocked:
-            self.app.get('/', headers=self.headers)
+        with mock.patch.object(statsd_client, "timing") as mocked:
+            self.app.get("/", headers=self.headers)
             timers = set(c[0][0] for c in mocked.call_args_list)
-            self.assertIn('authentication.basicauth.unauthenticated_userid',
-                          timers)
+            self.assertIn("authentication.basicauth.unauthenticated_userid", timers)

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -7,7 +7,7 @@ from kinto.core.storage import generators, memory, postgresql, exceptions, Stora
 from kinto.core.storage import Filter, Sort, MISSING
 from kinto.core.storage.testing import StorageTest
 from kinto.core.storage.utils import paginated
-from kinto.core.testing import (unittest, skip_if_no_postgresql)
+from kinto.core.testing import unittest, skip_if_no_postgresql
 
 
 class GeneratorTest(unittest.TestCase):
@@ -17,33 +17,33 @@ class GeneratorTest(unittest.TestCase):
     def test_id_generator_must_respect_storage_backends(self):
         class Dumb(generators.Generator):
             def __call__(self):
-                return '*' * 80
+                return "*" * 80
 
         self.assertRaises(ValueError, Dumb)
 
     def test_default_generator_allow_underscores_dash_alphabet(self):
         class Dumb(generators.Generator):
             def __call__(self):
-                return '1234'
+                return "1234"
 
         generator = Dumb()
-        self.assertTrue(generator.match('1_2_3-abc'))
-        self.assertTrue(generator.match('abc_123'))
-        self.assertFalse(generator.match('-1_2_3-abc'))
-        self.assertFalse(generator.match('_1_2_3-abc'))
+        self.assertTrue(generator.match("1_2_3-abc"))
+        self.assertTrue(generator.match("abc_123"))
+        self.assertFalse(generator.match("-1_2_3-abc"))
+        self.assertFalse(generator.match("_1_2_3-abc"))
 
     def test_uuid_generator_pattern_allows_uuid_only(self):
-        invalid_uuid = 'XXX-00000000-0000-5000-a000-000000000000'
+        invalid_uuid = "XXX-00000000-0000-5000-a000-000000000000"
         generator = generators.UUID4()
         self.assertFalse(generator.match(invalid_uuid))
 
     def test_uuid_generator_pattern_is_not_restricted_to_uuid4(self):
         generator = generators.UUID4()
-        valid_uuid = 'fd800e8d-e8e9-3cac-f502-816cbed9bb6c'
+        valid_uuid = "fd800e8d-e8e9-3cac-f502-816cbed9bb6c"
         self.assertTrue(generator.match(valid_uuid))
-        invalid_uuid4 = '00000000-0000-5000-a000-000000000000'
+        invalid_uuid4 = "00000000-0000-5000-a000-000000000000"
         self.assertTrue(generator.match(invalid_uuid4))
-        invalid_uuid4 = '00000000-0000-4000-e000-000000000000'
+        invalid_uuid4 = "00000000-0000-4000-e000-000000000000"
         self.assertTrue(generator.match(invalid_uuid4))
 
 
@@ -55,14 +55,14 @@ class StorageBaseTest(unittest.TestCase):
         calls = [
             (self.storage.initialize_schema,),
             (self.storage.flush,),
-            (self.storage.collection_timestamp, '', ''),
-            (self.storage.create, '', '', {}),
-            (self.storage.get, '', '', ''),
-            (self.storage.update, '', '', '', {}),
-            (self.storage.delete, '', '', ''),
-            (self.storage.delete_all, '', ''),
-            (self.storage.purge_deleted, '', ''),
-            (self.storage.get_all, '', ''),
+            (self.storage.collection_timestamp, "", ""),
+            (self.storage.create, "", "", {}),
+            (self.storage.get, "", "", ""),
+            (self.storage.update, "", "", "", {}),
+            (self.storage.delete, "", "", ""),
+            (self.storage.delete_all, "", ""),
+            (self.storage.purge_deleted, "", ""),
+            (self.storage.get_all, "", ""),
         ]
         for call in calls:
             self.assertRaises(NotImplementedError, *call)
@@ -85,16 +85,15 @@ class MemoryBasedStorageTest(unittest.TestCase):
 
 class MemoryStorageTest(StorageTest, unittest.TestCase):
     backend = memory
-    settings = {
-        'storage_strict_json': True
-    }
+    settings = {"storage_strict_json": True}
 
     def setUp(self):
         super().setUp()
         self.client_error_patcher = mock.patch.object(
             self.storage,
-            'bump_and_store_timestamp',
-            side_effect=exceptions.BackendError("Segmentation fault."))
+            "bump_and_store_timestamp",
+            side_effect=exceptions.BackendError("Segmentation fault."),
+        )
 
     def test_backend_error_provides_original_exception(self):
         pass
@@ -113,53 +112,49 @@ class MemoryStorageTest(StorageTest, unittest.TestCase):
 
 
 class LenientMemoryStorageTest(MemoryStorageTest):
-    settings = {
-        'storage_strict_json': False
-    }
+    settings = {"storage_strict_json": False}
 
     def test_create_bytes_raises(self):
-        data = {'steak': 'haché'.encode(encoding='utf-8')}
-        self.assertIsInstance(data['steak'], bytes)
+        data = {"steak": "haché".encode(encoding="utf-8")}
+        self.assertIsInstance(data["steak"], bytes)
         self.assertIsNotNone(self.create_record(data))
 
     def test_update_bytes_raises(self):
         record = self.create_record()
 
-        new_record = {'steak': 'haché'.encode(encoding='utf-8')}
-        self.assertIsInstance(new_record['steak'], bytes)
+        new_record = {"steak": "haché".encode(encoding="utf-8")}
+        self.assertIsInstance(new_record["steak"], bytes)
 
-        self.assertIsNotNone(self.storage.update(
-                                object_id=record['id'],
-                                record=new_record,
-                                **self.storage_kw))
+        self.assertIsNotNone(
+            self.storage.update(object_id=record["id"], record=new_record, **self.storage_kw)
+        )
 
 
 @skip_if_no_postgresql
 class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
     backend = postgresql
     settings = {
-        'storage_max_fetch_size': 10000,
-        'storage_backend': 'kinto.core.storage.postgresql',
-        'storage_poolclass': 'sqlalchemy.pool.StaticPool',
-        'storage_url': 'postgres://postgres:postgres@localhost:5432/testdb',
-        'storage_strict_json': True
+        "storage_max_fetch_size": 10000,
+        "storage_backend": "kinto.core.storage.postgresql",
+        "storage_poolclass": "sqlalchemy.pool.StaticPool",
+        "storage_url": "postgres://postgres:postgres@localhost:5432/testdb",
+        "storage_strict_json": True,
     }
 
     def setUp(self):
         super().setUp()
         self.client_error_patcher = mock.patch.object(
-            self.storage.client,
-            'session_factory',
-            side_effect=sqlalchemy.exc.SQLAlchemyError)
+            self.storage.client, "session_factory", side_effect=sqlalchemy.exc.SQLAlchemyError
+        )
 
     def test_number_of_fetched_records_can_be_limited_in_settings(self):
         for i in range(4):
-            self.create_record({'phone': 'tel-{}'.format(i)})
+            self.create_record({"phone": "tel-{}".format(i)})
 
         results, count = self.storage.get_all(**self.storage_kw)
         self.assertEqual(len(results), 4)
 
-        settings = {**self.settings, 'storage_max_fetch_size': 2}
+        settings = {**self.settings, "storage_max_fetch_size": 2}
         config = self._get_config(settings=settings)
         limited = self.backend.load_from_config(config)
 
@@ -169,15 +164,15 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
 
     def test_number_of_fetched_records_is_per_page(self):
         for i in range(10):
-            self.create_record({'number': i})
+            self.create_record({"number": i})
 
-        settings = {**self.settings, 'storage_max_fetch_size': 2}
+        settings = {**self.settings, "storage_max_fetch_size": 2}
         config = self._get_config(settings=settings)
         backend = self.backend.load_from_config(config)
 
-        results, count = backend.get_all(pagination_rules=[
-                                             [Filter('number', 1, COMPARISON.GT)]
-                                         ], **self.storage_kw)
+        results, count = backend.get_all(
+            pagination_rules=[[Filter("number", 1, COMPARISON.GT)]], **self.storage_kw
+        )
         self.assertEqual(count, 10)
         self.assertEqual(len(results), 2)
 
@@ -212,35 +207,37 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
         config = self._get_config()
         storage1 = self.backend.load_from_config(config)
         storage2 = self.backend.load_from_config(config)
-        self.assertEqual(id(storage1.client),
-                         id(storage2.client))
+        self.assertEqual(id(storage1.client), id(storage2.client))
 
     def test_warns_if_configured_pool_size_differs_for_same_backend_type(self):
         self.backend.load_from_config(self._get_config())
-        settings = {**self.settings, 'storage_pool_size': 1}
-        msg = ('Reuse existing PostgreSQL connection. Parameters storage_* '
-               'will be ignored.')
-        with mock.patch('kinto.core.storage.postgresql.client.'
-                        'warnings.warn') as mocked:
+        settings = {**self.settings, "storage_pool_size": 1}
+        msg = "Reuse existing PostgreSQL connection. Parameters storage_* " "will be ignored."
+        with mock.patch("kinto.core.storage.postgresql.client." "warnings.warn") as mocked:
             self.backend.load_from_config(self._get_config(settings=settings))
             mocked.assert_any_call(msg)
 
     def test_get_all_raises_if_missing_on_strange_query(self):
         with self.assertRaises(ValueError):
-            self.storage.get_all('some-collection', 'some-parent',
-                                 filters=[Filter("author", MISSING, COMPARISON.HAS)])
+            self.storage.get_all(
+                "some-collection",
+                "some-parent",
+                filters=[Filter("author", MISSING, COMPARISON.HAS)],
+            )
 
     def test_integrity_error_rollsback_transaction(self):
-        client = postgresql.create_from_config(self._get_config(),
-                                               prefix='storage_',
-                                               with_transaction=False)
+        client = postgresql.create_from_config(
+            self._get_config(), prefix="storage_", with_transaction=False
+        )
         with self.assertRaises(exceptions.IntegrityError):
             with client.connect() as conn:
                 # Make some change in a table.
-                conn.execute("""
+                conn.execute(
+                    """
                 INSERT INTO records
                 VALUES ('rock-and-roll', 'music', 'genre', NOW(), '{}', FALSE);
-                """)
+                """
+                )
                 # Go into a failing integrity constraint.
                 query = "INSERT INTO timestamps VALUES ('a', 'b', NOW());"
                 conn.execute(query)
@@ -250,26 +247,28 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
 
         # Check that change in the above table was rolledback.
         with client.connect() as conn:
-            result = conn.execute("""
+            result = conn.execute(
+                """
             SELECT FROM records
              WHERE parent_id = 'music'
                AND collection_id = 'genre';
-            """)
+            """
+            )
         self.assertEqual(result.rowcount, 0)
 
     def test_conflicts_handled_correctly(self):
         config = self._get_config()
         storage = self.backend.load_from_config(config)
-        storage.create(collection_id='genre', parent_id='music',
-                       record={'id': 'rock-and-roll'})
+        storage.create(collection_id="genre", parent_id="music", record={"id": "rock-and-roll"})
 
         def record_not_found(*args, **kwargs):
             raise exceptions.RecordNotFoundError()
 
-        with mock.patch.object(storage, 'get', side_effect=record_not_found):
+        with mock.patch.object(storage, "get", side_effect=record_not_found):
             with self.assertRaises(exceptions.UnicityError):
-                storage.create(collection_id='genre', parent_id='music',
-                               record={'id': 'rock-and-roll'})
+                storage.create(
+                    collection_id="genre", parent_id="music", record={"id": "rock-and-roll"}
+                )
 
 
 class PaginatedTest(unittest.TestCase):
@@ -289,19 +288,21 @@ class PaginatedTest(unittest.TestCase):
         self.storage.get_all.side_effect = sample_records_side_effect
 
     def test_paginated_passes_sort(self):
-        i = paginated(self.storage, sorting=[Sort('id', -1)])
-        next(i)   # make the generator do anything
-        self.storage.get_all.assert_called_with(sorting=[Sort('id', -1)],
-                                                limit=25, pagination_rules=None)
+        i = paginated(self.storage, sorting=[Sort("id", -1)])
+        next(i)  # make the generator do anything
+        self.storage.get_all.assert_called_with(
+            sorting=[Sort("id", -1)], limit=25, pagination_rules=None
+        )
 
     def test_paginated_passes_batch_size(self):
-        i = paginated(self.storage, sorting=[Sort('id', -1)], batch_size=17)
-        next(i)   # make the generator do anything
-        self.storage.get_all.assert_called_with(sorting=[Sort('id', -1)],
-                                                limit=17, pagination_rules=None)
+        i = paginated(self.storage, sorting=[Sort("id", -1)], batch_size=17)
+        next(i)  # make the generator do anything
+        self.storage.get_all.assert_called_with(
+            sorting=[Sort("id", -1)], limit=17, pagination_rules=None
+        )
 
     def test_paginated_yields_records(self):
-        iter = paginated(self.storage, sorting=[Sort('id', -1)])
+        iter = paginated(self.storage, sorting=[Sort("id", -1)])
         assert next(iter) == {"id": "record-01", "flavor": "strawberry"}
 
     def test_paginated_fetches_next_page(self):
@@ -315,13 +316,17 @@ class PaginatedTest(unittest.TestCase):
 
         self.storage.get_all.side_effect = get_all_mock
 
-        list(paginated(self.storage, sorting=[Sort('id', -1)]))
+        list(paginated(self.storage, sorting=[Sort("id", -1)]))
         assert self.storage.get_all.call_args_list == [
-            mock.call(sorting=[Sort('id', -1)], limit=25, pagination_rules=None),
-            mock.call(sorting=[Sort('id', -1)], limit=25, pagination_rules=[
-                [Filter('id', 'record-03', COMPARISON.LT)]
-            ]),
-            mock.call(sorting=[Sort('id', -1)], limit=25, pagination_rules=[
-                [Filter('id', 'record-01', COMPARISON.LT)]
-            ]),
+            mock.call(sorting=[Sort("id", -1)], limit=25, pagination_rules=None),
+            mock.call(
+                sorting=[Sort("id", -1)],
+                limit=25,
+                pagination_rules=[[Filter("id", "record-03", COMPARISON.LT)]],
+            ),
+            mock.call(
+                sorting=[Sort("id", -1)],
+                limit=25,
+                pagination_rules=[[Filter("id", "record-01", COMPARISON.LT)]],
+            ),
         ]

--- a/tests/core/test_storage_pool.py
+++ b/tests/core/test_storage_pool.py
@@ -15,17 +15,19 @@ class QueuePoolWithMaxBacklogTest(unittest.TestCase):
         self.connections = []
         self.errors = []
 
-        config = testing.setUp(settings={
-            'pooltest_url': 'sqlite:///:memory:',
-            'pooltest_pool_size': 2,
-            'pooltest_pool_timeout': 1,
-            'pooltest_max_backlog': 2,
-            'pooltest_max_overflow': 1,
-        })
+        config = testing.setUp(
+            settings={
+                "pooltest_url": "sqlite:///:memory:",
+                "pooltest_pool_size": 2,
+                "pooltest_pool_timeout": 1,
+                "pooltest_max_backlog": 2,
+                "pooltest_max_overflow": 1,
+            }
+        )
         # Create an engine with known pool parameters.
         # Use create_from_config() to make sure it is used by default
         # and handles parameters.
-        client = create_from_config(config, prefix='pooltest_')
+        client = create_from_config(config, prefix="pooltest_")
         session = client.session_factory()
         self.engine = session.get_bind()
 
@@ -75,6 +77,7 @@ class QueuePoolWithMaxBacklogTest(unittest.TestCase):
 
     def test_recreates_reinstantiate_with_same_pool_class(self):
         from kinto.core.storage.postgresql.pool import QueuePoolWithMaxBacklog
+
         pool = QueuePoolWithMaxBacklog(None, max_backlog=2, pool_size=2)
         other = pool.recreate()
         self.assertEqual(pool._pool.__class__, other._pool.__class__)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -11,11 +11,21 @@ from pyramid import request as pyramid_request
 from pyramid import testing
 
 from kinto.core.utils import (
-    native_value, strip_whitespace, random_bytes_hex, read_env, hmac_digest,
-    current_service, follow_subrequest, build_request, dict_subset, dict_merge,
-    parse_resource, prefixed_principals, recursive_update_dict,
+    native_value,
+    strip_whitespace,
+    random_bytes_hex,
+    read_env,
+    hmac_digest,
+    current_service,
+    follow_subrequest,
+    build_request,
+    dict_subset,
+    dict_merge,
+    parse_resource,
+    prefixed_principals,
+    recursive_update_dict,
     instance_uri_registry,
-    find_nested_value
+    find_nested_value,
 )
 from kinto.core.testing import DummyRequest
 
@@ -32,40 +42,40 @@ def build_real_request(wsgi_environ):
 
 class NativeValueTest(unittest.TestCase):
     def test_simple_string(self):
-        self.assertEqual(native_value('value'), 'value')
+        self.assertEqual(native_value("value"), "value")
 
     def test_defined_string(self):
-        self.assertEqual(native_value('"value"'), 'value')
+        self.assertEqual(native_value('"value"'), "value")
 
     def test_null_value(self):
-        self.assertEqual(native_value('null'), None)
+        self.assertEqual(native_value("null"), None)
 
     def test_defined_null_as_text_value(self):
-        self.assertEqual(native_value('"null"'), 'null')
+        self.assertEqual(native_value('"null"'), "null")
 
     def test_integer(self):
-        self.assertEqual(native_value('7'), 7)
+        self.assertEqual(native_value("7"), 7)
 
     def test_defined_integer_as_text_value(self):
-        self.assertEqual(native_value('"7"'), '7')
+        self.assertEqual(native_value('"7"'), "7")
 
     def test_defined_simple_quote_string_as_text_value(self):
         self.assertEqual(native_value("'7'"), "'7'")
 
     def test_zero_and_one_coerce_to_integers(self):
-        self.assertEqual(native_value('1'), 1)
-        self.assertEqual(native_value('0'), 0)
+        self.assertEqual(native_value("1"), 1)
+        self.assertEqual(native_value("0"), 0)
 
     def test_float(self):
-        self.assertEqual(native_value('3.14'), 3.14)
+        self.assertEqual(native_value("3.14"), 3.14)
 
     def test_true_values(self):
-        true_strings = ['true']
+        true_strings = ["true"]
         true_values = [native_value(s) for s in true_strings]
         self.assertTrue(all(true_values))
 
     def test_false_values(self):
-        false_strings = ['false']
+        false_strings = ["false"]
         false_values = [native_value(s) for s in false_strings]
         self.assertFalse(any(false_values))
 
@@ -80,10 +90,10 @@ class NativeValueTest(unittest.TestCase):
 class StripWhitespaceTest(unittest.TestCase):
     def test_removes_all_kinds_of_spaces(self):
         value = " \t teaser \n \r"
-        self.assertEqual(strip_whitespace(value), 'teaser')
+        self.assertEqual(strip_whitespace(value), "teaser")
 
     def test_does_remove_middle_spaces(self):
-        self.assertEqual(strip_whitespace('a b c'), 'a b c')
+        self.assertEqual(strip_whitespace("a b c"), "a b c")
 
     def test_idempotent_for_null_values(self):
         self.assertEqual(strip_whitespace(colander.null), colander.null)
@@ -119,69 +129,62 @@ class HmacDigestTest(unittest.TestCase):
 
 class ReadEnvironmentTest(unittest.TestCase):
     def test_return_passed_value_if_not_defined_in_env(self):
-        self.assertEqual(read_env('missing', 12), 12)
+        self.assertEqual(read_env("missing", 12), 12)
 
     def test_return_env_value_if_defined_in_env(self):
-        os.environ.setdefault('KINTO_CONF', 'abc')
-        self.assertEqual(read_env('KINTO_CONF', 12), 'abc')
+        os.environ.setdefault("KINTO_CONF", "abc")
+        self.assertEqual(read_env("KINTO_CONF", 12), "abc")
 
     def test_return_env_name_as_uppercase(self):
-        os.environ.setdefault('KINTO_NAME', 'abc')
-        self.assertEqual(read_env('kinto.name', 12), 'abc')
+        os.environ.setdefault("KINTO_NAME", "abc")
+        self.assertEqual(read_env("kinto.name", 12), "abc")
 
     def test_return_env_value_is_coerced_to_python(self):
-        os.environ.setdefault('KINTO_CONF_NAME', '3.14')
-        self.assertEqual(read_env('kinto-conf.name', 12), 3.14)
+        os.environ.setdefault("KINTO_CONF_NAME", "3.14")
+        self.assertEqual(read_env("kinto-conf.name", 12), 3.14)
 
 
 class CurrentServiceTest(unittest.TestCase):
-
     def test_current_service_returns_the_service_for_existing_patterns(self):
         request = DummyRequest()
-        request.matched_route.pattern = '/buckets'
-        request.registry.cornice_services = {'/buckets': mock.sentinel.service}
+        request.matched_route.pattern = "/buckets"
+        request.registry.cornice_services = {"/buckets": mock.sentinel.service}
 
         self.assertEqual(current_service(request), mock.sentinel.service)
 
     def test_current_service_returns_none_for_unexisting_patterns(self):
         request = DummyRequest()
-        request.matched_route.pattern = '/unexisting'
+        request.matched_route.pattern = "/unexisting"
         request.registry.cornice_services = {}
 
         self.assertEqual(current_service(request), None)
 
 
 class PrefixedPrincipalsTest(unittest.TestCase):
-
     def test_removes_unprefixed_from_principals(self):
         request = DummyRequest()
-        request.effective_principals = ['foo', 'system.Authenticated']
-        request.prefixed_userid = 'basic:foo'
-        self.assertEqual(prefixed_principals(request),
-                         ['basic:foo', 'system.Authenticated'])
+        request.effective_principals = ["foo", "system.Authenticated"]
+        request.prefixed_userid = "basic:foo"
+        self.assertEqual(prefixed_principals(request), ["basic:foo", "system.Authenticated"])
 
     def test_works_if_userid_is_not_in_principals(self):
         request = DummyRequest()
-        request.effective_principals = ['basic:foo', 'system.Authenticated']
-        request.prefixed_userid = 'basic:foo'
-        self.assertEqual(prefixed_principals(request),
-                         ['basic:foo', 'system.Authenticated'])
+        request.effective_principals = ["basic:foo", "system.Authenticated"]
+        request.prefixed_userid = "basic:foo"
+        self.assertEqual(prefixed_principals(request), ["basic:foo", "system.Authenticated"])
 
 
 class BuildRequestTest(unittest.TestCase):
-
     def test_built_request_has_kinto_core_custom_methods(self):
-        original = build_real_request({'PATH_INFO': '/foo'})
+        original = build_real_request({"PATH_INFO": "/foo"})
         request = build_request(original, {"path": "bar"})
-        self.assertTrue(hasattr(request, 'current_service'))
+        self.assertTrue(hasattr(request, "current_service"))
 
 
 class FollowSubrequestTest(unittest.TestCase):
-
     def test_parent_and_bound_data_are_preserved(self):
         request = DummyRequest()
-        request.invoke_subrequest.side_effect = (
-            httpexceptions.HTTPTemporaryRedirect, None)
+        request.invoke_subrequest.side_effect = (httpexceptions.HTTPTemporaryRedirect, None)
         subrequest = DummyRequest()
         subrequest.parent = mock.sentinel.parent
         subrequest.bound_data = mock.sentinel.bound_data
@@ -191,7 +194,6 @@ class FollowSubrequestTest(unittest.TestCase):
 
 
 class DictSubsetTest(unittest.TestCase):
-
     def test_extract_by_keys(self):
         obtained = dict_subset(dict(a=1, b=2), ["b"])
         expected = dict(b=2)
@@ -237,7 +239,6 @@ class DictSubsetTest(unittest.TestCase):
 
 
 class DictMergeTest(unittest.TestCase):
-
     def test_merge(self):
         obtained = dict_merge(dict(a=1, b=dict(c=2)), dict(b=dict(d=4)))
         expected = dict(a=1, b=dict(c=2, d=4))
@@ -245,7 +246,6 @@ class DictMergeTest(unittest.TestCase):
 
 
 class FindNestedValueTest(unittest.TestCase):
-
     def test_find_flat_value(self):
         record = {"a": 42}
         obtained = find_nested_value(record, "a")
@@ -302,12 +302,11 @@ class FindNestedValueTest(unittest.TestCase):
 
 
 class RecursiveUpdateDictTest(unittest.TestCase):
-
     def test_merge(self):
         a = {}
-        recursive_update_dict(a, {'b': {'c': 1}, 'd': 2})
-        self.assertEqual(a['b']['c'], 1)
-        self.assertEqual(a['d'], 2)
+        recursive_update_dict(a, {"b": {"c": 1}, "d": 2})
+        self.assertEqual(a["b"]["c"], 1)
+        self.assertEqual(a["d"], 2)
 
     def test_merge_non_dict(self):
         a = {}
@@ -317,10 +316,7 @@ class RecursiveUpdateDictTest(unittest.TestCase):
 
 class ParseResourceTest(unittest.TestCase):
 
-    expected = {
-        'bucket': 'bid',
-        'collection': 'cid'
-    }
+    expected = {"bucket": "bid", "collection": "cid"}
     error_msg = "Resources should be defined as "
     "'/buckets/<bid>/collections/<cid>' or '<bid>/<cid>'. "
     "with valid collection and bucket ids."
@@ -336,7 +332,7 @@ class ParseResourceTest(unittest.TestCase):
             self.assertEqual(str(excinfo.value), self.error_msg)
 
     def test_malformed_url_raises_an_exception(self):
-        input_arr = ['foo', '/', '/bar', 'baz/', '/fo/o', '/buckets/sbid/scid']
+        input_arr = ["foo", "/", "/bar", "baz/", "/fo/o", "/buckets/sbid/scid"]
         self._assert_error(input_arr)
 
     def test_returned_resources_match_the_expected_format(self):
@@ -348,20 +344,20 @@ class ParseResourceTest(unittest.TestCase):
         self._assert_success(input)
 
     def test_resources_must_be_valid_names(self):
-        input_arr = ['/buckets/bi+d1/collections/cid', '/buckets/bid1/collections/dci,d']
+        input_arr = ["/buckets/bi+d1/collections/cid", "/buckets/bid1/collections/dci,d"]
         self._assert_error(input_arr)
 
 
 class InstanceURIRegistryTest(unittest.TestCase):
-    @mock.patch('kinto.core.utils.instance_uri')
+    @mock.patch("kinto.core.utils.instance_uri")
     def test_instance_uri_registry_calls_instance_uri(self, instance_uri):
         registry = mock.Mock()
-        instance_uri_registry(registry, 'record', a=1)
+        instance_uri_registry(registry, "record", a=1)
         self.assertEqual(len(instance_uri.call_args_list), 1)
         (args, kwargs) = instance_uri.call_args_list[0]
         self.assertEqual(len(args), 2)
 
         self.assertEqual(args[0].registry, registry)
-        self.assertEqual(args[1], 'record')
+        self.assertEqual(args[1], "record")
 
-        self.assertEqual(kwargs, {'a': 1})
+        self.assertEqual(kwargs, {"a": 1})

--- a/tests/core/test_views_batch.py
+++ b/tests/core/test_views_batch.py
@@ -13,161 +13,152 @@ from .support import BaseWebTest
 
 
 class BatchViewTest(BaseWebTest, unittest.TestCase):
-
     def test_does_not_require_authentication(self):
-        body = {'requests': []}
-        self.app.post_json('/batch', body)
+        body = {"requests": []}
+        self.app.post_json("/batch", body)
 
     def test_returns_400_if_body_has_missing_requests(self):
-        self.app.post('/batch', {}, headers=self.headers, status=400)
+        self.app.post("/batch", {}, headers=self.headers, status=400)
 
     def test_returns_responses_if_schema_is_valid(self):
-        body = {'requests': []}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        self.assertIn('responses', resp.json)
+        body = {"requests": []}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        self.assertIn("responses", resp.json)
 
     def test_defaults_are_applied_to_requests(self):
-        request = {'path': '/v0/'}
-        defaults = {'method': 'POST'}
-        result = self.app.post_json('/batch',
-                                    {'requests': [request],
-                                     'defaults': defaults})
-        self.assertEqual(result.json['responses'][0]['status'], 405)
+        request = {"path": "/v0/"}
+        defaults = {"method": "POST"}
+        result = self.app.post_json("/batch", {"requests": [request], "defaults": defaults})
+        self.assertEqual(result.json["responses"][0]["status"], 405)
 
     def test_only_post_is_allowed(self):
-        self.app.get('/batch', headers=self.headers, status=405)
-        self.app.put('/batch', headers=self.headers, status=405)
-        self.app.patch('/batch', headers=self.headers, status=405)
-        self.app.delete('/batch', headers=self.headers, status=405)
+        self.app.get("/batch", headers=self.headers, status=405)
+        self.app.put("/batch", headers=self.headers, status=405)
+        self.app.patch("/batch", headers=self.headers, status=405)
+        self.app.delete("/batch", headers=self.headers, status=405)
 
     def test_batch_adds_missing_api_with_prefix(self):
-        request = {'path': '/v0/'}
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        hello = resp.json['responses'][0]
-        self.assertEqual(hello['path'], '/v0/')
-        self.assertEqual(hello['status'], 200)
-        self.assertEqual(hello['body']['project_name'], 'myapp')
-        self.assertIn('application/json', hello['headers']['Content-Type'])
+        request = {"path": "/v0/"}
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        hello = resp.json["responses"][0]
+        self.assertEqual(hello["path"], "/v0/")
+        self.assertEqual(hello["status"], 200)
+        self.assertEqual(hello["body"]["project_name"], "myapp")
+        self.assertIn("application/json", hello["headers"]["Content-Type"])
 
     def test_empty_response_body_with_head(self):
-        request = {'path': '/v0/', 'method': 'HEAD'}
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        head = resp.json['responses'][0]
-        self.assertEqual(head['body'], '')
-        self.assertNotEqual(len(head['headers']), 0)
+        request = {"path": "/v0/", "method": "HEAD"}
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        head = resp.json["responses"][0]
+        self.assertEqual(head["body"], "")
+        self.assertNotEqual(len(head["headers"]), 0)
 
     def test_api_errors_are_json_formatted(self):
-        request = {'path': '/unknown'}
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        error = resp.json['responses'][0]
-        self.assertEqual(error['body']['code'], 404)
+        request = {"path": "/unknown"}
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        error = resp.json["responses"][0]
+        self.assertEqual(error["body"]["code"], 404)
 
     def test_internal_errors_makes_the_batch_fail(self):
-        request = {'path': '/v0/'}
-        body = {'requests': [request]}
+        request = {"path": "/v0/"}
+        body = {"requests": [request]}
 
-        with mock.patch('kinto.core.views.hello.get_eos') as mocked:
+        with mock.patch("kinto.core.views.hello.get_eos") as mocked:
             mocked.side_effect = AttributeError
-            self.app.post_json('/batch', body, headers=self.headers,
-                               status=500)
+            self.app.post_json("/batch", body, headers=self.headers, status=500)
 
     def test_errors_handled_by_view_does_not_make_the_batch_fail(self):
         from requests.exceptions import HTTPError
 
-        request = {'path': '/v0/'}
-        body = {'requests': [request]}
+        request = {"path": "/v0/"}
+        body = {"requests": [request]}
 
-        with mock.patch('kinto.core.views.hello.get_eos') as mocked:
+        with mock.patch("kinto.core.views.hello.get_eos") as mocked:
             response = mock.MagicMock(status_code=404)
             mocked.side_effect = HTTPError(response=response)
-            resp = self.app.post_json('/batch', body, headers=self.headers,
-                                      status=200)
-            subresponse = resp.json['responses'][0]['body']
-            self.assertEqual(subresponse, {
-                'errno': 999,
-                'code': 404,
-                'error': 'Not Found'
-            })
+            resp = self.app.post_json("/batch", body, headers=self.headers, status=200)
+            subresponse = resp.json["responses"][0]["body"]
+            self.assertEqual(subresponse, {"errno": 999, "code": 404, "error": "Not Found"})
 
     def test_batch_cannot_be_recursive(self):
-        requests = {'requests': [{'path': '/v0/'}]}
-        request = {'method': 'POST', 'path': '/v0/batch', 'body': requests}
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, status=400)
-        self.assertIn('Recursive', resp.json['message'])
+        requests = {"requests": [{"path": "/v0/"}]}
+        request = {"method": "POST", "path": "/v0/batch", "body": requests}
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, status=400)
+        self.assertIn("Recursive", resp.json["message"])
 
     def test_batch_validates_json(self):
         body = """{"requests": [{"path": "/v0/"},]}"""
-        resp = self.app.post('/batch', body, status=400,
-                             headers={'Content-Type': 'application/json'})
-        self.assertIn('Invalid JSON', resp.json['message'])
+        resp = self.app.post(
+            "/batch", body, status=400, headers={"Content-Type": "application/json"}
+        )
+        self.assertIn("Invalid JSON", resp.json["message"])
 
     def test_batch_should_reject_unaccepted_request_content_type(self):
-        request = {'requests': [{'path': '/v0/mushrooms'}]}
-        self.app.post('/batch', request, status=415,
-                      headers={'Content-Type': 'text/plain'})
+        request = {"requests": [{"path": "/v0/mushrooms"}]}
+        self.app.post("/batch", request, status=415, headers={"Content-Type": "text/plain"})
 
     def test_responses_are_resolved_with_api_with_prefix(self):
-        request = {'path': '/'}
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        hello = resp.json['responses'][0]
-        self.assertEqual(hello['path'], '/v0/')
-        self.assertEqual(hello['status'], 200)
-        self.assertEqual(hello['body']['project_name'], 'myapp')
-        self.assertIn('application/json', hello['headers']['Content-Type'])
+        request = {"path": "/"}
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        hello = resp.json["responses"][0]
+        self.assertEqual(hello["path"], "/v0/")
+        self.assertEqual(hello["status"], 200)
+        self.assertEqual(hello["body"]["project_name"], "myapp")
+        self.assertIn("application/json", hello["headers"]["Content-Type"])
 
     def test_redirect_responses_are_followed(self):
-        request = {'path': '/mushrooms/'}  # trailing slash
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        collection = resp.json['responses'][0]
-        self.assertEqual(collection['status'], 200)
-        self.assertEqual(collection['path'], '/v0/mushrooms')
-        self.assertEqual(collection['body'], {'data': []})
+        request = {"path": "/mushrooms/"}  # trailing slash
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        collection = resp.json["responses"][0]
+        self.assertEqual(collection["status"], 200)
+        self.assertEqual(collection["path"], "/v0/mushrooms")
+        self.assertEqual(collection["body"], {"data": []})
 
     def test_body_is_transmitted_during_redirect(self):
         request = {
-            'method': 'PUT',
-            'path': '/mushrooms/{}/'.format(str(uuid.uuid4())),
-            'body': {'data': {'name': 'Trompette de la mort'}}
+            "method": "PUT",
+            "path": "/mushrooms/{}/".format(str(uuid.uuid4())),
+            "body": {"data": {"name": "Trompette de la mort"}},
         }
-        body = {'requests': [request]}
-        resp = self.app.post_json('/batch', body, headers=self.headers)
-        response = resp.json['responses'][0]
-        self.assertEqual(response['status'], 201)
-        record = response['body']['data']
-        self.assertEqual(record['name'], 'Trompette de la mort')
+        body = {"requests": [request]}
+        resp = self.app.post_json("/batch", body, headers=self.headers)
+        response = resp.json["responses"][0]
+        self.assertEqual(response["status"], 201)
+        record = response["body"]["data"]
+        self.assertEqual(record["name"], "Trompette de la mort")
 
     def test_400_error_message_is_forwarded(self):
-        headers = {**self.headers, 'If-Match': '"*"'}
+        headers = {**self.headers, "If-Match": '"*"'}
         request = {
-            'method': 'PUT',
-            'path': '/mushrooms/{}'.format(str(uuid.uuid4())),
-            'body': {'data': {'name': 'Trompette de la mort'}},
-            'headers': headers
+            "method": "PUT",
+            "path": "/mushrooms/{}".format(str(uuid.uuid4())),
+            "body": {"data": {"name": "Trompette de la mort"}},
+            "headers": headers,
         }
-        body = {'requests': [request, request]}
-        resp = self.app.post_json('/batch', body, status=200)
-        self.assertEqual(resp.json['responses'][1]['status'], 400)
-        msg = 'If-Match in header: The value should be integer between double quotes.'
-        self.assertEqual(resp.json['responses'][1]['body']['message'], msg)
+        body = {"requests": [request, request]}
+        resp = self.app.post_json("/batch", body, status=200)
+        self.assertEqual(resp.json["responses"][1]["status"], 400)
+        msg = "If-Match in header: The value should be integer between double quotes."
+        self.assertEqual(resp.json["responses"][1]["body"]["message"], msg)
 
     def test_412_errors_are_forwarded(self):
-        headers = {**self.headers, 'If-None-Match': '*'}
+        headers = {**self.headers, "If-None-Match": "*"}
         request = {
-            'method': 'PUT',
-            'path': '/mushrooms/{}'.format(str(uuid.uuid4())),
-            'body': {'data': {'name': 'Trompette de la mort'}},
-            'headers': headers
+            "method": "PUT",
+            "path": "/mushrooms/{}".format(str(uuid.uuid4())),
+            "body": {"data": {"name": "Trompette de la mort"}},
+            "headers": headers,
         }
-        body = {'requests': [request, request]}
-        resp = self.app.post_json('/batch', body, status=200)
-        self.assertEqual(resp.json['responses'][0]['status'], 201)
-        self.assertEqual(resp.json['responses'][1]['status'], 412)
+        body = {"requests": [request, request]}
+        resp = self.app.post_json("/batch", body, status=200)
+        self.assertEqual(resp.json["responses"][0]["status"], 201)
+        self.assertEqual(resp.json["responses"][1]["status"], 412)
 
 
 class BatchSchemaTest(unittest.TestCase):
@@ -181,54 +172,53 @@ class BatchSchemaTest(unittest.TestCase):
         self.assertInvalid({})
 
     def test_raise_invalid_on_unknown_attributes(self):
-        self.assertInvalid({'requests': [], 'unknown': 42})
+        self.assertInvalid({"requests": [], "unknown": 42})
 
     def test_list_of_requests_can_be_empty(self):
-        self.schema.deserialize({'requests': []})
+        self.schema.deserialize({"requests": []})
 
     def test_list_of_requests_must_be_a_list(self):
-        self.assertInvalid({'requests': {}})
+        self.assertInvalid({"requests": {}})
 
     def test_list_of_requests_must_be_dicts(self):
         request = 42
-        self.assertInvalid({'defaults': {'path': '/'}, 'requests': [request]})
+        self.assertInvalid({"defaults": {"path": "/"}, "requests": [request]})
 
     def test_request_path_must_start_with_slash(self):
-        request = {'path': 'http://localhost'}
-        self.assertInvalid({'requests': [request]})
+        request = {"path": "http://localhost"}
+        self.assertInvalid({"requests": [request]})
 
     def test_request_path_is_mandatory(self):
-        request = {'method': 'HEAD'}
-        self.assertInvalid({'requests': [request]})
+        request = {"method": "HEAD"}
+        self.assertInvalid({"requests": [request]})
 
     def test_request_method_must_be_known_uppercase_word(self):
-        request = {'path': '/', 'method': 'get'}
-        self.assertInvalid({'requests': [request]})
+        request = {"path": "/", "method": "get"}
+        self.assertInvalid({"requests": [request]})
 
     def test_raise_invalid_on_request_unknown_attributes(self):
-        request = {'path': '/', 'method': 'GET', 'foo': 42}
-        self.assertInvalid({'requests': [request]})
+        request = {"path": "/", "method": "GET", "foo": 42}
+        self.assertInvalid({"requests": [request]})
 
     #
     # headers
     #
 
     def test_request_headers_should_be_strings(self):
-        headers = {'Accept': 3.14}
-        request = {'path': '/', 'headers': headers}
-        self.assertInvalid({'requests': [request]})
+        headers = {"Accept": 3.14}
+        request = {"path": "/", "headers": headers}
+        self.assertInvalid({"requests": [request]})
 
     def test_request_headers_cannot_be_recursive(self):
-        headers = {'Accept': {'sub': 'dict'}}
-        request = {'path': '/', 'headers': headers}
-        self.assertInvalid({'requests': [request]})
+        headers = {"Accept": {"sub": "dict"}}
+        request = {"path": "/", "headers": headers}
+        self.assertInvalid({"requests": [request]})
 
     def test_request_headers_are_preserved(self):
-        headers = {'Accept': 'audio/*'}
-        request = {'path': '/', 'headers': headers}
-        deserialized = self.schema.deserialize({'requests': [request]})
-        self.assertEqual(deserialized['requests'][0]['headers']['Accept'],
-                         'audio/*')
+        headers = {"Accept": "audio/*"}
+        request = {"path": "/", "headers": headers}
+        deserialized = self.schema.deserialize({"requests": [request]})
+        self.assertEqual(deserialized["requests"][0]["headers"]["Accept"], "audio/*")
 
     #
     # body
@@ -236,70 +226,70 @@ class BatchSchemaTest(unittest.TestCase):
 
     def test_body_is_an_arbitrary_mapping(self):
         payload = {"json": "payload"}
-        request = {'path': '/', 'body': payload}
-        deserialized = self.schema.deserialize({'requests': [request]})
-        self.assertEqual(deserialized['requests'][0]['body'], payload)
+        request = {"path": "/", "body": payload}
+        deserialized = self.schema.deserialize({"requests": [request]})
+        self.assertEqual(deserialized["requests"][0]["body"], payload)
 
     #
     # defaults
     #
 
     def test_defaults_must_be_a_mapping_if_specified(self):
-        request = {'path': '/'}
-        batch_payload = {'requests': [request], 'defaults': 42}
+        request = {"path": "/"}
+        batch_payload = {"requests": [request], "defaults": 42}
         self.assertInvalid(batch_payload)
 
     def test_defaults_must_be_a_request_schema_if_specified(self):
-        request = {'path': '/'}
-        defaults = {'body': 3}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        request = {"path": "/"}
+        defaults = {"body": 3}
+        batch_payload = {"requests": [request], "defaults": defaults}
         self.assertInvalid(batch_payload)
 
     def test_raise_invalid_on_default_unknown_attributes(self):
-        request = {'path': '/'}
-        defaults = {'foo': 'bar'}
-        self.assertInvalid({'requests': [request], 'defaults': defaults})
+        request = {"path": "/"}
+        defaults = {"foo": "bar"}
+        self.assertInvalid({"requests": [request], "defaults": defaults})
 
     def test_defaults_can_be_specified_empty(self):
-        request = {'path': '/'}
+        request = {"path": "/"}
         defaults = {}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        batch_payload = {"requests": [request], "defaults": defaults}
         self.schema.deserialize(batch_payload)
 
     def test_defaults_path_is_applied_to_requests(self):
-        request = {'method': 'GET'}
-        defaults = {'path': '/'}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        request = {"method": "GET"}
+        defaults = {"path": "/"}
+        batch_payload = {"requests": [request], "defaults": defaults}
         result = self.schema.deserialize(batch_payload)
-        self.assertEqual(result['requests'][0]['path'], '/')
+        self.assertEqual(result["requests"][0]["path"], "/")
 
     def test_defaults_body_is_applied_to_requests(self):
-        request = {'path': '/'}
-        defaults = {'body': {'json': 'payload'}}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        request = {"path": "/"}
+        defaults = {"body": {"json": "payload"}}
+        batch_payload = {"requests": [request], "defaults": defaults}
         result = self.schema.deserialize(batch_payload)
-        self.assertEqual(result['requests'][0]['body'], {'json': 'payload'})
+        self.assertEqual(result["requests"][0]["body"], {"json": "payload"})
 
     def test_defaults_headers_are_applied_to_requests(self):
-        request = {'path': '/'}
-        defaults = {'headers': {'Content-Type': 'text/html'}}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        request = {"path": "/"}
+        defaults = {"headers": {"Content-Type": "text/html"}}
+        batch_payload = {"requests": [request], "defaults": defaults}
         result = self.schema.deserialize(batch_payload)
-        self.assertEqual(result['requests'][0]['headers']['Content-Type'],
-                         'text/html')
+        self.assertEqual(result["requests"][0]["headers"]["Content-Type"], "text/html")
 
     def test_defaults_values_do_not_overwrite_requests_values(self):
-        request = {'path': '/', 'headers': {'Authorization': 'me'}}
-        defaults = {'headers': {'Authorization': 'you', 'Accept': '*/*'}}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        request = {"path": "/", "headers": {"Authorization": "me"}}
+        defaults = {"headers": {"Authorization": "you", "Accept": "*/*"}}
+        batch_payload = {"requests": [request], "defaults": defaults}
         result = self.schema.deserialize(batch_payload)
-        self.assertEqual(result['requests'][0]['headers'],
-                         {'Authorization': 'me', 'Accept': '*/*'})
+        self.assertEqual(
+            result["requests"][0]["headers"], {"Authorization": "me", "Accept": "*/*"}
+        )
 
     def test_defaults_values_for_path_must_start_with_slash(self):
         request = {}
-        defaults = {'path': 'http://localhost'}
-        batch_payload = {'requests': [request], 'defaults': defaults}
+        defaults = {"path": "http://localhost"}
+        batch_payload = {"requests": [request], "defaults": defaults}
         self.assertInvalid(batch_payload)
 
 
@@ -309,114 +299,113 @@ class BatchServiceTest(unittest.TestCase):
         self.request = DummyRequest()
 
     def post(self, validated):
-        self.request.validated = {'body': validated}
+        self.request.validated = {"body": validated}
         return self.view(self.request)
 
     def test_returns_empty_list_of_responses_if_requests_empty(self):
-        result = self.post({'requests': []})
-        self.assertEqual(result['responses'], [])
+        result = self.post({"requests": []})
+        self.assertEqual(result["responses"], [])
 
     def test_returns_one_response_per_request(self):
-        requests = [{'path': '/'}]
-        result = self.post({'requests': requests})
-        self.assertEqual(len(result['responses']), len(requests))
+        requests = [{"path": "/"}]
+        result = self.post({"requests": requests})
+        self.assertEqual(len(result["responses"]), len(requests))
 
     def test_relies_on_pyramid_invoke_subrequest(self):
-        self.post({'requests': [{'path': '/'}]})
+        self.post({"requests": [{"path": "/"}]})
         self.assertTrue(self.request.invoke_subrequest.called)
 
     def test_returns_requests_path_in_responses(self):
-        result = self.post({'requests': [{'path': '/'}]})
-        self.assertEqual(result['responses'][0]['path'], '/v0/')
+        result = self.post({"requests": [{"path": "/"}]})
+        self.assertEqual(result["responses"][0]["path"], "/v0/")
 
     def test_subrequests_have_parent_attribute(self):
-        self.request.path = '/batch'
-        self.post({'requests': [{'path': '/'}]})
+        self.request.path = "/batch"
+        self.post({"requests": [{"path": "/"}]})
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertEqual(subrequest.parent.path, '/batch')
+        self.assertEqual(subrequest.parent.path, "/batch")
 
     def test_subrequests_are_GET_by_default(self):
-        self.post({'requests': [{'path': '/'}]})
+        self.post({"requests": [{"path": "/"}]})
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertEqual(subrequest.method, 'GET')
+        self.assertEqual(subrequest.method, "GET")
 
     def test_original_request_headers_are_passed_to_subrequests(self):
-        self.request.headers['Authorization'] = 'Basic ertyfghjkl'
-        self.post({'requests': [{'path': '/'}]})
+        self.request.headers["Authorization"] = "Basic ertyfghjkl"
+        self.post({"requests": [{"path": "/"}]})
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertIn('Basic', subrequest.headers['Authorization'])
+        self.assertIn("Basic", subrequest.headers["Authorization"])
 
     def test_subrequests_body_are_json_serialized(self):
-        request = {'path': '/', 'body': {'json': 'payload'}}
-        self.post({'requests': [request]})
+        request = {"path": "/", "body": {"json": "payload"}}
+        self.post({"requests": [request]})
         wanted = {"json": "payload"}
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertEqual(subrequest.body.decode('utf8'),
-                         json.dumps(wanted))
+        self.assertEqual(subrequest.body.decode("utf8"), json.dumps(wanted))
 
     def test_subrequests_body_have_json_content_type(self):
-        self.request.headers['Content-Type'] = 'text/xml'
-        request = {'path': '/', 'body': {'json': 'payload'}}
-        self.post({'requests': [request]})
+        self.request.headers["Content-Type"] = "text/xml"
+        request = {"path": "/", "body": {"json": "payload"}}
+        self.post({"requests": [request]})
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertIn('application/json',
-                      subrequest.headers['Content-Type'])
+        self.assertIn("application/json", subrequest.headers["Content-Type"])
 
     def test_subrequests_body_have_utf8_charset(self):
-        request = {'path': '/', 'body': {'json': "😂"}}
-        self.post({'requests': [request]})
+        request = {"path": "/", "body": {"json": "😂"}}
+        self.post({"requests": [request]})
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertIn('charset=utf-8', subrequest.headers['Content-Type'])
+        self.assertIn("charset=utf-8", subrequest.headers["Content-Type"])
         wanted = {"json": "😂"}
-        self.assertEqual(subrequest.body.decode('utf8'),
-                         json.dumps(wanted))
+        self.assertEqual(subrequest.body.decode("utf8"), json.dumps(wanted))
 
     def test_subrequests_paths_are_url_encoded(self):
-        request = {'path': '/test?param=©'}
-        self.post({'requests': [request]})
+        request = {"path": "/test?param=©"}
+        self.post({"requests": [request]})
         subrequest, = self.request.invoke_subrequest.call_args[0]
-        self.assertEqual(subrequest.path, '/v0/test')
-        self.assertEqual(subrequest.GET['param'], '©')
+        self.assertEqual(subrequest.path, "/v0/test")
+        self.assertEqual(subrequest.GET["param"], "©")
 
     def test_subrequests_responses_paths_are_url_decoded(self):
-        request = {'path': '/test?param=©'}
-        resp = self.post({'requests': [request]})
-        path = resp['responses'][0]['path']
-        self.assertEqual(path, '/v0/test')
+        request = {"path": "/test?param=©"}
+        resp = self.post({"requests": [request]})
+        path = resp["responses"][0]["path"]
+        self.assertEqual(path, "/v0/test")
 
     def test_response_body_is_string_if_remote_response_is_not_json(self):
-        response = Response(body='Internal Error')
+        response = Response(body="Internal Error")
         self.request.invoke_subrequest.return_value = response
-        request = {'path': '/test'}
-        resp = self.post({'requests': [request]})
-        body = resp['responses'][0]['body'].decode('utf-8')
-        self.assertEqual(body, 'Internal Error')
+        request = {"path": "/test"}
+        resp = self.post({"requests": [request]})
+        body = resp["responses"][0]["body"].decode("utf-8")
+        self.assertEqual(body, "Internal Error")
 
     def test_number_of_requests_is_not_limited_when_settings_set_to_none(self):
-        self.request.registry.settings['batch_max_requests'] = None
+        self.request.registry.settings["batch_max_requests"] = None
         requests = {}
         for i in range(30):
-            requests.setdefault('requests', []).append({'path': '/'})
+            requests.setdefault("requests", []).append({"path": "/"})
             self.post(requests)
 
     def test_number_of_requests_is_limited_to_25_by_default(self):
         requests = {}
         for i in range(26):
-            requests.setdefault('requests', []).append({'path': '/'})
+            requests.setdefault("requests", []).append({"path": "/"})
         result = self.post(requests)
 
-        self.assertEqual(self.request.errors[0]['description'],
-                         'Number of requests is limited to 25')
+        self.assertEqual(
+            self.request.errors[0]["description"], "Number of requests is limited to 25"
+        )
         self.assertIsNone(result)  # rest of view not executed
 
     def test_return_400_if_number_of_requests_is_greater_than_settings(self):
-        self.request.registry.settings['batch_max_requests'] = 22
+        self.request.registry.settings["batch_max_requests"] = 22
 
         requests = {}
         for i in range(23):
-            requests.setdefault('requests', []).append({'path': '/'})
+            requests.setdefault("requests", []).append({"path": "/"})
         result = self.post(requests)
 
-        self.assertEqual(self.request.errors[0]['description'],
-                         'Number of requests is limited to 22')
+        self.assertEqual(
+            self.request.errors[0]["description"], "Number of requests is limited to 22"
+        )
         self.assertIsNone(result)  # rest of view not executed

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -16,281 +16,361 @@ class ErrorViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
 
     def test_backoff_headers_is_not_present_by_default(self):
         response = self.app.get(self.sample_url, headers=self.headers, status=200)
-        self.assertNotIn('Backoff', response.headers)
+        self.assertNotIn("Backoff", response.headers)
 
     def test_backoff_headers_is_present_if_configured(self):
-        with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10)]):
+        with mock.patch.dict(self.app.app.registry.settings, [("backoff", 10)]):
             response = self.app.get(self.sample_url, headers=self.headers, status=200)
-        self.assertIn('Backoff', response.headers)
-        self.assertEqual(response.headers['Backoff'], '10')
+        self.assertIn("Backoff", response.headers)
+        self.assertEqual(response.headers["Backoff"], "10")
 
     def test_backoff_headers_is_present_if_less_than_percentage(self):
-        with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10),
-                             ('backoff_percentage', 50)]):
-            with mock.patch('kinto.core.initialization.random.random', return_value=0.4):
+        with mock.patch.dict(
+            self.app.app.registry.settings, [("backoff", 10), ("backoff_percentage", 50)]
+        ):
+            with mock.patch("kinto.core.initialization.random.random", return_value=0.4):
                 response = self.app.get(self.sample_url, headers=self.headers, status=200)
-        self.assertIn('Backoff', response.headers)
-        self.assertEqual(response.headers['Backoff'], '10')
+        self.assertIn("Backoff", response.headers)
+        self.assertEqual(response.headers["Backoff"], "10")
 
     def test_backoff_headers_is_not_present_if_greater_than_percentage(self):
-        with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10),
-                             ('backoff_percentage', 50)]):
-            with mock.patch('kinto.core.initialization.random.random', return_value=0.6):
+        with mock.patch.dict(
+            self.app.app.registry.settings, [("backoff", 10), ("backoff_percentage", 50)]
+        ):
+            with mock.patch("kinto.core.initialization.random.random", return_value=0.6):
                 response = self.app.get(self.sample_url, headers=self.headers, status=200)
-        self.assertNotIn('Backoff', response.headers)
+        self.assertNotIn("Backoff", response.headers)
 
     def test_backoff_headers_is_present_on_304(self):
         first = self.app.get(self.sample_url, headers=self.headers)
-        etag = first.headers['ETag']
-        headers = {**self.headers, 'If-None-Match': etag}
-        with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10)]):
+        etag = first.headers["ETag"]
+        headers = {**self.headers, "If-None-Match": etag}
+        with mock.patch.dict(self.app.app.registry.settings, [("backoff", 10)]):
             response = self.app.get(self.sample_url, headers=headers, status=304)
-        self.assertIn('Backoff', response.headers)
+        self.assertIn("Backoff", response.headers)
 
     def test_backoff_header_is_present_on_error_responses(self):
-        with mock.patch.dict(self.app.app.registry.settings, [('backoff', 10)]):
-            with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                            side_effect=ValueError):
+        with mock.patch.dict(self.app.app.registry.settings, [("backoff", 10)]):
+            with mock.patch(
+                "tests.core.testapp.views.Mushroom._extract_filters", side_effect=ValueError
+            ):
                 response = self.app.get(self.sample_url, headers=self.headers, status=500)
-        self.assertIn('Backoff', response.headers)
+        self.assertIn("Backoff", response.headers)
 
     def test_404_is_valid_formatted_error(self):
-        response = self.app.get('/unknown', status=404)
-        self.assertFormattedError(response, 404, ERRORS.MISSING_RESOURCE, "Not Found",
-                                  "The resource you are looking for could not be found.")
+        response = self.app.get("/unknown", status=404)
+        self.assertFormattedError(
+            response,
+            404,
+            ERRORS.MISSING_RESOURCE,
+            "Not Found",
+            "The resource you are looking for could not be found.",
+        )
 
     def test_404_can_be_overridden(self):
-        custom_404 = http_error(httpexceptions.HTTPNotFound(),
-                                errno=ERRORS.MISSING_RESOURCE,
-                                message="Customized.")
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=custom_404):
+        custom_404 = http_error(
+            httpexceptions.HTTPNotFound(), errno=ERRORS.MISSING_RESOURCE, message="Customized."
+        )
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=custom_404
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=404)
-        self.assertFormattedError(response, 404, ERRORS.MISSING_RESOURCE,
-                                  "Not Found", "Customized.")
+        self.assertFormattedError(
+            response, 404, ERRORS.MISSING_RESOURCE, "Not Found", "Customized."
+        )
 
     def test_401_is_valid_formatted_error(self):
         response = self.app.get(self.sample_url, status=401)
-        self.assertFormattedError(response, 401, ERRORS.MISSING_AUTH_TOKEN, "Unauthorized",
-                                  "Please authenticate yourself to use this endpoint.")
+        self.assertFormattedError(
+            response,
+            401,
+            ERRORS.MISSING_AUTH_TOKEN,
+            "Unauthorized",
+            "Please authenticate yourself to use this endpoint.",
+        )
 
     @authorize(False)
     def test_403_is_valid_formatted_error(self):
         response = self.app.get(self.sample_url, headers=self.headers, status=403)
-        self.assertFormattedError(response, 403, ERRORS.FORBIDDEN, "Forbidden",
-                                  "This user cannot access this resource.")
+        self.assertFormattedError(
+            response, 403, ERRORS.FORBIDDEN, "Forbidden", "This user cannot access this resource."
+        )
 
     def test_403_can_be_overridded(self):
-        custom_403 = http_error(httpexceptions.HTTPForbidden(), errno=ERRORS.FORBIDDEN,
-                                message="Customized.")
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=custom_403):
+        custom_403 = http_error(
+            httpexceptions.HTTPForbidden(), errno=ERRORS.FORBIDDEN, message="Customized."
+        )
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=custom_403
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=403)
         self.assertFormattedError(response, 403, ERRORS.FORBIDDEN, "Forbidden", "Customized.")
 
     def test_405_is_valid_formatted_error(self):
         response = self.app.patch(self.sample_url, headers=self.headers, status=405)
-        self.assertFormattedError(response, 405, ERRORS.METHOD_NOT_ALLOWED, "Method Not Allowed",
-                                  "Method not allowed on this endpoint.")
+        self.assertFormattedError(
+            response,
+            405,
+            ERRORS.METHOD_NOT_ALLOWED,
+            "Method Not Allowed",
+            "Method not allowed on this endpoint.",
+        )
 
     def test_405_can_have_custom_message(self):
-        custom_405 = http_error(httpexceptions.HTTPMethodNotAllowed(),
-                                errno=ERRORS.METHOD_NOT_ALLOWED, message="Disabled from conf.")
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=custom_405):
+        custom_405 = http_error(
+            httpexceptions.HTTPMethodNotAllowed(),
+            errno=ERRORS.METHOD_NOT_ALLOWED,
+            message="Disabled from conf.",
+        )
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=custom_405
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=405)
-        self.assertFormattedError(response, 405, ERRORS.METHOD_NOT_ALLOWED, "Method Not Allowed",
-                                  "Disabled from conf.")
+        self.assertFormattedError(
+            response, 405, ERRORS.METHOD_NOT_ALLOWED, "Method Not Allowed", "Disabled from conf."
+        )
 
     def test_500_is_valid_formatted_error(self):
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=ValueError):
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=ValueError
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=500)
         self.assertFormattedError(
-            response, 500, ERRORS.UNDEFINED, "Internal Server Error",
+            response,
+            500,
+            ERRORS.UNDEFINED,
+            "Internal Server Error",
             "A programmatic error occured, developers have been informed.",
-            "https://github.com/Kinto/kinto/issues/")
+            "https://github.com/Kinto/kinto/issues/",
+        )
 
     def test_400_with_invalid_url_path(self):
-        response = self.app.get('/%82%AC', status=400)
-        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS, "Bad Request",
-                                  "Invalid URL path.")
+        response = self.app.get("/%82%AC", status=400)
+        self.assertFormattedError(
+            response, 400, ERRORS.INVALID_PARAMETERS, "Bad Request", "Invalid URL path."
+        )
 
     def test_400_when_query_field_contains_nul_character(self):
-        response = self.app.get(self.sample_url + '?field\x00="2"',
-                                headers=self.headers, status=400)
-        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS,
-                                  "Invalid parameters", "Invalid character 0x00")
+        response = self.app.get(
+            self.sample_url + '?field\x00="2"', headers=self.headers, status=400
+        )
+        self.assertFormattedError(
+            response,
+            400,
+            ERRORS.INVALID_PARAMETERS,
+            "Invalid parameters",
+            "Invalid character 0x00",
+        )
 
     def test_400_when_query_value_contains_nul_character(self):
-        response = self.app.get(self.sample_url + '?field="\x00"',
-                                headers=self.headers, status=400)
-        self.assertFormattedError(response, 400, ERRORS.INVALID_PARAMETERS,
-                                  "Invalid parameters", "Invalid character 0x00")
+        response = self.app.get(
+            self.sample_url + '?field="\x00"', headers=self.headers, status=400
+        )
+        self.assertFormattedError(
+            response,
+            400,
+            ERRORS.INVALID_PARAMETERS,
+            "Invalid parameters",
+            "Invalid character 0x00",
+        )
 
     def test_info_link_in_error_responses_can_be_configured(self):
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=ValueError):
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=ValueError
+        ):
             link = "https://github.com/mozilla-services/kinto/issues/"
-            app = self.make_app({'error_info_link': link, 'readonly': False})
+            app = self.make_app({"error_info_link": link, "readonly": False})
             response = app.get(self.sample_url, headers=self.headers, status=500)
-        self.assertFormattedError(response, 500, ERRORS.UNDEFINED, "Internal Server Error",
-                                  "A programmatic error occured, developers have been informed.",
-                                  link)
+        self.assertFormattedError(
+            response,
+            500,
+            ERRORS.UNDEFINED,
+            "Internal Server Error",
+            "A programmatic error occured, developers have been informed.",
+            link,
+        )
 
     def test_503_is_valid_formatted_error(self):
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=httpexceptions.HTTPServiceUnavailable):
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters",
+            side_effect=httpexceptions.HTTPServiceUnavailable,
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=503)
-        self.assertFormattedError(response, 503, ERRORS.BACKEND, "Service Unavailable",
-                                  ("Service temporary unavailable "
-                                   "due to overloading or maintenance, please retry later."))
+        self.assertFormattedError(
+            response,
+            503,
+            ERRORS.BACKEND,
+            "Service Unavailable",
+            (
+                "Service temporary unavailable "
+                "due to overloading or maintenance, please retry later."
+            ),
+        )
         self.assertIn("Retry-After", response.headers)
 
     def test_503_can_have_custom_message(self):
-        custom_503 = http_error(httpexceptions.HTTPServiceUnavailable(),
-                                errno=ERRORS.BACKEND,
-                                message="Unable to connect the server.")
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=custom_503):
+        custom_503 = http_error(
+            httpexceptions.HTTPServiceUnavailable(),
+            errno=ERRORS.BACKEND,
+            message="Unable to connect the server.",
+        )
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=custom_503
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=503)
-        self.assertFormattedError(response, 503, ERRORS.BACKEND, "Service Unavailable",
-                                  "Unable to connect the server.")
+        self.assertFormattedError(
+            response, 503, ERRORS.BACKEND, "Service Unavailable", "Unable to connect the server."
+        )
 
     def test_integrity_errors_are_served_as_409(self):
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=storage_exceptions.IntegrityError):
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters",
+            side_effect=storage_exceptions.IntegrityError,
+        ):
             response = self.app.get(self.sample_url, headers=self.headers, status=409)
-        self.assertFormattedError(response, 409, ERRORS.CONSTRAINT_VIOLATED, "Conflict",
-                                  "Integrity constraint violated, please retry.")
+        self.assertFormattedError(
+            response,
+            409,
+            ERRORS.CONSTRAINT_VIOLATED,
+            "Conflict",
+            "Integrity constraint violated, please retry.",
+        )
         self.assertIn("Retry-After", response.headers)
 
     def test_500_provides_traceback_on_server(self):
-        mock_traceback = mock.patch('logging.traceback.print_exception')
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=ValueError):
+        mock_traceback = mock.patch("logging.traceback.print_exception")
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=ValueError
+        ):
             with mock_traceback as mocked_traceback:
                 self.app.get(self.sample_url, headers=self.headers, status=500)
                 self.assertTrue(mocked_traceback.called)
                 self.assertEqual(ValueError, mocked_traceback.call_args[0][0])
 
     def test_500_logs_request_information(self):
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=ValueError):
-            with mock.patch('kinto.core.views.errors.logger') as mocked_logger:
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=ValueError
+        ):
+            with mock.patch("kinto.core.views.errors.logger") as mocked_logger:
                 self.app.get(self.sample_url + "?q=-42", headers=self.headers, status=500)
 
         self.assertTrue(mocked_logger.error.called)
-        self.assertEqual(mocked_logger.error.call_args[1]['extra'], {
-            'errno': 999,
-            'method': 'GET',
-            'path': '/v0/mushrooms',
-            'querystring': {'q': '-42'}})
+        self.assertEqual(
+            mocked_logger.error.call_args[1]["extra"],
+            {"errno": 999, "method": "GET", "path": "/v0/mushrooms", "querystring": {"q": "-42"}},
+        )
 
     def test_500_logs_errno_from_exception(self):
-        custom_error = ValueError('Some error')
+        custom_error = ValueError("Some error")
         custom_error.errno = ERRORS.VERSION_NOT_AVAILABLE
 
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=custom_error):
-            with mock.patch('kinto.core.views.errors.logger') as mocked_logger:
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=custom_error
+        ):
+            with mock.patch("kinto.core.views.errors.logger") as mocked_logger:
                 self.app.get(self.sample_url, headers=self.headers, status=500)
         self.assertTrue(mocked_logger.error.called)
-        self.assertEqual(mocked_logger.error.call_args[1]['extra']['errno'], 116)
+        self.assertEqual(mocked_logger.error.call_args[1]["extra"]["errno"], 116)
 
     def test_500_passes_exception_as_exc_info(self):
-        custom_error = ValueError('Some error')
+        custom_error = ValueError("Some error")
 
-        with mock.patch('tests.core.testapp.views.Mushroom._extract_filters',
-                        side_effect=custom_error):
-            with mock.patch('kinto.core.views.errors.logger') as mocked_logger:
+        with mock.patch(
+            "tests.core.testapp.views.Mushroom._extract_filters", side_effect=custom_error
+        ):
+            with mock.patch("kinto.core.views.errors.logger") as mocked_logger:
                 self.app.get(self.sample_url, headers=self.headers, status=500)
         self.assertTrue(mocked_logger.error.called)
-        self.assertEqual(mocked_logger.error.call_args[1]['exc_info'], custom_error)
+        self.assertEqual(mocked_logger.error.call_args[1]["exc_info"], custom_error)
 
 
 class RedirectViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
-    api_prefix = ''
+    api_prefix = ""
 
     def test_do_not_redirect_to_version_if_not_supported_version(self):
-        resp = self.app.get('/v1/', status=404)
-        self.assertFormattedError(resp, 404, ERRORS.VERSION_NOT_AVAILABLE, "Not Found",
-                                  "The requested API version is not available on this server.")
+        resp = self.app.get("/v1/", status=404)
+        self.assertFormattedError(
+            resp,
+            404,
+            ERRORS.VERSION_NOT_AVAILABLE,
+            "Not Found",
+            "The requested API version is not available on this server.",
+        )
 
     def test_redirect_to_version(self):
         # GET on the hello view.
-        response = self.app.get('/')
+        response = self.app.get("/")
         self.assertEqual(response.status_int, 307)
-        self.assertEqual(response.location, 'http://localhost/v0/')
+        self.assertEqual(response.location, "http://localhost/v0/")
 
         # GET on the fields view.
-        response = self.app.get('/mushrooms')
+        response = self.app.get("/mushrooms")
         self.assertEqual(response.status_int, 307)
-        self.assertEqual(response.location, 'http://localhost/v0/mushrooms')
+        self.assertEqual(response.location, "http://localhost/v0/mushrooms")
 
     def test_redirects_benefits_from_cors_setup(self):
-        headers = {
-            'Origin': 'lolnet.org',
-            'Access-Control-Request-Method': 'GET'
-        }
-        resp = self.app.options('/', headers=headers, status=200)
-        self.assertIn('Access-Control-Allow-Origin', resp.headers)
+        headers = {"Origin": "lolnet.org", "Access-Control-Request-Method": "GET"}
+        resp = self.app.options("/", headers=headers, status=200)
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
 
     def test_do_not_redirect_to_version_if_disabled_in_settings(self):
         # GET on the hello view.
-        app = self.make_app({'version_prefix_redirect_enabled': False})
-        app.get('/', status=404)
+        app = self.make_app({"version_prefix_redirect_enabled": False})
+        app.get("/", status=404)
 
     def test_querystring_is_preserved_during_redirection(self):
-        response = self.app.get('/home/articles?_since=42')
-        self.assertEqual(response.location, 'http://localhost/v0/home/articles?_since=42')
+        response = self.app.get("/home/articles?_since=42")
+        self.assertEqual(response.location, "http://localhost/v0/home/articles?_since=42")
 
     def test_redirection_does_not_allow_crlf(self):
-        self.app.get('/crlftest%0DSet-Cookie:test%3Dtest%3Bdomain%3D.yelp.com',
-                     status=404)
+        self.app.get("/crlftest%0DSet-Cookie:test%3Dtest%3Bdomain%3D.yelp.com", status=404)
 
     def test_redirection_does_not_allow_control_characters(self):
-        self.app.get('/9l2j7%0A21m2n', status=404)
+        self.app.get("/9l2j7%0A21m2n", status=404)
 
     def test_redirection_allows_unicode_characters(self):
         # URL with unicode: /crlftest嘊/
-        self.app.get('/crlftest%E5%98%8A/', status=307)
+        self.app.get("/crlftest%E5%98%8A/", status=307)
 
     def test_redirection_allows_unicode_characters_in_querystring(self):
         # URL with unicode: /crlftest?name=嘊
-        self.app.get('/crlftest?name=%E5%98%8A', status=307)
+        self.app.get("/crlftest?name=%E5%98%8A", status=307)
 
 
-class TrailingSlashRedirectViewTest(FormattedErrorMixin, BaseWebTest,
-                                    unittest.TestCase):
+class TrailingSlashRedirectViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
     def test_doesnt_redirect_the_home_page(self):
-        response = self.app.get('/')
+        response = self.app.get("/")
         self.assertEqual(response.status_int, 200)
 
     def test_does_redirect_the_version_prefix(self):
-        response = self.app.get('')
+        response = self.app.get("")
         self.assertEqual(response.status_int, 307)
-        self.assertEqual(response.location, 'http://localhost/v0/')
+        self.assertEqual(response.location, "http://localhost/v0/")
 
     def test_it_redirects_if_it_ends_with_a__slash_(self):
-        response = self.app.get('/mushrooms/')
+        response = self.app.get("/mushrooms/")
         self.assertEqual(response.status_int, 307)
-        self.assertEqual(response.location, 'http://localhost/v0/mushrooms')
+        self.assertEqual(response.location, "http://localhost/v0/mushrooms")
 
     def test_do_not_redirect_if_disabled_in_settings(self):
-        app = self.make_app({'trailing_slash_redirect_enabled': False})
-        app.get('/', status=200)
-        app.get('/mushrooms/', status=404)
+        app = self.make_app({"trailing_slash_redirect_enabled": False})
+        app.get("/", status=200)
+        app.get("/mushrooms/", status=404)
 
     def test_querystring_is_preserved_during_redirection(self):
-        response = self.app.get('/home/articles/?_since=42')
-        self.assertEqual(response.location, 'http://localhost/v0/home/articles?_since=42')
+        response = self.app.get("/home/articles/?_since=42")
+        self.assertEqual(response.location, "http://localhost/v0/home/articles?_since=42")
 
     def test_it_does_not_redirect_if_the_url_exists(self):
-        self.app.get('/static/', status=200)
+        self.app.get("/static/", status=200)
 
     def test_display_an_error_message_if_disabled_in_settings(self):
-        app = self.make_app({'trailing_slash_redirect_enabled': False})
-        response = app.get('', status=404)
-        self.assertFormattedError(response, 404, ERRORS.MISSING_RESOURCE, "Not Found",
-                                  "The resource you are looking for could not be found.")
+        app = self.make_app({"trailing_slash_redirect_enabled": False})
+        response = app.get("", status=404)
+        self.assertFormattedError(
+            response,
+            404,
+            ERRORS.MISSING_RESOURCE,
+            "Not Found",
+            "The resource you are looking for could not be found.",
+        )

--- a/tests/core/test_views_heartbeat.py
+++ b/tests/core/test_views_heartbeat.py
@@ -6,23 +6,21 @@ from .support import BaseWebTest
 
 
 class SuccessTest(BaseWebTest, unittest.TestCase):
-
     def test_returns_storage_true_if_ok(self):
-        response = self.app.get('/__heartbeat__')
-        self.assertEqual(response.json['storage'], True)
+        response = self.app.get("/__heartbeat__")
+        self.assertEqual(response.json["storage"], True)
 
     def test_returns_cache_true_if_ok(self):
-        response = self.app.get('/__heartbeat__')
-        self.assertEqual(response.json['cache'], True)
+        response = self.app.get("/__heartbeat__")
+        self.assertEqual(response.json["cache"], True)
 
     def test_successful_if_one_heartbeat_is_none(self):
-        self.app.app.registry.heartbeats['probe'] = lambda r: None
-        response = self.app.get('/__heartbeat__', status=200)
-        self.assertEqual(response.json['probe'], None)
+        self.app.app.registry.heartbeats["probe"] = lambda r: None
+        response = self.app.get("/__heartbeat__", status=200)
+        self.assertEqual(response.json["probe"], None)
 
 
 class FailureTest(BaseWebTest, unittest.TestCase):
-
     def setUp(self):
         self._heartbeats = {**self.app.app.registry.heartbeats}
         super().setUp()
@@ -32,36 +30,37 @@ class FailureTest(BaseWebTest, unittest.TestCase):
         super().tearDown()
 
     def test_returns_storage_false_if_ko(self):
-        self.app.app.registry.heartbeats['storage'] = lambda r: False
-        response = self.app.get('/__heartbeat__', status=503)
-        self.assertEqual(response.json['storage'], False)
-        self.assertEqual(response.json['cache'], True)
+        self.app.app.registry.heartbeats["storage"] = lambda r: False
+        response = self.app.get("/__heartbeat__", status=503)
+        self.assertEqual(response.json["storage"], False)
+        self.assertEqual(response.json["cache"], True)
 
     def test_returns_cache_false_if_ko(self):
-        self.app.app.registry.heartbeats['cache'] = lambda r: False
-        response = self.app.get('/__heartbeat__', status=503)
-        self.assertEqual(response.json['cache'], False)
-        self.assertEqual(response.json['storage'], True)
+        self.app.app.registry.heartbeats["cache"] = lambda r: False
+        response = self.app.get("/__heartbeat__", status=503)
+        self.assertEqual(response.json["cache"], False)
+        self.assertEqual(response.json["storage"], True)
 
     def test_returns_false_if_heartbeat_times_out(self):
         def sleepy(request):
             import time
+
             time.sleep(1)
-        self.app.app.registry.heartbeats['cache'] = sleepy
-        with mock.patch.dict(self.app.app.registry.settings,
-                             [('heartbeat_timeout_seconds', 0.1)]):
-            response = self.app.get('/__heartbeat__', status=503)
-        self.assertEqual(response.json['cache'], False)
-        self.assertEqual(response.json['storage'], True)
+
+        self.app.app.registry.heartbeats["cache"] = sleepy
+        with mock.patch.dict(self.app.app.registry.settings, [("heartbeat_timeout_seconds", 0.1)]):
+            response = self.app.get("/__heartbeat__", status=503)
+        self.assertEqual(response.json["cache"], False)
+        self.assertEqual(response.json["storage"], True)
 
     def test_returns_false_if_heartbeat_fails(self):
-        self.app.app.registry.heartbeats['cache'] = lambda r: 1 / 0
-        response = self.app.get('/__heartbeat__', status=503)
-        self.assertEqual(response.json['cache'], False)
-        self.assertEqual(response.json['storage'], True)
+        self.app.app.registry.heartbeats["cache"] = lambda r: 1 / 0
+        response = self.app.get("/__heartbeat__", status=503)
+        self.assertEqual(response.json["cache"], False)
+        self.assertEqual(response.json["storage"], True)
 
 
 class LoadBalancerHeartbeat(BaseWebTest, unittest.TestCase):
     def test_returns_200_with_empty_body(self):
-        resp = self.app.get('/__lbheartbeat__', status=200)
+        resp = self.app.get("/__lbheartbeat__", status=200)
         self.assertEqual(resp.json, {})

--- a/tests/core/test_views_hello.py
+++ b/tests/core/test_views_hello.py
@@ -8,98 +8,98 @@ from .support import BaseWebTest
 
 
 class HelloViewTest(BaseWebTest, unittest.TestCase):
-
     def test_returns_info_about_url_and_version(self):
-        response = self.app.get('/')
-        self.assertEqual(response.json['project_version'], "0.0.1")
-        self.assertEqual(response.json['url'], 'http://localhost/v0/')
-        self.assertEqual(response.json['project_name'], 'myapp')
-        self.assertEqual(response.json['project_docs'],
-                         'https://kinto.readthedocs.io/')
+        response = self.app.get("/")
+        self.assertEqual(response.json["project_version"], "0.0.1")
+        self.assertEqual(response.json["url"], "http://localhost/v0/")
+        self.assertEqual(response.json["project_name"], "myapp")
+        self.assertEqual(response.json["project_docs"], "https://kinto.readthedocs.io/")
 
     def test_does_not_escape_forward_slashes(self):
-        response = self.app.get('/')
-        self.assertNotIn('\\/', str(response.body))
+        response = self.app.get("/")
+        self.assertNotIn("\\/", str(response.body))
 
     def test_do_not_returns_eos_if_empty_in_settings(self):
-        response = self.app.get('/')
-        self.assertNotIn('eos', response.json)
+        response = self.app.get("/")
+        self.assertNotIn("eos", response.json)
 
     def test_returns_eos_if_not_empty_in_settings(self):
-        eos = '2069-02-21'
-        with mock.patch.dict(
-                self.app.app.registry.settings,
-                [('eos', eos)]):
-            response = self.app.get('/')
-            self.assertEqual(response.json['eos'], eos)
+        eos = "2069-02-21"
+        with mock.patch.dict(self.app.app.registry.settings, [("eos", eos)]):
+            response = self.app.get("/")
+            self.assertEqual(response.json["eos"], eos)
 
     def test_public_settings_are_shown_in_view(self):
-        response = self.app.get('/')
-        settings = response.json['settings']
-        expected = {'batch_max_requests': 25, 'readonly': False}
+        response = self.app.get("/")
+        settings = response.json["settings"]
+        expected = {"batch_max_requests": 25, "readonly": False}
         self.assertEqual(expected, settings)
 
     def test_public_settings_can_be_set_from_registry(self):
-        self.app.app.registry.public_settings.add('paginate_by')
-        response = self.app.get('/')
-        settings = response.json['settings']
-        self.assertIn('paginate_by', settings)
+        self.app.app.registry.public_settings.add("paginate_by")
+        response = self.app.get("/")
+        settings = response.json["settings"]
+        self.assertIn("paginate_by", settings)
 
     def test_if_user_not_authenticated_no_userid_provided(self):
-        response = self.app.get('/')
-        self.assertNotIn('user', response.json)
+        response = self.app.get("/")
+        self.assertNotIn("user", response.json)
 
     def test_if_user_authenticated_userid_is_provided(self):
-        response = self.app.get('/', headers=self.headers)
-        userid = response.json['user']['id']
-        self.assertTrue(userid.startswith('basicauth:'),
-                        '"{}" does not start with "basicauth:"'.format(userid))
+        response = self.app.get("/", headers=self.headers)
+        userid = response.json["user"]["id"]
+        self.assertTrue(
+            userid.startswith("basicauth:"), '"{}" does not start with "basicauth:"'.format(userid)
+        )
 
     def test_return_http_api_version_when_set(self):
-        with mock.patch.dict(
-                self.app.app.registry.settings,
-                [('http_api_version', '1.2')]):
-            response = self.app.get('/')
+        with mock.patch.dict(self.app.app.registry.settings, [("http_api_version", "1.2")]):
+            response = self.app.get("/")
 
-        self.assertTrue(response.json['http_api_version'])
+        self.assertTrue(response.json["http_api_version"])
 
 
 class APICapabilitiesTest(BaseWebTest, unittest.TestCase):
     def test_list_of_capabilities_contains_basicauth_by_default(self):
         app = self.make_app()
-        response = app.get('/')
-        capabilities = response.json['capabilities']
-        self.assertEqual(capabilities, {"basicauth": {
-            'description': 'Very basic authentication sessions. Not for production use.',
-            'url': 'http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html'
-        }})
+        response = app.get("/")
+        capabilities = response.json["capabilities"]
+        self.assertEqual(
+            capabilities,
+            {
+                "basicauth": {
+                    "description": "Very basic authentication sessions. Not for production use.",
+                    "url": "http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html",
+                }
+            },
+        )
 
     def test_capabilities_can_be_specified_via_config(self):
         settings = self.get_app_settings()
-        settings['multiauth.policies'] = ""
+        settings["multiauth.policies"] = ""
         config = testing.setUp(settings=settings)
         app = self.make_app(config=config)
 
         config.add_api_capability("cook-coffee")
 
-        response = app.get('/')
-        capabilities = response.json['capabilities']
-        expected = {
-            "cook-coffee": {"description": "", "url": ""}
-        }
+        response = app.get("/")
+        capabilities = response.json["capabilities"]
+        expected = {"cook-coffee": {"description": "", "url": ""}}
         self.assertEqual(capabilities, expected)
 
     def test_capabilities_can_have_arbitrary_attributes(self):
         config = testing.setUp(settings=self.get_app_settings())
         app = self.make_app(config=config)
 
-        capability = dict(description="Track record change",
-                          url="https://github.com/Kinto/kinto-changes",
-                          status="beta")
+        capability = dict(
+            description="Track record change",
+            url="https://github.com/Kinto/kinto-changes",
+            status="beta",
+        )
         config.add_api_capability("record-changes", **capability)
 
-        response = app.get('/')
-        capabilities = response.json['capabilities']
+        response = app.get("/")
+        capabilities = response.json["capabilities"]
         self.assertEqual(capabilities["record-changes"], capability)
 
     def test_capability_fails_if_already_registered(self):

--- a/tests/core/test_views_openapi.py
+++ b/tests/core/test_views_openapi.py
@@ -5,14 +5,13 @@ from .support import BaseWebTest
 
 
 class OpenAPIViewTest(BaseWebTest, unittest.TestCase):
-
     def setUp(self):
         try:
-            delattr(openapi_view, '__json__')  # Clean-up memoization.
+            delattr(openapi_view, "__json__")  # Clean-up memoization.
         except AttributeError:
             pass
 
     tearDown = setUp
 
     def test_get_spec_at_root(self):
-        self.app.get('/__api__')
+        self.app.get("/__api__")

--- a/tests/core/test_views_postgresql.py
+++ b/tests/core/test_views_postgresql.py
@@ -7,7 +7,6 @@ from .support import PostgreSQLTest
 
 @skip_if_no_postgresql
 class PaginationTest(PostgreSQLTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
@@ -17,23 +16,22 @@ class PaginationTest(PostgreSQLTest, unittest.TestCase):
     def setUp(self):
         super().setUp()
         for i in range(10):
-            self.app.post_json('/mushrooms', {'data': {'name': str(i)}},
-                               headers=self.headers)
+            self.app.post_json("/mushrooms", {"data": {"name": str(i)}}, headers=self.headers)
 
     def test_storage_max_fetch_size_is_per_page(self):
-        resp = self.app.get('/mushrooms?_limit=6', headers=self.headers)
+        resp = self.app.get("/mushrooms?_limit=6", headers=self.headers)
         self.assertIn("Next-Page", resp.headers)
         self.assertEqual(int(resp.headers["Total-Records"]), 10)
-        self.assertEqual(len(resp.json['data']), 4)
+        self.assertEqual(len(resp.json["data"]), 4)
 
         next_page_url = resp.headers["Next-Page"].replace("http://localhost/v0", "")
         resp = self.app.get(next_page_url, headers=self.headers)
         self.assertIn("Next-Page", resp.headers)
         self.assertEqual(int(resp.headers["Total-Records"]), 10)
-        self.assertEqual(len(resp.json['data']), 4)
+        self.assertEqual(len(resp.json["data"]), 4)
 
         next_page_url = resp.headers["Next-Page"].replace("http://localhost/v0", "")
         resp = self.app.get(next_page_url, headers=self.headers)
         self.assertNotIn("Next-Page", resp.headers)
         self.assertEqual(int(resp.headers["Total-Records"]), 10)
-        self.assertEqual(len(resp.json['data']), 2)
+        self.assertEqual(len(resp.json["data"]), 2)

--- a/tests/core/test_views_version.py
+++ b/tests/core/test_views_version.py
@@ -11,32 +11,31 @@ from .support import BaseWebTest
 class VersionViewTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         try:
-            delattr(version_view, '__json__')  # Clean-up memoization.
+            delattr(version_view, "__json__")  # Clean-up memoization.
         except AttributeError:
             pass
 
     tearDown = setUp
 
     def test_return_the_version_file_in_current_folder_if_present(self):
-        content = {'version': '0.8.1'}
+        content = {"version": "0.8.1"}
         fake_file = mock.mock_open(read_data=json.dumps(content))
-        with mock.patch('os.path.exists'):
-            with mock.patch('kinto.core.views.version.open', fake_file, create=True):
-                response = self.app.get('/__version__')
+        with mock.patch("os.path.exists"):
+            with mock.patch("kinto.core.views.version.open", fake_file, create=True):
+                response = self.app.get("/__version__")
                 assert response.json == content
 
     def test_return_a_404_if_version_file_if_not_present(self):
-        self.app.get('/__version__', status=404)
+        self.app.get("/__version__", status=404)
 
     def test_return_the_version_file_specified_in_setting_if_present(self):
         custom_path = tempfile.mktemp()
-        content = {'foo': 'lala'}
-        with open(custom_path, 'w') as f:
+        content = {"foo": "lala"}
+        with open(custom_path, "w") as f:
             json.dump(content, f)
         self.addCleanup(lambda: os.remove(custom_path))
 
-        with mock.patch.dict(self.app.app.registry.settings,
-                             [('version_json_path', custom_path)]):
-            response = self.app.get('/__version__')
+        with mock.patch.dict(self.app.app.registry.settings, [("version_json_path", custom_path)]):
+            response = self.app.get("/__version__")
 
         assert response.json == content

--- a/tests/core/testapp/__init__.py
+++ b/tests/core/testapp/__init__.py
@@ -13,9 +13,9 @@ def includeme(config):
 
     # Add an example route with trailing slash (here to serve static files).
     # This is only used to test 404 redirection in ``test_views_errors.py``
-    abs_path = os.path.join(here, 'static')
+    abs_path = os.path.join(here, "static")
     static = static_view(abs_path, use_subpath=True)
-    config.add_route('catchall_static', '/static/*subpath')
+    config.add_route("catchall_static", "/static/*subpath")
     config.add_view(static, route_name="catchall_static")
 
 
@@ -24,7 +24,7 @@ def main(global_config, config=None, **settings):
     if config is None:
         config = Configurator(settings=settings)
 
-    kinto.core.initialize(config, version='0.0.1')
+    kinto.core.initialize(config, version="0.0.1")
     config.include(includeme)
     app = config.make_wsgi_app()
     # Install middleware (no-op if not enabled in setting)

--- a/tests/core/testplugin/__init__.py
+++ b/tests/core/testplugin/__init__.py
@@ -2,13 +2,15 @@ from kinto.core import Service
 from kinto.core.authorization import RouteFactory
 
 
-attachment = Service(name='attachment',
-                     description='Attach file to record',
-                     path='/attachment',
-                     factory=RouteFactory)
+attachment = Service(
+    name="attachment",
+    description="Attach file to record",
+    path="/attachment",
+    factory=RouteFactory,
+)
 
 
-@attachment.post(permission='attach')
+@attachment.post(permission="attach")
 def attachment_post(request):
     return {"ok": True}
 

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -13,7 +13,7 @@ import requests
 __HERE__ = os.path.abspath(os.path.dirname(__file__))
 
 SERVER_URL = "http://localhost:8888/v1"
-DEFAULT_AUTH = ('user', 'p4ssw0rd')
+DEFAULT_AUTH = ("user", "p4ssw0rd")
 
 
 def build_task():
@@ -26,7 +26,6 @@ def build_task():
 
 
 class FunctionalTest(unittest.TestCase):
-
     def __init__(self, *args, **kwargs):
         super(FunctionalTest, self).__init__(*args, **kwargs)
         # XXX Read the configuration from env variables.
@@ -37,25 +36,34 @@ class FunctionalTest(unittest.TestCase):
 
     def setUp(self):
         # Create accounts used in the different tests.
-        requests.post(urljoin(self.server_url, '/accounts'),
-                      json={"data": {"id": "user", "password": "p4ssw0rd"}})
-        requests.post(urljoin(self.server_url, '/accounts'),
-                      json={"data": {"id": "bob", "password": "s3cr3t"}})
-        requests.post(urljoin(self.server_url, '/accounts'),
-                      json={"data": {"id": "alice", "password": "wh1sp3r"}})
-        requests.post(urljoin(self.server_url, '/accounts'),
-                      json={"data": {"id": "mary", "password": "s4f3"}})
+        requests.post(
+            urljoin(self.server_url, "/accounts"),
+            json={"data": {"id": "user", "password": "p4ssw0rd"}},
+        )
+        requests.post(
+            urljoin(self.server_url, "/accounts"),
+            json={"data": {"id": "bob", "password": "s3cr3t"}},
+        )
+        requests.post(
+            urljoin(self.server_url, "/accounts"),
+            json={"data": {"id": "alice", "password": "wh1sp3r"}},
+        )
+        requests.post(
+            urljoin(self.server_url, "/accounts"),
+            json={"data": {"id": "mary", "password": "s4f3"}},
+        )
 
     def tearDown(self):
         # Delete all the created objects
-        flush_url = urljoin(self.server_url, '/__flush__')
+        flush_url = urljoin(self.server_url, "/__flush__")
         resp = requests.post(flush_url)
         resp.raise_for_status()
 
     def test_user_default_bucket_tutorial(self):
-        collection_id = 'tasks-%s' % uuid.uuid4()
-        collection_url = urljoin(self.server_url,
-                                 '/buckets/default/collections/{}/records'.format(collection_id))
+        collection_id = "tasks-%s" % uuid.uuid4()
+        collection_url = urljoin(
+            self.server_url, "/buckets/default/collections/{}/records".format(collection_id)
+        )
         task = build_task()
 
         # Create a task on a default collection
@@ -65,206 +73,185 @@ class FunctionalTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 201)
         record = resp.json()
 
-        self.assertEqual(record['data']['description'], task['description'])
-        self.assertEqual(record['data']['status'], task['status'])
-        self.assertIn('write', record['permissions'])
+        self.assertEqual(record["data"]["description"], task["description"])
+        self.assertEqual(record["data"]["status"], task["status"])
+        self.assertIn("write", record["permissions"])
 
         # Create a new one with PUT and If-None-Match: "*"
         task = build_task()
         record_id = str(uuid.uuid4())
-        record_url = urljoin(self.server_url,
-                             '{}/{}'.format(collection_url, record_id))
-        resp = self.session.put(record_url, json={'data': task},
-                                headers={'If-None-Match': '*'})
+        record_url = urljoin(self.server_url, "{}/{}".format(collection_url, record_id))
+        resp = self.session.put(record_url, json={"data": task}, headers={"If-None-Match": "*"})
         resp.raise_for_status()
         resp.raise_for_status()
         self.assertEqual(resp.status_code, 201)
         record = resp.json()
 
-        self.assertEqual(record['data']['description'], task['description'])
-        self.assertEqual(record['data']['status'], task['status'])
-        self.assertIn('write', record['permissions'])
+        self.assertEqual(record["data"]["description"], task["description"])
+        self.assertEqual(record["data"]["status"], task["status"])
+        self.assertIn("write", record["permissions"])
 
         # Fetch the collection list and see the tasks (save the etag)
         resp = self.session.get(collection_url)
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertEqual(len(record['data']), 2)
-        etag = resp.headers['ETag']
+        self.assertEqual(len(record["data"]), 2)
+        etag = resp.headers["ETag"]
 
         # Fetch the collection from the Etag and see nothing new
-        resp = self.session.get(
-            collection_url,
-            params={'_since': etag.strip('"')})
+        resp = self.session.get(collection_url, params={"_since": etag.strip('"')})
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertEqual(len(record['data']), 0)
+        self.assertEqual(len(record["data"]), 0)
 
         # Update a task
-        resp = self.session.patch(
-            record_url,
-            json={'data': {'status': 'done'}})
+        resp = self.session.patch(record_url, json={"data": {"status": "done"}})
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertEqual(record['data']['status'], 'done')
-        self.assertIn('write', record['permissions'])
+        self.assertEqual(record["data"]["status"], "done")
+        self.assertIn("write", record["permissions"])
 
         # Try an update with If-Match on the saved ETag and see it fails
         resp = self.session.patch(
-            record_url,
-            json={'data': {'status': 'done'}},
-            headers={'If-Match': etag})
+            record_url, json={"data": {"status": "done"}}, headers={"If-Match": etag}
+        )
         self.assertEqual(resp.status_code, 412)
-        self.assertEqual(resp.headers['ETag'],
-                         '"%s"' % record['data']['last_modified'])
+        self.assertEqual(resp.headers["ETag"], '"%s"' % record["data"]["last_modified"])
 
         # Get the list of records and update the ETag
-        resp = self.session.get(
-            '%s?_since=%s' % (collection_url, etag.strip('"')))
+        resp = self.session.get("%s?_since=%s" % (collection_url, etag.strip('"')))
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertEqual(len(record['data']), 1)
-        etag = resp.headers['ETag']
+        self.assertEqual(len(record["data"]), 1)
+        etag = resp.headers["ETag"]
 
         # Try an update with If-Match on the new ETag and see it works
         resp = self.session.patch(
-            record_url,
-            json={'data': {'status': 'done'}},
-            headers={'If-Match': etag})
+            record_url, json={"data": {"status": "done"}}, headers={"If-Match": etag}
+        )
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        etag = resp.headers['ETag']
+        etag = resp.headers["ETag"]
 
         # Delete the record with If-Match
-        resp = self.session.delete(
-            record_url,
-            headers={'If-Match': etag})
+        resp = self.session.delete(record_url, headers={"If-Match": etag})
 
         self.assertEqual(resp.status_code, 200)
 
         # Try the collection get with the ``_since`` parameter
         resp = self.session.get(
-            '%s?_since=%s' % (collection_url, etag.strip('"')),
-            headers={'If-None-Match': etag})
+            "%s?_since=%s" % (collection_url, etag.strip('"')), headers={"If-None-Match": etag}
+        )
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertEqual(len(record['data']), 1)
-        self.assertIn('deleted', record['data'][0])
+        self.assertEqual(len(record["data"]), 1)
+        self.assertIn("deleted", record["data"][0])
 
         # Delete all the things
         resp = self.session.delete(collection_url)
         self.assertEqual(resp.status_code, 200)
 
     def test_user_shared_bucket_tutorial(self):
-        bucket_id = 'bucket-%s' % uuid.uuid4()
-        collection_id = 'tasks-%s' % uuid.uuid4()
-        bucket_url = urljoin(self.server_url, '/buckets/{}'.format(bucket_id))
-        collection_url = '{}/collections/{}/records'.format(bucket_url, collection_id)
+        bucket_id = "bucket-%s" % uuid.uuid4()
+        collection_id = "tasks-%s" % uuid.uuid4()
+        bucket_url = urljoin(self.server_url, "/buckets/{}".format(bucket_id))
+        collection_url = "{}/collections/{}/records".format(bucket_url, collection_id)
 
         # Create a new bucket and check for permissions
         resp = self.session.put(bucket_url)
         # In case of concurrent execution, it may have been created already.
         self.assertIn(resp.status_code, (200, 201))
         bucket = resp.json()
-        self.assertIn('write', bucket['permissions'])
+        self.assertIn("write", bucket["permissions"])
 
         # Create a new collection and check for permissions
-        permissions = {"record:create": ['system.Authenticated']}
+        permissions = {"record:create": ["system.Authenticated"]}
         resp = self.session.put(
-            re.sub('/records$', '', collection_url),
-            json={'permissions': permissions})
+            re.sub("/records$", "", collection_url), json={"permissions": permissions}
+        )
         # In case of concurrent execution, it may have been created already.
         self.assertIn(resp.status_code, (200, 201))
         collection = resp.json()
-        self.assertIn('record:create', collection['permissions'])
-        self.assertIn('system.Authenticated',
-                      collection['permissions']['record:create'])
+        self.assertIn("record:create", collection["permissions"])
+        self.assertIn("system.Authenticated", collection["permissions"]["record:create"])
 
         # Create a new tasks for Alice
-        alice_auth = ('alice', 'wh1sp3r')
+        alice_auth = ("alice", "wh1sp3r")
         alice_task = build_task()
-        resp = self.session.post(
-            collection_url,
-            json={'data': alice_task},
-            auth=alice_auth)
+        resp = self.session.post(collection_url, json={"data": alice_task}, auth=alice_auth)
         self.assertEqual(resp.status_code, 201)
         collection = resp.json()
-        self.assertIn('write', collection['permissions'])
-        alice_task_id = collection['data']['id']
+        self.assertIn("write", collection["permissions"])
+        alice_task_id = collection["data"]["id"]
 
-        bob_auth = ('bob', 's3cr3t')
+        bob_auth = ("bob", "s3cr3t")
 
         # Bob has no task yet.
         resp = self.session.get(collection_url, auth=bob_auth)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.json()['data']), 0)
+        self.assertEqual(len(resp.json()["data"]), 0)
 
         # Create a new tasks for Bob
         bob_task = build_task()
-        resp = self.session.post(
-            collection_url,
-            json={'data': bob_task},
-            auth=bob_auth)
+        resp = self.session.post(collection_url, json={"data": bob_task}, auth=bob_auth)
         self.assertEqual(resp.status_code, 201)
         collection = resp.json()
-        self.assertIn('write', collection['permissions'])
-        bob_user_id = collection['permissions']['write'][0]
-        bob_task_id = collection['data']['id']
+        self.assertIn("write", collection["permissions"])
+        bob_user_id = collection["permissions"]["write"][0]
+        bob_task_id = collection["data"]["id"]
 
         # Now that he has a task, he should see his.
         resp = self.session.get(collection_url, auth=bob_auth)
         self.assertEqual(resp.status_code, 200)
-        records = resp.json()['data']
+        records = resp.json()["data"]
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['id'], bob_task_id)
+        self.assertEqual(records[0]["id"], bob_task_id)
 
-        record_url = '{}/{}'.format(collection_url, alice_task_id)
+        record_url = "{}/{}".format(collection_url, alice_task_id)
 
         # Share Alice's task with Bob
-        resp = self.session.patch(record_url,
-                                  json={'permissions': {'read': [bob_user_id]}},
-                                  auth=alice_auth)
+        resp = self.session.patch(
+            record_url, json={"permissions": {"read": [bob_user_id]}}, auth=alice_auth
+        )
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertIn('write', record['permissions'])
-        alice_task_id = record['data']['id']
+        self.assertIn("write", record["permissions"])
+        alice_task_id = record["data"]["id"]
 
         # Check that Bob can access it
         resp = self.session.get(record_url, auth=bob_auth)
         self.assertEqual(resp.status_code, 200)
 
         # Get mary's userid
-        mary_auth = ('mary', 's4f3')
-        resp = self.session.get('{}/'.format(self.server_url), auth=mary_auth)
+        mary_auth = ("mary", "s4f3")
+        resp = self.session.get("{}/".format(self.server_url), auth=mary_auth)
         self.assertEqual(resp.status_code, 200)
         hello = resp.json()
-        mary_user_id = hello['user']['id']
+        mary_user_id = hello["user"]["id"]
 
         # Allow group creation on bucket
-        permissions = {"group:create": ['system.Authenticated']}
-        resp = self.session.put(bucket_url,
-                                json={'permissions': permissions})
+        permissions = {"group:create": ["system.Authenticated"]}
+        resp = self.session.put(bucket_url, json={"permissions": permissions})
         self.assertEqual(resp.status_code, 200)
         bucket = resp.json()
-        self.assertIn('group:create', bucket['permissions'])
-        self.assertIn('system.Authenticated',
-                      bucket['permissions']['group:create'])
+        self.assertIn("group:create", bucket["permissions"])
+        self.assertIn("system.Authenticated", bucket["permissions"]["group:create"])
 
         # Create Alice's friend group with Bob and Mary
-        group_url = '{}/groups/alices-friends'.format(bucket_url)
-        resp = self.session.put(group_url,
-                                json={'data': {'members': [mary_user_id, bob_user_id]}},
-                                auth=alice_auth)
+        group_url = "{}/groups/alices-friends".format(bucket_url)
+        resp = self.session.put(
+            group_url, json={"data": {"members": [mary_user_id, bob_user_id]}}, auth=alice_auth
+        )
         self.assertEqual(resp.status_code, 201)
 
         # Give Alice's task permission for that group
-        group_id = '/buckets/{}/groups/alices-friends'.format(bucket_id)
-        resp = self.session.patch(record_url,
-                                  json={'permissions': {'read': [group_id]}},
-                                  auth=alice_auth)
+        group_id = "/buckets/{}/groups/alices-friends".format(bucket_id)
+        resp = self.session.patch(
+            record_url, json={"permissions": {"read": [group_id]}}, auth=alice_auth
+        )
         self.assertEqual(resp.status_code, 200)
         record = resp.json()
-        self.assertIn(group_id, record['permissions']['read'])
+        self.assertIn(group_id, record["permissions"]["read"])
 
         # Try to access Alice's task with Mary
         resp = self.session.get(record_url, auth=mary_auth)
@@ -273,20 +260,20 @@ class FunctionalTest(unittest.TestCase):
         # Check that Mary's collection_get sees Alice's task
         resp = self.session.get(collection_url, auth=mary_auth)
         self.assertEqual(resp.status_code, 200)
-        records = resp.json()['data']
+        records = resp.json()["data"]
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['id'], alice_task_id)
+        self.assertEqual(records[0]["id"], alice_task_id)
 
         # Check that Bob's collection_get sees both his and Alice's tasks
         resp = self.session.get(collection_url, auth=bob_auth)
         self.assertEqual(resp.status_code, 200)
-        records = resp.json()['data']
+        records = resp.json()["data"]
         self.assertEqual(len(records), 2)
-        records_ids = [r['id'] for r in records]
+        records_ids = [r["id"] for r in records]
         self.assertIn(alice_task_id, records_ids)
         self.assertIn(bob_task_id, records_ids)
 
     def test_check_for_lists(self):
         # List buckets should not be forbidden
-        resp = self.session.get('{}/buckets'.format(self.server_url))
+        resp = self.session.get("{}/buckets".format(self.server_url))
         self.assertEqual(resp.status_code, 200)

--- a/tests/openapi/support.py
+++ b/tests/openapi/support.py
@@ -6,23 +6,27 @@ from bravado_core.resource import build_resources
 from bravado_core.response import OutgoingResponse, validate_response
 from bravado_core.request import IncomingRequest, unmarshal_request
 
-from ..support import (BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_GROUP,
-                       MINIMALIST_COLLECTION, MINIMALIST_RECORD)
+from ..support import (
+    BaseWebTest,
+    MINIMALIST_BUCKET,
+    MINIMALIST_GROUP,
+    MINIMALIST_COLLECTION,
+    MINIMALIST_RECORD,
+)
 
 
 class OpenAPITest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.spec_dict = cls.app.get('/__api__').json
+        cls.spec_dict = cls.app.get("/__api__").json
         bravado_config = {
             # use_models causes us to break in bravado-core 4.13.0,
             # probably because of
             # https://github.com/Yelp/bravado-core/pull/254, and we
             # don't actually use the generated models in our tests
             # here anyhow.
-            "use_models": False,
+            "use_models": False
         }
         cls.spec = Spec.from_dict(cls.spec_dict, config=bravado_config)
         cls.resources = build_resources(cls.spec)
@@ -30,33 +34,32 @@ class OpenAPITest(BaseWebTest, unittest.TestCase):
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['includes'] = ['kinto.plugins.history',
-                                'kinto.plugins.admin']
+        settings["includes"] = ["kinto.plugins.history", "kinto.plugins.admin"]
         return settings
 
     def setUp(self):
         super().setUp()
 
-        self.bucket = self.app.put_json('/buckets/b1',
-                                        MINIMALIST_BUCKET,
-                                        headers=self.headers).json
+        self.bucket = self.app.put_json(
+            "/buckets/b1", MINIMALIST_BUCKET, headers=self.headers
+        ).json
 
-        self.group = self.app.put_json('/buckets/b1/groups/g1',
-                                       MINIMALIST_GROUP,
-                                       headers=self.headers).json
+        self.group = self.app.put_json(
+            "/buckets/b1/groups/g1", MINIMALIST_GROUP, headers=self.headers
+        ).json
 
-        self.collection = self.app.put_json('/buckets/b1/collections/c1',
-                                            MINIMALIST_COLLECTION,
-                                            headers=self.headers).json
+        self.collection = self.app.put_json(
+            "/buckets/b1/collections/c1", MINIMALIST_COLLECTION, headers=self.headers
+        ).json
 
-        self.record = self.app.put_json('/buckets/b1/collections/c1/records/r1',
-                                        MINIMALIST_RECORD,
-                                        headers=self.headers).json
+        self.record = self.app.put_json(
+            "/buckets/b1/collections/c1/records/r1", MINIMALIST_RECORD, headers=self.headers
+        ).json
 
         # Create raw Bravado request
         self.request = IncomingRequest()
-        self.request.url = ''
-        self.request.data = ''
+        self.request.url = ""
+        self.request.data = ""
         self.request.path = {}
         self.request.headers = {}
         self.request.query = {}
@@ -82,18 +85,21 @@ class OpenAPITest(BaseWebTest, unittest.TestCase):
 
         # FIXME: Drop charset from application/json response on Pyramid
         # See https://github.com/Pylons/pyramid/issues/2860
-        resp.content_type = response.headers.get('Content-Type', '').split(';')[0]
+        resp.content_type = response.headers.get("Content-Type", "").split(";")[0]
         resp.json = lambda: response.json
 
         return resp
 
     def validate_request_call(self, op, **kargs):
         params = unmarshal_request(self.request, op)
-        response = self.app.request(op.path_name.format_map(params),
-                                    body=json.dumps(self.request.json()).encode(),
-                                    method=op.http_method.upper(),
-                                    headers=self.headers, **kargs)
-        schema = self.spec.deref(op.op_spec['responses'][str(response.status_code)])
+        response = self.app.request(
+            op.path_name.format_map(params),
+            body=json.dumps(self.request.json()).encode(),
+            method=op.http_method.upper(),
+            headers=self.headers,
+            **kargs
+        )
+        schema = self.spec.deref(op.op_spec["responses"][str(response.status_code)])
         casted_resp = self.cast_bravado_response(response)
         validate_response(schema, op, casted_resp)
         return response

--- a/tests/openapi/test_plugins.py
+++ b/tests/openapi/test_plugins.py
@@ -2,17 +2,12 @@ from .support import OpenAPITest
 
 
 class OpenAPIPluginsTest(OpenAPITest):
-
     def test_get_history(self):
-        op = self.resources['History'].get_history
-        self.request.path = {
-            'bucket_id': 'b1',
-        }
+        op = self.resources["History"].get_history
+        self.request.path = {"bucket_id": "b1"}
         self.validate_request_call(op)
 
     def test_delete_history(self):
-        op = self.resources['History'].delete_history
-        self.request.path = {
-            'bucket_id': 'b1',
-        }
+        op = self.resources["History"].delete_history
+        self.request.path = {"bucket_id": "b1"}
         self.validate_request_call(op)

--- a/tests/openapi/test_resources.py
+++ b/tests/openapi/test_resources.py
@@ -1,78 +1,68 @@
-from .support import (OpenAPITest, MINIMALIST_BUCKET, MINIMALIST_GROUP,
-                      MINIMALIST_COLLECTION, MINIMALIST_RECORD)
+from .support import (
+    OpenAPITest,
+    MINIMALIST_BUCKET,
+    MINIMALIST_GROUP,
+    MINIMALIST_COLLECTION,
+    MINIMALIST_RECORD,
+)
 
 
 class OpenAPIResourcesTest(OpenAPITest):
 
-    allowed_failures = ['version']
+    allowed_failures = ["version"]
 
     def test_resource_utilities(self):
-        resource = self.resources['Utilities']
+        resource = self.resources["Utilities"]
         for op_id, op in resource.operations.items():
-                if op_id not in self.allowed_failures:
-                    self.validate_request_call(op)
+            if op_id not in self.allowed_failures:
+                self.validate_request_call(op)
 
     def test_resource_batch(self):
-        resource = self.resources['Batch']
+        resource = self.resources["Batch"]
         for op in resource.operations.values():
-            requests = [{'path': '/v1/buckets'}]
-            defaults = {'method': 'POST'}
-            self.request.json = lambda: dict(
-                requests=requests,
-                defaults=defaults
-            )
+            requests = [{"path": "/v1/buckets"}]
+            defaults = {"method": "POST"}
+            self.request.json = lambda: dict(requests=requests, defaults=defaults)
             self.validate_request_call(op)
 
     def test_resource_buckets(self):
-        resource = self.resources['Buckets']
+        resource = self.resources["Buckets"]
 
         for op in resource.operations.values():
-            self.app.put_json('/buckets/b1',
-                              MINIMALIST_BUCKET, headers=self.headers)
-            self.request.path = {
-                'id': 'b1',
-            }
-            bucket = {**MINIMALIST_BUCKET, 'data': {'foo': 'bar'}}
+            self.app.put_json("/buckets/b1", MINIMALIST_BUCKET, headers=self.headers)
+            self.request.path = {"id": "b1"}
+            bucket = {**MINIMALIST_BUCKET, "data": {"foo": "bar"}}
             self.request.json = lambda: bucket
             self.validate_request_call(op)
 
     def test_resource_groups(self):
-        resource = self.resources['Groups']
+        resource = self.resources["Groups"]
 
         for op in resource.operations.values():
-            self.app.put_json('/buckets/b1/groups/g1',
-                              MINIMALIST_GROUP, headers=self.headers)
-            self.request.path = {
-                'bucket_id': 'b1',
-                'id': 'g1',
-            }
+            self.app.put_json("/buckets/b1/groups/g1", MINIMALIST_GROUP, headers=self.headers)
+            self.request.path = {"bucket_id": "b1", "id": "g1"}
             self.request.json = lambda: MINIMALIST_GROUP
             self.validate_request_call(op)
 
     def test_resource_collections(self):
-        resource = self.resources['Collections']
+        resource = self.resources["Collections"]
 
         for op in resource.operations.values():
-            self.app.put_json('/buckets/b1/collections/c1',
-                              MINIMALIST_COLLECTION, headers=self.headers)
-            self.request.path = {
-                'bucket_id': 'b1',
-                'id': 'c1',
-            }
-            collection = {**MINIMALIST_COLLECTION, 'data': {'foo': 'bar'}}
+            self.app.put_json(
+                "/buckets/b1/collections/c1", MINIMALIST_COLLECTION, headers=self.headers
+            )
+            self.request.path = {"bucket_id": "b1", "id": "c1"}
+            collection = {**MINIMALIST_COLLECTION, "data": {"foo": "bar"}}
             self.request.json = lambda: collection
             self.validate_request_call(op)
 
     def test_resource_records(self):
-        resource = self.resources['Records']
+        resource = self.resources["Records"]
 
         for op in resource.operations.values():
-            self.app.put_json('/buckets/b1/collections/c1/records/r1',
-                              MINIMALIST_RECORD, headers=self.headers)
-            self.request.path = {
-                'bucket_id': 'b1',
-                'collection_id': 'c1',
-                'id': 'r1',
-            }
+            self.app.put_json(
+                "/buckets/b1/collections/c1/records/r1", MINIMALIST_RECORD, headers=self.headers
+            )
+            self.request.path = {"bucket_id": "b1", "collection_id": "c1", "id": "r1"}
             self.request.json = lambda: MINIMALIST_RECORD
             self.validate_request_call(op)

--- a/tests/openapi/test_responses_buckets.py
+++ b/tests/openapi/test_responses_buckets.py
@@ -4,67 +4,60 @@ from .support import OpenAPITest, MINIMALIST_BUCKET
 
 
 class OpenAPIBucketResponsesTest(OpenAPITest):
-
     def test_get_bucket_200(self):
-        response = self.app.get('/buckets/b1',
-                                headers=self.headers, status=200)
+        response = self.app.get("/buckets/b1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_bucket_200(self):
-        response = self.app.post_json('/buckets', self.bucket,
-                                      headers=self.headers, status=200)
+        response = self.app.post_json("/buckets", self.bucket, headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].create_bucket
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Buckets"].create_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_bucket_201(self):
-        response = self.app.post_json('/buckets', MINIMALIST_BUCKET,
-                                      headers=self.headers, status=201)
+        response = self.app.post_json(
+            "/buckets", MINIMALIST_BUCKET, headers=self.headers, status=201
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].create_bucket
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Buckets"].create_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_put_bucket_200(self):
-        response = self.app.put('/buckets/b1',
-                                headers=self.headers, status=200)
+        response = self.app.put("/buckets/b1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_put_bucket_201(self):
-        response = self.app.put('/buckets/b2',
-                                headers=self.headers, status=201)
+        response = self.app.put("/buckets/b2", headers=self.headers, status=201)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_delete_bucket_200(self):
-        response = self.app.delete('/buckets/b1',
-                                   headers=self.headers, status=200)
+        response = self.app.delete("/buckets/b1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_bucket
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Buckets"].delete_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_get_buckets_200(self):
-        response = self.app.get('/buckets',
-                                headers=self.headers, status=200)
+        response = self.app.get("/buckets", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_buckets
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Buckets"].get_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_delete_buckets_200(self):
-        response = self.app.delete('/buckets',
-                                   headers=self.headers, status=200)
+        response = self.app.delete("/buckets", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_buckets
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Buckets"].delete_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)

--- a/tests/openapi/test_responses_collections.py
+++ b/tests/openapi/test_responses_collections.py
@@ -4,67 +4,66 @@ from .support import OpenAPITest, MINIMALIST_COLLECTION
 
 
 class OpenAPICollectionResponsesTest(OpenAPITest):
-
     def test_get_collection_200(self):
-        response = self.app.get('/buckets/b1/collections/c1',
-                                headers=self.headers, status=200)
+        response = self.app.get("/buckets/b1/collections/c1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].get_collection
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Collections"].get_collection
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_collection_200(self):
-        response = self.app.post_json('/buckets/b1/collections', self.collection,
-                                      headers=self.headers, status=200)
+        response = self.app.post_json(
+            "/buckets/b1/collections", self.collection, headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].create_collection
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Collections"].create_collection
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_collection_201(self):
-        response = self.app.post_json('/buckets/b1/collections', MINIMALIST_COLLECTION,
-                                      headers=self.headers, status=201)
+        response = self.app.post_json(
+            "/buckets/b1/collections", MINIMALIST_COLLECTION, headers=self.headers, status=201
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].create_collection
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Collections"].create_collection
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_put_collection_200(self):
-        response = self.app.put_json('/buckets/b1/collections/c1', MINIMALIST_COLLECTION,
-                                     headers=self.headers, status=200)
+        response = self.app.put_json(
+            "/buckets/b1/collections/c1", MINIMALIST_COLLECTION, headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].update_collection
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Collections"].update_collection
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_put_collection_201(self):
-        response = self.app.put_json('/buckets/b1/collections/c2', MINIMALIST_COLLECTION,
-                                     headers=self.headers, status=201)
+        response = self.app.put_json(
+            "/buckets/b1/collections/c2", MINIMALIST_COLLECTION, headers=self.headers, status=201
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].update_collection
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Collections"].update_collection
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_delete_collection_200(self):
-        response = self.app.delete('/buckets/b1/collections/c1',
-                                   headers=self.headers, status=200)
+        response = self.app.delete("/buckets/b1/collections/c1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].delete_collection
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Collections"].delete_collection
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_get_collections_200(self):
-        response = self.app.get('/buckets/b1/collections',
-                                headers=self.headers, status=200)
+        response = self.app.get("/buckets/b1/collections", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].get_collections
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Collections"].get_collections
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_delete_collections_200(self):
-        response = self.app.delete('/buckets/b1/collections',
-                                   headers=self.headers, status=200)
+        response = self.app.delete("/buckets/b1/collections", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].delete_collections
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Collections"].delete_collections
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)

--- a/tests/openapi/test_responses_errors.py
+++ b/tests/openapi/test_responses_errors.py
@@ -2,325 +2,318 @@ from bravado_core.response import validate_response
 
 from kinto.core import testing
 from .support import OpenAPITest
-from ..support import (MINIMALIST_BUCKET, MINIMALIST_GROUP,
-                       MINIMALIST_COLLECTION, MINIMALIST_RECORD)
+from ..support import MINIMALIST_BUCKET, MINIMALIST_GROUP, MINIMALIST_COLLECTION, MINIMALIST_RECORD
 
 
 class OpenAPIObjectErrorResponsesTest(OpenAPITest):
-
     def setUp(self):
         super().setUp()
 
-        self.bucket = self.app.put_json('/buckets/b1',
-                                        MINIMALIST_BUCKET,
-                                        headers=self.headers).json
+        self.bucket = self.app.put_json(
+            "/buckets/b1", MINIMALIST_BUCKET, headers=self.headers
+        ).json
 
-        self.group = self.app.put_json('/buckets/b1/groups/g1',
-                                       MINIMALIST_GROUP,
-                                       headers=self.headers).json
+        self.group = self.app.put_json(
+            "/buckets/b1/groups/g1", MINIMALIST_GROUP, headers=self.headers
+        ).json
 
-        self.collection = self.app.put_json('/buckets/b1/collections/c1',
-                                            MINIMALIST_COLLECTION,
-                                            headers=self.headers).json
+        self.collection = self.app.put_json(
+            "/buckets/b1/collections/c1", MINIMALIST_COLLECTION, headers=self.headers
+        ).json
 
-        self.record = self.app.put_json('/buckets/b1/collections/c1/records/r1',
-                                        MINIMALIST_RECORD,
-                                        headers=self.headers).json
+        self.record = self.app.put_json(
+            "/buckets/b1/collections/c1/records/r1", MINIMALIST_RECORD, headers=self.headers
+        ).json
 
     def test_object_get_304(self):
-        headers = {**self.headers,
-                   'If-None-Match': '"{}"'.format(self.bucket['data']['last_modified'])}
-        response = self.app.get('/buckets/b1',
-                                headers=headers, status=304)
+        headers = {
+            **self.headers,
+            "If-None-Match": '"{}"'.format(self.bucket["data"]["last_modified"]),
+        }
+        response = self.app.get("/buckets/b1", headers=headers, status=304)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['304'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["304"])
         validate_response(schema, op, response)
 
     def test_object_get_400(self):
-        headers = {**self.headers, 'If-None-Match': 'aaa'}
-        response = self.app.get('/buckets/b1',
-                                headers=headers, status=400)
+        headers = {**self.headers, "If-None-Match": "aaa"}
+        response = self.app.get("/buckets/b1", headers=headers, status=400)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['400'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["400"])
         validate_response(schema, op, response)
 
     def test_object_get_401(self):
-        response = self.app.get('/buckets/b1', status=401)
+        response = self.app.get("/buckets/b1", status=401)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['401'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["401"])
         validate_response(schema, op, response)
 
     def test_object_get_403(self):
-        headers = {**self.headers, **testing.get_user_headers('aaa')}
-        response = self.app.get('/buckets/b1',
-                                headers=headers, status=403)
+        headers = {**self.headers, **testing.get_user_headers("aaa")}
+        response = self.app.get("/buckets/b1", headers=headers, status=403)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['403'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["403"])
         validate_response(schema, op, response)
 
     def test_object_get_404(self):
-        response = self.app.get('/buckets/b1/collections/col',
-                                headers=self.headers, status=404)
+        response = self.app.get("/buckets/b1/collections/col", headers=self.headers, status=404)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].get_collection
-        schema = self.spec.deref(op.op_spec['responses']['404'])
+        op = self.resources["Collections"].get_collection
+        schema = self.spec.deref(op.op_spec["responses"]["404"])
         validate_response(schema, op, response)
 
     def test_object_get_406(self):
-        headers = {**self.headers, 'Accept': 'text/html'}
-        response = self.app.get('/buckets/b1',
-                                headers=headers, status=406)
+        headers = {**self.headers, "Accept": "text/html"}
+        response = self.app.get("/buckets/b1", headers=headers, status=406)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['406'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["406"])
         validate_response(schema, op, response)
 
     def test_object_get_412(self):
-        headers = {**self.headers,
-                   'If-Match': '"{}"'.format(self.bucket['data']['last_modified']-1)}
-        response = self.app.get('/buckets/b1',
-                                headers=headers, status=412)
+        headers = {
+            **self.headers,
+            "If-Match": '"{}"'.format(self.bucket["data"]["last_modified"] - 1),
+        }
+        response = self.app.get("/buckets/b1", headers=headers, status=412)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_bucket
-        schema = self.spec.deref(op.op_spec['responses']['412'])
+        op = self.resources["Buckets"].get_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["412"])
         validate_response(schema, op, response)
 
     def test_object_put_400(self):
-        response = self.app.put_json('/buckets/b1', [],
-                                     headers=self.headers, status=400)
+        response = self.app.put_json("/buckets/b1", [], headers=self.headers, status=400)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['400'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["400"])
         validate_response(schema, op, response)
 
     def test_object_put_401(self):
-        response = self.app.put_json('/buckets/b1', MINIMALIST_BUCKET, status=401)
+        response = self.app.put_json("/buckets/b1", MINIMALIST_BUCKET, status=401)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['401'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["401"])
         validate_response(schema, op, response)
 
     def test_object_put_403(self):
-        headers = {**self.headers, **testing.get_user_headers('aaa')}
-        response = self.app.put_json('/buckets/b1', MINIMALIST_BUCKET,
-                                     headers=headers, status=403)
+        headers = {**self.headers, **testing.get_user_headers("aaa")}
+        response = self.app.put_json("/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=403)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['403'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["403"])
         validate_response(schema, op, response)
 
     def test_object_put_406(self):
-        headers = {**self.headers, 'Accept': 'text/html'}
-        response = self.app.put_json('/buckets/b1', MINIMALIST_BUCKET,
-                                     headers=headers, status=406)
+        headers = {**self.headers, "Accept": "text/html"}
+        response = self.app.put_json("/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=406)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['406'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["406"])
         validate_response(schema, op, response)
 
     def test_object_put_412(self):
-        headers = {**self.headers,
-                   'If-Match': '"{}"'.format(self.bucket['data']['last_modified']-1)}
-        response = self.app.put_json('/buckets/b1', MINIMALIST_BUCKET,
-                                     headers=headers, status=412)
+        headers = {
+            **self.headers,
+            "If-Match": '"{}"'.format(self.bucket["data"]["last_modified"] - 1),
+        }
+        response = self.app.put_json("/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=412)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['412'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["412"])
         validate_response(schema, op, response)
 
     def test_object_put_415(self):
-        headers = {**self.headers, 'Content-Type': 'text/html'}
-        response = self.app.put_json('/buckets/b1', MINIMALIST_BUCKET,
-                                     headers=headers, status=415)
+        headers = {**self.headers, "Content-Type": "text/html"}
+        response = self.app.put_json("/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=415)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].update_bucket
-        schema = self.spec.deref(op.op_spec['responses']['415'])
+        op = self.resources["Buckets"].update_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["415"])
         validate_response(schema, op, response)
 
     def test_object_patch_400(self):
-        response = self.app.patch_json('/buckets/b1', [],
-                                       headers=self.headers, status=400)
+        response = self.app.patch_json("/buckets/b1", [], headers=self.headers, status=400)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].patch_bucket
-        schema = self.spec.deref(op.op_spec['responses']['400'])
+        op = self.resources["Buckets"].patch_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["400"])
         validate_response(schema, op, response)
 
     def test_object_patch_401(self):
-        response = self.app.patch_json('/buckets/b1', MINIMALIST_BUCKET, status=401)
+        response = self.app.patch_json("/buckets/b1", MINIMALIST_BUCKET, status=401)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].patch_bucket
-        schema = self.spec.deref(op.op_spec['responses']['401'])
+        op = self.resources["Buckets"].patch_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["401"])
         validate_response(schema, op, response)
 
     def test_object_patch_403(self):
-        headers = {**self.headers, **testing.get_user_headers('aaa')}
-        response = self.app.patch_json('/buckets/b1', MINIMALIST_BUCKET,
-                                       headers=headers, status=403)
+        headers = {**self.headers, **testing.get_user_headers("aaa")}
+        response = self.app.patch_json(
+            "/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=403
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].patch_bucket
-        schema = self.spec.deref(op.op_spec['responses']['403'])
+        op = self.resources["Buckets"].patch_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["403"])
         validate_response(schema, op, response)
 
     def test_object_patch_404(self):
-        response = self.app.patch_json('/buckets/b1/collections/col',
-                                       MINIMALIST_COLLECTION,
-                                       headers=self.headers, status=404)
+        response = self.app.patch_json(
+            "/buckets/b1/collections/col", MINIMALIST_COLLECTION, headers=self.headers, status=404
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].patch_collection
-        schema = self.spec.deref(op.op_spec['responses']['404'])
+        op = self.resources["Collections"].patch_collection
+        schema = self.spec.deref(op.op_spec["responses"]["404"])
         validate_response(schema, op, response)
 
     def test_object_patch_406(self):
-        headers = {**self.headers, 'Accept': 'text/html'}
-        response = self.app.patch_json('/buckets/b1', MINIMALIST_BUCKET,
-                                       headers=headers, status=406)
+        headers = {**self.headers, "Accept": "text/html"}
+        response = self.app.patch_json(
+            "/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=406
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].patch_bucket
-        schema = self.spec.deref(op.op_spec['responses']['406'])
+        op = self.resources["Buckets"].patch_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["406"])
         validate_response(schema, op, response)
 
     def test_object_patch_412(self):
-        headers = {**self.headers,
-                   'If-Match': '"{}"'.format(self.bucket['data']['last_modified']-1)}
-        response = self.app.patch_json('/buckets/b1', MINIMALIST_BUCKET,
-                                       headers=headers, status=412)
+        headers = {
+            **self.headers,
+            "If-Match": '"{}"'.format(self.bucket["data"]["last_modified"] - 1),
+        }
+        response = self.app.patch_json(
+            "/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=412
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].patch_bucket
-        schema = self.spec.deref(op.op_spec['responses']['412'])
+        op = self.resources["Buckets"].patch_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["412"])
         validate_response(schema, op, response)
 
     def test_object_patch_415(self):
-        headers = {**self.headers, 'Content-Type': 'text/html'}
-        response = self.app.patch_json('/buckets/b1', MINIMALIST_BUCKET,
-                                       headers=headers, status=415)
+        headers = {**self.headers, "Content-Type": "text/html"}
+        response = self.app.patch_json(
+            "/buckets/b1", MINIMALIST_BUCKET, headers=headers, status=415
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].patch_bucket
-        schema = self.spec.deref(op.op_spec['responses']['415'])
+        op = self.resources["Buckets"].patch_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["415"])
         validate_response(schema, op, response)
 
     def test_object_delete_400(self):
-        headers = {**self.headers, 'If-Match': 'aaa'}
-        response = self.app.delete('/buckets/b1',
-                                   headers=headers, status=400)
+        headers = {**self.headers, "If-Match": "aaa"}
+        response = self.app.delete("/buckets/b1", headers=headers, status=400)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_bucket
-        schema = self.spec.deref(op.op_spec['responses']['400'])
+        op = self.resources["Buckets"].delete_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["400"])
         validate_response(schema, op, response)
 
     def test_object_delete_401(self):
-        response = self.app.delete('/buckets/b1', status=401)
+        response = self.app.delete("/buckets/b1", status=401)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_bucket
-        schema = self.spec.deref(op.op_spec['responses']['401'])
+        op = self.resources["Buckets"].delete_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["401"])
         validate_response(schema, op, response)
 
     def test_object_delete_403(self):
-        headers = {**self.headers, **testing.get_user_headers('aaa')}
-        response = self.app.delete('/buckets/b1',
-                                   headers=headers, status=403)
+        headers = {**self.headers, **testing.get_user_headers("aaa")}
+        response = self.app.delete("/buckets/b1", headers=headers, status=403)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_bucket
-        schema = self.spec.deref(op.op_spec['responses']['403'])
+        op = self.resources["Buckets"].delete_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["403"])
         validate_response(schema, op, response)
 
     def test_object_delete_404(self):
-        response = self.app.delete('/buckets/b1/collections/col',
-                                   headers=self.headers, status=404)
+        response = self.app.delete("/buckets/b1/collections/col", headers=self.headers, status=404)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].delete_collection
-        schema = self.spec.deref(op.op_spec['responses']['404'])
+        op = self.resources["Collections"].delete_collection
+        schema = self.spec.deref(op.op_spec["responses"]["404"])
         validate_response(schema, op, response)
 
     def test_object_delete_406(self):
-        headers = {**self.headers, 'Accept': 'text/html'}
-        response = self.app.delete('/buckets/b1',
-                                   headers=headers, status=406)
+        headers = {**self.headers, "Accept": "text/html"}
+        response = self.app.delete("/buckets/b1", headers=headers, status=406)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_bucket
-        schema = self.spec.deref(op.op_spec['responses']['406'])
+        op = self.resources["Buckets"].delete_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["406"])
         validate_response(schema, op, response)
 
     def test_object_delete_412(self):
-        headers = {**self.headers,
-                   'If-Match': '"{}"'.format(self.bucket['data']['last_modified']-1)}
-        response = self.app.delete('/buckets/b1',
-                                   headers=headers, status=412)
+        headers = {
+            **self.headers,
+            "If-Match": '"{}"'.format(self.bucket["data"]["last_modified"] - 1),
+        }
+        response = self.app.delete("/buckets/b1", headers=headers, status=412)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_bucket
-        schema = self.spec.deref(op.op_spec['responses']['412'])
+        op = self.resources["Buckets"].delete_bucket
+        schema = self.spec.deref(op.op_spec["responses"]["412"])
         validate_response(schema, op, response)
 
     def test_list_get_304(self):
-        headers = {**self.headers,
-                   'If-None-Match': '"{}"'.format(self.bucket['data']['last_modified'])}
-        response = self.app.get('/buckets',
-                                headers=headers, status=304)
+        headers = {
+            **self.headers,
+            "If-None-Match": '"{}"'.format(self.bucket["data"]["last_modified"]),
+        }
+        response = self.app.get("/buckets", headers=headers, status=304)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_buckets
-        schema = self.spec.deref(op.op_spec['responses']['304'])
+        op = self.resources["Buckets"].get_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["304"])
         validate_response(schema, op, response)
 
     def test_list_get_400(self):
-        response = self.app.get('/buckets?_since=aaa',
-                                headers=self.headers, status=400)
+        response = self.app.get("/buckets?_since=aaa", headers=self.headers, status=400)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_buckets
-        schema = self.spec.deref(op.op_spec['responses']['400'])
+        op = self.resources["Buckets"].get_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["400"])
         validate_response(schema, op, response)
 
     def test_list_get_401(self):
-        response = self.app.get('/buckets', status=401)
+        response = self.app.get("/buckets", status=401)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_buckets
-        schema = self.spec.deref(op.op_spec['responses']['401'])
+        op = self.resources["Buckets"].get_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["401"])
         validate_response(schema, op, response)
 
     def test_list_get_403(self):
-        headers = {**self.headers, **testing.get_user_headers('aaa')}
-        response = self.app.get('/buckets/b1/collections',
-                                headers=headers, status=403)
+        headers = {**self.headers, **testing.get_user_headers("aaa")}
+        response = self.app.get("/buckets/b1/collections", headers=headers, status=403)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].get_collections
-        schema = self.spec.deref(op.op_spec['responses']['403'])
+        op = self.resources["Collections"].get_collections
+        schema = self.spec.deref(op.op_spec["responses"]["403"])
         validate_response(schema, op, response)
 
     def test_list_get_406(self):
-        headers = {**self.headers, 'Accept': 'text/html'}
-        response = self.app.get('/buckets',
-                                headers=headers, status=406)
+        headers = {**self.headers, "Accept": "text/html"}
+        response = self.app.get("/buckets", headers=headers, status=406)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_buckets
-        schema = self.spec.deref(op.op_spec['responses']['406'])
+        op = self.resources["Buckets"].get_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["406"])
         validate_response(schema, op, response)
 
     def test_list_get_412(self):
-        headers = {**self.headers,
-                   'If-Match': '"{}"'.format(self.bucket['data']['last_modified']-1)}
-        response = self.app.get('/buckets/b1',
-                                headers=headers, status=412)
+        headers = {
+            **self.headers,
+            "If-Match": '"{}"'.format(self.bucket["data"]["last_modified"] - 1),
+        }
+        response = self.app.get("/buckets/b1", headers=headers, status=412)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].get_buckets
-        schema = self.spec.deref(op.op_spec['responses']['412'])
+        op = self.resources["Buckets"].get_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["412"])
         validate_response(schema, op, response)
 
     def test_list_delete_401(self):
-        response = self.app.delete('/buckets', status=401)
+        response = self.app.delete("/buckets", status=401)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_buckets
-        schema = self.spec.deref(op.op_spec['responses']['401'])
+        op = self.resources["Buckets"].delete_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["401"])
         validate_response(schema, op, response)
 
     def test_lidt_delete_403(self):
-        headers = {**self.headers, **testing.get_user_headers('aaa')}
-        response = self.app.delete('/buckets/b1/collections',
-                                   headers=headers, status=403)
+        headers = {**self.headers, **testing.get_user_headers("aaa")}
+        response = self.app.delete("/buckets/b1/collections", headers=headers, status=403)
         response = self.cast_bravado_response(response)
-        op = self.resources['Collections'].delete_collections
-        schema = self.spec.deref(op.op_spec['responses']['403'])
+        op = self.resources["Collections"].delete_collections
+        schema = self.spec.deref(op.op_spec["responses"]["403"])
         validate_response(schema, op, response)
 
     def test_list_delete_405(self):
@@ -328,20 +321,20 @@ class OpenAPIObjectErrorResponsesTest(OpenAPITest):
         pass
 
     def test_list_delete_406(self):
-        headers = {**self.headers, 'Accept': 'text/html'}
-        response = self.app.delete('/buckets',
-                                   headers=headers, status=406)
+        headers = {**self.headers, "Accept": "text/html"}
+        response = self.app.delete("/buckets", headers=headers, status=406)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_buckets
-        schema = self.spec.deref(op.op_spec['responses']['406'])
+        op = self.resources["Buckets"].delete_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["406"])
         validate_response(schema, op, response)
 
     def test_list_delete_412(self):
-        headers = {**self.headers,
-                   'If-Match': '"{}"'.format(self.bucket['data']['last_modified']-1)}
-        response = self.app.delete('/buckets',
-                                   headers=headers, status=412)
+        headers = {
+            **self.headers,
+            "If-Match": '"{}"'.format(self.bucket["data"]["last_modified"] - 1),
+        }
+        response = self.app.delete("/buckets", headers=headers, status=412)
         response = self.cast_bravado_response(response)
-        op = self.resources['Buckets'].delete_buckets
-        schema = self.spec.deref(op.op_spec['responses']['412'])
+        op = self.resources["Buckets"].delete_buckets
+        schema = self.spec.deref(op.op_spec["responses"]["412"])
         validate_response(schema, op, response)

--- a/tests/openapi/test_responses_groups.py
+++ b/tests/openapi/test_responses_groups.py
@@ -4,67 +4,66 @@ from .support import OpenAPITest, MINIMALIST_GROUP
 
 
 class OpenAPIGroupResponsesTest(OpenAPITest):
-
     def test_get_group_200(self):
-        response = self.app.get('/buckets/b1/groups/g1',
-                                headers=self.headers, status=200)
+        response = self.app.get("/buckets/b1/groups/g1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].get_group
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Groups"].get_group
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_group_200(self):
-        response = self.app.post_json('/buckets/b1/groups', self.group,
-                                      headers=self.headers, status=200)
+        response = self.app.post_json(
+            "/buckets/b1/groups", self.group, headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].create_group
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Groups"].create_group
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_group_201(self):
-        response = self.app.post_json('/buckets/b1/groups', MINIMALIST_GROUP,
-                                      headers=self.headers, status=201)
+        response = self.app.post_json(
+            "/buckets/b1/groups", MINIMALIST_GROUP, headers=self.headers, status=201
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].create_group
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Groups"].create_group
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_put_group_200(self):
-        response = self.app.put_json('/buckets/b1/groups/g1', MINIMALIST_GROUP,
-                                     headers=self.headers, status=200)
+        response = self.app.put_json(
+            "/buckets/b1/groups/g1", MINIMALIST_GROUP, headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].update_group
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Groups"].update_group
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_put_group_201(self):
-        response = self.app.put_json('/buckets/b1/groups/g2', MINIMALIST_GROUP,
-                                     headers=self.headers, status=201)
+        response = self.app.put_json(
+            "/buckets/b1/groups/g2", MINIMALIST_GROUP, headers=self.headers, status=201
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].update_group
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Groups"].update_group
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_delete_group_200(self):
-        response = self.app.delete('/buckets/b1/groups/g1',
-                                   headers=self.headers, status=200)
+        response = self.app.delete("/buckets/b1/groups/g1", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].delete_group
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Groups"].delete_group
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_get_groups_200(self):
-        response = self.app.get('/buckets/b1/groups',
-                                headers=self.headers, status=200)
+        response = self.app.get("/buckets/b1/groups", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].get_groups
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Groups"].get_groups
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_delete_groups_200(self):
-        response = self.app.delete('/buckets/b1/groups',
-                                   headers=self.headers, status=200)
+        response = self.app.delete("/buckets/b1/groups", headers=self.headers, status=200)
         response = self.cast_bravado_response(response)
-        op = self.resources['Groups'].delete_groups
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Groups"].delete_groups
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)

--- a/tests/openapi/test_responses_records.py
+++ b/tests/openapi/test_responses_records.py
@@ -4,67 +4,83 @@ from .support import OpenAPITest, MINIMALIST_RECORD
 
 
 class OpenAPIRecordResponsesTest(OpenAPITest):
-
     def test_get_record_200(self):
-        response = self.app.get('/buckets/b1/collections/c1/records/r1',
-                                headers=self.headers, status=200)
+        response = self.app.get(
+            "/buckets/b1/collections/c1/records/r1", headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].get_record
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Records"].get_record
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_record_200(self):
-        response = self.app.post_json('/buckets/b1/collections/c1/records',
-                                      self.record, headers=self.headers, status=200)
+        response = self.app.post_json(
+            "/buckets/b1/collections/c1/records", self.record, headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].create_record
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Records"].create_record
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_post_record_201(self):
-        response = self.app.post_json('/buckets/b1/collections/c1/records',
-                                      MINIMALIST_RECORD, headers=self.headers, status=201)
+        response = self.app.post_json(
+            "/buckets/b1/collections/c1/records",
+            MINIMALIST_RECORD,
+            headers=self.headers,
+            status=201,
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].create_record
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Records"].create_record
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_put_record_200(self):
-        response = self.app.put_json('/buckets/b1/collections/c1/records/r1',
-                                     MINIMALIST_RECORD, headers=self.headers, status=200)
+        response = self.app.put_json(
+            "/buckets/b1/collections/c1/records/r1",
+            MINIMALIST_RECORD,
+            headers=self.headers,
+            status=200,
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].update_record
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Records"].update_record
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_put_record_201(self):
-        response = self.app.put_json('/buckets/b1/collections/c1/records/r2',
-                                     MINIMALIST_RECORD, headers=self.headers, status=201)
+        response = self.app.put_json(
+            "/buckets/b1/collections/c1/records/r2",
+            MINIMALIST_RECORD,
+            headers=self.headers,
+            status=201,
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].update_record
-        schema = self.spec.deref(op.op_spec['responses']['201'])
+        op = self.resources["Records"].update_record
+        schema = self.spec.deref(op.op_spec["responses"]["201"])
         validate_response(schema, op, response)
 
     def test_delete_record_200(self):
-        response = self.app.delete('/buckets/b1/collections/c1/records/r1',
-                                   headers=self.headers, status=200)
+        response = self.app.delete(
+            "/buckets/b1/collections/c1/records/r1", headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].delete_record
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Records"].delete_record
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_get_records_200(self):
-        response = self.app.get('/buckets/b1/collections/c1/records',
-                                headers=self.headers, status=200)
+        response = self.app.get(
+            "/buckets/b1/collections/c1/records", headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].get_records
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Records"].get_records
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)
 
     def test_delete_records_200(self):
-        response = self.app.delete('/buckets/b1/collections/c1/records',
-                                   headers=self.headers, status=200)
+        response = self.app.delete(
+            "/buckets/b1/collections/c1/records", headers=self.headers, status=200
+        )
         response = self.cast_bravado_response(response)
-        op = self.resources['Records'].delete_records
-        schema = self.spec.deref(op.op_spec['responses']['200'])
+        op = self.resources["Records"].delete_records
+        schema = self.spec.deref(op.op_spec["responses"]["200"])
         validate_response(schema, op, response)

--- a/tests/openapi/test_validation.py
+++ b/tests/openapi/test_validation.py
@@ -5,7 +5,6 @@ from .support import OpenAPITest
 
 
 class OpenAPIRequestsValidationTest(OpenAPITest):
-
     def setUp(self):
         super().setUp()
 
@@ -17,207 +16,170 @@ class OpenAPIRequestsValidationTest(OpenAPITest):
         self.request.json = lambda: self.request._json
 
     def test_validate_bucket_path(self):
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Buckets'].get_bucket)
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Buckets"].get_bucket
+        )
 
     def test_validate_groups_path(self):
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Groups'].get_groups)
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Groups"].get_groups
+        )
 
     def test_validate_group_path(self):
-        paths = [
-            {},
-            {'bucket_id': 'b1'},
-            {'id': 'g1'}
-        ]
+        paths = [{}, {"bucket_id": "b1"}, {"id": "g1"}]
         for path in paths:
             self.request.path = path
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Groups'].get_group)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Groups"].get_group,
+            )
 
     def test_validate_collections_path(self):
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Collections'].get_collections)
+        self.assertRaises(
+            ValidationError,
+            unmarshal_request,
+            self.request,
+            self.resources["Collections"].get_collections,
+        )
 
     def test_validate_collection_path(self):
-        paths = [
-            {},
-            {'bucket_id': 'b1'},
-            {'id': 'c1'}
-        ]
+        paths = [{}, {"bucket_id": "b1"}, {"id": "c1"}]
         for path in paths:
             self.request.path = path
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Collections'].get_collection)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Collections"].get_collection,
+            )
 
     def test_validate_records_path(self):
-        paths = [
-            {},
-            {'bucket_id': 'b1'},
-            {'collection_id': 'c1'}
-        ]
+        paths = [{}, {"bucket_id": "b1"}, {"collection_id": "c1"}]
         for path in paths:
             self.request.path = path
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Records'].get_records)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Records"].get_records,
+            )
 
     def test_validate_record_path(self):
-        paths = [
-            {},
-            {'bucket_id': 'b1', 'collection_id': 'c1'},
-            {'id': 'r1'},
-        ]
+        paths = [{}, {"bucket_id": "b1", "collection_id": "c1"}, {"id": "r1"}]
         for path in paths:
             self.request.path = path
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Records'].get_record)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Records"].get_record,
+            )
 
     def test_validate_data(self):
-        bodies = [
-            {'data': 'aaa'},
-        ]
+        bodies = [{"data": "aaa"}]
         for body in bodies:
             self.request._json = body
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Buckets'].create_bucket)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Buckets"].create_bucket,
+            )
 
     def test_validate_permissions(self):
         bodies = [
-            {'permissions': 'aaa'},
-            {'permissions': {'read': 'aaa'}},
-            {'permissions': {'read': [111]}},
+            {"permissions": "aaa"},
+            {"permissions": {"read": "aaa"}},
+            {"permissions": {"read": [111]}},
         ]
         for body in bodies:
             self.request._json = body
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Buckets'].create_bucket)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Buckets"].create_bucket,
+            )
 
     def test_validate_queries(self):
-        queries = [
-            {'_since': 'aaa'},
-            {'_before': 'aaa'},
-            {'_limit': 'aaa'},
-            {'_token': {}},
-        ]
+        queries = [{"_since": "aaa"}, {"_before": "aaa"}, {"_limit": "aaa"}, {"_token": {}}]
         for query in queries:
             self.request.query = query
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Buckets'].get_buckets)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Buckets"].get_buckets,
+            )
 
     def test_validate_headers(self):
-        headers = [
-            {'If-None-Match': '123'},
-            {'If-Match': '123'},
-        ]
+        headers = [{"If-None-Match": "123"}, {"If-Match": "123"}]
         for head in headers:
             self.request.headers = head
-            self.assertRaises(ValidationError, unmarshal_request,
-                              self.request, self.resources['Buckets'].get_buckets)
+            self.assertRaises(
+                ValidationError,
+                unmarshal_request,
+                self.request,
+                self.resources["Buckets"].get_buckets,
+            )
 
     def test_validate_batch_requests_method(self):
-        self.request._json = {
-            'requests': [
-                {
-                    'method': 'AAA',
-                    'path': '/buckets/b1',
-                },
-            ]
-        }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.request._json = {"requests": [{"method": "AAA", "path": "/buckets/b1"}]}
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_requests_path(self):
-        self.request._json = {
-            'requests': [
-                {
-                    'method': 'GET',
-                    'path': 123,
-                },
-            ]
-        }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.request._json = {"requests": [{"method": "GET", "path": 123}]}
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_requests_body(self):
-        self.request._json = {
-            'requests': [
-                {
-                    'method': 'GET',
-                    'path': '/buckets/b1',
-                    'body': []
-                },
-            ]
-        }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.request._json = {"requests": [{"method": "GET", "path": "/buckets/b1", "body": []}]}
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_requests_header(self):
         self.request._json = {
-            'requests': [
-                {
-                    'method': 'GET',
-                    'path': '/buckets/b1',
-                    'body': {},
-                    'headers': []
-                },
-            ]
+            "requests": [{"method": "GET", "path": "/buckets/b1", "body": {}, "headers": []}]
         }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_defaults(self):
         self.request._json = {
-            'defaults': [],
-            'requests': [
-                {
-                    'method': 'GET',
-                    'path': '/buckets/b1',
-                },
-            ]
+            "defaults": [],
+            "requests": [{"method": "GET", "path": "/buckets/b1"}],
         }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_defaults_method(self):
-        self.request._json = {
-            'defaults': {
-                'method': 'AAA'
-            },
-            'requests': [
-                {
-                    'path': '/buckets/b1',
-                },
-            ]
-        }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.request._json = {"defaults": {"method": "AAA"}, "requests": [{"path": "/buckets/b1"}]}
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_defaults_body(self):
         self.request._json = {
-            'defaults': {
-                'body': []
-            },
-            'requests': [
-                {
-                    'method': 'PUT',
-                    'path': '/buckets/b1',
-                },
-            ]
+            "defaults": {"body": []},
+            "requests": [{"method": "PUT", "path": "/buckets/b1"}],
         }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )
 
     def test_validate_batch_defaults_headers(self):
         self.request._json = {
-            'defaults': {
-                'headers': []
-            },
-            'requests': [
-                {
-                    'method': 'GET',
-                    'path': '/buckets/b1',
-                },
-            ]
+            "defaults": {"headers": []},
+            "requests": [{"method": "GET", "path": "/buckets/b1"}],
         }
-        self.assertRaises(ValidationError, unmarshal_request,
-                          self.request, self.resources['Batch'].batch)
+        self.assertRaises(
+            ValidationError, unmarshal_request, self.request, self.resources["Batch"].batch
+        )

--- a/tests/plugins/test_accounts.py
+++ b/tests/plugins/test_accounts.py
@@ -10,469 +10,503 @@ from .. import support
 
 
 class AccountsWebTest(support.BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         if extras is None:
             extras = {}
-        extras.setdefault('multiauth.policies', 'account')
-        extras.setdefault('includes', 'kinto.plugins.accounts')
-        extras.setdefault('account_create_principals', 'system.Everyone')
+        extras.setdefault("multiauth.policies", "account")
+        extras.setdefault("includes", "kinto.plugins.accounts")
+        extras.setdefault("account_create_principals", "system.Everyone")
         # XXX: this should be a default setting.
-        extras.setdefault('multiauth.policy.account.use', 'kinto.plugins.accounts.authentication.'
-                                                          'AccountsAuthenticationPolicy')
-        extras.setdefault('account_cache_ttl_seconds', '30')
+        extras.setdefault(
+            "multiauth.policy.account.use",
+            "kinto.plugins.accounts.authentication." "AccountsAuthenticationPolicy",
+        )
+        extras.setdefault("account_cache_ttl_seconds", "30")
         return super().get_app_settings(extras)
 
 
 class BadAccountsConfigTest(support.BaseWebTest, unittest.TestCase):
-
     def test_raise_configuration_if_accounts_not_mentioned(self):
         with self.assertRaises(ConfigurationError) as cm:
-            self.make_app({
-                'includes': 'kinto.plugins.accounts',
-                'multiauth.policies': 'basicauth',
-            })
+            self.make_app(
+                {"includes": "kinto.plugins.accounts", "multiauth.policies": "basicauth"}
+            )
         assert "Account policy missing" in str(cm.exception)
 
 
 class HelloViewTest(AccountsWebTest):
-
     def test_accounts_capability_if_enabled(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('accounts', capabilities)
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("accounts", capabilities)
 
 
 class AccountCreationTest(AccountsWebTest):
-
     def test_anyone_can_create_an_account(self):
-        self.app.post_json('/accounts', {'data': {'id': 'alice', 'password': '12éé6'}},
-                           status=201)
+        self.app.post_json("/accounts", {"data": {"id": "alice", "password": "12éé6"}}, status=201)
 
     def test_account_can_be_created_with_put(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
+        self.app.put_json("/accounts/alice", {"data": {"password": "123456"}}, status=201)
 
     def test_password_is_stored_encrypted(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
-        stored = self.app.app.registry.storage.get(parent_id='alice',
-                                                   collection_id='account',
-                                                   object_id='alice')
-        assert stored['password'] != '123456'
+        self.app.put_json("/accounts/alice", {"data": {"password": "123456"}}, status=201)
+        stored = self.app.app.registry.storage.get(
+            parent_id="alice", collection_id="account", object_id="alice"
+        )
+        assert stored["password"] != "123456"
 
     def test_authentication_is_accepted_if_account_exists(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        resp = self.app.get('/', headers=get_user_headers('me', 'bouh'))
-        assert resp.json['user']['id'] == 'account:me'
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        resp = self.app.get("/", headers=get_user_headers("me", "bouh"))
+        assert resp.json["user"]["id"] == "account:me"
 
     def test_password_field_is_mandatory(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me'}}, status=400)
+        self.app.post_json("/accounts", {"data": {"id": "me"}}, status=400)
 
     def test_id_field_is_mandatory(self):
-        self.app.post_json('/accounts', {'data': {'password': 'pass'}}, status=400)
+        self.app.post_json("/accounts", {"data": {"password": "pass"}}, status=400)
 
     def test_id_can_be_email(self):
-        self.app.put_json('/accounts/alice@example.com', {'data': {'password': '123456'}},
-                          status=201)
+        self.app.put_json(
+            "/accounts/alice@example.com", {"data": {"password": "123456"}}, status=201
+        )
 
     def test_account_can_have_metadata(self):
-        resp = self.app.post_json('/accounts',
-                                  {'data': {'id': 'me', 'password': 'bouh', 'age': 42}},
-                                  status=201)
-        assert resp.json['data']['age'] == 42
+        resp = self.app.post_json(
+            "/accounts", {"data": {"id": "me", "password": "bouh", "age": 42}}, status=201
+        )
+        assert resp.json["data"]["age"] == 42
 
     def test_cannot_create_account_if_already_exists(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        resp = self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                                  status=403)
-        assert 'already exists' in resp.json['message']
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        resp = self.app.post_json(
+            "/accounts", {"data": {"id": "me", "password": "bouh"}}, status=403
+        )
+        assert "already exists" in resp.json["message"]
 
     def test_username_and_account_id_must_match(self):
-        resp = self.app.put_json('/accounts/alice', {'data': {'id': 'bob', 'password': 'bouh'}},
-                                 status=400)
-        assert 'does not match' in resp.json['message']
+        resp = self.app.put_json(
+            "/accounts/alice", {"data": {"id": "bob", "password": "bouh"}}, status=400
+        )
+        assert "does not match" in resp.json["message"]
 
     def test_returns_existing_account_if_authenticated(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           headers=get_user_headers('me', 'bouh'),
-                           status=200)
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        self.app.post_json(
+            "/accounts",
+            {"data": {"id": "me", "password": "bouh"}},
+            headers=get_user_headers("me", "bouh"),
+            status=200,
+        )
 
     def test_cannot_create_other_account_if_authenticated(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        resp = self.app.post_json('/accounts', {'data': {'id': 'you', 'password': 'bouh'}},
-                                  headers=get_user_headers('me', 'bouh'),
-                                  status=400)
-        assert 'do not match' in resp.json['message']
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        resp = self.app.post_json(
+            "/accounts",
+            {"data": {"id": "you", "password": "bouh"}},
+            headers=get_user_headers("me", "bouh"),
+            status=400,
+        )
+        assert "do not match" in resp.json["message"]
 
     def test_authentication_does_not_call_bcrypt_twice(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        with mock.patch('kinto.plugins.accounts.authentication.bcrypt') as mocked_bcrypt:
-            resp = self.app.get('/', headers=get_user_headers('me', 'bouh'))
-            assert resp.json['user']['id'] == 'account:me'
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        with mock.patch("kinto.plugins.accounts.authentication.bcrypt") as mocked_bcrypt:
+            resp = self.app.get("/", headers=get_user_headers("me", "bouh"))
+            assert resp.json["user"]["id"] == "account:me"
 
-            resp = self.app.get('/', headers=get_user_headers('me', 'bouh'))
-            assert resp.json['user']['id'] == 'account:me'
+            resp = self.app.get("/", headers=get_user_headers("me", "bouh"))
+            assert resp.json["user"]["id"] == "account:me"
 
             assert mocked_bcrypt.checkpw.call_count == 1
 
     def test_authentication_checks_bcrypt_again_if_password_changes(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        with mock.patch('kinto.plugins.accounts.authentication.bcrypt') as mocked_bcrypt:
-            resp = self.app.get('/', headers=get_user_headers('me', 'bouh'))
-            assert resp.json['user']['id'] == 'account:me'
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        with mock.patch("kinto.plugins.accounts.authentication.bcrypt") as mocked_bcrypt:
+            resp = self.app.get("/", headers=get_user_headers("me", "bouh"))
+            assert resp.json["user"]["id"] == "account:me"
 
-            self.app.patch_json('/accounts/me', {'data': {'password': 'blah'}},
-                                status=200, headers=get_user_headers('me', 'bouh'))
+            self.app.patch_json(
+                "/accounts/me",
+                {"data": {"password": "blah"}},
+                status=200,
+                headers=get_user_headers("me", "bouh"),
+            )
 
-            resp = self.app.get('/', headers=get_user_headers('me', 'blah'))
-            assert resp.json['user']['id'] == 'account:me'
+            resp = self.app.get("/", headers=get_user_headers("me", "blah"))
+            assert resp.json["user"]["id"] == "account:me"
 
             assert mocked_bcrypt.checkpw.call_count == 2
 
     def test_authentication_refresh_the_cache_each_time_we_authenticate(self):
-        hmac_secret = self.app.app.registry.settings['userid_hmac_secret']
-        cache_key = utils.hmac_digest(hmac_secret, ACCOUNT_CACHE_KEY.format('me'))
+        hmac_secret = self.app.app.registry.settings["userid_hmac_secret"]
+        cache_key = utils.hmac_digest(hmac_secret, ACCOUNT_CACHE_KEY.format("me"))
 
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bouh'}},
-                           status=201)
-        resp = self.app.get('/', headers=get_user_headers('me', 'bouh'))
-        assert resp.json['user']['id'] == 'account:me'
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bouh"}}, status=201)
+        resp = self.app.get("/", headers=get_user_headers("me", "bouh"))
+        assert resp.json["user"]["id"] == "account:me"
 
         self.app.app.registry.cache.expire(cache_key, 10)
 
-        resp = self.app.get('/', headers=get_user_headers('me', 'bouh'))
-        assert resp.json['user']['id'] == 'account:me'
+        resp = self.app.get("/", headers=get_user_headers("me", "bouh"))
+        assert resp.json["user"]["id"] == "account:me"
 
         assert self.app.app.registry.cache.ttl(cache_key) >= 20
 
-        resp = self.app.get('/', headers=get_user_headers('me', 'blah'))
-        assert 'user' not in resp.json
+        resp = self.app.get("/", headers=get_user_headers("me", "blah"))
+        assert "user" not in resp.json
 
 
 class AccountUpdateTest(AccountsWebTest):
-
     def setUp(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
+        self.app.put_json("/accounts/alice", {"data": {"password": "123456"}}, status=201)
 
     def test_password_can_be_changed(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': 'bouh'}},
-                          headers=get_user_headers('alice', '123456'),
-                          status=200)
+        self.app.put_json(
+            "/accounts/alice",
+            {"data": {"password": "bouh"}},
+            headers=get_user_headers("alice", "123456"),
+            status=200,
+        )
 
     def test_authentication_with_old_password_is_denied_after_change(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': 'bouh'}},
-                          headers=get_user_headers('alice', '123456'),
-                          status=200)
-        self.app.get('/accounts/alice', headers=get_user_headers('alice', '123456'),
-                     status=401)
+        self.app.put_json(
+            "/accounts/alice",
+            {"data": {"password": "bouh"}},
+            headers=get_user_headers("alice", "123456"),
+            status=200,
+        )
+        self.app.get("/accounts/alice", headers=get_user_headers("alice", "123456"), status=401)
 
     def test_authentication_with_new_password_is_accepted_after_change(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': 'bouh'}},
-                          headers=get_user_headers('alice', '123456'),
-                          status=200)
-        self.app.get('/accounts/alice', headers=get_user_headers('alice', 'bouh'))
+        self.app.put_json(
+            "/accounts/alice",
+            {"data": {"password": "bouh"}},
+            headers=get_user_headers("alice", "123456"),
+            status=200,
+        )
+        self.app.get("/accounts/alice", headers=get_user_headers("alice", "bouh"))
 
     def test_username_and_account_id_must_match(self):
-        resp = self.app.patch_json('/accounts/alice', {'data': {'id': 'bob', 'password': 'bouh'}},
-                                   headers=get_user_headers('alice', '123456'),
-                                   status=400)
-        assert 'does not match' in resp.json['message']
+        resp = self.app.patch_json(
+            "/accounts/alice",
+            {"data": {"id": "bob", "password": "bouh"}},
+            headers=get_user_headers("alice", "123456"),
+            status=400,
+        )
+        assert "does not match" in resp.json["message"]
 
     def test_cannot_patch_unknown_account(self):
-        self.app.patch_json('/accounts/bob', {'data': {'password': 'bouh'}},
-                            headers=get_user_headers('alice', '123456'),
-                            status=403)
+        self.app.patch_json(
+            "/accounts/bob",
+            {"data": {"password": "bouh"}},
+            headers=get_user_headers("alice", "123456"),
+            status=403,
+        )
 
     def test_cannot_patch_someone_else_account(self):
-        self.app.put_json('/accounts/bob', {'data': {'password': 'bob'}}, status=201)
-        self.app.patch_json('/accounts/bob', {'data': {'password': 'bouh'}},
-                            headers=get_user_headers('alice', '123456'),
-                            status=403)
+        self.app.put_json("/accounts/bob", {"data": {"password": "bob"}}, status=201)
+        self.app.patch_json(
+            "/accounts/bob",
+            {"data": {"password": "bouh"}},
+            headers=get_user_headers("alice", "123456"),
+            status=403,
+        )
 
     def test_metadata_can_be_changed(self):
-        resp = self.app.patch_json('/accounts/alice', {'data': {'age': 'captain'}},
-                                   headers=get_user_headers('alice', '123456'))
-        assert resp.json['data']['age'] == 'captain'
+        resp = self.app.patch_json(
+            "/accounts/alice",
+            {"data": {"age": "captain"}},
+            headers=get_user_headers("alice", "123456"),
+        )
+        assert resp.json["data"]["age"] == "captain"
 
 
 class AccountDeleteTest(AccountsWebTest):
-
     def setUp(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
+        self.app.put_json("/accounts/alice", {"data": {"password": "123456"}}, status=201)
 
     def test_account_can_be_deleted(self):
-        self.app.delete('/accounts/alice', headers=get_user_headers('alice', '123456'))
+        self.app.delete("/accounts/alice", headers=get_user_headers("alice", "123456"))
 
     def test_authentication_is_denied_after_delete(self):
-        self.app.delete('/accounts/alice', headers=get_user_headers('alice', '123456'))
-        self.app.get('/accounts/alice', headers=get_user_headers('alice', '123456'),
-                     status=401)
+        self.app.delete("/accounts/alice", headers=get_user_headers("alice", "123456"))
+        self.app.get("/accounts/alice", headers=get_user_headers("alice", "123456"), status=401)
 
 
 class AccountViewsTest(AccountsWebTest):
-
     def setUp(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
-        self.app.put_json('/accounts/bob', {'data': {'password': 'azerty'}}, status=201)
+        self.app.put_json("/accounts/alice", {"data": {"password": "123456"}}, status=201)
+        self.app.put_json("/accounts/bob", {"data": {"password": "azerty"}}, status=201)
 
     def test_account_list_is_forbidden_if_anonymous(self):
-        self.app.get('/accounts', status=401)
+        self.app.get("/accounts", status=401)
 
     def test_account_detail_is_forbidden_if_anonymous(self):
-        self.app.get('/accounts/alice', status=401)
+        self.app.get("/accounts/alice", status=401)
 
     def test_accounts_list_contains_only_one_record(self):
-        resp = self.app.get('/accounts', headers=get_user_headers('alice', '123456'))
-        assert len(resp.json['data']) == 1
+        resp = self.app.get("/accounts", headers=get_user_headers("alice", "123456"))
+        assert len(resp.json["data"]) == 1
 
     def test_account_record_can_be_obtained_if_authenticated(self):
-        self.app.get('/accounts/alice', headers=get_user_headers('alice', '123456'))
+        self.app.get("/accounts/alice", headers=get_user_headers("alice", "123456"))
 
     def test_cannot_obtain_someone_else_account(self):
-        self.app.get('/accounts/bob', headers=get_user_headers('alice', '123456'),
-                     status=403)
+        self.app.get("/accounts/bob", headers=get_user_headers("alice", "123456"), status=403)
 
     def test_cannot_obtain_unknown_account(self):
-        self.app.get('/accounts/jeanine', headers=get_user_headers('alice', '123456'),
-                     status=403)
+        self.app.get("/accounts/jeanine", headers=get_user_headers("alice", "123456"), status=403)
 
 
 class PermissionsEndpointTest(AccountsWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_permissions_endpoint'] = 'True'
+        settings["experimental_permissions_endpoint"] = "True"
         return settings
 
     def setUp(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': '123456'}}, status=201)
-        self.headers = get_user_headers('alice', '123456')
-        self.app.put('/buckets/a', headers=self.headers)
-        self.app.put('/buckets/a/collections/b', headers=self.headers)
-        self.app.put('/buckets/a/collections/b/records/c', headers=self.headers)
+        self.app.put_json("/accounts/alice", {"data": {"password": "123456"}}, status=201)
+        self.headers = get_user_headers("alice", "123456")
+        self.app.put("/buckets/a", headers=self.headers)
+        self.app.put("/buckets/a/collections/b", headers=self.headers)
+        self.app.put("/buckets/a/collections/b/records/c", headers=self.headers)
 
     def test_permissions_endpoint_is_compatible_with_accounts_plugin(self):
-        resp = self.app.get('/permissions', headers=self.headers)
+        resp = self.app.get("/permissions", headers=self.headers)
         uris = [r["uri"] for r in resp.json["data"]]
-        assert uris == ['/buckets/a/collections/b/records/c',
-                        '/buckets/a/collections/b',
-                        '/buckets/a',
-                        '/accounts/alice',
-                        '/']
+        assert uris == [
+            "/buckets/a/collections/b/records/c",
+            "/buckets/a/collections/b",
+            "/buckets/a",
+            "/accounts/alice",
+            "/",
+        ]
 
     def test_account_create_read_write_permissions_(self):
-        resp = self.app.get('/permissions', headers=self.headers)
-        buckets = resp.json['data']
+        resp = self.app.get("/permissions", headers=self.headers)
+        buckets = resp.json["data"]
         account = buckets[3]
-        account['permissions'].sort()
+        account["permissions"].sort()
         root = buckets[4]
-        root['permissions'].sort()
-        self.assertEqual(account, {
-            'account_id': 'alice',
-            'id': 'alice',
-            'permissions': ['read', 'write'],
-            'resource_name': 'account',
-            'uri': '/accounts/alice'})
-        self.assertEqual(root, {
-            'permissions': ['account:create', 'bucket:create'],
-            'resource_name': 'root',
-            'uri': '/'})
+        root["permissions"].sort()
+        self.assertEqual(
+            account,
+            {
+                "account_id": "alice",
+                "id": "alice",
+                "permissions": ["read", "write"],
+                "resource_name": "account",
+                "uri": "/accounts/alice",
+            },
+        )
+        self.assertEqual(
+            root,
+            {
+                "permissions": ["account:create", "bucket:create"],
+                "resource_name": "root",
+                "uri": "/",
+            },
+        )
 
 
 class PermissionsEndpointTestUnauthenticatedCreatePermission(AccountsWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_permissions_endpoint'] = 'True'
-        settings['bucket_create_principals'] = 'system.Everyone'
+        settings["experimental_permissions_endpoint"] = "True"
+        settings["bucket_create_principals"] = "system.Everyone"
         return settings
 
     def setUp(self):
-        self.everyone_headers = get_user_headers('')
+        self.everyone_headers = get_user_headers("")
 
     def test_permissions_endpoint_is_compatible_with_accounts_plugin(self):
-        resp = self.app.get('/permissions', headers=self.everyone_headers)
-        buckets = resp.json['data']
+        resp = self.app.get("/permissions", headers=self.everyone_headers)
+        buckets = resp.json["data"]
         root = buckets[0]
-        root['permissions'].sort()
-        self.assertEqual(root, {
-            'permissions': ['account:create', 'bucket:create'],
-            'resource_name': 'root',
-            'uri': '/'})
+        root["permissions"].sort()
+        self.assertEqual(
+            root,
+            {
+                "permissions": ["account:create", "bucket:create"],
+                "resource_name": "root",
+                "uri": "/",
+            },
+        )
 
 
 class AdminTest(AccountsWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['account_write_principals'] = 'account:admin'
-        settings['account_read_principals'] = 'account:admin'
+        settings["account_write_principals"] = "account:admin"
+        settings["account_read_principals"] = "account:admin"
         return settings
 
     def setUp(self):
-        self.app.put_json('/accounts/admin', {'data': {'password': '123456'}}, status=201)
-        self.admin_headers = get_user_headers('admin', '123456')
+        self.app.put_json("/accounts/admin", {"data": {"password": "123456"}}, status=201)
+        self.admin_headers = get_user_headers("admin", "123456")
 
-        self.app.put_json('/accounts/bob', {'data': {'password': '987654'}}, status=201)
+        self.app.put_json("/accounts/bob", {"data": {"password": "987654"}}, status=201)
 
     def test_admin_can_get_other_accounts(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': 'azerty'}}, status=201)
+        self.app.put_json("/accounts/alice", {"data": {"password": "azerty"}}, status=201)
 
-        resp = self.app.get('/accounts/alice', headers=get_user_headers('alice', 'azerty'))
-        assert resp.json['data']['id'] == 'alice'
+        resp = self.app.get("/accounts/alice", headers=get_user_headers("alice", "azerty"))
+        assert resp.json["data"]["id"] == "alice"
 
     def test_admin_can_delete_other_accounts(self):
-        self.app.delete_json('/accounts/bob', headers=self.admin_headers)
-        self.app.get('/accounts/bob', headers=get_user_headers('bob', '987654'),
-                     status=401)
+        self.app.delete_json("/accounts/bob", headers=self.admin_headers)
+        self.app.get("/accounts/bob", headers=get_user_headers("bob", "987654"), status=401)
 
     def test_admin_can_set_others_password(self):
-        self.app.patch_json('/accounts/bob', {'data': {'password': 'bouh'}},
-                            headers=self.admin_headers)
-        self.app.get('/accounts/bob', headers=get_user_headers('bob', '987654'),
-                     status=401)
-        self.app.get('/accounts/bob', headers=get_user_headers('bob', 'bouh'))
+        self.app.patch_json(
+            "/accounts/bob", {"data": {"password": "bouh"}}, headers=self.admin_headers
+        )
+        self.app.get("/accounts/bob", headers=get_user_headers("bob", "987654"), status=401)
+        self.app.get("/accounts/bob", headers=get_user_headers("bob", "bouh"))
 
     def test_admin_can_retrieve_accounts_list(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': 'azerty'}}, status=201)
+        self.app.put_json("/accounts/alice", {"data": {"password": "azerty"}}, status=201)
 
-        resp = self.app.get('/accounts', headers=self.admin_headers)
-        usernames = [r['id'] for r in resp.json['data']]
-        assert sorted(usernames) == ['admin', 'alice', 'bob']
+        resp = self.app.get("/accounts", headers=self.admin_headers)
+        usernames = [r["id"] for r in resp.json["data"]]
+        assert sorted(usernames) == ["admin", "alice", "bob"]
 
     def test_user_created_by_admin_with_put_can_see_her_record(self):
-        self.app.put_json('/accounts/alice',
-                          {'data': {'password': 'bouh'}},
-                          headers=self.admin_headers)
+        self.app.put_json(
+            "/accounts/alice", {"data": {"password": "bouh"}}, headers=self.admin_headers
+        )
 
-        resp = self.app.get('/accounts/alice', headers=get_user_headers('alice', 'bouh'))
-        assert resp.json['permissions'] == {'write': ['account:alice']}
+        resp = self.app.get("/accounts/alice", headers=get_user_headers("alice", "bouh"))
+        assert resp.json["permissions"] == {"write": ["account:alice"]}
 
     def test_user_created_by_admin_with_post_can_see_her_record(self):
-        self.app.post_json('/accounts',
-                           {'data': {'id': 'alice', 'password': 'bouh'}},
-                           headers=self.admin_headers)
+        self.app.post_json(
+            "/accounts", {"data": {"id": "alice", "password": "bouh"}}, headers=self.admin_headers
+        )
 
-        resp = self.app.get('/accounts/alice', headers=get_user_headers('alice', 'bouh'))
-        assert resp.json['permissions'] == {'write': ['account:alice']}
+        resp = self.app.get("/accounts/alice", headers=get_user_headers("alice", "bouh"))
+        assert resp.json["permissions"] == {"write": ["account:alice"]}
 
     def test_user_created_by_admin_can_delete_her_record(self):
-        self.app.post_json('/accounts',
-                           {'data': {'id': 'alice', 'password': 'bouh'}},
-                           headers=self.admin_headers)
+        self.app.post_json(
+            "/accounts", {"data": {"id": "alice", "password": "bouh"}}, headers=self.admin_headers
+        )
 
-        self.app.delete('/accounts/alice', headers=get_user_headers('alice', 'bouh'))
+        self.app.delete("/accounts/alice", headers=get_user_headers("alice", "bouh"))
 
 
 class CheckAdminCreateTest(AccountsWebTest):
     def test_raise_if_create_but_no_write(self):
         with self.assertRaises(ConfigurationError):
-            self.make_app({'account_create_principals': 'account:admin'})
+            self.make_app({"account_create_principals": "account:admin"})
 
 
 class CreateOtherUserTest(AccountsWebTest):
     def setUp(self):
-        self.app.put_json('/accounts/bob', {'data': {'password': '123456'}}, status=201)
-        self.bob_headers = get_user_headers('bob', '123456')
+        self.app.put_json("/accounts/bob", {"data": {"password": "123456"}}, status=201)
+        self.bob_headers = get_user_headers("bob", "123456")
 
     def test_create_other_id_is_still_required(self):
-        self.app.post_json('/accounts', {'data': {'password': 'azerty'}}, status=400,
-                           headers=self.bob_headers)
+        self.app.post_json(
+            "/accounts", {"data": {"password": "azerty"}}, status=400, headers=self.bob_headers
+        )
 
     def test_create_other_forbidden_without_write(self):
-        self.app.put_json('/accounts/alice', {'data': {'password': 'azerty'}}, status=400,
-                          headers=self.bob_headers)
+        self.app.put_json(
+            "/accounts/alice",
+            {"data": {"password": "azerty"}},
+            status=400,
+            headers=self.bob_headers,
+        )
 
 
 class WithBasicAuthTest(AccountsWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         if extras is None:
-            extras = {'multiauth.policies': 'account basicauth'}
+            extras = {"multiauth.policies": "account basicauth"}
         return super().get_app_settings(extras)
 
     def test_password_field_is_mandatory(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me'}}, status=400)
+        self.app.post_json("/accounts", {"data": {"id": "me"}}, status=400)
 
     def test_id_field_is_mandatory(self):
-        self.app.post_json('/accounts', {'data': {'password': 'pass'}}, status=400)
+        self.app.post_json("/accounts", {"data": {"password": "pass"}}, status=400)
 
     def test_fallsback_on_basicauth(self):
-        self.app.post_json('/accounts', {'data': {'id': 'me', 'password': 'bleh'}})
+        self.app.post_json("/accounts", {"data": {"id": "me", "password": "bleh"}})
 
-        resp = self.app.get('/', headers=get_user_headers('me', 'wrong'))
-        assert 'basicauth' in resp.json['user']['id']
+        resp = self.app.get("/", headers=get_user_headers("me", "wrong"))
+        assert "basicauth" in resp.json["user"]["id"]
 
-        resp = self.app.get('/', headers=get_user_headers('me', 'bleh'))
-        assert 'account' in resp.json['user']['id']
+        resp = self.app.get("/", headers=get_user_headers("me", "bleh"))
+        assert "account" in resp.json["user"]["id"]
 
     def test_raise_configuration_if_wrong_error(self):
         with self.assertRaises(ConfigurationError):
-            self.make_app({'multiauth.policies': 'basicauth account'})
+            self.make_app({"multiauth.policies": "basicauth account"})
 
 
 class CreateUserTest(unittest.TestCase):
     def setUp(self):
         self.registry = mock.MagicMock()
-        self.registry.settings = {
-            "includes": "kinto.plugins.accounts",
-        }
+        self.registry.settings = {"includes": "kinto.plugins.accounts"}
 
     def test_create_user_in_read_only_displays_an_error(self):
-        with mock.patch('kinto.plugins.accounts.scripts.logger') as mocked:
-            self.registry.settings['readonly'] = 'true'
-            code = scripts.create_user({'registry': self.registry})
+        with mock.patch("kinto.plugins.accounts.scripts.logger") as mocked:
+            self.registry.settings["readonly"] = "true"
+            code = scripts.create_user({"registry": self.registry})
             assert code == 51
-            mocked.error.assert_called_once_with('Cannot create a user with '
-                                                 'a readonly server.')
+            mocked.error.assert_called_once_with("Cannot create a user with " "a readonly server.")
 
     def test_create_user_when_not_included_displays_an_error(self):
-        with mock.patch('kinto.plugins.accounts.scripts.logger') as mocked:
-            self.registry.settings['includes'] = ''
-            code = scripts.create_user({'registry': self.registry})
+        with mock.patch("kinto.plugins.accounts.scripts.logger") as mocked:
+            self.registry.settings["includes"] = ""
+            code = scripts.create_user({"registry": self.registry})
             assert code == 52
-            mocked.error.assert_called_once_with('Cannot create a user when the accounts '
-                                                 'plugin is not installed.')
+            mocked.error.assert_called_once_with(
+                "Cannot create a user when the accounts " "plugin is not installed."
+            )
 
     def test_create_user_with_an_invalid_username_and_password_confirmation_recovers(self):
-        with mock.patch('kinto.plugins.accounts.scripts.input', side_effect=["&zert", "username"]):
-            with mock.patch('kinto.plugins.accounts.scripts.getpass.getpass', side_effect=[
-                    "password", "p4ssw0rd", "password", "password"]):
-                code = scripts.create_user({'registry': self.registry}, None, None)
+        with mock.patch("kinto.plugins.accounts.scripts.input", side_effect=["&zert", "username"]):
+            with mock.patch(
+                "kinto.plugins.accounts.scripts.getpass.getpass",
+                side_effect=["password", "p4ssw0rd", "password", "password"],
+            ):
+                code = scripts.create_user({"registry": self.registry}, None, None)
                 assert self.registry.storage.update.call_count == 1
                 self.registry.permission.add_principal_to_ace.assert_called_with(
-                    "/accounts/username", "write", "account:username")
+                    "/accounts/username", "write", "account:username"
+                )
                 assert code == 0
 
     def test_create_user_with_a_valid_username_and_password_confirmation(self):
-        with mock.patch('kinto.plugins.accounts.scripts.input', return_value="username"):
-            with mock.patch('kinto.plugins.accounts.scripts.getpass.getpass',
-                            return_value="password"):
-                code = scripts.create_user({'registry': self.registry})
+        with mock.patch("kinto.plugins.accounts.scripts.input", return_value="username"):
+            with mock.patch(
+                "kinto.plugins.accounts.scripts.getpass.getpass", return_value="password"
+            ):
+                code = scripts.create_user({"registry": self.registry})
                 assert self.registry.storage.update.call_count == 1
                 self.registry.permission.add_principal_to_ace.assert_called_with(
-                    "/accounts/username", "write", "account:username")
+                    "/accounts/username", "write", "account:username"
+                )
                 assert code == 0
 
     def test_create_user_with_valid_username_and_password_parameters(self):
-        code = scripts.create_user({'registry': self.registry}, "username", "password")
+        code = scripts.create_user({"registry": self.registry}, "username", "password")
         assert self.registry.storage.update.call_count == 1
         self.registry.permission.add_principal_to_ace.assert_called_with(
-            "/accounts/username", "write", "account:username")
+            "/accounts/username", "write", "account:username"
+        )
         assert code == 0
 
     def test_create_user_aborted_by_eof(self):
-        with mock.patch('kinto.plugins.accounts.scripts.input', side_effect=EOFError):
-            code = scripts.create_user({'registry': self.registry})
+        with mock.patch("kinto.plugins.accounts.scripts.input", side_effect=EOFError):
+            code = scripts.create_user({"registry": self.registry})
             assert code == 53

--- a/tests/plugins/test_admin.py
+++ b/tests/plugins/test_admin.py
@@ -11,7 +11,6 @@ built_index = os.path.join(build_folder, "index.html")
 
 
 class AdminViewTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -31,7 +30,7 @@ class AdminViewTest(BaseWebTest, unittest.TestCase):
     @classmethod
     def get_app_settings(self, extras=None):
         settings = super().get_app_settings(extras)
-        settings['includes'] = 'kinto.plugins.admin'
+        settings["includes"] = "kinto.plugins.admin"
         return settings
 
     def setUp(self):
@@ -39,27 +38,27 @@ class AdminViewTest(BaseWebTest, unittest.TestCase):
 
     def test_capability_is_exposed(self):
         self.maxDiff = None
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('admin', capabilities)
-        self.assertIn('version', capabilities['admin'])
-        del capabilities['admin']['version']
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("admin", capabilities)
+        self.assertIn("version", capabilities["admin"])
+        del capabilities["admin"]["version"]
         expected = {
             "description": "Serves the admin console.",
             "url": ("https://github.com/Kinto/kinto-admin/"),
         }
-        self.assertEqual(expected, capabilities['admin'])
+        self.assertEqual(expected, capabilities["admin"])
 
     def test_permission_endpoint_is_enabled_with_admin(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        assert 'permissions_endpoint' in capabilities
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        assert "permissions_endpoint" in capabilities
 
     def test_admin_index_cat_be_reached(self):
         self.maxDiff = None
-        resp = self.app.get('/admin/')
-        assert "html" in resp.body.decode('utf-8')
+        resp = self.app.get("/admin/")
+        assert "html" in resp.body.decode("utf-8")
 
     def test_admin_redirect_without_trailing_slash(self):
-        resp = self.app.get('/admin', status=307)
-        self.assertTrue(resp.headers['location'].endswith('/admin/'))
+        resp = self.app.get("/admin", status=307)
+        self.assertTrue(resp.headers["location"].endswith("/admin/"))

--- a/tests/plugins/test_default_bucket.py
+++ b/tests/plugins/test_default_bucket.py
@@ -13,73 +13,73 @@ from ..support import BaseWebTest, MINIMALIST_RECORD
 
 
 class DefaultBucketWebTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['includes'] = 'kinto.plugins.default_bucket'
+        settings["includes"] = "kinto.plugins.default_bucket"
         return settings
 
 
 class DefaultBucketViewTest(FormattedErrorMixin, DefaultBucketWebTest):
 
-    bucket_url = '/buckets/default'
-    collection_url = '/buckets/default/collections/tasks'
+    bucket_url = "/buckets/default"
+    collection_url = "/buckets/default/collections/tasks"
 
     def test_default_bucket_exists_and_has_user_id(self):
         bucket = self.app.get(self.bucket_url, headers=self.headers)
         result = bucket.json
         settings = self.app.app.registry.settings
-        hmac_secret = settings['userid_hmac_secret']
+        hmac_secret = settings["userid_hmac_secret"]
         bucket_id = hmac_digest(hmac_secret, self.principal)[:32]
 
-        self.assertEqual(result['data']['id'], str(UUID(bucket_id)))
-        self.assertEqual(result['permissions']['write'], [self.principal])
+        self.assertEqual(result["data"]["id"], str(UUID(bucket_id)))
+        self.assertEqual(result["permissions"]["write"], [self.principal])
 
     def test_default_bucket_can_still_be_explicitly_created(self):
-        bucket = {'permissions': {'read': ['system.Everyone']}}
+        bucket = {"permissions": {"read": ["system.Everyone"]}}
         resp = self.app.put_json(self.bucket_url, bucket, headers=self.headers)
         result = resp.json
-        self.assertIn('system.Everyone', result['permissions']['read'])
+        self.assertIn("system.Everyone", result["permissions"]["read"])
 
     def test_default_bucket_collection_can_still_be_explicitly_created(self):
-        collection = {'data': {'synced': True}}
+        collection = {"data": {"synced": True}}
         resp = self.app.put_json(self.collection_url, collection, headers=self.headers)
         result = resp.json
-        self.assertIn('synced', result['data'])
-        self.assertTrue(result['data']['synced'])
+        self.assertIn("synced", result["data"])
+        self.assertTrue(result["data"]["synced"])
         resp = self.app.get(self.collection_url, headers=self.headers)
         result = resp.json
-        self.assertIn('synced', result['data'])
-        self.assertTrue('synced', result['data']['synced'])
+        self.assertIn("synced", result["data"])
+        self.assertTrue("synced", result["data"]["synced"])
 
     def test_default_bucket_can_be_created_with_simple_put(self):
-        self.app.put(self.bucket_url, headers=get_user_headers('bob'), status=201)
+        self.app.put(self.bucket_url, headers=get_user_headers("bob"), status=201)
 
     def test_default_bucket_collections_are_automatically_created(self):
         self.app.get(self.collection_url, headers=self.headers, status=200)
 
     def test_adding_a_task_for_bob_doesnt_add_it_for_alice(self):
         record = {**MINIMALIST_RECORD}
-        resp = self.app.post_json(self.collection_url + '/records',
-                                  record, headers=get_user_headers('bob'))
-        record_id = '{}/records/{}'.format(self.collection_url, resp.json['data']['id'])
-        resp = self.app.get(record_id, headers=get_user_headers('alice'),
-                            status=404)
+        resp = self.app.post_json(
+            self.collection_url + "/records", record, headers=get_user_headers("bob")
+        )
+        record_id = "{}/records/{}".format(self.collection_url, resp.json["data"]["id"])
+        resp = self.app.get(record_id, headers=get_user_headers("alice"), status=404)
 
     def test_unauthenticated_bucket_access_raises_json_401(self):
         resp = self.app.get(self.bucket_url, status=401)
-        self.assertEqual(resp.json['message'],
-                         'Please authenticate yourself to use this endpoint.')
+        self.assertEqual(
+            resp.json["message"], "Please authenticate yourself to use this endpoint."
+        )
 
     def test_bucket_id_is_an_uuid_with_dashes(self):
         bucket = self.app.get(self.bucket_url, headers=self.headers)
-        bucket_id = bucket.json['data']['id']
-        self.assertIn('-', bucket_id)
+        bucket_id = bucket.json["data"]["id"]
+        self.assertIn("-", bucket_id)
         try:
             UUID(bucket_id)
         except ValueError:
-            self.fail('bucket_id: {} is not a valid UUID.'.format(bucket_id))
+            self.fail("bucket_id: {} is not a valid UUID.".format(bucket_id))
 
     def test_second_call_on_default_bucket_doesnt_raise_a_412(self):
         self.app.get(self.bucket_url, headers=self.headers)
@@ -90,93 +90,97 @@ class DefaultBucketViewTest(FormattedErrorMixin, DefaultBucketWebTest):
         self.app.get(self.collection_url, headers=self.headers)
 
     def test_querystring_parameters_are_taken_into_account(self):
-        self.app.get(self.collection_url + '/records?_since=invalid',
-                     headers=self.headers,
-                     status=400)
+        self.app.get(
+            self.collection_url + "/records?_since=invalid", headers=self.headers, status=400
+        )
 
     def test_option_is_possible_without_authentication_for_default(self):
-        headers = 'authorization,content-type'
-        self.app.options(self.collection_url + '/records',
-                         headers={
-                             'Origin': 'http://localhost:8000',
-                             'Access-Control-Request-Method': 'GET',
-                             'Access-Control-Request-Headers': headers})
+        headers = "authorization,content-type"
+        self.app.options(
+            self.collection_url + "/records",
+            headers={
+                "Origin": "http://localhost:8000",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": headers,
+            },
+        )
 
     def test_cors_headers_are_provided_on_errors(self):
-        resp = self.app.post_json(self.collection_url + '/records',
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        current = resp.json['data']['last_modified']
-        headers = {**self.headers, 'Origin': 'http://localhost:8000',
-                   'If-None-Match': ('"{}"'.format(current)).encode('utf-8')}
-        resp = self.app.get(self.collection_url + '/records',
-                            headers=headers, status=304)
-        self.assertIn('Access-Control-Allow-Origin', resp.headers)
-        self.assertIn('ETag', resp.headers['Access-Control-Expose-Headers'])
+        resp = self.app.post_json(
+            self.collection_url + "/records", MINIMALIST_RECORD, headers=self.headers
+        )
+        current = resp.json["data"]["last_modified"]
+        headers = {
+            **self.headers,
+            "Origin": "http://localhost:8000",
+            "If-None-Match": ('"{}"'.format(current)).encode("utf-8"),
+        }
+        resp = self.app.get(self.collection_url + "/records", headers=headers, status=304)
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
+        self.assertIn("ETag", resp.headers["Access-Control-Expose-Headers"])
 
     def test_etag_is_present_and_exposed_in_304_error(self):
-        resp = self.app.post_json(self.collection_url + '/records',
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        current = resp.json['data']['last_modified']
-        headers = {**self.headers, 'Origin': 'http://localhost:8000',
-                   'If-None-Match': ('"{}"'.format(current)).encode('utf-8')}
-        resp = self.app.get(self.collection_url + '/records',
-                            headers=headers, status=304)
-        self.assertIn('Access-Control-Expose-Headers', resp.headers)
-        self.assertIn('ETag', resp.headers)
-        self.assertIn('ETag', resp.headers['Access-Control-Expose-Headers'])
+        resp = self.app.post_json(
+            self.collection_url + "/records", MINIMALIST_RECORD, headers=self.headers
+        )
+        current = resp.json["data"]["last_modified"]
+        headers = {
+            **self.headers,
+            "Origin": "http://localhost:8000",
+            "If-None-Match": ('"{}"'.format(current)).encode("utf-8"),
+        }
+        resp = self.app.get(self.collection_url + "/records", headers=headers, status=304)
+        self.assertIn("Access-Control-Expose-Headers", resp.headers)
+        self.assertIn("ETag", resp.headers)
+        self.assertIn("ETag", resp.headers["Access-Control-Expose-Headers"])
 
     def test_bucket_id_starting_with_default_can_still_be_created(self):
         # We need to create the bucket first since it is not the default bucket
         resp = self.app.put(
-            self.bucket_url.replace('default', 'default-1234'),
-            headers=self.headers, status=201)
-        bucket_id = resp.json['data']['id']
-        self.assertEqual(bucket_id, 'default-1234')
+            self.bucket_url.replace("default", "default-1234"), headers=self.headers, status=201
+        )
+        bucket_id = resp.json["data"]["id"]
+        self.assertEqual(bucket_id, "default-1234")
 
         # We can then create the collection
-        collection_url = '/buckets/default-1234/collections/default'
-        self.app.put(
-            collection_url,
-            headers=self.headers,
-            status=201)
-        resp = self.app.get('/buckets/default-1234/collections',
-                            headers=self.headers)
-        self.assertEqual(resp.json['data'][0]['id'], 'default')
+        collection_url = "/buckets/default-1234/collections/default"
+        self.app.put(collection_url, headers=self.headers, status=201)
+        resp = self.app.get("/buckets/default-1234/collections", headers=self.headers)
+        self.assertEqual(resp.json["data"][0]["id"], "default")
 
     def test_bucket_id_in_body_can_be_default(self):
-        self.app.put_json('/buckets/default',
-                          {'data': {'id': 'default'}},
-                          headers=self.headers,
-                          status=201)
+        self.app.put_json(
+            "/buckets/default", {"data": {"id": "default"}}, headers=self.headers, status=201
+        )
 
     def test_default_bucket_objects_are_checked_only_once_in_batch(self):
-        batch = {'requests': []}
+        batch = {"requests": []}
         nb_create = 25
         for i in range(nb_create):
-            request = {'method': 'POST',
-                       'path': self.collection_url + '/records',
-                       'body': MINIMALIST_RECORD}
-            batch['requests'].append(request)
+            request = {
+                "method": "POST",
+                "path": self.collection_url + "/records",
+                "body": MINIMALIST_RECORD,
+            }
+            batch["requests"].append(request)
 
-        with mock.patch.object(self.storage, 'create',
-                               wraps=self.storage.create) as patched:
-            self.app.post_json('/batch', batch, headers=self.headers)
+        with mock.patch.object(self.storage, "create", wraps=self.storage.create) as patched:
+            self.app.post_json("/batch", batch, headers=self.headers)
             self.assertEqual(patched.call_count, nb_create + 2)
 
     def test_parent_collection_is_taken_from_the_one_created_in_batch(self):
-        batch = {'requests': []}
+        batch = {"requests": []}
         nb_create = 25
         for i in range(nb_create):
-            request = {'method': 'POST',
-                       'path': self.collection_url + '/records',
-                       'body': MINIMALIST_RECORD}
-            batch['requests'].append(request)
+            request = {
+                "method": "POST",
+                "path": self.collection_url + "/records",
+                "body": MINIMALIST_RECORD,
+            }
+            batch["requests"].append(request)
 
-        with mock.patch.object(self.storage, 'create',
-                               wraps=self.storage.create) as patched:
-            self.app.post_json('/batch', batch, headers=self.headers)
+        with mock.patch.object(self.storage, "create", wraps=self.storage.create) as patched:
+            self.app.post_json("/batch", batch, headers=self.headers)
             # Called twice only: bucket + collection ids unicity.
             self.assertEqual(patched.call_count, 25 + 2)
 
@@ -184,94 +188,95 @@ class DefaultBucketViewTest(FormattedErrorMixin, DefaultBucketWebTest):
         # Create it first.
         self.app.put(self.collection_url, headers=self.headers, status=201)
 
-        batch = {'requests': []}
+        batch = {"requests": []}
         nb_create = 25
         for i in range(nb_create):
-            request = {'method': 'POST',
-                       'path': self.collection_url + '/records',
-                       'body': MINIMALIST_RECORD}
-            batch['requests'].append(request)
+            request = {
+                "method": "POST",
+                "path": self.collection_url + "/records",
+                "body": MINIMALIST_RECORD,
+            }
+            batch["requests"].append(request)
 
-        with mock.patch.object(self.storage, 'create',
-                               wraps=self.storage.create) as patched:
-            self.app.post_json('/batch', batch, headers=self.headers)
+        with mock.patch.object(self.storage, "create", wraps=self.storage.create) as patched:
+            self.app.post_json("/batch", batch, headers=self.headers)
             # Called twice only: bucket + collection ids unicity.
             self.assertEqual(patched.call_count, 25 + 2)
 
     def test_collection_id_is_validated(self):
-        collection_url = '/buckets/default/collections/__files__/records'
+        collection_url = "/buckets/default/collections/__files__/records"
         self.app.get(collection_url, headers=self.headers, status=400)
 
     def test_collection_id_does_not_support_unicode(self):
-        collection_url = '/buckets/default/collections/%E8%A6%8B/records'
+        collection_url = "/buckets/default/collections/%E8%A6%8B/records"
         self.app.get(collection_url, headers=self.headers, status=400)
 
     def test_405_is_a_valid_formatted_error(self):
-        response = self.app.post(self.collection_url,
-                                 headers=self.headers, status=405)
+        response = self.app.post(self.collection_url, headers=self.headers, status=405)
         self.assertFormattedError(
-            response, 405, ERRORS.METHOD_NOT_ALLOWED, "Method Not Allowed",
-            "Method not allowed on this endpoint.")
+            response,
+            405,
+            ERRORS.METHOD_NOT_ALLOWED,
+            "Method Not Allowed",
+            "Method not allowed on this endpoint.",
+        )
 
     def test_formatted_error_are_passed_through(self):
         # Create the parent objects
-        self.app.post(self.collection_url + '/records', headers=self.headers)
+        self.app.post(self.collection_url + "/records", headers=self.headers)
 
         # Simulate a validation error.
-        fake400 = http_error(HTTPBadRequest(),
-                             errno=ERRORS.INVALID_PARAMETERS,
-                             message='Yop')
-        with mock.patch.object(self.storage, 'create') as mocked:
+        fake400 = http_error(HTTPBadRequest(), errno=ERRORS.INVALID_PARAMETERS, message="Yop")
+        with mock.patch.object(self.storage, "create") as mocked:
             mocked.side_effect = [
                 {"id": "abc", "last_modified": 43},
                 {"id": "abc", "last_modified": 44},
-                fake400
+                fake400,
             ]
-            resp = self.app.post(self.collection_url + '/records',
-                                 headers=self.headers,
-                                 status=400)
+            resp = self.app.post(
+                self.collection_url + "/records", headers=self.headers, status=400
+            )
             self.assertEqual(resp.body, fake400.body)
 
     def test_trailing_slash_redirection_works_for_default_bucket(self):
-        collection_url = '/buckets/default/'
+        collection_url = "/buckets/default/"
         resp = self.app.get(collection_url, headers=self.headers, status=307)
-        assert resp.headers['Location'].endswith('/buckets/default')
+        assert resp.headers["Location"].endswith("/buckets/default")
 
     def test_trailing_slash_redirection_works_for_collections(self):
-        collection_url = '/buckets/default/collections/'
+        collection_url = "/buckets/default/collections/"
         resp = self.app.get(collection_url, headers=self.headers, status=307)
-        assert resp.headers['Location'].endswith('/buckets/default/collections')
+        assert resp.headers["Location"].endswith("/buckets/default/collections")
 
     def test_trailing_slash_redirection_works_for_collection(self):
-        collection_url = '/buckets/default/collections/foo/'
+        collection_url = "/buckets/default/collections/foo/"
         resp = self.app.get(collection_url, headers=self.headers, status=307)
-        assert resp.headers['Location'].endswith('/buckets/default/collections/foo')
+        assert resp.headers["Location"].endswith("/buckets/default/collections/foo")
 
     def test_trailing_slash_redirection_works_for_records(self):
-        records_url = '/buckets/default/collections/foo/records/'
+        records_url = "/buckets/default/collections/foo/records/"
         resp = self.app.get(records_url, headers=self.headers, status=307)
-        assert resp.headers['Location'].endswith('/buckets/default/collections/foo/records')
+        assert resp.headers["Location"].endswith("/buckets/default/collections/foo/records")
 
     def test_trailing_slash_redirection_works_for_record(self):
-        records_url = '/buckets/default/collections/foo/records/bar/'
+        records_url = "/buckets/default/collections/foo/records/bar/"
         resp = self.app.get(records_url, headers=self.headers, status=307)
-        assert resp.headers['Location'].endswith('/buckets/default/collections/foo/records/bar')
+        assert resp.headers["Location"].endswith("/buckets/default/collections/foo/records/bar")
 
 
 class HelloViewTest(DefaultBucketWebTest):
-
     def test_returns_bucket_id_and_url_if_authenticated(self):
-        response = self.app.get('/', headers=self.headers)
-        userinfo = response.json['user']
-        self.assertIn('id', userinfo)
-        self.assertIn('principals', userinfo)
-        self.assertIn('bucket', userinfo)
-        self.assertEqual(userinfo['bucket'], 'ddaf8694-fa9e-2949-ed0e-77198a7907fb')
+        response = self.app.get("/", headers=self.headers)
+        userinfo = response.json["user"]
+        self.assertIn("id", userinfo)
+        self.assertIn("principals", userinfo)
+        self.assertIn("bucket", userinfo)
+        self.assertEqual(userinfo["bucket"], "ddaf8694-fa9e-2949-ed0e-77198a7907fb")
 
     def test_flush_capability_if_enabled(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('default_bucket', capabilities)
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("default_bucket", capabilities)
 
 
 _events = []
@@ -292,60 +297,62 @@ class EventsTest(DefaultBucketWebTest):
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings = {**settings, 'event_listeners': 'testevent',
-                    'event_listeners.testevent.use': 'tests.plugins.test_default_bucket'}
+        settings = {
+            **settings,
+            "event_listeners": "testevent",
+            "event_listeners.testevent.use": "tests.plugins.test_default_bucket",
+        }
         return settings
 
     def test_an_event_is_sent_on_implicit_bucket_creation(self):
-        bucket_url = '/buckets/default'
+        bucket_url = "/buckets/default"
         self.app.get(bucket_url, headers=self.headers)
         assert len(_events) == 1
-        assert 'last_modified' in _events[-1].impacted_records[0]['new']
+        assert "last_modified" in _events[-1].impacted_records[0]["new"]
         payload = _events[-1].payload
-        assert payload['resource_name'] == 'bucket'
-        assert payload['action'] == 'create'
+        assert payload["resource_name"] == "bucket"
+        assert payload["action"] == "create"
 
     def test_an_event_is_sent_on_implicit_collection_creation(self):
-        collection_url = '/buckets/default/collections/articles'
+        collection_url = "/buckets/default/collections/articles"
         self.app.get(collection_url, headers=self.headers)
         assert len(_events) == 2
         payload = _events[-1].payload
-        assert payload['resource_name'] == 'collection'
-        assert payload['action'] == 'create'
+        assert payload["resource_name"] == "collection"
+        assert payload["action"] == "create"
 
     def test_events_sent_on_bucket_and_collection_creation(self):
-        records_uri = '/buckets/default/collections/articles/records/implicit'
+        records_uri = "/buckets/default/collections/articles/records/implicit"
         body = {"data": {"implicit": "creations"}}
         self.app.put_json(records_uri, body, headers=self.headers)
 
         assert len(_events) == 3
 
         # Implicit creation of bucket
-        resp = self.app.get('/', headers=self.headers)
-        bucket_id = resp.json['user']['bucket']
-        assert 'subpath' not in _events[0].payload
-        assert _events[0].payload['action'] == 'create'
-        assert _events[0].payload['bucket_id'] == bucket_id
-        assert _events[0].payload['uri'] == '/buckets/{}'.format(bucket_id)
+        resp = self.app.get("/", headers=self.headers)
+        bucket_id = resp.json["user"]["bucket"]
+        assert "subpath" not in _events[0].payload
+        assert _events[0].payload["action"] == "create"
+        assert _events[0].payload["bucket_id"] == bucket_id
+        assert _events[0].payload["uri"] == "/buckets/{}".format(bucket_id)
 
         # Implicit creation of collection
-        assert 'subpath' not in _events[1].payload
-        assert _events[1].payload['action'] == 'create'
-        assert _events[1].payload['resource_name'] == 'collection'
-        assert _events[1].payload['bucket_id'] == bucket_id
-        assert _events[1].payload['collection_id'] == 'articles'
-        assert _events[1].payload['uri'] == '/buckets/{}/collections/articles'.format(bucket_id)
+        assert "subpath" not in _events[1].payload
+        assert _events[1].payload["action"] == "create"
+        assert _events[1].payload["resource_name"] == "collection"
+        assert _events[1].payload["bucket_id"] == bucket_id
+        assert _events[1].payload["collection_id"] == "articles"
+        assert _events[1].payload["uri"] == "/buckets/{}/collections/articles".format(bucket_id)
 
         # Creation of record
-        assert _events[2].payload['action'] == 'create'
-        assert _events[2].payload['resource_name'] == 'record'
-        assert _events[2].payload['bucket_id'] == bucket_id
-        assert _events[2].payload['collection_id'] == 'articles'
-        assert _events[2].payload['uri'] == records_uri.replace('default',
-                                                                bucket_id)
+        assert _events[2].payload["action"] == "create"
+        assert _events[2].payload["resource_name"] == "record"
+        assert _events[2].payload["bucket_id"] == bucket_id
+        assert _events[2].payload["collection_id"] == "articles"
+        assert _events[2].payload["uri"] == records_uri.replace("default", bucket_id)
 
     def test_second_call_on_default_bucket_doesnt_send_create_events(self):
-        bucket_url = '/buckets/default'
+        bucket_url = "/buckets/default"
         self.app.get(bucket_url, headers=self.headers)
         # An event is generated -- it's the same event from
         # test_an_event_is_sent_on_implicit_bucket_creation.
@@ -356,7 +363,7 @@ class EventsTest(DefaultBucketWebTest):
         assert len(_events) == 1
 
     def test_second_call_on_default_bucket_collection_doesnt_send_create_events(self):
-        collection_url = '/buckets/default/collections/articles'
+        collection_url = "/buckets/default/collections/articles"
         self.app.get(collection_url, headers=self.headers)
         # Events are generated -- they're the same event from
         # test_an_event_is_sent_on_implicit_collection_creation.
@@ -368,31 +375,29 @@ class EventsTest(DefaultBucketWebTest):
 
 
 class ReadonlyDefaultBucket(DefaultBucketWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['readonly'] = True
+        settings["readonly"] = True
         return settings
 
     def test_implicit_creation_is_rejected(self):
-        self.app.get('/buckets/default', headers=self.headers, status=405)
+        self.app.get("/buckets/default", headers=self.headers, status=405)
 
 
 class BackendErrorTest(DefaultBucketWebTest):
     def setUp(self):
         super().setUp()
         self.patcher = mock.patch.object(
-            self.storage, 'create',
-            side_effect=storage_exceptions.BackendError())
+            self.storage, "create", side_effect=storage_exceptions.BackendError()
+        )
         self.addCleanup(self.patcher.stop)
 
     def test_implicit_bucket_creation_raises_503_if_backend_fails(self):
         self.patcher.start()
-        self.app.get('/buckets/default', headers=self.headers, status=503)
+        self.app.get("/buckets/default", headers=self.headers, status=503)
 
     def test_implicit_collection_creation_raises_503_if_backend_fails(self):
-        self.app.get('/buckets/default', headers=self.headers)
+        self.app.get("/buckets/default", headers=self.headers)
         self.patcher.start()
-        self.app.get('/buckets/default/collections/articles',
-                     headers=self.headers, status=503)
+        self.app.get("/buckets/default/collections/articles", headers=self.headers, status=503)

--- a/tests/plugins/test_flush.py
+++ b/tests/plugins/test_flush.py
@@ -5,14 +5,12 @@ from pyramid.config import Configurator
 from kinto.core.testing import get_user_headers
 from kinto.events import ServerFlushed
 
-from ..support import (BaseWebTest,
-                       MINIMALIST_BUCKET, MINIMALIST_COLLECTION,
-                       MINIMALIST_RECORD)
+from ..support import BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_COLLECTION, MINIMALIST_RECORD
 
 
 class FlushViewTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets/beers/collections/barley/records'
+    collection_url = "/buckets/beers/collections/barley/records"
     events = []
 
     def setUp(self):
@@ -22,28 +20,25 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
 
         bucket = {**MINIMALIST_BUCKET}
 
-        self.alice_headers = {**self.headers, **get_user_headers('alice')}
+        self.alice_headers = {**self.headers, **get_user_headers("alice")}
 
-        resp = self.app.get('/', headers=self.alice_headers)
-        alice_principal = resp.json['user']['id']
-        bucket['permissions'] = {'write': [alice_principal]}
+        resp = self.app.get("/", headers=self.alice_headers)
+        alice_principal = resp.json["user"]["id"]
+        bucket["permissions"] = {"write": [alice_principal]}
 
         # Create shared bucket.
-        self.app.put_json('/buckets/beers', bucket,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beers", bucket, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
 
         # Records for alice and bob.
-        self.app.post_json(self.collection_url,
-                           MINIMALIST_RECORD,
-                           headers=self.headers,
-                           status=201)
-        self.app.post_json(self.collection_url,
-                           MINIMALIST_RECORD,
-                           headers=self.alice_headers,
-                           status=201)
+        self.app.post_json(
+            self.collection_url, MINIMALIST_RECORD, headers=self.headers, status=201
+        )
+        self.app.post_json(
+            self.collection_url, MINIMALIST_RECORD, headers=self.alice_headers, status=201
+        )
 
     def tearDown(self):
         del self.events[:]
@@ -61,7 +56,7 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
     def get_app_settings(cls, extras=None):
         if extras is None:
             extras = {}
-        extras.setdefault('includes', 'kinto.plugins.flush')
+        extras.setdefault("includes", "kinto.plugins.flush")
         settings = super().get_app_settings(extras)
         return settings
 
@@ -70,38 +65,36 @@ class FlushViewTest(BaseWebTest, unittest.TestCase):
         cls.events.append(event)
 
     def test_returns_404_if_not_enabled_in_configuration(self):
-        app = self.make_app(settings={'includes': ''})
-        app.post('/__flush__', headers=self.headers, status=404)
+        app = self.make_app(settings={"includes": ""})
+        app.post("/__flush__", headers=self.headers, status=404)
 
     def test_removes_every_records_of_everykind(self):
         self.app.get(self.collection_url, headers=self.headers)
         self.app.get(self.collection_url, headers=self.alice_headers)
 
-        self.app.post('/__flush__', headers=self.headers, status=202)
+        self.app.post("/__flush__", headers=self.headers, status=202)
 
         self.app.get(self.collection_url, headers=self.headers, status=403)
-        self.app.get(self.collection_url,
-                     headers=self.alice_headers,
-                     status=403)
+        self.app.get(self.collection_url, headers=self.alice_headers, status=403)
 
     def test_event_triggered_post(self):
         self.app.get(self.collection_url, headers=self.headers)
         self.app.get(self.collection_url, headers=self.alice_headers)
-        self.app.post('/__flush__', headers=self.headers, status=202)
+        self.app.post("/__flush__", headers=self.headers, status=202)
         self.assertEqual(len(self.events), 1)
         self.assertTrue(isinstance(self.events[0], ServerFlushed))
 
     def test_flush_returns_json(self):
-        response = self.app.post('/__flush__', headers=self.headers, status=202)
+        response = self.app.post("/__flush__", headers=self.headers, status=202)
         self.assertEqual(response.json, {})
 
     def test_flush_capability_if_enabled(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('flush_endpoint', capabilities)
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("flush_endpoint", capabilities)
         expected = {
             "description": "The __flush__ endpoint can be used to remove "
-                           "all data from all backends.",
-            "url": "https://kinto.readthedocs.io/en/latest/api/1.x/flush.html"
+            "all data from all backends.",
+            "url": "https://kinto.readthedocs.io/en/latest/api/1.x/flush.html",
         }
-        self.assertEqual(expected, capabilities['flush_endpoint'])
+        self.assertEqual(expected, capabilities["flush_endpoint"])

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -12,58 +12,54 @@ from .. import support
 
 
 class PluginSetup(unittest.TestCase):
-
     @skip_if_no_statsd
     def test_a_statsd_timer_is_used_for_history_if_configured(self):
         settings = {
             "statsd_url": "udp://127.0.0.1:8125",
             "includes": "kinto.plugins.history",
-            "storage_strict_json": True
+            "storage_strict_json": True,
         }
         config = testing.setUp(settings=settings)
-        with mock.patch('kinto.core.statsd.Client.timer') as mocked:
+        with mock.patch("kinto.core.statsd.Client.timer") as mocked:
             kinto_main(None, config=config)
-            mocked.assert_called_with('plugins.history')
+            mocked.assert_called_with("plugins.history")
 
 
 class HistoryWebTest(support.BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['includes'] = 'kinto.plugins.history'
+        settings["includes"] = "kinto.plugins.history"
         return settings
 
 
 class HelloViewTest(HistoryWebTest):
-
     def test_history_capability_if_enabled(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('history', capabilities)
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("history", capabilities)
 
 
 class HistoryViewTest(HistoryWebTest):
-
     def setUp(self):
-        self.bucket_uri = '/buckets/test'
+        self.bucket_uri = "/buckets/test"
         self.app.put(self.bucket_uri, headers=self.headers)
 
-        self.collection_uri = self.bucket_uri + '/collections/col'
+        self.collection_uri = self.bucket_uri + "/collections/col"
         resp = self.app.put(self.collection_uri, headers=self.headers)
-        self.collection = resp.json['data']
+        self.collection = resp.json["data"]
 
-        self.group_uri = self.bucket_uri + '/groups/grp'
-        body = {'data': {'members': ['elle']}}
+        self.group_uri = self.bucket_uri + "/groups/grp"
+        body = {"data": {"members": ["elle"]}}
         resp = self.app.put_json(self.group_uri, body, headers=self.headers)
-        self.group = resp.json['data']
+        self.group = resp.json["data"]
 
-        self.record_uri = '/buckets/test/collections/col/records/rec'
-        body = {'data': {'foo': 42}}
+        self.record_uri = "/buckets/test/collections/col/records/rec"
+        body = {"data": {"foo": 42}}
         resp = self.app.put_json(self.record_uri, body, headers=self.headers)
-        self.record = resp.json['data']
+        self.record = resp.json["data"]
 
-        self.history_uri = '/buckets/test/history'
+        self.history_uri = "/buckets/test/history"
 
     def test_only_get_and_delete_on_collection_are_allowed(self):
         self.app.put(self.history_uri, headers=self.headers, status=405)
@@ -71,8 +67,8 @@ class HistoryViewTest(HistoryWebTest):
 
     def test_only_collection_endpoint_is_available(self):
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        url = '{}/{}'.format(self.bucket_uri, entry['id'])
+        entry = resp.json["data"][0]
+        url = "{}/{}".format(self.bucket_uri, entry["id"])
         self.app.get(url, headers=self.headers, status=404)
         self.app.put(url, headers=self.headers, status=404)
         self.app.patch(url, headers=self.headers, status=404)
@@ -80,10 +76,9 @@ class HistoryViewTest(HistoryWebTest):
 
     def test_tracks_user_and_date(self):
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][-1]
-        assert entry['user_id'] == self.principal
-        assert re.match('^\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}',
-                        entry['date'])
+        entry = resp.json["data"][-1]
+        assert entry["user_id"] == self.principal
+        assert re.match("^\d{4}\-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}", entry["date"])
 
     #
     # Bucket
@@ -91,64 +86,58 @@ class HistoryViewTest(HistoryWebTest):
 
     def test_history_contains_bucket_creation(self):
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][-1]
-        assert entry['resource_name'] == 'bucket'
-        assert entry['bucket_id'] == 'test'
-        assert entry['action'] == 'create'
-        assert entry['uri'] == '/buckets/test'
+        entry = resp.json["data"][-1]
+        assert entry["resource_name"] == "bucket"
+        assert entry["bucket_id"] == "test"
+        assert entry["action"] == "create"
+        assert entry["uri"] == "/buckets/test"
 
     def test_history_supports_creation_via_plural_endpoint(self):
-        resp = self.app.post_json('/buckets', {'data': {'id': 'posted'}},
-                                  headers=self.headers)
-        resp = self.app.get('/buckets/posted/history', headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['resource_name'] == 'bucket'
-        assert entry['bucket_id'] == 'posted'
-        assert entry['action'] == 'create'
-        assert entry['uri'] == '/buckets/posted'
+        resp = self.app.post_json("/buckets", {"data": {"id": "posted"}}, headers=self.headers)
+        resp = self.app.get("/buckets/posted/history", headers=self.headers)
+        entry = resp.json["data"][0]
+        assert entry["resource_name"] == "bucket"
+        assert entry["bucket_id"] == "posted"
+        assert entry["action"] == "create"
+        assert entry["uri"] == "/buckets/posted"
 
     def test_tracks_bucket_attributes_update(self):
-        body = {'data': {'foo': 'baz'}}
-        self.app.patch_json(self.bucket_uri, body,
-                            headers=self.headers)
+        body = {"data": {"foo": "baz"}}
+        self.app.patch_json(self.bucket_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['data']['foo'] == 'baz'
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["data"]["foo"] == "baz"
 
     def test_tracks_bucket_permissions_update(self):
-        body = {'permissions': {'read': ['admins']}}
-        self.app.patch_json(self.bucket_uri, body,
-                            headers=self.headers)
+        body = {"permissions": {"read": ["admins"]}}
+        self.app.patch_json(self.bucket_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['permissions']['read'] == ['admins']
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["permissions"]["read"] == ["admins"]
 
     def test_bucket_delete_destroys_its_history_entries(self):
         self.app.delete(self.bucket_uri, headers=self.headers)
         storage = self.app.app.registry.storage
-        stored_in_backend, _ = storage.get_all(parent_id='/buckets/test',
-                                               collection_id='history')
+        stored_in_backend, _ = storage.get_all(parent_id="/buckets/test", collection_id="history")
         assert len(stored_in_backend) == 0
 
     def test_delete_all_buckets_destroys_history_entries(self):
-        self.app.put_json('/buckets/1', {"data": {"a": 1}},
-                          headers=self.headers)
+        self.app.put_json("/buckets/1", {"data": {"a": 1}}, headers=self.headers)
 
-        self.app.delete('/buckets?a=1', headers=self.headers)
+        self.app.delete("/buckets?a=1", headers=self.headers)
 
         # Entries about deleted bucket are gone.
         storage = self.app.app.registry.storage
-        stored_in_backend, _ = storage.get_all(parent_id='/buckets/1',
-                                               collection_id='history')
+        stored_in_backend, _ = storage.get_all(parent_id="/buckets/1", collection_id="history")
         assert len(stored_in_backend) == 0
 
         # Entries of other buckets are still here.
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][-1]
-        assert entry['bucket_id'] == 'test'
-        assert entry['action'] == 'create'
+        entry = resp.json["data"][-1]
+        assert entry["bucket_id"] == "test"
+        assert entry["action"] == "create"
 
     #
     # Collection
@@ -156,49 +145,46 @@ class HistoryViewTest(HistoryWebTest):
 
     def test_tracks_collection_creation(self):
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][2]
-        cid = self.collection['id']
-        assert entry['resource_name'] == 'collection'
-        assert 'bucket_id' not in entry
-        assert entry['collection_id'] == cid
-        assert entry['action'] == 'create'
-        assert entry['uri'] == '/buckets/test/collections/{}'.format(cid)
+        entry = resp.json["data"][2]
+        cid = self.collection["id"]
+        assert entry["resource_name"] == "collection"
+        assert "bucket_id" not in entry
+        assert entry["collection_id"] == cid
+        assert entry["action"] == "create"
+        assert entry["uri"] == "/buckets/test/collections/{}".format(cid)
 
     def test_tracks_collection_attributes_update(self):
-        body = {'data': {'foo': 'baz'}}
-        self.app.patch_json(self.collection_uri, body,
-                            headers=self.headers)
+        body = {"data": {"foo": "baz"}}
+        self.app.patch_json(self.collection_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['data']['foo'] == 'baz'
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["data"]["foo"] == "baz"
 
     def test_tracks_collection_permissions_update(self):
-        body = {'permissions': {'read': ['admins']}}
-        self.app.patch_json(self.collection_uri, body,
-                            headers=self.headers)
+        body = {"permissions": {"read": ["admins"]}}
+        self.app.patch_json(self.collection_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['permissions']['read'] == ['admins']
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["permissions"]["read"] == ["admins"]
 
     def test_tracks_collection_delete(self):
         self.app.delete(self.collection_uri, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'delete'
-        assert entry['target']['data']['deleted'] is True
+        entry = resp.json["data"][0]
+        assert entry["action"] == "delete"
+        assert entry["target"]["data"]["deleted"] is True
 
     def test_tracks_multiple_collections_delete(self):
-        self.app.put(self.bucket_uri + '/collections/col2',
-                     headers=self.headers)
+        self.app.put(self.bucket_uri + "/collections/col2", headers=self.headers)
 
-        self.app.delete(self.bucket_uri + '/collections', headers=self.headers)
+        self.app.delete(self.bucket_uri + "/collections", headers=self.headers)
 
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'delete'
-        assert entry['target']['data']['id'] in (self.collection['id'], 'col2')
+        entry = resp.json["data"][0]
+        assert entry["action"] == "delete"
+        assert entry["target"]["data"]["id"] in (self.collection["id"], "col2")
 
     #
     # Group
@@ -206,50 +192,48 @@ class HistoryViewTest(HistoryWebTest):
 
     def test_tracks_group_creation(self):
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][1]
-        assert entry['resource_name'] == 'group'
-        assert 'bucket_id' not in entry
-        assert entry['group_id'] == self.group['id']
-        assert entry['action'] == 'create'
-        assert entry['uri'] == '/buckets/test/groups/{}'.format(self.group['id'])
+        entry = resp.json["data"][1]
+        assert entry["resource_name"] == "group"
+        assert "bucket_id" not in entry
+        assert entry["group_id"] == self.group["id"]
+        assert entry["action"] == "create"
+        assert entry["uri"] == "/buckets/test/groups/{}".format(self.group["id"])
 
     def test_tracks_group_attributes_update(self):
-        body = {'data': {'foo': 'baz', 'members': ['lui']}}
-        self.app.patch_json(self.group_uri, body,
-                            headers=self.headers)
+        body = {"data": {"foo": "baz", "members": ["lui"]}}
+        self.app.patch_json(self.group_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['data']['foo'] == 'baz'
-        assert entry['target']['data']['members'] == ['lui']
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["data"]["foo"] == "baz"
+        assert entry["target"]["data"]["members"] == ["lui"]
 
     def test_tracks_group_permissions_update(self):
-        body = {'permissions': {'read': ['admins']}}
-        self.app.patch_json(self.group_uri, body,
-                            headers=self.headers)
+        body = {"permissions": {"read": ["admins"]}}
+        self.app.patch_json(self.group_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['permissions']['read'] == ['admins']
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["permissions"]["read"] == ["admins"]
 
     def test_tracks_group_delete(self):
         self.app.delete(self.group_uri, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'delete'
-        assert entry['target']['data']['deleted'] is True
+        entry = resp.json["data"][0]
+        assert entry["action"] == "delete"
+        assert entry["target"]["data"]["deleted"] is True
 
     def test_tracks_multiple_groups_delete(self):
-        self.app.put_json(self.bucket_uri + '/groups/g2',
-                          {"data": {"members": ["her"]}},
-                          headers=self.headers)
+        self.app.put_json(
+            self.bucket_uri + "/groups/g2", {"data": {"members": ["her"]}}, headers=self.headers
+        )
 
-        self.app.delete(self.bucket_uri + '/groups', headers=self.headers)
+        self.app.delete(self.bucket_uri + "/groups", headers=self.headers)
 
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'delete'
-        assert entry['target']['data']['id'] in (self.group['id'], 'g2')
+        entry = resp.json["data"][0]
+        assert entry["action"] == "delete"
+        assert entry["target"]["data"]["id"] in (self.group["id"], "g2")
 
     #
     # Record
@@ -257,505 +241,429 @@ class HistoryViewTest(HistoryWebTest):
 
     def test_tracks_record_creation(self):
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        cid = self.collection['id']
-        rid = self.record['id']
-        assert entry['resource_name'] == 'record'
-        assert 'bucket_id' not in entry
-        assert entry['collection_id'] == cid
-        assert entry['record_id'] == rid
-        assert entry['action'] == 'create'
-        assert entry['uri'] == '/buckets/test/collections/{}/records/{}'.format(cid, rid)
-        assert entry['target']['data']['foo'] == 42
-        assert entry['target']['permissions']['write'][0].startswith('basicauth:')
+        entry = resp.json["data"][0]
+        cid = self.collection["id"]
+        rid = self.record["id"]
+        assert entry["resource_name"] == "record"
+        assert "bucket_id" not in entry
+        assert entry["collection_id"] == cid
+        assert entry["record_id"] == rid
+        assert entry["action"] == "create"
+        assert entry["uri"] == "/buckets/test/collections/{}/records/{}".format(cid, rid)
+        assert entry["target"]["data"]["foo"] == 42
+        assert entry["target"]["permissions"]["write"][0].startswith("basicauth:")
 
     def test_tracks_record_attributes_update(self):
-        resp = self.app.patch_json(self.record_uri, {'data': {'foo': 'baz'}},
-                                   headers=self.headers)
+        resp = self.app.patch_json(self.record_uri, {"data": {"foo": "baz"}}, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['data']['foo'] == 'baz'
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["data"]["foo"] == "baz"
 
     def test_tracks_record_permissions_update(self):
-        body = {'permissions': {'read': ['admins']}}
-        resp = self.app.patch_json(self.record_uri, body,
-                                   headers=self.headers)
+        body = {"permissions": {"read": ["admins"]}}
+        resp = self.app.patch_json(self.record_uri, body, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'update'
-        assert entry['target']['permissions']['read'] == ['admins']
+        entry = resp.json["data"][0]
+        assert entry["action"] == "update"
+        assert entry["target"]["permissions"]["read"] == ["admins"]
 
     def test_tracks_record_delete(self):
         resp = self.app.delete(self.record_uri, headers=self.headers)
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'delete'
-        assert entry['target']['data']['deleted'] is True
+        entry = resp.json["data"][0]
+        assert entry["action"] == "delete"
+        assert entry["target"]["data"]["deleted"] is True
 
     def test_tracks_multiple_records_delete(self):
-        records_uri = self.collection_uri + '/records'
-        body = {'data': {'foo': 43}}
+        records_uri = self.collection_uri + "/records"
+        body = {"data": {"foo": 43}}
         resp = self.app.post_json(records_uri, body, headers=self.headers)
-        rid = resp.json['data']['id']
+        rid = resp.json["data"]["id"]
 
         self.app.delete(records_uri, headers=self.headers)
 
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entry = resp.json['data'][0]
-        assert entry['action'] == 'delete'
-        assert entry['target']['data']['id'] in (self.record['id'], rid)
+        entry = resp.json["data"][0]
+        assert entry["action"] == "delete"
+        assert entry["target"]["data"]["id"] in (self.record["id"], rid)
 
     def test_does_not_track_records_during_massive_deletion(self):
-        body = {'data': {'pim': 'pam'}}
-        records_uri = self.collection_uri + '/records'
+        body = {"data": {"pim": "pam"}}
+        records_uri = self.collection_uri + "/records"
         self.app.post_json(records_uri, body, headers=self.headers)
 
         self.app.delete(self.collection_uri, headers=self.headers)
 
         resp = self.app.get(self.history_uri, headers=self.headers)
-        deletion_entries = [e for e in resp.json['data'] if e['action'] == 'delete']
+        deletion_entries = [e for e in resp.json["data"] if e["action"] == "delete"]
         assert len(deletion_entries) == 1
 
 
 class HistoryDeletionTest(HistoryWebTest):
-
     def setUp(self):
-        self.app.put('/buckets/bid', headers=self.headers)
-        self.app.put('/buckets/bid/collections/cid',
-                     headers=self.headers)
-        body = {'data': {'foo': 42}}
-        self.app.put_json('/buckets/bid/collections/cid/records/rid',
-                          body,
-                          headers=self.headers)
+        self.app.put("/buckets/bid", headers=self.headers)
+        self.app.put("/buckets/bid/collections/cid", headers=self.headers)
+        body = {"data": {"foo": 42}}
+        self.app.put_json("/buckets/bid/collections/cid/records/rid", body, headers=self.headers)
 
     def test_full_deletion(self):
-        self.app.delete('/buckets/bid/history', headers=self.headers)
-        resp = self.app.get('/buckets/bid/history', headers=self.headers)
-        assert len(resp.json['data']) == 0
+        self.app.delete("/buckets/bid/history", headers=self.headers)
+        resp = self.app.get("/buckets/bid/history", headers=self.headers)
+        assert len(resp.json["data"]) == 0
 
     def test_partial_deletion(self):
-        resp = self.app.get('/buckets/bid/history', headers=self.headers)
-        before = int(json.loads(resp.headers['ETag']))
-        self.app.put('/buckets/bid/collections/cid2', headers=self.headers)
+        resp = self.app.get("/buckets/bid/history", headers=self.headers)
+        before = int(json.loads(resp.headers["ETag"]))
+        self.app.put("/buckets/bid/collections/cid2", headers=self.headers)
 
         # Delete everything before the last entry (exclusive)
-        self.app.delete('/buckets/bid/history?_before={}'.format(before),
-                        headers=self.headers)
+        self.app.delete("/buckets/bid/history?_before={}".format(before), headers=self.headers)
 
-        resp = self.app.get('/buckets/bid/history', headers=self.headers)
-        assert len(resp.json['data']) == 2  # record + new collection
+        resp = self.app.get("/buckets/bid/history", headers=self.headers)
+        assert len(resp.json["data"]) == 2  # record + new collection
 
 
 class FilteringTest(HistoryWebTest):
-
     def setUp(self):
-        self.app.put('/buckets/bid', headers=self.headers)
-        self.app.put('/buckets/0', headers=self.headers)
-        self.app.put('/buckets/bid/collections/cid',
-                     headers=self.headers)
-        self.app.put('/buckets/0/collections/1',
-                     headers=self.headers)
-        body = {'data': {'foo': 42}}
-        self.app.put_json('/buckets/bid/collections/cid/records/rid',
-                          body,
-                          headers=self.headers)
-        body = {'data': {'foo': 0}}
-        self.app.put_json('/buckets/0/collections/1/records/2',
-                          body,
-                          headers=self.headers)
-        body = {'data': {'foo': 'bar'}}
-        self.app.patch_json('/buckets/bid/collections/cid/records/rid',
-                            body,
-                            headers=self.headers)
-        self.app.delete('/buckets/bid/collections/cid/records/rid',
-                        headers=self.headers)
+        self.app.put("/buckets/bid", headers=self.headers)
+        self.app.put("/buckets/0", headers=self.headers)
+        self.app.put("/buckets/bid/collections/cid", headers=self.headers)
+        self.app.put("/buckets/0/collections/1", headers=self.headers)
+        body = {"data": {"foo": 42}}
+        self.app.put_json("/buckets/bid/collections/cid/records/rid", body, headers=self.headers)
+        body = {"data": {"foo": 0}}
+        self.app.put_json("/buckets/0/collections/1/records/2", body, headers=self.headers)
+        body = {"data": {"foo": "bar"}}
+        self.app.patch_json("/buckets/bid/collections/cid/records/rid", body, headers=self.headers)
+        self.app.delete("/buckets/bid/collections/cid/records/rid", headers=self.headers)
 
     def test_filter_by_unknown_field_is_not_allowed(self):
-        self.app.get('/buckets/bid/history?movie=bourne',
-                     headers=self.headers,
-                     status=400)
+        self.app.get("/buckets/bid/history?movie=bourne", headers=self.headers, status=400)
 
     def test_filter_by_action(self):
-        resp = self.app.get('/buckets/bid/history?action=delete',
-                            headers=self.headers)
-        assert len(resp.json['data']) == 1
+        resp = self.app.get("/buckets/bid/history?action=delete", headers=self.headers)
+        assert len(resp.json["data"]) == 1
 
     def test_filter_by_resource(self):
-        resp = self.app.get('/buckets/bid/history?resource_name=bucket',
-                            headers=self.headers)
-        assert len(resp.json['data']) == 1
+        resp = self.app.get("/buckets/bid/history?resource_name=bucket", headers=self.headers)
+        assert len(resp.json["data"]) == 1
 
     def test_filter_by_uri(self):
-        uri = '/buckets/bid/collections/cid/records/rid'
-        resp = self.app.get('/buckets/bid/history?uri={}'.format(uri),
-                            headers=self.headers)
-        assert len(resp.json['data']) == 3  # create / update / delete
+        uri = "/buckets/bid/collections/cid/records/rid"
+        resp = self.app.get("/buckets/bid/history?uri={}".format(uri), headers=self.headers)
+        assert len(resp.json["data"]) == 3  # create / update / delete
 
     def test_allows_diff_between_two_versions_of_a_record(self):
-        uri = '/buckets/bid/collections/cid/records/rid'
-        querystring = '?uri={}&_limit=2&_sort=last_modified'.format(uri)
-        resp = self.app.get('/buckets/bid/history{}'.format(querystring),
-                            headers=self.headers)
-        entries = resp.json['data']
-        version1 = entries[0]['target']['data']
-        version2 = entries[1]['target']['data']
-        diff = [(k, version1[k], version2[k])
-                for k in version1.keys()
-                if k != 'last_modified' and version2[k] != version1[k]]
-        assert diff == [('foo', 42, 'bar')]
+        uri = "/buckets/bid/collections/cid/records/rid"
+        querystring = "?uri={}&_limit=2&_sort=last_modified".format(uri)
+        resp = self.app.get("/buckets/bid/history{}".format(querystring), headers=self.headers)
+        entries = resp.json["data"]
+        version1 = entries[0]["target"]["data"]
+        version2 = entries[1]["target"]["data"]
+        diff = [
+            (k, version1[k], version2[k])
+            for k in version1.keys()
+            if k != "last_modified" and version2[k] != version1[k]
+        ]
+        assert diff == [("foo", 42, "bar")]
 
     def test_filter_by_bucket(self):
-        uri = '/buckets/bid/history?bucket_id=bid'
-        resp = self.app.get(uri,
-                            headers=self.headers)
+        uri = "/buckets/bid/history?bucket_id=bid"
+        resp = self.app.get(uri, headers=self.headers)
         # This is equivalent to filtering by resource_name=bucket,
         # since only entries for bucket have ``bucket_id`` attribute.
-        assert len(resp.json['data']) == 1
+        assert len(resp.json["data"]) == 1
 
     def test_filter_by_collection(self):
-        uri = '/buckets/bid/history?collection_id=cid'
-        resp = self.app.get(uri,
-                            headers=self.headers)
-        assert len(resp.json['data']) == 4
+        uri = "/buckets/bid/history?collection_id=cid"
+        resp = self.app.get(uri, headers=self.headers)
+        assert len(resp.json["data"]) == 4
 
     def test_filter_by_numeric_bucket(self):
-        uri = '/buckets/0/history?bucket_id=0'
-        resp = self.app.get(uri,
-                            headers=self.headers)
-        assert len(resp.json['data']) == 1
+        uri = "/buckets/0/history?bucket_id=0"
+        resp = self.app.get(uri, headers=self.headers)
+        assert len(resp.json["data"]) == 1
 
     def test_filter_by_numeric_collection(self):
-        uri = '/buckets/0/history?collection_id=1'
-        resp = self.app.get(uri,
-                            headers=self.headers)
-        assert len(resp.json['data']) == 2
+        uri = "/buckets/0/history?collection_id=1"
+        resp = self.app.get(uri, headers=self.headers)
+        assert len(resp.json["data"]) == 2
 
     def test_filter_by_numeric_record(self):
-        uri = '/buckets/0/history?record_id=2'
-        resp = self.app.get(uri,
-                            headers=self.headers)
-        assert len(resp.json['data']) == 1
+        uri = "/buckets/0/history?record_id=2"
+        resp = self.app.get(uri, headers=self.headers)
+        assert len(resp.json["data"]) == 1
 
     def test_filter_by_target_fields(self):
-        uri = '/buckets/bid/history?target.data.id=rid'
-        resp = self.app.get(uri,
-                            headers=self.headers)
-        assert len(resp.json['data']) == 3  # create, update, delete
+        uri = "/buckets/bid/history?target.data.id=rid"
+        resp = self.app.get(uri, headers=self.headers)
+        assert len(resp.json["data"]) == 3  # create, update, delete
 
     def test_limit_results(self):
-        resp = self.app.get('/buckets/bid/history?_limit=2',
-                            headers=self.headers)
-        assert len(resp.json['data']) == 2
-        assert 'Next-Page' in resp.headers
+        resp = self.app.get("/buckets/bid/history?_limit=2", headers=self.headers)
+        assert len(resp.json["data"]) == 2
+        assert "Next-Page" in resp.headers
 
     def test_filter_returned_fields(self):
-        resp = self.app.get('/buckets/bid/history?_fields=uri,action',
-                            headers=self.headers)
-        assert sorted(resp.json['data'][0].keys()) == ['action', 'id',
-                                                       'last_modified', 'uri']
+        resp = self.app.get("/buckets/bid/history?_fields=uri,action", headers=self.headers)
+        assert sorted(resp.json["data"][0].keys()) == ["action", "id", "last_modified", "uri"]
 
     def test_sort_by_date(self):
-        resp = self.app.get('/buckets/bid/history?_sort=date',
-                            headers=self.headers)
-        entries = resp.json['data']
-        assert entries[0]['date'] < entries[-1]['date']
+        resp = self.app.get("/buckets/bid/history?_sort=date", headers=self.headers)
+        entries = resp.json["data"]
+        assert entries[0]["date"] < entries[-1]["date"]
 
 
 class BulkTest(HistoryWebTest):
     def setUp(self):
         body = {
-            'defaults': {
-                'method': 'POST',
-                'path': '/buckets/bid/collections/cid/records',
-            },
-            'requests': [{
-                'path': '/buckets/bid',
-                'method': 'PUT'
-            }, {
-                'path': '/buckets/bid/collections',
-                'body': {'data': {'id': 'cid'}}
-            }, {
-                'body': {'data': {'id': 'a', 'attr': 1}},
-            }, {
-                'body': {'data': {'id': 'b', 'attr': 2}},
-            }, {
-                'body': {'data': {'id': 'c', 'attr': 3}}
-            }]
+            "defaults": {"method": "POST", "path": "/buckets/bid/collections/cid/records"},
+            "requests": [
+                {"path": "/buckets/bid", "method": "PUT"},
+                {"path": "/buckets/bid/collections", "body": {"data": {"id": "cid"}}},
+                {"body": {"data": {"id": "a", "attr": 1}}},
+                {"body": {"data": {"id": "b", "attr": 2}}},
+                {"body": {"data": {"id": "c", "attr": 3}}},
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
+        self.app.post_json("/batch", body, headers=self.headers)
 
     def test_post_on_collection(self):
-        resp = self.app.get('/buckets/bid/history', headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/bid/history", headers=self.headers)
+        entries = resp.json["data"]
         assert len(entries) == 5
-        assert entries[0]['uri'] == '/buckets/bid/collections/cid/records/c'
-        assert entries[-2]['uri'] == '/buckets/bid/collections/cid'
+        assert entries[0]["uri"] == "/buckets/bid/collections/cid/records/c"
+        assert entries[-2]["uri"] == "/buckets/bid/collections/cid"
 
     def test_delete_on_collection(self):
         body = {
-            'defaults': {
-                'method': 'DELETE',
-            },
-            'requests': [{
-                'path': '/buckets/bid/collections/cid/records/a',
-            }, {
-                'path': '/buckets/bid/collections/cid/records/b',
-            }, {
-                'path': '/buckets/bid/collections/cid/records/c',
-            }]
+            "defaults": {"method": "DELETE"},
+            "requests": [
+                {"path": "/buckets/bid/collections/cid/records/a"},
+                {"path": "/buckets/bid/collections/cid/records/b"},
+                {"path": "/buckets/bid/collections/cid/records/c"},
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
-        resp = self.app.get('/buckets/bid/history', headers=self.headers)
-        entries = resp.json['data']
-        assert entries[0]['uri'] == '/buckets/bid/collections/cid/records/c'
-        assert entries[1]['uri'] == '/buckets/bid/collections/cid/records/b'
-        assert entries[2]['uri'] == '/buckets/bid/collections/cid/records/a'
+        self.app.post_json("/batch", body, headers=self.headers)
+        resp = self.app.get("/buckets/bid/history", headers=self.headers)
+        entries = resp.json["data"]
+        assert entries[0]["uri"] == "/buckets/bid/collections/cid/records/c"
+        assert entries[1]["uri"] == "/buckets/bid/collections/cid/records/b"
+        assert entries[2]["uri"] == "/buckets/bid/collections/cid/records/a"
 
     def test_multiple_patch(self):
         # Kinto/kinto#942
-        requests = [{
-            'method': 'PATCH',
-            'path': '/buckets/bid/collections/cid/records/{}'.format(l),
-            'body': {'data': {'label': l}}} for l in ('a', 'b', 'c')]
-        self.app.post_json('/batch', {'requests': requests}, headers=self.headers)
-        resp = self.app.get('/buckets/bid/history', headers=self.headers)
-        entries = resp.json['data']
+        requests = [
+            {
+                "method": "PATCH",
+                "path": "/buckets/bid/collections/cid/records/{}".format(l),
+                "body": {"data": {"label": l}},
+            }
+            for l in ("a", "b", "c")
+        ]
+        self.app.post_json("/batch", {"requests": requests}, headers=self.headers)
+        resp = self.app.get("/buckets/bid/history", headers=self.headers)
+        entries = resp.json["data"]
         for entry in entries:
-            if entry['resource_name'] != 'record':
+            if entry["resource_name"] != "record":
                 continue
-            assert entry['record_id'] == entry['target']['data']['id']
+            assert entry["record_id"] == entry["target"]["data"]["id"]
 
 
 class DefaultBucketTest(HistoryWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['includes'] = ('kinto.plugins.default_bucket '
-                                'kinto.plugins.history')
+        settings["includes"] = "kinto.plugins.default_bucket " "kinto.plugins.history"
         return settings
 
     def setUp(self):
-        resp = self.app.get('/', headers=self.headers)
-        self.bucket_id = resp.json['user']['bucket']
-        self.history_uri = '/buckets/{}/history'.format(self.bucket_id)
+        resp = self.app.get("/", headers=self.headers)
+        self.bucket_id = resp.json["user"]["bucket"]
+        self.history_uri = "/buckets/{}/history".format(self.bucket_id)
 
     def test_history_can_be_accessed_via_default_alias(self):
-        self.app.get('/buckets/default/collections/blah',
-                     headers=self.headers)
-        resp = self.app.get('/buckets/default/history', headers=self.headers)
-        assert len(resp.json['data']) == 2
+        self.app.get("/buckets/default/collections/blah", headers=self.headers)
+        resp = self.app.get("/buckets/default/history", headers=self.headers)
+        assert len(resp.json["data"]) == 2
 
     def test_implicit_creations_are_listed(self):
-        body = {'data': {'foo': 42}}
-        resp = self.app.post_json('/buckets/default/collections/blah/records',
-                                  body,
-                                  headers=self.headers)
-        record = resp.json['data']
+        body = {"data": {"foo": 42}}
+        resp = self.app.post_json(
+            "/buckets/default/collections/blah/records", body, headers=self.headers
+        )
+        record = resp.json["data"]
 
         resp = self.app.get(self.history_uri, headers=self.headers)
-        entries = resp.json['data']
+        entries = resp.json["data"]
         assert len(entries) == 3
 
-        bucket_uri = '/buckets/{}'.format(self.bucket_id)
-        assert entries[2]['resource_name'] == 'bucket'
-        assert entries[2]['bucket_id'] == self.bucket_id
-        assert entries[2]['uri'] == bucket_uri
-        assert entries[2]['target']['permissions']['write'][0] == self.principal
+        bucket_uri = "/buckets/{}".format(self.bucket_id)
+        assert entries[2]["resource_name"] == "bucket"
+        assert entries[2]["bucket_id"] == self.bucket_id
+        assert entries[2]["uri"] == bucket_uri
+        assert entries[2]["target"]["permissions"]["write"][0] == self.principal
 
-        collection_uri = bucket_uri + '/collections/blah'
-        assert entries[1]['resource_name'] == 'collection'
-        assert 'bucket_id' not in entries[1]
-        assert entries[1]['collection_id'] == 'blah'
-        assert entries[1]['uri'] == collection_uri
-        assert entries[1]['target']['permissions']['write'][0] == self.principal
+        collection_uri = bucket_uri + "/collections/blah"
+        assert entries[1]["resource_name"] == "collection"
+        assert "bucket_id" not in entries[1]
+        assert entries[1]["collection_id"] == "blah"
+        assert entries[1]["uri"] == collection_uri
+        assert entries[1]["target"]["permissions"]["write"][0] == self.principal
 
-        record_uri = collection_uri + '/records/{}'.format(record['id'])
-        assert entries[0]['resource_name'] == 'record'
-        assert 'bucket_id' not in entries[1]
-        assert entries[0]['collection_id'] == 'blah'
-        assert entries[0]['record_id'] == record['id']
-        assert entries[0]['uri'] == record_uri
-        assert entries[0]['target']['data']['foo'] == 42
-        assert entries[0]['target']['permissions']['write'][0] == self.principal
+        record_uri = collection_uri + "/records/{}".format(record["id"])
+        assert entries[0]["resource_name"] == "record"
+        assert "bucket_id" not in entries[1]
+        assert entries[0]["collection_id"] == "blah"
+        assert entries[0]["record_id"] == record["id"]
+        assert entries[0]["uri"] == record_uri
+        assert entries[0]["target"]["data"]["foo"] == 42
+        assert entries[0]["target"]["permissions"]["write"][0] == self.principal
 
 
 class PermissionsTest(HistoryWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_permissions_endpoint'] = 'true'
+        settings["experimental_permissions_endpoint"] = "true"
         return settings
 
     def setUp(self):
-        self.alice_headers = get_user_headers('alice')
-        self.bob_headers = get_user_headers('bob')
-        self.julia_headers = get_user_headers('julia')
+        self.alice_headers = get_user_headers("alice")
+        self.bob_headers = get_user_headers("bob")
+        self.julia_headers = get_user_headers("julia")
 
-        self.alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155e16'
-                                '812e3c64ff7ae053fe3542e2ca1570')
-        self.bob_principal = ('basicauth:c031ced27503f788b102ca54269a062ec737'
-                              '94bb075154c74a0d4311e74ca8b6')
-        self.julia_principal = ('basicauth:d8bab8d9fe0510fcaf9b5ad5942c027fc'
-                                '2fdf80b6dc59cc3c48d12a2fcb18f1c')
+        self.alice_principal = (
+            "basicauth:d5b0026601f1b251974e09548d44155e16" "812e3c64ff7ae053fe3542e2ca1570"
+        )
+        self.bob_principal = (
+            "basicauth:c031ced27503f788b102ca54269a062ec737" "94bb075154c74a0d4311e74ca8b6"
+        )
+        self.julia_principal = (
+            "basicauth:d8bab8d9fe0510fcaf9b5ad5942c027fc" "2fdf80b6dc59cc3c48d12a2fcb18f1c"
+        )
 
-        bucket = {
-            'permissions': {
-                'read': [self.alice_principal]
-            }
-        }
-        collection = {
-            'permissions': {
-                'read': [self.julia_principal]
-            }
-        }
-        record = {
-            'permissions': {
-                'write': [self.bob_principal, self.alice_principal],
-            }
-        }
-        self.app.put('/buckets/author-only',
-                     headers=self.headers)
-        self.app.put_json('/buckets/test',
-                          bucket,
-                          headers=self.headers)
-        self.app.put_json('/buckets/test/groups/admins',
-                          {'data': {'members': []}},
-                          headers=self.headers)
-        self.app.put_json('/buckets/test/collections/alice-julia',
-                          collection,
-                          headers=self.headers)
-        self.app.put_json('/buckets/test/collections/author-only',
-                          headers=self.headers)
-        self.app.post_json('/buckets/test/collections/alice-julia/records',
-                           record,
-                           headers=self.headers)
-        self.app.post_json('/buckets/test/collections/alice-julia/records',
-                           {'permissions': {'read': ['system.Authenticated']}},
-                           headers=self.headers)
+        bucket = {"permissions": {"read": [self.alice_principal]}}
+        collection = {"permissions": {"read": [self.julia_principal]}}
+        record = {"permissions": {"write": [self.bob_principal, self.alice_principal]}}
+        self.app.put("/buckets/author-only", headers=self.headers)
+        self.app.put_json("/buckets/test", bucket, headers=self.headers)
+        self.app.put_json(
+            "/buckets/test/groups/admins", {"data": {"members": []}}, headers=self.headers
+        )
+        self.app.put_json(
+            "/buckets/test/collections/alice-julia", collection, headers=self.headers
+        )
+        self.app.put_json("/buckets/test/collections/author-only", headers=self.headers)
+        self.app.post_json(
+            "/buckets/test/collections/alice-julia/records", record, headers=self.headers
+        )
+        self.app.post_json(
+            "/buckets/test/collections/alice-julia/records",
+            {"permissions": {"read": ["system.Authenticated"]}},
+            headers=self.headers,
+        )
 
     def test_author_can_read_everything(self):
-        resp = self.app.get('/buckets/test/history',
-                            headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/test/history", headers=self.headers)
+        entries = resp.json["data"]
         assert len(entries) == 6  # everything.
 
     def test_read_permission_can_be_given_to_anybody_via_settings(self):
-        with mock.patch.dict(self.app.app.registry.settings,
-                             [('history_read_principals', 'system.Everyone')]):
-            resp = self.app.get('/buckets/test/history',
-                                headers=get_user_headers('tartan:pion'))
-            entries = resp.json['data']
+        with mock.patch.dict(
+            self.app.app.registry.settings, [("history_read_principals", "system.Everyone")]
+        ):
+            resp = self.app.get("/buckets/test/history", headers=get_user_headers("tartan:pion"))
+            entries = resp.json["data"]
             assert len(entries) == 6  # everything.
 
     def test_bucket_read_allows_whole_history(self):
-        resp = self.app.get('/buckets/test/history',
-                            headers=self.alice_headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/test/history", headers=self.alice_headers)
+        entries = resp.json["data"]
         assert len(entries) == 6  # everything.
 
-        self.app.get('/buckets/author-only/history',
-                     headers=self.alice_headers,
-                     status=403)
+        self.app.get("/buckets/author-only/history", headers=self.alice_headers, status=403)
 
     def test_collection_read_restricts_to_collection(self):
-        resp = self.app.get('/buckets/test/history',
-                            headers=self.julia_headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/test/history", headers=self.julia_headers)
+        entries = resp.json["data"]
         assert len(entries) == 3
-        assert entries[0]['resource_name'] == 'record'
-        assert entries[1]['resource_name'] == 'record'
-        assert entries[2]['resource_name'] == 'collection'
+        assert entries[0]["resource_name"] == "record"
+        assert entries[1]["resource_name"] == "record"
+        assert entries[2]["resource_name"] == "collection"
 
     def test_write_on_record_restricts_to_record(self):
-        resp = self.app.get('/buckets/test/history',
-                            headers=self.bob_headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/test/history", headers=self.bob_headers)
+        entries = resp.json["data"]
         assert len(entries) == 2
-        assert ('system.Authenticated' in
-                entries[0]['target']['permissions']['read'])
-        assert entries[0]['resource_name'] == 'record'
-        assert (self.bob_principal in
-                entries[1]['target']['permissions']['write'])
-        assert entries[1]['resource_name'] == 'record'
+        assert "system.Authenticated" in entries[0]["target"]["permissions"]["read"]
+        assert entries[0]["resource_name"] == "record"
+        assert self.bob_principal in entries[1]["target"]["permissions"]["write"]
+        assert entries[1]["resource_name"] == "record"
 
     def test_publicly_readable_record_allows_any_authenticated(self):
-        resp = self.app.get('/buckets/test/history',
-                            headers=get_user_headers('jack:'))
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/test/history", headers=get_user_headers("jack:"))
+        entries = resp.json["data"]
         assert len(entries) == 1
-        assert ('system.Authenticated' in
-                entries[0]['target']['permissions']['read'])
-        assert entries[0]['resource_name'] == 'record'
+        assert "system.Authenticated" in entries[0]["target"]["permissions"]["read"]
+        assert entries[0]["resource_name"] == "record"
 
     def test_new_entries_are_not_readable_if_permission_is_removed(self):
-        resp = self.app.get('/buckets/test/history',
-                            headers=self.alice_headers)
-        before = resp.headers['ETag']
+        resp = self.app.get("/buckets/test/history", headers=self.alice_headers)
+        before = resp.headers["ETag"]
 
         # Remove alice from read permission.
-        self.app.patch_json('/buckets/test',
-                            {'permissions': {'read': []}},
-                            headers=self.headers)
+        self.app.patch_json("/buckets/test", {"permissions": {"read": []}}, headers=self.headers)
 
         # Create new collection.
-        self.app.put_json('/buckets/test/collections/new-one',
-                          headers=self.headers)
+        self.app.put_json("/buckets/test/collections/new-one", headers=self.headers)
 
         # History did not evolve for alice.
-        resp = self.app.get('/buckets/test/history',
-                            headers=self.alice_headers)
-        assert resp.headers['ETag'] != before
+        resp = self.app.get("/buckets/test/history", headers=self.alice_headers)
+        assert resp.headers["ETag"] != before
 
     def test_history_entries_are_not_listed_in_permissions_endpoint(self):
-        resp = self.app.get('/permissions',
-                            headers=self.headers)
-        entries = [e['resource_name'] == 'history' for e in resp.json["data"]]
+        resp = self.app.get("/permissions", headers=self.headers)
+        entries = [e["resource_name"] == "history" for e in resp.json["data"]]
         assert not any(entries)
 
 
 class ExcludeResourcesTest(HistoryWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['history.exclude_resources'] = ('/buckets/a '
-                                                 '/buckets/b/collections/a '
-                                                 '/buckets/b/groups/a')
+        settings["history.exclude_resources"] = (
+            "/buckets/a " "/buckets/b/collections/a " "/buckets/b/groups/a"
+        )
         return settings
 
     def setUp(self):
-        group = {'data': {'members': []}}
-        self.app.put_json('/buckets/a', headers=self.headers)
-        self.app.put_json('/buckets/a/groups/admins', group, headers=self.headers)
-        self.app.put_json('/buckets/b', headers=self.headers)
-        self.app.put_json('/buckets/b/groups/a', group, headers=self.headers)
-        self.app.put_json('/buckets/b/collections/a', headers=self.headers)
-        self.app.put_json('/buckets/b/collections/a/records/1', headers=self.headers)
-        self.app.put_json('/buckets/b/collections/b', headers=self.headers)
-        self.app.put_json('/buckets/b/collections/b/records/1', headers=self.headers)
+        group = {"data": {"members": []}}
+        self.app.put_json("/buckets/a", headers=self.headers)
+        self.app.put_json("/buckets/a/groups/admins", group, headers=self.headers)
+        self.app.put_json("/buckets/b", headers=self.headers)
+        self.app.put_json("/buckets/b/groups/a", group, headers=self.headers)
+        self.app.put_json("/buckets/b/collections/a", headers=self.headers)
+        self.app.put_json("/buckets/b/collections/a/records/1", headers=self.headers)
+        self.app.put_json("/buckets/b/collections/b", headers=self.headers)
+        self.app.put_json("/buckets/b/collections/b/records/1", headers=self.headers)
 
     def test_whole_buckets_can_be_excluded(self):
-        resp = self.app.get('/buckets/a/history',
-                            headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/a/history", headers=self.headers)
+        entries = resp.json["data"]
         assert len(entries) == 0  # nothing.
 
     def test_some_specific_collection_can_be_excluded(self):
-        resp = self.app.get('/buckets/b/history?collection_id=b',
-                            headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/b/history?collection_id=b", headers=self.headers)
+        entries = resp.json["data"]
         assert len(entries) > 0
 
-        resp = self.app.get('/buckets/b/history?collection_id=a',
-                            headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/b/history?collection_id=a", headers=self.headers)
+        entries = resp.json["data"]
         assert len(entries) == 0  # nothing.
 
     def test_some_specific_object_can_be_excluded(self):
-        resp = self.app.get('/buckets/b/history?group_id=a',
-                            headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/buckets/b/history?group_id=a", headers=self.headers)
+        entries = resp.json["data"]
         assert len(entries) == 0  # nothing.

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -9,164 +9,160 @@ from .. import support
 
 
 def get_openid_configuration(url):
-    base_url = url.replace('/.well-known/openid-configuration', '')
+    base_url = url.replace("/.well-known/openid-configuration", "")
     m = mock.Mock()
     m.json.return_value = {
-        'issuer': '{base_url} issuer'.format(base_url=base_url),
-        'authorization_endpoint': '{base_url}/authorize'.format(base_url=base_url),
-        'userinfo_endpoint': '{base_url}/oauth/user'.format(base_url=base_url),
-        'token_endpoint': '{base_url}/oauth/token'.format(base_url=base_url),
+        "issuer": "{base_url} issuer".format(base_url=base_url),
+        "authorization_endpoint": "{base_url}/authorize".format(base_url=base_url),
+        "userinfo_endpoint": "{base_url}/oauth/user".format(base_url=base_url),
+        "token_endpoint": "{base_url}/oauth/token".format(base_url=base_url),
     }
     return m
 
 
 class OpenIDWebTest(support.BaseWebTest, unittest.TestCase):
-
     @classmethod
     def make_app(cls, *args, **kwargs):
-        with mock.patch('kinto.plugins.openid.requests.get') as get:
+        with mock.patch("kinto.plugins.openid.requests.get") as get:
             get.side_effect = get_openid_configuration
             return super(OpenIDWebTest, cls).make_app(*args, **kwargs)
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        openid_policy = 'kinto.plugins.openid.OpenIDConnectPolicy'
-        settings['includes'] = 'kinto.plugins.openid'
-        settings['multiauth.policies'] = 'auth0 google'
-        settings['multiauth.policy.auth0.use'] = openid_policy
-        settings['multiauth.policy.auth0.issuer'] = 'https://auth.mozilla.auth0.com'
-        settings['multiauth.policy.auth0.client_id'] = 'abc'
-        settings["multiauth.policy.auth0.client_secret"] = 'xyz'
+        openid_policy = "kinto.plugins.openid.OpenIDConnectPolicy"
+        settings["includes"] = "kinto.plugins.openid"
+        settings["multiauth.policies"] = "auth0 google"
+        settings["multiauth.policy.auth0.use"] = openid_policy
+        settings["multiauth.policy.auth0.issuer"] = "https://auth.mozilla.auth0.com"
+        settings["multiauth.policy.auth0.client_id"] = "abc"
+        settings["multiauth.policy.auth0.client_secret"] = "xyz"
 
-        settings['multiauth.policy.google.use'] = openid_policy
-        settings['multiauth.policy.google.issuer'] = 'https://accounts.google.com'
-        settings['multiauth.policy.google.client_id'] = '123'
-        settings["multiauth.policy.google.client_secret"] = '789'
-        settings["multiauth.policy.google.userid_field"] = 'email'
+        settings["multiauth.policy.google.use"] = openid_policy
+        settings["multiauth.policy.google.issuer"] = "https://accounts.google.com"
+        settings["multiauth.policy.google.client_id"] = "123"
+        settings["multiauth.policy.google.client_secret"] = "789"
+        settings["multiauth.policy.google.userid_field"] = "email"
         return settings
 
     def test_openid_multiple_providers(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        providers = capabilities['openid']['providers']
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        providers = capabilities["openid"]["providers"]
         assert len(providers) == 2
 
 
 class OpenIDWithoutPolicyTest(support.BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['includes'] = 'kinto.plugins.openid'
+        settings["includes"] = "kinto.plugins.openid"
         return settings
 
     def test_openid_capability_is_not_added(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        assert 'openid' not in capabilities
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        assert "openid" not in capabilities
 
 
 class OpenIDOnePolicyTest(support.BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        openid_policy = 'kinto.plugins.openid.OpenIDConnectPolicy'
-        settings['includes'] = 'kinto.plugins.openid'
-        settings['multiauth.policies'] = 'google'
-        settings['multiauth.policy.auth0.use'] = openid_policy
-        settings['multiauth.policy.auth0.issuer'] = 'https://auth.mozilla.auth0.com'
-        settings['multiauth.policy.auth0.client_id'] = 'abc'
-        settings["multiauth.policy.auth0.client_secret"] = 'xyz'
+        openid_policy = "kinto.plugins.openid.OpenIDConnectPolicy"
+        settings["includes"] = "kinto.plugins.openid"
+        settings["multiauth.policies"] = "google"
+        settings["multiauth.policy.auth0.use"] = openid_policy
+        settings["multiauth.policy.auth0.issuer"] = "https://auth.mozilla.auth0.com"
+        settings["multiauth.policy.auth0.client_id"] = "abc"
+        settings["multiauth.policy.auth0.client_secret"] = "xyz"
 
-        settings['multiauth.policy.google.use'] = openid_policy
-        settings['multiauth.policy.google.issuer'] = 'https://accounts.google.com'
-        settings['multiauth.policy.google.client_id'] = '123'
-        settings["multiauth.policy.google.client_secret"] = '789'
-        settings["multiauth.policy.google.userid_field"] = 'email'
+        settings["multiauth.policy.google.use"] = openid_policy
+        settings["multiauth.policy.google.issuer"] = "https://accounts.google.com"
+        settings["multiauth.policy.google.client_id"] = "123"
+        settings["multiauth.policy.google.client_secret"] = "789"
+        settings["multiauth.policy.google.userid_field"] = "email"
         return settings
 
     def test_openid_one_provider(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        providers = capabilities['openid']['providers']
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        providers = capabilities["openid"]["providers"]
         assert len(providers) == 1
 
 
 class HelloViewTest(OpenIDWebTest):
-
     def test_openid_capability_if_enabled(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        assert 'openid' in capabilities
-        assert len(capabilities['openid']['providers']) == 2
-        assert 'userinfo_endpoint' in capabilities['openid']['providers'][0]
-        assert 'auth_path' in capabilities['openid']['providers'][0]
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        assert "openid" in capabilities
+        assert len(capabilities["openid"]["providers"]) == 2
+        assert "userinfo_endpoint" in capabilities["openid"]["providers"][0]
+        assert "auth_path" in capabilities["openid"]["providers"][0]
 
     def test_openid_in_openapi(self):
-        resp = self.app.get('/__api__')
-        assert 'auth0' in resp.json['securityDefinitions']
-        auth = resp.json['securityDefinitions']['auth0']['authorizationUrl']
-        assert auth == 'https://auth.mozilla.auth0.com/authorize'
+        resp = self.app.get("/__api__")
+        assert "auth0" in resp.json["securityDefinitions"]
+        auth = resp.json["securityDefinitions"]["auth0"]["authorizationUrl"]
+        assert auth == "https://auth.mozilla.auth0.com/authorize"
 
 
 class PolicyTest(unittest.TestCase):
     def setUp(self):
-        mocked = mock.patch('kinto.plugins.openid.requests.get')
+        mocked = mock.patch("kinto.plugins.openid.requests.get")
         self.mocked_get = mocked.start()
         self.addCleanup(mocked.stop)
 
-        self.policy = OpenIDConnectPolicy(issuer='https://idp', client_id='abc')
+        self.policy = OpenIDConnectPolicy(issuer="https://idp", client_id="abc")
 
         self.request = DummyRequest()
         self.request.registry.cache.get.return_value = None
 
-        mocked = mock.patch.object(self.policy, '_verify_token')
+        mocked = mock.patch.object(self.policy, "_verify_token")
         self.verify = mocked.start()
         self.addCleanup(mocked.stop)
-        self.verify.return_value = {'sub': 'userid'}
+        self.verify.return_value = {"sub": "userid"}
 
     def test_returns_none_if_no_authorization(self):
         assert self.policy.unauthenticated_userid(self.request) is None
 
     def test_returns_header_type_in_forget(self):
         h = self.policy.forget(self.request)
-        assert 'Bearer ' in h[0][1]
+        assert "Bearer " in h[0][1]
 
     def test_header_type_can_be_configured(self):
-        self.policy.header_type = 'bearer+oidc'
+        self.policy.header_type = "bearer+oidc"
         h = self.policy.forget(self.request)
-        assert 'bearer+oidc ' in h[0][1]
+        assert "bearer+oidc " in h[0][1]
 
     def test_returns_none_if_no_authorization_prefix(self):
-        self.request.headers['Authorization'] = 'avrbnnbrbr'
+        self.request.headers["Authorization"] = "avrbnnbrbr"
         assert self.policy.unauthenticated_userid(self.request) is None
 
     def test_returns_none_if_bad_prefix(self):
-        self.request.headers['Authorization'] = 'Basic avrbnnbrbr'
+        self.request.headers["Authorization"] = "Basic avrbnnbrbr"
         assert self.policy.unauthenticated_userid(self.request) is None
 
     def test_can_specify_only_opaque_access_token(self):
-        self.request.headers['Authorization'] = 'Bearer xyz'
-        assert self.policy.unauthenticated_userid(self.request) == 'userid'
-        self.verify.assert_called_with('xyz')
+        self.request.headers["Authorization"] = "Bearer xyz"
+        assert self.policy.unauthenticated_userid(self.request) == "userid"
+        self.verify.assert_called_with("xyz")
 
     def test_returns_none_if_no_cache_and_invalid_access_token(self):
-        self.request.headers['Authorization'] = 'Bearer xyz'
+        self.request.headers["Authorization"] = "Bearer xyz"
         self.request.registry.cache.get.return_value = None
         self.verify.return_value = None
         assert self.policy.unauthenticated_userid(self.request) is None
         assert not self.request.registry.cache.set.called
 
     def test_payload_is_read_from_cache(self):
-        self.request.headers['Authorization'] = 'Bearer xyz'
-        self.request.registry.cache.get.return_value = {'sub': 'me'}
-        assert self.policy.unauthenticated_userid(self.request) == 'me'
+        self.request.headers["Authorization"] = "Bearer xyz"
+        self.request.registry.cache.get.return_value = {"sub": "me"}
+        assert self.policy.unauthenticated_userid(self.request) == "me"
 
     def test_payload_is_stored_in_cache(self):
-        self.request.headers['Authorization'] = 'Bearer xyz'
-        assert self.policy.unauthenticated_userid(self.request) == 'userid'
+        self.request.headers["Authorization"] = "Bearer xyz"
+        assert self.policy.unauthenticated_userid(self.request) == "userid"
         assert self.request.registry.cache.set.called
 
     def test_payload_is_read_from_cache_but_differently_by_access_token(self):
@@ -178,145 +174,146 @@ class PolicyTest(unittest.TestCase):
             assert cache_key not in cache_keys_used
             cache_keys_used.append(cache_key)
             if len(cache_keys_used) == 1:
-                return {'sub': 'me'}
+                return {"sub": "me"}
             elif len(cache_keys_used) == 2:
-                return {'sub': 'you'}
+                return {"sub": "you"}
 
         self.request.registry.cache.get.side_effect = mocked_cache_get
 
-        self.request.headers['Authorization'] = 'Bearer xyz'
-        assert self.policy.unauthenticated_userid(self.request) == 'me'
+        self.request.headers["Authorization"] = "Bearer xyz"
+        assert self.policy.unauthenticated_userid(self.request) == "me"
 
         # Change the Authorization header the second time
-        self.request.headers['Authorization'] = 'Bearer abc'
-        assert self.policy.unauthenticated_userid(self.request) == 'you'
+        self.request.headers["Authorization"] = "Bearer abc"
+        assert self.policy.unauthenticated_userid(self.request) == "you"
 
 
 class VerifyTokenTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(self):
         # Populate OpenID config cache.
-        with mock.patch('kinto.plugins.openid.utils.requests.get') as m:
-            m.return_value.json.return_value = {'userinfo_endpoint': 'http://uinfo',
-                                                'jwks_uri': 'https://jwks'}
-            fetch_openid_config('https://fxa')
+        with mock.patch("kinto.plugins.openid.utils.requests.get") as m:
+            m.return_value.json.return_value = {
+                "userinfo_endpoint": "http://uinfo",
+                "jwks_uri": "https://jwks",
+            }
+            fetch_openid_config("https://fxa")
 
     def setUp(self):
-        mocked = mock.patch('kinto.plugins.openid.requests.get')
+        mocked = mock.patch("kinto.plugins.openid.requests.get")
         self.mocked_get = mocked.start()
         self.addCleanup(mocked.stop)
 
-        self.policy = OpenIDConnectPolicy(issuer='https://fxa', client_id='abc')
+        self.policy = OpenIDConnectPolicy(issuer="https://fxa", client_id="abc")
 
     def test_fetches_userinfo_if_id_token_is_none(self):
-        self.mocked_get.return_value.json.side_effect = [
-            {"sub": "me"},
-        ]
-        payload = self.policy._verify_token(access_token='abc')
+        self.mocked_get.return_value.json.side_effect = [{"sub": "me"}]
+        payload = self.policy._verify_token(access_token="abc")
         assert payload["sub"] == "me"
 
     def test_returns_none_if_fetching_userinfo_fails(self):
         self.mocked_get.return_value.raise_for_status.side_effect = ValueError
-        payload = self.policy._verify_token(access_token='abc')
+        payload = self.policy._verify_token(access_token="abc")
         assert payload is None
 
 
 class LoginViewTest(OpenIDWebTest):
-
     def test_returns_400_if_parameters_are_missing_or_bad(self):
-        self.app.get('/openid/auth0/login', status=400)
-        self.app.get('/openid/auth0/login', params={'callback': 'http://no-scope'}, status=400)
-        self.app.get('/openid/auth0/login', params={'callback': 'bad', 'scope': 'openid'},
-                     status=400)
+        self.app.get("/openid/auth0/login", status=400)
+        self.app.get("/openid/auth0/login", params={"callback": "http://no-scope"}, status=400)
+        self.app.get(
+            "/openid/auth0/login", params={"callback": "bad", "scope": "openid"}, status=400
+        )
 
     def test_returns_400_if_provider_is_unknown(self):
-        self.app.get('/openid/fxa/login', status=400)
+        self.app.get("/openid/fxa/login", status=400)
 
     def test_returns_400_if_email_is_not_in_scope_when_userid_field_is_email(self):
-        scope = 'openid'
-        cb = 'http://ui'
-        self.app.get('/openid/auth0/login', params={'callback': cb, 'scope': scope},
-                     status=307)
+        scope = "openid"
+        cb = "http://ui"
+        self.app.get("/openid/auth0/login", params={"callback": cb, "scope": scope}, status=307)
         # See config above (email is userid field)
-        self.app.get('/openid/google/login', params={'callback': cb, 'scope': scope},
-                     status=400)
+        self.app.get("/openid/google/login", params={"callback": cb, "scope": scope}, status=400)
 
     def test_returns_400_if_prompt_is_not_recognized(self):
-        scope = 'openid'
-        cb = 'http://ui'
-        self.app.get('/openid/auth0/login',
-                     params={'callback': cb, 'scope': scope, 'prompt': 'junk'},
-                     status=400)
+        scope = "openid"
+        cb = "http://ui"
+        self.app.get(
+            "/openid/auth0/login",
+            params={"callback": cb, "scope": scope, "prompt": "junk"},
+            status=400,
+        )
 
     def test_redirects_to_the_identity_provider(self):
-        params = {'callback': 'http://ui', 'scope': 'openid'}
-        resp = self.app.get('/openid/auth0/login', params=params, status=307)
-        location = resp.headers['Location']
-        assert 'auth0.com/authorize?' in location
-        assert '%2Fv1%2Fopenid%2Fauth0%2Ftoken' in location
-        assert 'scope=openid' in location
-        assert 'client_id=abc' in location
+        params = {"callback": "http://ui", "scope": "openid"}
+        resp = self.app.get("/openid/auth0/login", params=params, status=307)
+        location = resp.headers["Location"]
+        assert "auth0.com/authorize?" in location
+        assert "%2Fv1%2Fopenid%2Fauth0%2Ftoken" in location
+        assert "scope=openid" in location
+        assert "client_id=abc" in location
 
     def test_redirects_to_the_identity_provider_with_prompt_none(self):
-        params = {'callback': 'http://ui', 'scope': 'openid', 'prompt': 'none'}
-        resp = self.app.get('/openid/auth0/login', params=params, status=307)
-        location = resp.headers['Location']
-        assert 'auth0.com/authorize?' in location
-        assert '%2Fv1%2Fopenid%2Fauth0%2Ftoken' in location
-        assert 'scope=openid' in location
-        assert 'client_id=abc' in location
-        assert 'prompt=none' in location
+        params = {"callback": "http://ui", "scope": "openid", "prompt": "none"}
+        resp = self.app.get("/openid/auth0/login", params=params, status=307)
+        location = resp.headers["Location"]
+        assert "auth0.com/authorize?" in location
+        assert "%2Fv1%2Fopenid%2Fauth0%2Ftoken" in location
+        assert "scope=openid" in location
+        assert "client_id=abc" in location
+        assert "prompt=none" in location
 
     def test_callback_is_stored_in_cache(self):
-        params = {'callback': 'http://ui', 'scope': 'openid'}
-        with mock.patch('kinto.plugins.openid.views.random_bytes_hex') as m:
-            m.return_value = 'key'
-            self.app.get('/openid/auth0/login', params=params, status=307)
+        params = {"callback": "http://ui", "scope": "openid"}
+        with mock.patch("kinto.plugins.openid.views.random_bytes_hex") as m:
+            m.return_value = "key"
+            self.app.get("/openid/auth0/login", params=params, status=307)
 
-        cached = self.app.app.registry.cache.get('openid:state:key')
-        assert cached == 'http://ui'
+        cached = self.app.app.registry.cache.get("openid:state:key")
+        assert cached == "http://ui"
 
 
 class TokenViewTest(OpenIDWebTest):
-
     def test_returns_400_if_parameters_are_missing_or_bad(self):
-        self.app.get('/openid/auth0/token', status=400)
-        self.app.get('/openid/auth0/token', params={'code': 'abc'}, status=400)
-        self.app.get('/openid/auth0/token', params={'state': 'abc'}, status=400)
+        self.app.get("/openid/auth0/token", status=400)
+        self.app.get("/openid/auth0/token", params={"code": "abc"}, status=400)
+        self.app.get("/openid/auth0/token", params={"state": "abc"}, status=400)
 
     def test_returns_400_if_provider_is_unknown(self):
-        self.app.get('/openid/fxa/token', status=400)
+        self.app.get("/openid/fxa/token", status=400)
 
     def test_returns_400_if_state_is_invalid(self):
-        self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'abc'}, status=400)
+        self.app.get("/openid/auth0/token", params={"code": "abc", "state": "abc"}, status=400)
 
     def test_code_is_traded_using_client_secret(self):
-        self.app.app.registry.cache.set('openid:state:key', 'http://ui', ttl=100)
-        with mock.patch('kinto.plugins.openid.views.requests.post') as m:
+        self.app.app.registry.cache.set("openid:state:key", "http://ui", ttl=100)
+        with mock.patch("kinto.plugins.openid.views.requests.post") as m:
             m.return_value.text = '{"access_token": "token"}'
-            self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'})
+            self.app.get("/openid/auth0/token", params={"code": "abc", "state": "key"})
             m.assert_called_with(
-                'https://auth.mozilla.auth0.com/oauth/token',
+                "https://auth.mozilla.auth0.com/oauth/token",
                 data={
-                    'code': 'abc',
-                    'client_id': 'abc',
-                    'client_secret': 'xyz',
-                    'redirect_uri': 'http://localhost/v1/openid/auth0/token?',
-                    'grant_type': 'authorization_code'})
+                    "code": "abc",
+                    "client_id": "abc",
+                    "client_secret": "xyz",
+                    "redirect_uri": "http://localhost/v1/openid/auth0/token?",
+                    "grant_type": "authorization_code",
+                },
+            )
 
     def test_state_cannot_be_reused(self):
-        self.app.app.registry.cache.set('openid:state:key', 'http://ui', ttl=100)
-        with mock.patch('kinto.plugins.openid.views.requests.post') as m:
+        self.app.app.registry.cache.set("openid:state:key", "http://ui", ttl=100)
+        with mock.patch("kinto.plugins.openid.views.requests.post") as m:
             m.return_value.text = '{"access_token": "token"}'
-            self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'})
-            self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'}, status=400)
+            self.app.get("/openid/auth0/token", params={"code": "abc", "state": "key"})
+            self.app.get("/openid/auth0/token", params={"code": "abc", "state": "key"}, status=400)
 
     def test_redirects_to_callback_using_authorization_response(self):
-        self.app.app.registry.cache.set('openid:state:key', 'http://ui/#token=', ttl=100)
-        with mock.patch('kinto.plugins.openid.views.requests.post') as m:
+        self.app.app.registry.cache.set("openid:state:key", "http://ui/#token=", ttl=100)
+        with mock.patch("kinto.plugins.openid.views.requests.post") as m:
             m.return_value.text = '{"access_token": "token"}'
-            resp = self.app.get('/openid/auth0/token', params={'code': 'abc', 'state': 'key'},
-                                status=307)
-        location = resp.headers['Location']
-        assert location == 'http://ui/#token=%7B%22access_token%22%3A%20%22token%22%7D'
+            resp = self.app.get(
+                "/openid/auth0/token", params={"code": "abc", "state": "key"}, status=307
+            )
+        location = resp.headers["Location"]
+        assert location == "http://ui/#token=%7B%22access_token%22%3A%20%22token%22%7D"

--- a/tests/plugins/test_quotas.py
+++ b/tests/plugins/test_quotas.py
@@ -12,33 +12,35 @@ from kinto.core.storage.exceptions import RecordNotFoundError
 from kinto.core.testing import FormattedErrorMixin, sqlalchemy, skip_if_no_statsd
 from kinto.plugins.quotas import scripts
 from kinto.plugins.quotas.listener import (
-    QUOTA_RESOURCE_NAME, BUCKET_QUOTA_OBJECT_ID, COLLECTION_QUOTA_OBJECT_ID)
+    QUOTA_RESOURCE_NAME,
+    BUCKET_QUOTA_OBJECT_ID,
+    COLLECTION_QUOTA_OBJECT_ID,
+)
 from kinto.plugins.quotas.utils import record_size
 
 from .. import support
 
 
 class PluginSetup(unittest.TestCase):
-
     @skip_if_no_statsd
     def test_a_statsd_timer_is_used_for_quotas_if_configured(self):
         settings = {
             "statsd_url": "udp://127.0.0.1:8125",
             "includes": "kinto.plugins.quotas",
-            "storage_strict_json": True
+            "storage_strict_json": True,
         }
         config = testing.setUp(settings=settings)
-        with mock.patch('kinto.core.statsd.Client.timer') as mocked:
+        with mock.patch("kinto.core.statsd.Client.timer") as mocked:
             kinto_main(None, config=config)
-            mocked.assert_called_with('plugins.quotas')
+            mocked.assert_called_with("plugins.quotas")
 
 
 class QuotaWebTest(support.BaseWebTest, unittest.TestCase):
 
-    bucket_uri = '/buckets/test'
-    collection_uri = '/buckets/test/collections/col'
-    record_uri = '/buckets/test/collections/col/records/rec'
-    group_uri = '/buckets/test/groups/grp'
+    bucket_uri = "/buckets/test"
+    collection_uri = "/buckets/test/collections/col"
+    record_uri = "/buckets/test/collections/col/records/rec"
+    group_uri = "/buckets/test/groups/grp"
 
     @classmethod
     def setUpClass(cls):
@@ -48,35 +50,35 @@ class QuotaWebTest(support.BaseWebTest, unittest.TestCase):
 
     def create_bucket(self):
         resp = self.app.put(self.bucket_uri, headers=self.headers)
-        self.bucket = resp.json['data']
+        self.bucket = resp.json["data"]
 
     def create_collection(self):
         resp = self.app.put(self.collection_uri, headers=self.headers)
-        self.collection = resp.json['data']
+        self.collection = resp.json["data"]
 
     def create_group(self):
-        body = {'data': {'members': ['elle']}}
+        body = {"data": {"members": ["elle"]}}
         resp = self.app.put_json(self.group_uri, body, headers=self.headers)
-        self.group = resp.json['data']
+        self.group = resp.json["data"]
 
     def create_record(self):
-        body = {'data': {'foo': 42}}
+        body = {"data": {"foo": 42}}
         resp = self.app.put_json(self.record_uri, body, headers=self.headers)
-        self.record = resp.json['data']
+        self.record = resp.json["data"]
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
 
         # Setup the postgresql backend for transaction support.
-        settings['storage_backend'] = 'kinto.core.storage.postgresql'
+        settings["storage_backend"] = "kinto.core.storage.postgresql"
         db = "postgres://postgres:postgres@localhost/testdb"
-        settings['storage_url'] = db
-        settings['permission_backend'] = 'kinto.core.permission.postgresql'
-        settings['permission_url'] = db
-        settings['cache_backend'] = 'kinto.core.cache.memory'
+        settings["storage_url"] = db
+        settings["permission_backend"] = "kinto.core.permission.postgresql"
+        settings["permission_url"] = db
+        settings["cache_backend"] = "kinto.core.cache.memory"
 
-        settings['includes'] = 'kinto.plugins.quotas'
+        settings["includes"] = "kinto.plugins.quotas"
         return settings
 
     def assertStatsEqual(self, data, stats):
@@ -85,11 +87,10 @@ class QuotaWebTest(support.BaseWebTest, unittest.TestCase):
 
 
 class HelloViewTest(QuotaWebTest):
-
     def test_quota_capability_if_enabled(self):
-        resp = self.app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('quotas', capabilities)
+        resp = self.app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("quotas", capabilities)
 
 
 class QuotaListenerTest(QuotaWebTest):
@@ -104,33 +105,32 @@ class QuotaListenerTest(QuotaWebTest):
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
         storage_size += record_size(self.record)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
     def test_tracks_bucket_attributes_update(self):
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 'baz'}}
-        resp = self.app.patch_json(self.bucket_uri, body,
-                                   headers=self.headers)
-        storage_size = record_size(resp.json['data'])
+        body = {"data": {"foo": "baz"}}
+        resp = self.app.patch_json(self.bucket_uri, body, headers=self.headers)
+        storage_size = record_size(resp.json["data"])
         storage_size += record_size(self.collection)
         storage_size += record_size(self.record)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
     def test_delete_all_buckets_destroys_all_quota_entries(self):
         self.app.put("/buckets/a", headers=self.headers)
@@ -139,23 +139,25 @@ class QuotaListenerTest(QuotaWebTest):
         self.app.delete("/buckets", headers=self.headers)
 
         stored_in_backend, _ = self.storage.get_all(
-            parent_id='/buckets/*',
-            collection_id=QUOTA_RESOURCE_NAME)
+            parent_id="/buckets/*", collection_id=QUOTA_RESOURCE_NAME
+        )
         assert len(stored_in_backend) == 0
 
     def test_bucket_delete_destroys_its_quota_entries(self):
         self.create_bucket()
         self.app.delete(self.bucket_uri, headers=self.headers)
         stored_in_backend, _ = self.storage.get_all(
-            parent_id='/buckets/test',
-            collection_id=QUOTA_RESOURCE_NAME)
+            parent_id="/buckets/test", collection_id=QUOTA_RESOURCE_NAME
+        )
         assert len(stored_in_backend) == 0
 
     def test_bucket_delete_doesnt_raise_if_quota_entries_do_not_exist(self):
         self.create_bucket()
-        self.storage.delete(parent_id='/buckets/test',
-                            collection_id=QUOTA_RESOURCE_NAME,
-                            object_id=BUCKET_QUOTA_OBJECT_ID)
+        self.storage.delete(
+            parent_id="/buckets/test",
+            collection_id=QUOTA_RESOURCE_NAME,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
         transaction.commit()
         self.app.delete(self.bucket_uri, headers=self.headers)
 
@@ -172,108 +174,103 @@ class QuotaListenerTest(QuotaWebTest):
 
         # Bucket stats
         storage_size = record_size(self.bucket) + record_size(self.collection)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 0, "storage_size": storage_size}
+        )
 
         # Collection stats
         storage_size = record_size(self.collection)
-        data = self.storage.get(QUOTA_RESOURCE_NAME, self.collection_uri,
-                                COLLECTION_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            QUOTA_RESOURCE_NAME, self.collection_uri, COLLECTION_QUOTA_OBJECT_ID
+        )
+        self.assertStatsEqual(data, {"record_count": 0, "storage_size": storage_size})
 
     def test_tracks_collection_attributes_update(self):
         self.create_bucket()
         self.create_collection()
-        body = {'data': {'foo': 'baz'}}
-        resp = self.app.patch_json(self.collection_uri, body,
-                                   headers=self.headers)
+        body = {"data": {"foo": "baz"}}
+        resp = self.app.patch_json(self.collection_uri, body, headers=self.headers)
         # Bucket stats
         storage_size = record_size(self.bucket)
-        storage_size += record_size(resp.json['data'])
+        storage_size += record_size(resp.json["data"])
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 0, "storage_size": storage_size}
+        )
 
         # Collection stats
         storage_size -= record_size(self.bucket)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.collection_uri,
-                                object_id=COLLECTION_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.collection_uri,
+            object_id=COLLECTION_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(data, {"record_count": 0, "storage_size": storage_size})
 
     def test_tracks_collection_delete(self):
         self.create_bucket()
         self.create_collection()
-        body = {'data': {'foo': 'baz'}}
-        self.app.patch_json(self.collection_uri, body,
-                            headers=self.headers)
+        body = {"data": {"foo": "baz"}}
+        self.app.patch_json(self.collection_uri, body, headers=self.headers)
         self.app.delete(self.collection_uri, headers=self.headers)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": record_size(self.bucket)
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data,
+            {"collection_count": 0, "record_count": 0, "storage_size": record_size(self.bucket)},
+        )
 
     def test_collection_delete_destroys_its_quota_entries(self):
         self.create_bucket()
         self.create_collection()
         self.app.delete(self.collection_uri, headers=self.headers)
         stored_in_backend, _ = self.storage.get_all(
-            parent_id=self.collection_uri,
-            collection_id=QUOTA_RESOURCE_NAME)
+            parent_id=self.collection_uri, collection_id=QUOTA_RESOURCE_NAME
+        )
         assert len(stored_in_backend) == 0
 
     def test_collection_delete_doesnt_raise_if_quota_entries_dont_exist(self):
         self.create_bucket()
         self.create_collection()
-        self.storage.delete(parent_id=self.collection_uri,
-                            collection_id=QUOTA_RESOURCE_NAME,
-                            object_id=COLLECTION_QUOTA_OBJECT_ID)
+        self.storage.delete(
+            parent_id=self.collection_uri,
+            collection_id=QUOTA_RESOURCE_NAME,
+            object_id=COLLECTION_QUOTA_OBJECT_ID,
+        )
         transaction.commit()
         self.app.delete(self.collection_uri, headers=self.headers)
 
     def test_tracks_collection_delete_with_multiple_records(self):
         self.create_bucket()
         self.create_collection()
-        body = {'data': {'foo': 42}}
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
+        body = {"data": {"foo": 42}}
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
         self.app.delete(self.collection_uri, headers=self.headers)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": record_size(self.bucket)
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data,
+            {"collection_count": 0, "record_count": 0, "storage_size": record_size(self.bucket)},
+        )
 
     #
     # Group
@@ -283,44 +280,44 @@ class QuotaListenerTest(QuotaWebTest):
         self.create_bucket()
         self.create_group()
         storage_size = record_size(self.bucket) + record_size(self.group)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 0, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_tracks_group_attributes_update(self):
         self.create_bucket()
         self.create_group()
-        body = {'data': {'foo': 'baz', 'members': ['lui']}}
-        resp = self.app.patch_json(self.group_uri, body,
-                                   headers=self.headers)
+        body = {"data": {"foo": "baz", "members": ["lui"]}}
+        resp = self.app.patch_json(self.group_uri, body, headers=self.headers)
         storage_size = record_size(self.bucket)
-        storage_size += record_size(resp.json['data'])
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        storage_size += record_size(resp.json["data"])
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 0, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_tracks_group_delete(self):
         self.create_bucket()
         self.create_group()
         self.app.delete(self.group_uri, headers=self.headers)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": record_size(self.bucket)
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data,
+            {"collection_count": 0, "record_count": 0, "storage_size": record_size(self.bucket)},
+        )
 
     #
     # Record
@@ -333,32 +330,31 @@ class QuotaListenerTest(QuotaWebTest):
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
         storage_size += record_size(self.record)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
     def test_tracks_record_attributes_update(self):
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        resp = self.app.patch_json(self.record_uri, {'data': {'foo': 'baz'}},
-                                   headers=self.headers)
+        resp = self.app.patch_json(self.record_uri, {"data": {"foo": "baz"}}, headers=self.headers)
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
-        storage_size += record_size(resp.json['data'])
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        storage_size += record_size(resp.json["data"])
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
     def test_tracks_record_delete(self):
         self.create_bucket()
@@ -367,119 +363,100 @@ class QuotaListenerTest(QuotaWebTest):
         self.app.delete(self.record_uri, headers=self.headers)
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_tracks_records_delete_with_multiple_records(self):
         self.create_bucket()
         self.create_collection()
-        body = {'data': {'foo': 42}}
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.post_json('{}/records'.format(self.collection_uri),
-                           body, headers=self.headers)
-        self.app.delete('{}/records'.format(self.collection_uri),
-                        headers=self.headers)
+        body = {"data": {"foo": 42}}
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.post_json("{}/records".format(self.collection_uri), body, headers=self.headers)
+        self.app.delete("{}/records".format(self.collection_uri), headers=self.headers)
         storage_size = record_size(self.bucket) + record_size(self.collection)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_bulk_create(self):
         body = {
-            'defaults': {
-                'method': 'POST',
-                'path': '{}/records'.format(self.collection_uri),
-            },
-            'requests': [{
-                'path': self.bucket_uri,
-                'method': 'PUT'
-            }, {
-                'path': self.collection_uri,
-                'method': 'PUT'
-            }, {
-                'body': {'data': {'id': 'a', 'attr': 1}},
-            }, {
-                'body': {'data': {'id': 'b', 'attr': 2}},
-            }, {
-                'body': {'data': {'id': 'c', 'attr': 3}}
-            }]
+            "defaults": {"method": "POST", "path": "{}/records".format(self.collection_uri)},
+            "requests": [
+                {"path": self.bucket_uri, "method": "PUT"},
+                {"path": self.collection_uri, "method": "PUT"},
+                {"body": {"data": {"id": "a", "attr": 1}}},
+                {"body": {"data": {"id": "b", "attr": 2}}},
+                {"body": {"data": {"id": "c", "attr": 3}}},
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 3,
-            "storage_size": 232
-        })
+        self.app.post_json("/batch", body, headers=self.headers)
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 3, "storage_size": 232}
+        )
 
     def test_bulk_update(self):
         body = {
-            'defaults': {
-                'method': 'POST',
-                'path': '{}/collections'.format(self.bucket_uri),
-            },
-            'requests': [{
-                'path': self.bucket_uri,
-                'method': 'PUT'
-            }, {
-                'body': {'data': {'id': 'a', 'attr': 10}},
-            }, {
-                'body': {'data': {'id': 'b', 'attr': 200}},
-            }, {
-                'body': {'data': {'id': 'c', 'attr': 3000}}
-            }]
+            "defaults": {"method": "POST", "path": "{}/collections".format(self.bucket_uri)},
+            "requests": [
+                {"path": self.bucket_uri, "method": "PUT"},
+                {"body": {"data": {"id": "a", "attr": 10}}},
+                {"body": {"data": {"id": "b", "attr": 200}}},
+                {"body": {"data": {"id": "c", "attr": 3000}}},
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 3,
-            "record_count": 0,
-            "storage_size": 196
-        })
+        self.app.post_json("/batch", body, headers=self.headers)
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 3, "record_count": 0, "storage_size": 196}
+        )
         body = {
-            'defaults': {
-                'method': 'PUT',
-            },
-            'requests': [{
-                'path': '{}/collections/a'.format(self.bucket_uri),
-                'body': {'data': {'attr': 100}},
-            }, {
-                'path': '{}/collections/b'.format(self.bucket_uri),
-                'body': {'data': {'attr': 2000}},
-            }, {
-                'path': '{}/collections/c'.format(self.bucket_uri),
-                'body': {'data': {'attr': 30000}}
-            }]
+            "defaults": {"method": "PUT"},
+            "requests": [
+                {
+                    "path": "{}/collections/a".format(self.bucket_uri),
+                    "body": {"data": {"attr": 100}},
+                },
+                {
+                    "path": "{}/collections/b".format(self.bucket_uri),
+                    "body": {"data": {"attr": 2000}},
+                },
+                {
+                    "path": "{}/collections/c".format(self.bucket_uri),
+                    "body": {"data": {"attr": 30000}},
+                },
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 3,
-            "record_count": 0,
-            "storage_size": 199
-        })
+        self.app.post_json("/batch", body, headers=self.headers)
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 3, "record_count": 0, "storage_size": 199}
+        )
 
     def test_bulk_delete(self):
         self.create_bucket()
@@ -487,64 +464,63 @@ class QuotaListenerTest(QuotaWebTest):
         self.create_record()
 
         body = {
-            'defaults': {
-                'method': 'POST',
-                'path': '{}/collections'.format(self.bucket_uri),
-            },
-            'requests': [{
-                'body': {'data': {'id': 'a', 'attr': 1}},
-            }, {
-                'body': {'data': {'id': 'b', 'attr': 2}},
-            }, {
-                'body': {'data': {'id': 'c', 'attr': 3}}
-            }]
+            "defaults": {"method": "POST", "path": "{}/collections".format(self.bucket_uri)},
+            "requests": [
+                {"body": {"data": {"id": "a", "attr": 1}}},
+                {"body": {"data": {"id": "b", "attr": 2}}},
+                {"body": {"data": {"id": "c", "attr": 3}}},
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
+        self.app.post_json("/batch", body, headers=self.headers)
 
         body = {
-            'defaults': {
-                'method': 'DELETE',
-            },
-            'requests': [{
-                'path': '{}/collections/a'.format(self.bucket_uri)
-            }, {
-                'path': '{}/collections/b'.format(self.bucket_uri)
-            }, {
-                'path': '{}/collections/c'.format(self.bucket_uri)
-            }, {
-                'path': self.collection_uri
-            }]
+            "defaults": {"method": "DELETE"},
+            "requests": [
+                {"path": "{}/collections/a".format(self.bucket_uri)},
+                {"path": "{}/collections/b".format(self.bucket_uri)},
+                {"path": "{}/collections/c".format(self.bucket_uri)},
+                {"path": self.collection_uri},
+            ],
         }
-        self.app.post_json('/batch', body, headers=self.headers)
+        self.app.post_json("/batch", body, headers=self.headers)
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": record_size(self.bucket)
-        })
-
-        with pytest.raises(RecordNotFoundError):
-            self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                             parent_id='{}/collections/a'.format(self.bucket_uri),
-                             object_id=COLLECTION_QUOTA_OBJECT_ID)
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data,
+            {"collection_count": 0, "record_count": 0, "storage_size": record_size(self.bucket)},
+        )
 
         with pytest.raises(RecordNotFoundError):
-            self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                             parent_id='{}/collections/b'.format(self.bucket_uri),
-                             object_id=COLLECTION_QUOTA_OBJECT_ID)
+            self.storage.get(
+                collection_id=QUOTA_RESOURCE_NAME,
+                parent_id="{}/collections/a".format(self.bucket_uri),
+                object_id=COLLECTION_QUOTA_OBJECT_ID,
+            )
 
         with pytest.raises(RecordNotFoundError):
-            self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                             parent_id='{}/collections/c'.format(self.bucket_uri),
-                             object_id=COLLECTION_QUOTA_OBJECT_ID)
+            self.storage.get(
+                collection_id=QUOTA_RESOURCE_NAME,
+                parent_id="{}/collections/b".format(self.bucket_uri),
+                object_id=COLLECTION_QUOTA_OBJECT_ID,
+            )
 
         with pytest.raises(RecordNotFoundError):
-            self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                             parent_id=self.collection_uri,
-                             object_id=COLLECTION_QUOTA_OBJECT_ID)
+            self.storage.get(
+                collection_id=QUOTA_RESOURCE_NAME,
+                parent_id="{}/collections/c".format(self.bucket_uri),
+                object_id=COLLECTION_QUOTA_OBJECT_ID,
+            )
+
+        with pytest.raises(RecordNotFoundError):
+            self.storage.get(
+                collection_id=QUOTA_RESOURCE_NAME,
+                parent_id=self.collection_uri,
+                object_id=COLLECTION_QUOTA_OBJECT_ID,
+            )
 
 
 class QuotaBucketRecordMixin:
@@ -552,9 +528,10 @@ class QuotaBucketRecordMixin:
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 42}}
-        resp = self.app.post_json('{}/records'.format(self.collection_uri),
-                                  body, headers=self.headers, status=507)
+        body = {"data": {"foo": 42}}
+        resp = self.app.post_json(
+            "{}/records".format(self.collection_uri), body, headers=self.headers, status=507
+        )
 
         # Check that the storage was not updated.
         storage_size = record_size(self.bucket)
@@ -562,22 +539,21 @@ class QuotaBucketRecordMixin:
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
         # Check that the record wasn't created
-        resp = self.app.get('{}/records'.format(self.collection_uri),
-                            headers=self.headers)
-        assert len(resp.json['data']) == 1
+        resp = self.app.get("{}/records".format(self.collection_uri), headers=self.headers)
+        assert len(resp.json["data"]) == 1
 
 
 class QuotaBucketUpdateMixin:
@@ -585,9 +561,8 @@ class QuotaBucketUpdateMixin:
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 42, 'bar': 'This is a very long string.'}}
-        resp = self.app.patch_json(self.record_uri,
-                                   body, headers=self.headers, status=507)
+        body = {"data": {"foo": 42, "bar": "This is a very long string."}}
+        resp = self.app.patch_json(self.record_uri, body, headers=self.headers, status=507)
 
         # Check that the storage was not updated.
         storage_size = record_size(self.bucket)
@@ -595,71 +570,69 @@ class QuotaBucketUpdateMixin:
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
     def test_507_is_raised_if_quota_exceeded_on_collection_update(self):
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 42, 'bar': 'This is a very long string.'}}
-        resp = self.app.patch_json(self.collection_uri,
-                                   body, headers=self.headers, status=507)
+        body = {"data": {"foo": 42, "bar": "This is a very long string."}}
+        resp = self.app.patch_json(self.collection_uri, body, headers=self.headers, status=507)
 
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
     def test_507_is_raised_if_quota_exceeded_on_group_update(self):
         self.create_bucket()
         self.create_collection()
-        body = {'data': {'members': []}}
-        resp = self.app.put_json(self.group_uri, body,
-                                 headers=self.headers)
-        group = resp.json['data']
-        body = {'data': {'members': ['elle', 'lui', 'je', 'tu', 'il', 'nous',
-                                     'vous', 'ils', 'elles']}}
-        resp = self.app.put_json(self.group_uri, body,
-                                 headers=self.headers, status=507)
+        body = {"data": {"members": []}}
+        resp = self.app.put_json(self.group_uri, body, headers=self.headers)
+        group = resp.json["data"]
+        body = {
+            "data": {"members": ["elle", "lui", "je", "tu", "il", "nous", "vous", "ils", "elles"]}
+        }
+        resp = self.app.put_json(self.group_uri, body, headers=self.headers, status=507)
 
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
         storage_size += record_size(group)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_507_is_not_raised_if_quota_exceeded_on_record_delete(self):
         self.create_bucket()
@@ -670,70 +643,77 @@ class QuotaBucketUpdateMixin:
         # Check that the storage was not updated.
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_507_is_not_raised_if_quota_exceeded_on_collection_delete(self):
         self.create_bucket()
         self.create_collection()
         # fake the quota to the Max
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        data['storage_size'] = 140
-        self.storage.update(collection_id=QUOTA_RESOURCE_NAME,
-                            parent_id=self.bucket_uri,
-                            object_id=BUCKET_QUOTA_OBJECT_ID,
-                            record=data)
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        data["storage_size"] = 140
+        self.storage.update(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+            record=data,
+        )
         transaction.commit()
-        self.app.delete(self.collection_uri,
-                        headers=self.headers)
+        self.app.delete(self.collection_uri, headers=self.headers)
 
         storage_size = 140
         storage_size -= record_size(self.collection)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 0, "record_count": 0, "storage_size": storage_size}
+        )
 
     def test_507_is_raised_if_quota_exceeded_on_group_delete(self):
         self.create_bucket()
         body = {"data": {"members": []}}
         resp = self.app.put_json(self.group_uri, body, headers=self.headers)
-        group = resp.json['data']
+        group = resp.json["data"]
         # fake the quota to the Max
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        data['storage_size'] = 140
-        self.storage.update(collection_id=QUOTA_RESOURCE_NAME,
-                            parent_id=self.bucket_uri,
-                            object_id=BUCKET_QUOTA_OBJECT_ID,
-                            record=data)
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        data["storage_size"] = 140
+        self.storage.update(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+            record=data,
+        )
         transaction.commit()
 
         self.app.delete(self.group_uri, headers=self.headers)
 
         storage_size = 140
         storage_size -= record_size(group)
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 0,
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 0, "record_count": 0, "storage_size": storage_size}
+        )
 
 
 class QuotaBucketMixin:
@@ -741,136 +721,152 @@ class QuotaBucketMixin:
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 42}}
-        resp = self.app.post_json('{}/collections'.format(self.bucket_uri),
-                                  body, headers=self.headers, status=507)
+        body = {"data": {"foo": 42}}
+        resp = self.app.post_json(
+            "{}/collections".format(self.bucket_uri), body, headers=self.headers, status=507
+        )
 
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
         # Check that the collection wasn't created
-        resp = self.app.get('{}/collections'.format(self.bucket_uri),
-                            headers=self.headers)
-        assert len(resp.json['data']) == 1
+        resp = self.app.get("{}/collections".format(self.bucket_uri), headers=self.headers)
+        assert len(resp.json["data"]) == 1
 
     def test_507_is_raised_if_quota_exceeded_on_group_creation(self):
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'members': ['elle']}}
-        resp = self.app.put_json(self.group_uri, body,
-                                 headers=self.headers, status=507)
+        body = {"data": {"members": ["elle"]}}
+        resp = self.app.put_json(self.group_uri, body, headers=self.headers, status=507)
 
         storage_size = record_size(self.bucket)
         storage_size += record_size(self.collection)
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(collection_id=QUOTA_RESOURCE_NAME,
-                                parent_id=self.bucket_uri,
-                                object_id=BUCKET_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "collection_count": 1,
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            collection_id=QUOTA_RESOURCE_NAME,
+            parent_id=self.bucket_uri,
+            object_id=BUCKET_QUOTA_OBJECT_ID,
+        )
+        self.assertStatsEqual(
+            data, {"collection_count": 1, "record_count": 1, "storage_size": storage_size}
+        )
 
         # Check that the group wasn't created
-        resp = self.app.get('{}/groups'.format(self.bucket_uri),
-                            headers=self.headers)
-        assert len(resp.json['data']) == 0
+        resp = self.app.get("{}/groups".format(self.bucket_uri), headers=self.headers)
+        assert len(resp.json["data"]) == 0
 
 
 class QuotaMaxBytesExceededSettingsListenerTest(
-        FormattedErrorMixin, QuotaBucketRecordMixin, QuotaBucketUpdateMixin,
-        QuotaBucketMixin, QuotaWebTest):
+    FormattedErrorMixin,
+    QuotaBucketRecordMixin,
+    QuotaBucketUpdateMixin,
+    QuotaBucketMixin,
+    QuotaWebTest,
+):
 
     error_message = "Bucket maximum total size exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.bucket_max_bytes'] = '150'
+        settings["quotas.bucket_max_bytes"] = "150"
         return settings
 
 
 class QuotaMaxBytesExceededBucketSettingsListenerTest(
-        FormattedErrorMixin, QuotaBucketRecordMixin, QuotaBucketUpdateMixin,
-        QuotaBucketMixin, QuotaWebTest):
+    FormattedErrorMixin,
+    QuotaBucketRecordMixin,
+    QuotaBucketUpdateMixin,
+    QuotaBucketMixin,
+    QuotaWebTest,
+):
 
     error_message = "Bucket maximum total size exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.bucket_test_max_bytes'] = '150'
+        settings["quotas.bucket_test_max_bytes"] = "150"
         return settings
 
 
 class QuotaMaxItemsExceededSettingsListenerTest(
-        FormattedErrorMixin, QuotaBucketRecordMixin, QuotaWebTest):
+    FormattedErrorMixin, QuotaBucketRecordMixin, QuotaWebTest
+):
 
     error_message = "Bucket maximum number of objects exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.bucket_max_items'] = '1'
+        settings["quotas.bucket_max_items"] = "1"
         return settings
 
 
 class QuotaMaxItemsExceededBucketSettingsListenerTest(
-        FormattedErrorMixin, QuotaBucketRecordMixin, QuotaWebTest):
+    FormattedErrorMixin, QuotaBucketRecordMixin, QuotaWebTest
+):
 
     error_message = "Bucket maximum number of objects exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.bucket_test_max_items'] = '1'
+        settings["quotas.bucket_test_max_items"] = "1"
         return settings
 
 
 class QuotaMaxBytesPerItemExceededListenerTest(
-        FormattedErrorMixin, QuotaBucketRecordMixin, QuotaBucketUpdateMixin,
-        QuotaBucketMixin, QuotaWebTest):
+    FormattedErrorMixin,
+    QuotaBucketRecordMixin,
+    QuotaBucketUpdateMixin,
+    QuotaBucketMixin,
+    QuotaWebTest,
+):
 
     error_message = "Maximum bytes per object exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.bucket_max_bytes_per_item'] = '55'
+        settings["quotas.bucket_max_bytes_per_item"] = "55"
         return settings
 
 
 class QuotaMaxBytesPerItemExceededBucketListenerTest(
-        FormattedErrorMixin, QuotaBucketRecordMixin, QuotaBucketUpdateMixin,
-        QuotaBucketMixin, QuotaWebTest):
+    FormattedErrorMixin,
+    QuotaBucketRecordMixin,
+    QuotaBucketUpdateMixin,
+    QuotaBucketMixin,
+    QuotaWebTest,
+):
 
     error_message = "Maximum bytes per object exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.bucket_test_max_bytes_per_item'] = '55'
+        settings["quotas.bucket_test_max_bytes_per_item"] = "55"
         return settings
 
 
@@ -879,24 +875,23 @@ class QuotaCollectionMixin:
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 42}}
-        resp = self.app.post_json('{}/records'.format(self.collection_uri),
-                                  body, headers=self.headers, status=507)
+        body = {"data": {"foo": 42}}
+        resp = self.app.post_json(
+            "{}/records".format(self.collection_uri), body, headers=self.headers, status=507
+        )
 
         # Check that the storage was not updated.
         storage_size = record_size(self.collection)
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(QUOTA_RESOURCE_NAME, self.collection_uri,
-                                COLLECTION_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            QUOTA_RESOURCE_NAME, self.collection_uri, COLLECTION_QUOTA_OBJECT_ID
+        )
+        self.assertStatsEqual(data, {"record_count": 1, "storage_size": storage_size})
 
 
 class QuotaCollectionUpdateMixin:
@@ -904,24 +899,21 @@ class QuotaCollectionUpdateMixin:
         self.create_bucket()
         self.create_collection()
         self.create_record()
-        body = {'data': {'foo': 42, 'bar': 'This is a very long string.'}}
-        resp = self.app.patch_json(self.record_uri,
-                                   body, headers=self.headers, status=507)
+        body = {"data": {"foo": 42, "bar": "This is a very long string."}}
+        resp = self.app.patch_json(self.record_uri, body, headers=self.headers, status=507)
 
         # Check that the storage was not updated.
         storage_size = record_size(self.collection)
         storage_size += record_size(self.record)
 
         self.assertFormattedError(
-            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage",
-            self.error_message)
+            resp, 507, ERRORS.FORBIDDEN, "Insufficient Storage", self.error_message
+        )
 
-        data = self.storage.get(QUOTA_RESOURCE_NAME, self.collection_uri,
-                                COLLECTION_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "record_count": 1,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            QUOTA_RESOURCE_NAME, self.collection_uri, COLLECTION_QUOTA_OBJECT_ID
+        )
+        self.assertStatsEqual(data, {"record_count": 1, "storage_size": storage_size})
 
     def test_507_is_not_raised_if_quota_exceeded_on_record_delete(self):
         self.create_bucket()
@@ -931,129 +923,131 @@ class QuotaCollectionUpdateMixin:
 
         # Check that the storage was not updated.
         storage_size = record_size(self.collection)
-        data = self.storage.get(QUOTA_RESOURCE_NAME, self.collection_uri,
-                                COLLECTION_QUOTA_OBJECT_ID)
-        self.assertStatsEqual(data, {
-            "record_count": 0,
-            "storage_size": storage_size
-        })
+        data = self.storage.get(
+            QUOTA_RESOURCE_NAME, self.collection_uri, COLLECTION_QUOTA_OBJECT_ID
+        )
+        self.assertStatsEqual(data, {"record_count": 0, "storage_size": storage_size})
 
 
 class QuotaMaxBytesExceededCollectionSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin,
-        QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin, QuotaWebTest
+):
 
     error_message = "Collection maximum size exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_max_bytes'] = '100'
+        settings["quotas.collection_max_bytes"] = "100"
         return settings
 
 
 class QuotaMaxBytesExceededCollectionBucketSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin,
-        QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin, QuotaWebTest
+):
 
     error_message = "Collection maximum size exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_test_max_bytes'] = '100'
+        settings["quotas.collection_test_max_bytes"] = "100"
         return settings
 
 
 class QuotaMaxBytesExceededBucketCollectionSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin,
-        QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin, QuotaWebTest
+):
 
     error_message = "Collection maximum size exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_test_col_max_bytes'] = '100'
+        settings["quotas.collection_test_col_max_bytes"] = "100"
         return settings
 
 
 class QuotaMaxItemsExceededCollectionSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest
+):
 
     error_message = "Collection maximum number of objects exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_max_items'] = '1'
+        settings["quotas.collection_max_items"] = "1"
         return settings
 
 
 class QuotaMaxItemsExceededCollectionBucketSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest
+):
 
     error_message = "Collection maximum number of objects exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_test_max_items'] = '1'
+        settings["quotas.collection_test_max_items"] = "1"
         return settings
 
 
 class QuotaMaxItemsExceededBucketCollectionSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest
+):
 
     error_message = "Collection maximum number of objects exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_test_col_max_items'] = '1'
+        settings["quotas.collection_test_col_max_items"] = "1"
         return settings
 
 
 class QuotaMaxBytesPerItemExceededCollectionSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaWebTest
+):
 
     error_message = "Maximum bytes per object exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_max_bytes_per_item'] = '80'
+        settings["quotas.collection_max_bytes_per_item"] = "80"
         return settings
 
 
 class QuotaMaxBytesPerItemExceededCollectionBucketSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin,
-        QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin, QuotaWebTest
+):
 
     error_message = "Maximum bytes per object exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_test_max_bytes_per_item'] = '80'
+        settings["quotas.collection_test_max_bytes_per_item"] = "80"
         return settings
 
 
 class QuotaMaxBytesPerItemExceededBucketCollectionSettingsListenerTest(
-        FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin,
-        QuotaWebTest):
+    FormattedErrorMixin, QuotaCollectionMixin, QuotaCollectionUpdateMixin, QuotaWebTest
+):
 
     error_message = "Maximum bytes per object exceeded "
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['quotas.collection_test_col_max_bytes_per_item'] = '80'
+        settings["quotas.collection_test_col_max_bytes_per_item"] = "80"
         return settings
 
 
 class QuotasScriptsTest(unittest.TestCase):
-    OLDEST_FIRST = Sort('last_modified', 1)
+    OLDEST_FIRST = Sort("last_modified", 1)
     BATCH_SIZE = 25
 
     def setUp(self):
@@ -1064,8 +1058,12 @@ class QuotasScriptsTest(unittest.TestCase):
             # get buckets
             iter([{"id": "bucket-1", "last_modified": 10}]),
             # get collections for first bucket
-            iter([{"id": "collection-1", "last_modified": 100},
-                  {"id": "collection-2", "last_modified": 200}]),
+            iter(
+                [
+                    {"id": "collection-1", "last_modified": 100},
+                    {"id": "collection-2", "last_modified": 200},
+                ]
+            ),
             # get records for first collection
             iter([{"id": "record-1", "last_modified": 110}]),
             # get records for second collection
@@ -1075,58 +1073,62 @@ class QuotasScriptsTest(unittest.TestCase):
         def paginated_mock(*args, **kwargs):
             return paginated_data.pop(0)
 
-        with mock.patch('kinto.plugins.quotas.scripts.logger') as mocked_logger:
-            with mock.patch('kinto.plugins.quotas.scripts.paginated',
-                            side_effect=paginated_mock) as mocked_paginated:
+        with mock.patch("kinto.plugins.quotas.scripts.logger") as mocked_logger:
+            with mock.patch(
+                "kinto.plugins.quotas.scripts.paginated", side_effect=paginated_mock
+            ) as mocked_paginated:
                 scripts.rebuild_quotas(self.storage)
 
         mocked_paginated.assert_any_call(
-            self.storage,
-            collection_id='bucket',
-            parent_id='',
-            sorting=[self.OLDEST_FIRST],
-            )
+            self.storage, collection_id="bucket", parent_id="", sorting=[self.OLDEST_FIRST]
+        )
         mocked_paginated.assert_any_call(
             self.storage,
-            collection_id='collection',
-            parent_id='/buckets/bucket-1',
+            collection_id="collection",
+            parent_id="/buckets/bucket-1",
             sorting=[self.OLDEST_FIRST],
-            )
+        )
         mocked_paginated.assert_any_call(
             self.storage,
-            collection_id='record',
-            parent_id='/buckets/bucket-1/collections/collection-1',
+            collection_id="record",
+            parent_id="/buckets/bucket-1/collections/collection-1",
             sorting=[self.OLDEST_FIRST],
-            )
+        )
         mocked_paginated.assert_any_call(
             self.storage,
-            collection_id='record',
-            parent_id='/buckets/bucket-1/collections/collection-2',
+            collection_id="record",
+            parent_id="/buckets/bucket-1/collections/collection-2",
             sorting=[self.OLDEST_FIRST],
-            )
+        )
 
         self.storage.update.assert_any_call(
-            collection_id='quota',
-            parent_id='/buckets/bucket-1',
-            object_id='bucket_info',
-            record={'record_count': 2, 'storage_size': 193, 'collection_count': 2})
+            collection_id="quota",
+            parent_id="/buckets/bucket-1",
+            object_id="bucket_info",
+            record={"record_count": 2, "storage_size": 193, "collection_count": 2},
+        )
         self.storage.update.assert_any_call(
-            collection_id='quota',
-            parent_id='/buckets/bucket-1/collections/collection-1',
-            object_id='collection_info',
-            record={'record_count': 1, 'storage_size': 78})
+            collection_id="quota",
+            parent_id="/buckets/bucket-1/collections/collection-1",
+            object_id="collection_info",
+            record={"record_count": 1, "storage_size": 78},
+        )
         self.storage.update.assert_any_call(
-            collection_id='quota',
-            parent_id='/buckets/bucket-1/collections/collection-2',
-            object_id='collection_info',
-            record={'record_count': 1, 'storage_size': 79})
+            collection_id="quota",
+            parent_id="/buckets/bucket-1/collections/collection-2",
+            object_id="collection_info",
+            record={"record_count": 1, "storage_size": 79},
+        )
 
-        mocked_logger.info.assert_any_call('Bucket bucket-1, collection collection-1. '
-                                           'Final size: 1 records, 78 bytes.')
-        mocked_logger.info.assert_any_call('Bucket bucket-1, collection collection-2. '
-                                           'Final size: 1 records, 79 bytes.')
-        mocked_logger.info.assert_any_call('Bucket bucket-1. Final size: '
-                                           '2 collections, 2 records, 193 bytes.')
+        mocked_logger.info.assert_any_call(
+            "Bucket bucket-1, collection collection-1. " "Final size: 1 records, 78 bytes."
+        )
+        mocked_logger.info.assert_any_call(
+            "Bucket bucket-1, collection collection-2. " "Final size: 1 records, 79 bytes."
+        )
+        mocked_logger.info.assert_any_call(
+            "Bucket bucket-1. Final size: " "2 collections, 2 records, 193 bytes."
+        )
 
     def test_rebuild_quotas_doesnt_update_if_dry_run(self):
         paginated_data = [
@@ -1141,13 +1143,15 @@ class QuotasScriptsTest(unittest.TestCase):
         def paginated_mock(*args, **kwargs):
             return paginated_data.pop(0)
 
-        with mock.patch('kinto.plugins.quotas.scripts.logger') as mocked:
-            with mock.patch('kinto.plugins.quotas.scripts.paginated', side_effect=paginated_mock):
+        with mock.patch("kinto.plugins.quotas.scripts.logger") as mocked:
+            with mock.patch("kinto.plugins.quotas.scripts.paginated", side_effect=paginated_mock):
                 scripts.rebuild_quotas(self.storage, dry_run=True)
 
         assert not self.storage.update.called
 
-        mocked.info.assert_any_call('Bucket bucket-1, collection collection-1. '
-                                    'Final size: 1 records, 78 bytes.')
-        mocked.info.assert_any_call('Bucket bucket-1. Final size: 1 collections, '
-                                    '1 records, 114 bytes.')
+        mocked.info.assert_any_call(
+            "Bucket bucket-1, collection collection-1. " "Final size: 1 records, 78 bytes."
+        )
+        mocked.info.assert_any_call(
+            "Bucket bucket-1. Final size: 1 collections, " "1 records, 114 bytes."
+        )

--- a/tests/support.py
+++ b/tests/support.py
@@ -5,11 +5,9 @@ from kinto import DEFAULT_SETTINGS
 
 MINIMALIST_BUCKET = {}
 MINIMALIST_COLLECTION = {}
-MINIMALIST_GROUP = {'data': dict(members=['fxa:user'])}
-MINIMALIST_RECORD = {'data': dict(name="Hulled Barley",
-                                  type="Whole Grain")}
-USER_PRINCIPAL = 'basicauth:8a931a10fc88ab2f6d1cc02a07d3a81b5d4768f6f13e85c5' \
-                 'd8d4180419acb1b4'
+MINIMALIST_GROUP = {"data": dict(members=["fxa:user"])}
+MINIMALIST_RECORD = {"data": dict(name="Hulled Barley", type="Whole Grain")}
+USER_PRINCIPAL = "basicauth:8a931a10fc88ab2f6d1cc02a07d3a81b5d4768f6f13e85c5" "d8d4180419acb1b4"
 
 
 class BaseWebTest(testing.BaseWebTest):
@@ -21,14 +19,11 @@ class BaseWebTest(testing.BaseWebTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.headers.update(testing.get_user_headers('mat'))
+        cls.headers.update(testing.get_user_headers("mat"))
 
     @classmethod
     def get_app_settings(cls, extras=None):
-        settings = {
-            **DEFAULT_SETTINGS,
-            'multiauth.policies': 'basicauth',
-        }
+        settings = {**DEFAULT_SETTINGS, "multiauth.policies": "basicauth"}
         if extras is not None:
             settings.update(extras)
         settings = super().get_app_settings(extras=settings)
@@ -38,11 +33,11 @@ class BaseWebTest(testing.BaseWebTest):
         if members is None:
             group = MINIMALIST_GROUP
         else:
-            group = {'data': {'members': members}}
-        group_url = '/buckets/{}/groups/{}'.format(bucket_id, group_id)
-        self.app.put_json(group_url, group,
-                          headers=self.headers, status=201)
+            group = {"data": {"members": members}}
+        group_url = "/buckets/{}/groups/{}".format(bucket_id, group_id)
+        self.app.put_json(group_url, group, headers=self.headers, status=201)
 
     def create_bucket(self, bucket_id):
-        self.app.put_json('/buckets/{}'.format(bucket_id), MINIMALIST_BUCKET,
-                          headers=self.headers, status=201)
+        self.app.put_json(
+            "/buckets/{}".format(bucket_id), MINIMALIST_BUCKET, headers=self.headers, status=201
+        )

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,187 +1,199 @@
 from kinto.core.testing import unittest
 
-from kinto.authorization import (_resource_endpoint, _relative_object_uri,
-                                 _inherited_permissions)
+from kinto.authorization import _resource_endpoint, _relative_object_uri, _inherited_permissions
 
 
 class ResourceEndpointTest(unittest.TestCase):
     def test_resource_endpoint_return_right_type_for_key(self):
-        self.assertEqual(_resource_endpoint('/buckets/bid/collections/cid/records/rid'),
-                         ('record', False))
-        self.assertEqual(_resource_endpoint('/buckets/bid/collections/cid'),
-                         ('collection', False))
-        self.assertEqual(_resource_endpoint('/buckets'), ('', False))
-        self.assertEqual(_resource_endpoint('/buckets/bid'), ('bucket', False))
-        self.assertEqual(_resource_endpoint('/buckets/bid/history/xx'), ('history', False))
-        self.assertEqual(_resource_endpoint('/buckets/bid/groups/moderators'),
-                         ('group', False))
+        self.assertEqual(
+            _resource_endpoint("/buckets/bid/collections/cid/records/rid"), ("record", False)
+        )
+        self.assertEqual(_resource_endpoint("/buckets/bid/collections/cid"), ("collection", False))
+        self.assertEqual(_resource_endpoint("/buckets"), ("", False))
+        self.assertEqual(_resource_endpoint("/buckets/bid"), ("bucket", False))
+        self.assertEqual(_resource_endpoint("/buckets/bid/history/xx"), ("history", False))
+        self.assertEqual(_resource_endpoint("/buckets/bid/groups/moderators"), ("group", False))
 
     def test_resource_endpoint_return_right_type_for_children_collection(self):
-        self.assertEqual(_resource_endpoint('/buckets/bid/collections/cid/records'),
-                         ('collection', True))
-        self.assertEqual(_resource_endpoint('/buckets/bid/collections'), ('bucket', True))
-        self.assertEqual(_resource_endpoint('/buckets/bid/history'), ('bucket', True))
-        self.assertEqual(_resource_endpoint('/buckets/bid/groups'), ('bucket', True))
+        self.assertEqual(
+            _resource_endpoint("/buckets/bid/collections/cid/records"), ("collection", True)
+        )
+        self.assertEqual(_resource_endpoint("/buckets/bid/collections"), ("bucket", True))
+        self.assertEqual(_resource_endpoint("/buckets/bid/history"), ("bucket", True))
+        self.assertEqual(_resource_endpoint("/buckets/bid/groups"), ("bucket", True))
 
 
 class RelativeObjectUri(unittest.TestCase):
-    record_uri = '/buckets/blog/collections/articles/records/article1'
-    records_uri = '/buckets/blog/collections/articles/records'
-    collection_uri = '/buckets/blog/collections/articles'
-    collections_uri = '/buckets/blog/collections'
-    group_uri = '/buckets/blog/groups/moderators'
-    groups_uri = '/buckets/blog/groups'
-    bucket_uri = '/buckets/blog'
-    buckets_uri = '/buckets'
+    record_uri = "/buckets/blog/collections/articles/records/article1"
+    records_uri = "/buckets/blog/collections/articles/records"
+    collection_uri = "/buckets/blog/collections/articles"
+    collections_uri = "/buckets/blog/collections"
+    group_uri = "/buckets/blog/groups/moderators"
+    groups_uri = "/buckets/blog/groups"
+    bucket_uri = "/buckets/blog"
+    buckets_uri = "/buckets"
 
     def test_related_object_uri_can_construct_parents_set_uris(self):
-        record_uri = '/buckets/bid/collections/cid/records/rid'
-        self.assertEqual(_relative_object_uri('record', record_uri), record_uri)
+        record_uri = "/buckets/bid/collections/cid/records/rid"
+        self.assertEqual(_relative_object_uri("record", record_uri), record_uri)
 
-        self.assertEqual(_relative_object_uri('collection', self.record_uri),
-                         self.collection_uri)
-        self.assertEqual(_relative_object_uri('collection', self.records_uri),
-                         self.collection_uri)
+        self.assertEqual(_relative_object_uri("collection", self.record_uri), self.collection_uri)
+        self.assertEqual(_relative_object_uri("collection", self.records_uri), self.collection_uri)
 
         # Can build bucket_uri from obj_parts
-        self.assertEqual(_relative_object_uri('bucket', self.record_uri),
-                         self.bucket_uri)
+        self.assertEqual(_relative_object_uri("bucket", self.record_uri), self.bucket_uri)
 
         # Can build group_uri from group obj_parts
-        self.assertEqual(_relative_object_uri('group', self.group_uri),
-                         self.group_uri)
+        self.assertEqual(_relative_object_uri("group", self.group_uri), self.group_uri)
 
         # Can build bucket_uri from group obj_parts
-        self.assertEqual(_relative_object_uri('bucket', self.group_uri),
-                         self.bucket_uri)
-        self.assertEqual(_relative_object_uri('bucket', self.groups_uri),
-                         self.bucket_uri)
+        self.assertEqual(_relative_object_uri("bucket", self.group_uri), self.bucket_uri)
+        self.assertEqual(_relative_object_uri("bucket", self.groups_uri), self.bucket_uri)
 
     def test_relative_object_uri_fail_construct_children_set_uris(self):
         # Cannot build record_uri from bucket obj_parts
-        self.assertRaises(ValueError,
-                          _relative_object_uri,
-                          'record', self.bucket_uri)
+        self.assertRaises(ValueError, _relative_object_uri, "record", self.bucket_uri)
 
         # Cannot build collection_uri from obj_parts
-        self.assertRaises(ValueError,
-                          _relative_object_uri,
-                          'collection', self.bucket_uri)
+        self.assertRaises(ValueError, _relative_object_uri, "collection", self.bucket_uri)
 
         # Cannot build bucket_uri from empty obj_parts
-        self.assertRaises(ValueError,
-                          _relative_object_uri,
-                          'collection', '')
+        self.assertRaises(ValueError, _relative_object_uri, "collection", "")
 
 
 class PermissionInheritanceTest(unittest.TestCase):
-    record_uri = '/buckets/blog/collections/articles/records/article1'
-    collection_uri = '/buckets/blog/collections/articles'
-    group_uri = '/buckets/blog/groups/moderators'
-    bucket_uri = '/buckets/blog'
+    record_uri = "/buckets/blog/collections/articles/records/article1"
+    collection_uri = "/buckets/blog/collections/articles"
+    group_uri = "/buckets/blog/groups/moderators"
+    bucket_uri = "/buckets/blog"
 
     def test_relative_object_uri_fail_on_wrong_type(self):
-        self.assertRaises(ValueError,
-                          _relative_object_uri,
-                          'schema', self.record_uri)
+        self.assertRaises(ValueError, _relative_object_uri, "schema", self.record_uri)
 
     def test_inherited_permissions_supports_buckets_named_collections(self):
-        uri = '/buckets/collections'
-        self.assertEqual(set(_inherited_permissions(uri, 'write')),
-                         set([(uri, 'write')]))
+        uri = "/buckets/collections"
+        self.assertEqual(set(_inherited_permissions(uri, "write")), set([(uri, "write")]))
 
     def test_inherited_permissions_for_bucket_permission(self):
         # write
         self.assertEqual(
-            _inherited_permissions(self.bucket_uri, 'write'),
-            [(self.bucket_uri, 'write')])
+            _inherited_permissions(self.bucket_uri, "write"), [(self.bucket_uri, "write")]
+        )
         # read
         self.assertEqual(
-            set(_inherited_permissions(self.bucket_uri, 'read')),
-            set([(self.bucket_uri, 'write'),
-                 (self.bucket_uri, 'read'),
-                 (self.bucket_uri, 'collection:create'),
-                 (self.bucket_uri, 'group:create')]))
+            set(_inherited_permissions(self.bucket_uri, "read")),
+            set(
+                [
+                    (self.bucket_uri, "write"),
+                    (self.bucket_uri, "read"),
+                    (self.bucket_uri, "collection:create"),
+                    (self.bucket_uri, "group:create"),
+                ]
+            ),
+        )
 
         # group:create
-        groups_uri = self.bucket_uri + '/groups'
+        groups_uri = self.bucket_uri + "/groups"
         self.assertEqual(
-            set(_inherited_permissions(groups_uri, 'group:create')),
-            set(
-                [(self.bucket_uri, 'write'),
-                 (self.bucket_uri, 'group:create')])
-            )
+            set(_inherited_permissions(groups_uri, "group:create")),
+            set([(self.bucket_uri, "write"), (self.bucket_uri, "group:create")]),
+        )
 
         # collection:create
-        collections_uri = self.bucket_uri + '/collections'
+        collections_uri = self.bucket_uri + "/collections"
         self.assertEqual(
-            set(_inherited_permissions(collections_uri, 'collection:create')),
-            set([(self.bucket_uri, 'write'),
-                 (self.bucket_uri, 'collection:create')]))
+            set(_inherited_permissions(collections_uri, "collection:create")),
+            set([(self.bucket_uri, "write"), (self.bucket_uri, "collection:create")]),
+        )
 
     def test_inherited_permissions_for_group_permission(self):
         # write
         self.assertEqual(
-            _inherited_permissions(self.group_uri, 'write'),
-            [(self.group_uri, 'write'),
-             (self.bucket_uri, 'write')])
+            _inherited_permissions(self.group_uri, "write"),
+            [(self.group_uri, "write"), (self.bucket_uri, "write")],
+        )
         # read
         self.assertEqual(
-            set(_inherited_permissions(self.group_uri, 'read')),
-            set([(self.bucket_uri, 'write'),
-                 (self.bucket_uri, 'read'),
-                 (self.group_uri, 'write'),
-                 (self.group_uri, 'read')]))
+            set(_inherited_permissions(self.group_uri, "read")),
+            set(
+                [
+                    (self.bucket_uri, "write"),
+                    (self.bucket_uri, "read"),
+                    (self.group_uri, "write"),
+                    (self.group_uri, "read"),
+                ]
+            ),
+        )
 
     def test_inherited_permissions_for_collection_permission(self):
         # write
         self.assertEqual(
-            _inherited_permissions(self.collection_uri, 'write'),
-            [(self.collection_uri, 'write'),
-             (self.bucket_uri, 'write')])
+            _inherited_permissions(self.collection_uri, "write"),
+            [(self.collection_uri, "write"), (self.bucket_uri, "write")],
+        )
         # read
         self.assertEqual(
-            set(_inherited_permissions(self.collection_uri, 'read')),
-            set([(self.bucket_uri, 'write'),
-                 (self.bucket_uri, 'read'),
-                 (self.collection_uri, 'write'),
-                 (self.collection_uri, 'read'),
-                 (self.collection_uri, 'record:create')]))
+            set(_inherited_permissions(self.collection_uri, "read")),
+            set(
+                [
+                    (self.bucket_uri, "write"),
+                    (self.bucket_uri, "read"),
+                    (self.collection_uri, "write"),
+                    (self.collection_uri, "read"),
+                    (self.collection_uri, "record:create"),
+                ]
+            ),
+        )
         # records:create
-        records_uri = self.collection_uri + '/records'
+        records_uri = self.collection_uri + "/records"
         self.assertEqual(
-            set(_inherited_permissions(records_uri, 'record:create')),
-            set([(self.bucket_uri, 'write'),
-                 (self.collection_uri, 'write'),
-                 (self.collection_uri, 'record:create')]))
+            set(_inherited_permissions(records_uri, "record:create")),
+            set(
+                [
+                    (self.bucket_uri, "write"),
+                    (self.collection_uri, "write"),
+                    (self.collection_uri, "record:create"),
+                ]
+            ),
+        )
 
     def test_inherited_permissions_for_record_permission(self):
         # write
         self.assertEqual(
-            set(_inherited_permissions(self.record_uri, 'write')),
-            set([(self.bucket_uri, 'write'),
-                 (self.collection_uri, 'write'),
-                 (self.record_uri, 'write')]))
+            set(_inherited_permissions(self.record_uri, "write")),
+            set(
+                [
+                    (self.bucket_uri, "write"),
+                    (self.collection_uri, "write"),
+                    (self.record_uri, "write"),
+                ]
+            ),
+        )
         # read
         self.assertEqual(
-            set(_inherited_permissions(self.record_uri, 'read')),
-            set([(self.bucket_uri, 'write'),
-                 (self.bucket_uri, 'read'),
-                 (self.collection_uri, 'write'),
-                 (self.collection_uri, 'read'),
-                 (self.record_uri, 'write'),
-                 (self.record_uri, 'read')]))
+            set(_inherited_permissions(self.record_uri, "read")),
+            set(
+                [
+                    (self.bucket_uri, "write"),
+                    (self.bucket_uri, "read"),
+                    (self.collection_uri, "write"),
+                    (self.collection_uri, "read"),
+                    (self.record_uri, "write"),
+                    (self.record_uri, "read"),
+                ]
+            ),
+        )
 
     def test_inherited_permissions_for_list_of_buckets(self):
-        permissions = _inherited_permissions('/buckets', 'read')
+        permissions = _inherited_permissions("/buckets", "read")
         self.assertEqual(permissions, [])
 
     def test_inherited_permissions_for_non_resource_url(self):
-        unknown = '/resource/unknown'
-        permissions = _inherited_permissions(unknown, 'read')
+        unknown = "/resource/unknown"
+        permissions = _inherited_permissions(unknown, "read")
         self.assertEqual(permissions, [])
 
     def test_inherited_permissions_for_attachment_url(self):
-        attachment = '/buckets/bid/collections/cid/records/rid/attachment'
-        permissions = _inherited_permissions(attachment, 'read')
-        self.assertIn(('/buckets/bid/collections/cid/records/rid', 'read'), permissions)
+        attachment = "/buckets/bid/collections/cid/records/rid/attachment"
+        permissions = _inherited_permissions(attachment, "read")
+        self.assertIn(("/buckets/bid/collections/cid/records/rid", "read"), permissions)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,151 +14,170 @@ class ConfigTest(unittest.TestCase):
         self.maxDiff = None
         template = "kinto.tpl"
         dest = tempfile.mktemp()
-        config.render_template(template, dest,
-                               host='127.0.0.1',
-                               secret='secret',
-                               storage_backend='storage_backend',
-                               cache_backend='cache_backend',
-                               permission_backend='permission_backend',
-                               storage_url='storage_url',
-                               cache_url='cache_url',
-                               permission_url='permission_url',
-                               kinto_version='kinto_version',
-                               config_file_timestamp='config_file_timestamp')
+        config.render_template(
+            template,
+            dest,
+            host="127.0.0.1",
+            secret="secret",
+            storage_backend="storage_backend",
+            cache_backend="cache_backend",
+            permission_backend="permission_backend",
+            storage_url="storage_url",
+            cache_url="cache_url",
+            permission_url="permission_url",
+            kinto_version="kinto_version",
+            config_file_timestamp="config_file_timestamp",
+        )
 
-        with codecs.open(dest, 'r', encoding='utf-8') as d:
+        with codecs.open(dest, "r", encoding="utf-8") as d:
             destination_temp = d.read()
 
-        sample_path = os.path.join(os.path.dirname(__file__),
-                                   "test_configuration/test.ini")
-        with codecs.open(sample_path, 'r', encoding='utf-8') as c:
+        sample_path = os.path.join(os.path.dirname(__file__), "test_configuration/test.ini")
+        with codecs.open(sample_path, "r", encoding="utf-8") as c:
             sample = c.read()
 
         self.assertEqual(destination_temp, sample)
 
     def test_create_destination_directory(self):
-        dest = os.path.join(tempfile.mkdtemp(), 'config', 'kinto.ini')
+        dest = os.path.join(tempfile.mkdtemp(), "config", "kinto.ini")
 
-        config.render_template("kinto.tpl", dest,
-                               host='127.0.0.1',
-                               secret='secret',
-                               storage_backend='storage_backend',
-                               cache_backend='cache_backend',
-                               permission_backend='permission_backend',
-                               storage_url='storage_url',
-                               cache_url='cache_url',
-                               permission_url='permission_url',
-                               kinto_version='kinto_version',
-                               config_file_timestamp='config_file_timestamp')
+        config.render_template(
+            "kinto.tpl",
+            dest,
+            host="127.0.0.1",
+            secret="secret",
+            storage_backend="storage_backend",
+            cache_backend="cache_backend",
+            permission_backend="permission_backend",
+            storage_url="storage_url",
+            cache_url="cache_url",
+            permission_url="permission_url",
+            kinto_version="kinto_version",
+            config_file_timestamp="config_file_timestamp",
+        )
 
         self.assertTrue(os.path.exists(dest))
 
-    @mock.patch('kinto.config.render_template')
+    @mock.patch("kinto.config.render_template")
     def test_hmac_secret_is_text(self, mocked_render_template):
-        config.init('kinto.ini', backend='postgresql', cache_backend='postgresql')
+        config.init("kinto.ini", backend="postgresql", cache_backend="postgresql")
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(type(kwargs['secret']), str)
+        self.assertEqual(type(kwargs["secret"]), str)
 
-    @mock.patch('kinto.config.render_template')
+    @mock.patch("kinto.config.render_template")
     def test_init_postgresql_values(self, mocked_render_template):
-        config.init('kinto.ini', backend='postgresql', cache_backend='postgresql')
+        config.init("kinto.ini", backend="postgresql", cache_backend="postgresql")
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
 
         postgresql_url = "postgres://postgres:postgres@localhost/postgres"
-        self.assertDictEqual(kwargs, {
-            'host': '127.0.0.1',
-            'secret': kwargs['secret'],
-            'storage_backend': 'kinto.core.storage.postgresql',
-            'cache_backend': 'kinto.core.cache.postgresql',
-            'permission_backend': 'kinto.core.permission.postgresql',
-            'storage_url': postgresql_url,
-            'cache_url':  postgresql_url,
-            'permission_url': postgresql_url,
-            'kinto_version': __version__,
-            'config_file_timestamp': strftime('%a, %d %b %Y %H:%M:%S %z')
-        })
+        self.assertDictEqual(
+            kwargs,
+            {
+                "host": "127.0.0.1",
+                "secret": kwargs["secret"],
+                "storage_backend": "kinto.core.storage.postgresql",
+                "cache_backend": "kinto.core.cache.postgresql",
+                "permission_backend": "kinto.core.permission.postgresql",
+                "storage_url": postgresql_url,
+                "cache_url": postgresql_url,
+                "permission_url": postgresql_url,
+                "kinto_version": __version__,
+                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+            },
+        )
 
-    @mock.patch('kinto.config.render_template')
+    @mock.patch("kinto.config.render_template")
     def test_init_postgresql_memcached_values(self, mocked_render_template):
-        config.init('kinto.ini', backend='postgresql', cache_backend='memcached')
+        config.init("kinto.ini", backend="postgresql", cache_backend="memcached")
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
 
         postgresql_url = "postgres://postgres:postgres@localhost/postgres"
-        cache_url = '127.0.0.1:11211 127.0.0.2:11211'
-        self.assertDictEqual(kwargs, {
-            'host': '127.0.0.1',
-            'secret': kwargs['secret'],
-            'storage_backend': 'kinto.core.storage.postgresql',
-            'cache_backend': 'kinto.core.cache.memcached',
-            'permission_backend': 'kinto.core.permission.postgresql',
-            'storage_url': postgresql_url,
-            'cache_url':  cache_url,
-            'permission_url': postgresql_url,
-            'kinto_version': __version__,
-            'config_file_timestamp': strftime('%a, %d %b %Y %H:%M:%S %z')
-        })
+        cache_url = "127.0.0.1:11211 127.0.0.2:11211"
+        self.assertDictEqual(
+            kwargs,
+            {
+                "host": "127.0.0.1",
+                "secret": kwargs["secret"],
+                "storage_backend": "kinto.core.storage.postgresql",
+                "cache_backend": "kinto.core.cache.memcached",
+                "permission_backend": "kinto.core.permission.postgresql",
+                "storage_url": postgresql_url,
+                "cache_url": cache_url,
+                "permission_url": postgresql_url,
+                "kinto_version": __version__,
+                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+            },
+        )
 
-    @mock.patch('kinto.config.render_template')
+    @mock.patch("kinto.config.render_template")
     def test_init_redis_values(self, mocked_render_template):
-        config.init('kinto.ini', backend='redis', cache_backend='redis')
+        config.init("kinto.ini", backend="redis", cache_backend="redis")
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
 
         redis_url = "redis://localhost:6379"
         self.maxDiff = None  # See the full diff in case of error
-        self.assertDictEqual(kwargs, {
-            'host': '127.0.0.1',
-            'secret': kwargs['secret'],
-            'storage_backend': 'kinto_redis.storage',
-            'cache_backend': 'kinto_redis.cache',
-            'permission_backend': 'kinto_redis.permission',
-            'storage_url': redis_url + '/1',
-            'cache_url': redis_url + '/2',
-            'permission_url': redis_url + '/3',
-            'kinto_version': __version__,
-            'config_file_timestamp': strftime('%a, %d %b %Y %H:%M:%S %z')
-        })
+        self.assertDictEqual(
+            kwargs,
+            {
+                "host": "127.0.0.1",
+                "secret": kwargs["secret"],
+                "storage_backend": "kinto_redis.storage",
+                "cache_backend": "kinto_redis.cache",
+                "permission_backend": "kinto_redis.permission",
+                "storage_url": redis_url + "/1",
+                "cache_url": redis_url + "/2",
+                "permission_url": redis_url + "/3",
+                "kinto_version": __version__,
+                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+            },
+        )
 
-    @mock.patch('kinto.config.render_template')
+    @mock.patch("kinto.config.render_template")
     def test_init_memory_values(self, mocked_render_template):
-        config.init('kinto.ini', backend='memory', cache_backend='memory')
+        config.init("kinto.ini", backend="memory", cache_backend="memory")
 
         args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(args, ('kinto.tpl', 'kinto.ini'))
+        self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
 
-        self.assertDictEqual(kwargs, {
-            'host': '127.0.0.1',
-            'secret': kwargs['secret'],
-            'storage_backend': 'kinto.core.storage.memory',
-            'cache_backend': 'kinto.core.cache.memory',
-            'permission_backend': 'kinto.core.permission.memory',
-            'storage_url': '',
-            'cache_url':  '',
-            'permission_url': '',
-            'kinto_version': __version__,
-            'config_file_timestamp': strftime('%a, %d %b %Y %H:%M:%S %z')
-        })
+        self.assertDictEqual(
+            kwargs,
+            {
+                "host": "127.0.0.1",
+                "secret": kwargs["secret"],
+                "storage_backend": "kinto.core.storage.memory",
+                "cache_backend": "kinto.core.cache.memory",
+                "permission_backend": "kinto.core.permission.memory",
+                "storage_url": "",
+                "cache_url": "",
+                "permission_url": "",
+                "kinto_version": __version__,
+                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+            },
+        )
 
     def test_render_template_works_with_file_in_cwd(self):
         temp_path = tempfile.mkdtemp()
         os.chdir(temp_path)
-        config.render_template('kinto.tpl', 'kinto.ini', **{
-            'host': '127.0.0.1',
-            'secret': "abcd-ceci-est-un-secret",
-            'storage_backend': 'kinto.core.storage.memory',
-            'cache_backend': 'kinto.core.cache.memory',
-            'permission_backend': 'kinto.core.permission.memory',
-            'storage_url': '',
-            'cache_url':  '',
-            'permission_url': '',
-            'kinto_version': '',
-            'config_file_timestamp': ''
-        })
-        self.assertTrue(os.path.exists(
-            os.path.join(temp_path, 'kinto.ini')
-        ))
+        config.render_template(
+            "kinto.tpl",
+            "kinto.ini",
+            **{
+                "host": "127.0.0.1",
+                "secret": "abcd-ceci-est-un-secret",
+                "storage_backend": "kinto.core.storage.memory",
+                "cache_backend": "kinto.core.cache.memory",
+                "permission_backend": "kinto.core.permission.memory",
+                "storage_url": "",
+                "cache_url": "",
+                "permission_url": "",
+                "kinto_version": "",
+                "config_file_timestamp": "",
+            }
+        )
+        self.assertTrue(os.path.exists(os.path.join(temp_path, "kinto.ini")))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,9 +6,9 @@ from .support import BaseWebTest
 
 class TestMain(BaseWebTest, unittest.TestCase):
     def test_init_sets_command_on_registry(self):
-        app = main({'command': 'migrate'}, None, **self.get_app_settings())
+        app = main({"command": "migrate"}, None, **self.get_app_settings())
 
-        self.assertEqual(app.registry.command, 'migrate')
+        self.assertEqual(app.registry.command, "migrate")
 
     def test_init_with_no_global_config_doesnt_crash(self):
         app = main(None, None, **self.get_app_settings())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ from io import StringIO
 from kinto import __version__ as kinto_version
 from kinto.__main__ import main, DEFAULT_LOG_FORMAT
 
-_, TEMP_KINTO_INI = tempfile.mkstemp(prefix='kinto_config', suffix='.ini')
+_, TEMP_KINTO_INI = tempfile.mkstemp(prefix="kinto_config", suffix=".ini")
 
 
 class TestMain(unittest.TestCase):
@@ -23,65 +23,67 @@ class TestMain(unittest.TestCase):
             pass
 
     def test_cli_init_generates_configuration(self):
-        res = main(['init', '--ini', TEMP_KINTO_INI,
-                    '--backend', 'memory', '--cache-backend', 'memory'])
+        res = main(
+            ["init", "--ini", TEMP_KINTO_INI, "--backend", "memory", "--cache-backend", "memory"]
+        )
         assert res == 0
         assert os.path.exists(TEMP_KINTO_INI)
 
     def test_cli_init_returns_if_file_exists(self):
-        with open(TEMP_KINTO_INI, 'w') as f:
+        with open(TEMP_KINTO_INI, "w") as f:
             f.write("exists")
-        with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
-            res = main(['init', '--ini', TEMP_KINTO_INI, '--backend', 'memory'])
+        with mock.patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            res = main(["init", "--ini", TEMP_KINTO_INI, "--backend", "memory"])
             assert res == 1
             content = mock_stderr.getvalue()
-            assert '{} already exists.'.format(TEMP_KINTO_INI) in content
+            assert "{} already exists.".format(TEMP_KINTO_INI) in content
 
     def test_cli_init_asks_for_backend_if_not_specified(self):
         with mock.patch("kinto.__main__.input", create=True, return_value="2"):
-            res = main(['init', '--ini', TEMP_KINTO_INI])
+            res = main(["init", "--ini", TEMP_KINTO_INI])
             assert res == 0
         with open(TEMP_KINTO_INI) as f:
             content = f.read()
-        assert 'redis' in content
+        assert "redis" in content
 
     def test_cli_init_asks_until_backend_is_valid(self):
         with mock.patch("kinto.__main__.input", create=True, side_effect=["10", "2", "2"]):
-            res = main(['init', '--ini', TEMP_KINTO_INI])
+            res = main(["init", "--ini", TEMP_KINTO_INI])
             assert res == 0
             with open(TEMP_KINTO_INI) as f:
                 content = f.read()
-            assert 'redis' in content
+            assert "redis" in content
 
     def test_cli_init_asks_until_cache_backend_is_valid(self):
         with mock.patch("kinto.__main__.input", create=True, side_effect=["2", "21", "2"]):
-            res = main(['init', '--ini', TEMP_KINTO_INI])
+            res = main(["init", "--ini", TEMP_KINTO_INI])
             assert res == 0
             with open(TEMP_KINTO_INI) as f:
                 content = f.read()
-            assert 'redis' in content
+            assert "redis" in content
 
     def test_fails_if_not_enough_args(self):
-        with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+        with mock.patch("sys.stderr", new_callable=StringIO) as mock_stderr:
             with pytest.raises(SystemExit) as excinfo:
                 main([])
-            assert 'arguments are required: subcommand' in mock_stderr.getvalue()
+            assert "arguments are required: subcommand" in mock_stderr.getvalue()
             assert excinfo.value.code == 2
 
     def test_cli_init_installs_postgresql_dependencies_if_needed(self):
         realimport = builtins.__import__
 
         def psycopg2_missing(name, *args, **kwargs):
-            if name == 'psycopg2':
+            if name == "psycopg2":
                 raise ImportError()
             else:
                 return realimport(name, *args, **kwargs)
 
-        with mock.patch('builtins.__import__', side_effect=psycopg2_missing):
-            with mock.patch('kinto.__main__.subprocess.check_call',
-                            return_value=None) as mocked_pip:
+        with mock.patch("builtins.__import__", side_effect=psycopg2_missing):
+            with mock.patch(
+                "kinto.__main__.subprocess.check_call", return_value=None
+            ) as mocked_pip:
                 with mock.patch("kinto.__main__.input", create=True, return_value="1"):
-                    res = main(['init', '--ini', TEMP_KINTO_INI])
+                    res = main(["init", "--ini", TEMP_KINTO_INI])
                     assert res == 0
                     assert mocked_pip.call_count == 1
 
@@ -89,16 +91,17 @@ class TestMain(unittest.TestCase):
         realimport = builtins.__import__
 
         def redis_missing(name, *args, **kwargs):
-            if name == 'kinto_redis':
+            if name == "kinto_redis":
                 raise ImportError()
             else:
                 return realimport(name, *args, **kwargs)
 
-        with mock.patch('builtins.__import__', side_effect=redis_missing):
-            with mock.patch('kinto.__main__.subprocess.check_call',
-                            return_value=None) as mocked_pip:
+        with mock.patch("builtins.__import__", side_effect=redis_missing):
+            with mock.patch(
+                "kinto.__main__.subprocess.check_call", return_value=None
+            ) as mocked_pip:
                 with mock.patch("kinto.__main__.input", create=True, return_value="2"):
-                    res = main(['init', '--ini', TEMP_KINTO_INI])
+                    res = main(["init", "--ini", TEMP_KINTO_INI])
                     assert res == 0
                     assert mocked_pip.call_count == 1
 
@@ -106,135 +109,254 @@ class TestMain(unittest.TestCase):
         realimport = builtins.__import__
 
         def memcached_missing(name, *args, **kwargs):
-            if name == 'memcache':
+            if name == "memcache":
                 raise ImportError()
             else:
                 return realimport(name, *args, **kwargs)
 
-        with mock.patch('builtins.__import__', side_effect=memcached_missing):
-            with mock.patch('kinto.__main__.subprocess.check_call',
-                            return_value=None) as mocked_pip:
+        with mock.patch("builtins.__import__", side_effect=memcached_missing):
+            with mock.patch(
+                "kinto.__main__.subprocess.check_call", return_value=None
+            ) as mocked_pip:
                 with mock.patch("kinto.__main__.input", create=True, return_value="3"):
-                    res = main(['init', '--ini', TEMP_KINTO_INI, '--backend', 'memory'])
+                    res = main(["init", "--ini", TEMP_KINTO_INI, "--backend", "memory"])
                     assert res == 0
                     assert mocked_pip.call_count == 1
 
     def test_main_takes_sys_argv_by_default(self):
-        testargs = ['prog', 'init', '--ini', TEMP_KINTO_INI,
-                    '--backend', 'memory', '--cache-backend', 'memory']
-        with mock.patch.object(sys, 'argv', testargs):
+        testargs = [
+            "prog",
+            "init",
+            "--ini",
+            TEMP_KINTO_INI,
+            "--backend",
+            "memory",
+            "--cache-backend",
+            "memory",
+        ]
+        with mock.patch.object(sys, "argv", testargs):
             main()
 
         with open(TEMP_KINTO_INI) as f:
             content = f.read()
-        assert 'memory' in content
+        assert "memory" in content
 
     def test_cli_migrate_command_runs_init_schema(self):
-        with mock.patch('kinto.__main__.scripts.migrate') as mocked_migrate:
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.scripts.migrate") as mocked_migrate:
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['migrate', '--ini', TEMP_KINTO_INI])
+            res = main(["migrate", "--ini", TEMP_KINTO_INI])
             assert res == 0
             assert mocked_migrate.call_count == 1
 
     def test_cli_delete_collection_run_delete_collection_script(self):
-        with mock.patch('kinto.__main__.scripts.delete_collection') as del_col:
+        with mock.patch("kinto.__main__.scripts.delete_collection") as del_col:
             del_col.return_value = mock.sentinel.del_col_code
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['delete-collection', '--ini', TEMP_KINTO_INI,
-                        '--bucket', 'test_bucket',
-                        '--collection', 'test_collection'])
+            res = main(
+                [
+                    "delete-collection",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--bucket",
+                    "test_bucket",
+                    "--collection",
+                    "test_collection",
+                ]
+            )
             assert res == mock.sentinel.del_col_code
             assert del_col.call_count == 1
 
     def test_cli_rebuild_quotas_run_rebuild_quotas_script(self):
-        with mock.patch('kinto.__main__.scripts.rebuild_quotas') as reb_quo:
+        with mock.patch("kinto.__main__.scripts.rebuild_quotas") as reb_quo:
             reb_quo.return_value = mock.sentinel.reb_quo_code
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['rebuild-quotas', '--ini', TEMP_KINTO_INI])
+            res = main(["rebuild-quotas", "--ini", TEMP_KINTO_INI])
             assert res == mock.sentinel.reb_quo_code
             assert reb_quo.call_count == 1
 
     def test_cli_start_runs_pserve(self):
-        with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.pserve.main") as mocked_pserve:
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['start', '--ini', TEMP_KINTO_INI])
+            res = main(["start", "--ini", TEMP_KINTO_INI])
             assert res == 0
             assert mocked_pserve.call_count == 1
 
     def test_cli_start_with_quiet_option_runs_pserve_with_quiet(self):
-        with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.pserve.main") as mocked_pserve:
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['start', '-q', '--ini', TEMP_KINTO_INI])
+            res = main(["start", "-q", "--ini", TEMP_KINTO_INI])
             assert res == 0
             assert mocked_pserve.call_count == 1
-            assert mocked_pserve.call_args[1]['argv'][1] == '-q'
+            assert mocked_pserve.call_args[1]["argv"][1] == "-q"
 
     def test_cli_start_with_verbose_option_runs_pserve_with_verbose(self):
-        with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.pserve.main") as mocked_pserve:
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['start', '-v', '--ini', TEMP_KINTO_INI])
+            res = main(["start", "-v", "--ini", TEMP_KINTO_INI])
             assert res == 0
             assert mocked_pserve.call_count == 1
-            assert mocked_pserve.call_args[1]['argv'][1] == '-v'
+            assert mocked_pserve.call_args[1]["argv"][1] == "-v"
 
     def test_cli_start_with_reload_runs_pserve_with_reload(self):
-        with mock.patch('kinto.__main__.pserve.main') as mocked_pserve:
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.pserve.main") as mocked_pserve:
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['start', '--reload', '--ini', TEMP_KINTO_INI])
+            res = main(["start", "--reload", "--ini", TEMP_KINTO_INI])
             assert res == 0
             assert mocked_pserve.call_count == 1
-            assert '--reload' in mocked_pserve.call_args[1]['argv']
+            assert "--reload" in mocked_pserve.call_args[1]["argv"]
 
     def test_cli_create_user_runs_account_script(self):
-        with mock.patch('kinto.__main__.create_user', return_value=0) as mocked_create_user:
-            res = main(['init', '--ini', TEMP_KINTO_INI,
-                        '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.create_user", return_value=0) as mocked_create_user:
+            res = main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             assert res == 0
-            res = main(['create-user', '--ini', TEMP_KINTO_INI,
-                        '-u', 'username', '-p', 'password'])
+            res = main(
+                ["create-user", "--ini", TEMP_KINTO_INI, "-u", "username", "-p", "password"]
+            )
             assert res == 0
             mocked_create_user.call_count == 1
 
     def test_cli_can_display_kinto_version(self):
-        with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
-            res = main(['version'])
-            assert mock_stdout.getvalue() == '{}\n'.format(kinto_version)
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            res = main(["version"])
+            assert mock_stdout.getvalue() == "{}\n".format(kinto_version)
             assert res == 0
 
     def test_cli_can_configure_logger_in_quiet(self):
-        with mock.patch('kinto.__main__.logging') as mocked_logging:
-            main(['init', '-q', '--ini', TEMP_KINTO_INI,
-                  '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.logging") as mocked_logging:
+            main(
+                [
+                    "init",
+                    "-q",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             mocked_logging.basicConfig.assert_called_with(
-                level=mocked_logging.CRITICAL,
-                format=DEFAULT_LOG_FORMAT)
+                level=mocked_logging.CRITICAL, format=DEFAULT_LOG_FORMAT
+            )
 
     def test_cli_can_configure_logger_in_debug(self):
-        with mock.patch('kinto.__main__.logging') as mocked_logging:
-            main(['init', '--debug', '--ini', TEMP_KINTO_INI,
-                  '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.logging") as mocked_logging:
+            main(
+                [
+                    "init",
+                    "--debug",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             mocked_logging.basicConfig.assert_called_with(
-                level=mocked_logging.DEBUG,
-                format=DEFAULT_LOG_FORMAT)
+                level=mocked_logging.DEBUG, format=DEFAULT_LOG_FORMAT
+            )
 
     def test_cli_use_default_logging_logger(self):
-        with mock.patch('kinto.__main__.logging') as mocked_logging:
-            main(['init', '--ini', TEMP_KINTO_INI,
-                  '--backend', 'memory', '--cache-backend', 'memory'])
+        with mock.patch("kinto.__main__.logging") as mocked_logging:
+            main(
+                [
+                    "init",
+                    "--ini",
+                    TEMP_KINTO_INI,
+                    "--backend",
+                    "memory",
+                    "--cache-backend",
+                    "memory",
+                ]
+            )
             mocked_logging.basicConfig.assert_called_with(
-                level=logging.INFO,
-                format=DEFAULT_LOG_FORMAT)
+                level=logging.INFO, format=DEFAULT_LOG_FORMAT
+            )

--- a/tests/test_views_buckets.py
+++ b/tests/test_views_buckets.py
@@ -4,95 +4,80 @@ from pyramid.security import Authenticated
 
 from kinto.core.testing import get_user_headers
 
-from .support import (BaseWebTest,
-                      MINIMALIST_BUCKET, MINIMALIST_GROUP,
-                      MINIMALIST_COLLECTION, MINIMALIST_RECORD)
+from .support import (
+    BaseWebTest,
+    MINIMALIST_BUCKET,
+    MINIMALIST_GROUP,
+    MINIMALIST_COLLECTION,
+    MINIMALIST_RECORD,
+)
 
 
 class BucketViewTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets'
-    record_url = '/buckets/beers'
+    collection_url = "/buckets"
+    record_url = "/buckets/beers"
 
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(self.record_url,
-                                 MINIMALIST_BUCKET,
-                                 headers=self.headers)
-        self.record = resp.json['data']
+        resp = self.app.put_json(self.record_url, MINIMALIST_BUCKET, headers=self.headers)
+        self.record = resp.json["data"]
 
     def test_buckets_are_global_to_every_users(self):
-        self.app.patch_json(self.record_url,
-                            {'permissions': {'read': [Authenticated]}},
-                            headers=self.headers)
-        self.app.get(self.record_url, headers=get_user_headers('alice'))
+        self.app.patch_json(
+            self.record_url, {"permissions": {"read": [Authenticated]}}, headers=self.headers
+        )
+        self.app.get(self.record_url, headers=get_user_headers("alice"))
 
     def test_buckets_can_be_put_with_simple_name(self):
-        self.assertEqual(self.record['id'], 'beers')
+        self.assertEqual(self.record["id"], "beers")
 
     def test_buckets_names_can_have_underscores(self):
         bucket = {**MINIMALIST_BUCKET}
-        record_url = '/buckets/alexis_beers'
-        resp = self.app.put_json(record_url,
-                                 bucket,
-                                 headers=self.headers)
-        self.assertEqual(resp.json['data']['id'], 'alexis_beers')
+        record_url = "/buckets/alexis_beers"
+        resp = self.app.put_json(record_url, bucket, headers=self.headers)
+        self.assertEqual(resp.json["data"]["id"], "alexis_beers")
 
     def test_can_list_buckets_by_default_since_allowed_to_create(self):
-        resp = self.app.get('/buckets',
-                            headers=get_user_headers('alice'),
-                            status=200)
-        assert resp.json['data'] == []
+        resp = self.app.get("/buckets", headers=get_user_headers("alice"), status=200)
+        assert resp.json["data"] == []
 
     def test_buckets_name_should_be_simple(self):
-        self.app.put_json('/buckets/__beers__',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(
+            "/buckets/__beers__", MINIMALIST_BUCKET, headers=self.headers, status=400
+        )
 
     def test_buckets_should_reject_unaccepted_request_content_type(self):
-        headers = {**self.headers, 'Content-Type': 'text/plain'}
-        self.app.put('/buckets/beers',
-                     MINIMALIST_BUCKET,
-                     headers=headers,
-                     status=415)
+        headers = {**self.headers, "Content-Type": "text/plain"}
+        self.app.put("/buckets/beers", MINIMALIST_BUCKET, headers=headers, status=415)
 
     def test_create_permissions_can_be_added_on_buckets(self):
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {'collection:create': ['fxa:user'],
-                                                       'group:create': ['fxa:user']}}
-        resp = self.app.put_json('/buckets/beers',
-                                 bucket,
-                                 headers=self.headers,
-                                 status=200)
-        permissions = resp.json['permissions']
-        self.assertIn('fxa:user', permissions['collection:create'])
-        self.assertIn('fxa:user', permissions['group:create'])
+        bucket = {
+            **MINIMALIST_BUCKET,
+            "permissions": {"collection:create": ["fxa:user"], "group:create": ["fxa:user"]},
+        }
+        resp = self.app.put_json("/buckets/beers", bucket, headers=self.headers, status=200)
+        permissions = resp.json["permissions"]
+        self.assertIn("fxa:user", permissions["collection:create"])
+        self.assertIn("fxa:user", permissions["group:create"])
 
     def test_wrong_create_permissions_cannot_be_added_on_buckets(self):
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {'record:create': ['fxa:user']}}
-        self.app.put_json('/buckets/beers',
-                          bucket,
-                          headers=self.headers,
-                          status=400)
+        bucket = {**MINIMALIST_BUCKET, "permissions": {"record:create": ["fxa:user"]}}
+        self.app.put_json("/buckets/beers", bucket, headers=self.headers, status=400)
 
     def test_buckets_can_handle_arbitrary_attributes(self):
         public_key = "5866f245a00bb3a39100d31b2f14d453"
-        bucket = {**MINIMALIST_BUCKET, 'data': {'public_key': public_key}}
-        resp = self.app.put_json('/buckets/beers',
-                                 bucket,
-                                 headers=self.headers,
-                                 status=200)
-        data = resp.json['data']
-        self.assertIn('public_key', data)
-        self.assertEqual(data['public_key'], public_key)
+        bucket = {**MINIMALIST_BUCKET, "data": {"public_key": public_key}}
+        resp = self.app.put_json("/buckets/beers", bucket, headers=self.headers, status=200)
+        data = resp.json["data"]
+        self.assertIn("public_key", data)
+        self.assertEqual(data["public_key"], public_key)
 
     def test_buckets_can_be_filtered_by_arbitrary_attribute(self):
-        bucket = {**MINIMALIST_BUCKET, 'data': {'size': 3}}
-        self.app.put_json('/buckets/beers',
-                          bucket,
-                          headers=self.headers)
-        resp = self.app.get('/buckets?min_size=2', headers=self.headers)
-        data = resp.json['data']
+        bucket = {**MINIMALIST_BUCKET, "data": {"size": 3}}
+        self.app.put_json("/buckets/beers", bucket, headers=self.headers)
+        resp = self.app.get("/buckets?min_size=2", headers=self.headers)
+        data = resp.json["data"]
         self.assertEqual(len(data), 1)
 
 
@@ -100,102 +85,90 @@ class BucketListTest(BaseWebTest, unittest.TestCase):
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['bucket_create_principals'] = cls.principal
+        settings["bucket_create_principals"] = cls.principal
         return settings
 
     def test_can_list_buckets_by_default_if_allowed_to_create(self):
-        resp = self.app.get('/buckets',
-                            headers=self.headers,
-                            status=200)
-        assert resp.json['data'] == []
+        resp = self.app.get("/buckets", headers=self.headers, status=200)
+        assert resp.json["data"] == []
 
     def test_cannot_list_buckets_if_empty_and_not_allowed_to_create(self):
-        self.app.get('/buckets', status=401)
-        self.app.get('/buckets', headers=get_user_headers('alice'), status=403)
+        self.app.get("/buckets", status=401)
+        self.app.get("/buckets", headers=get_user_headers("alice"), status=403)
 
     def test_can_list_buckets_if_some_are_shared(self):
-        self.app.put_json('/buckets/whiskies', headers=self.headers)
-        self.app.put_json('/buckets/beers',
-                          {'permissions': {'write': ['system.Everyone']}},
-                          headers=self.headers)
+        self.app.put_json("/buckets/whiskies", headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers", {"permissions": {"write": ["system.Everyone"]}}, headers=self.headers
+        )
 
-        resp = self.app.get('/buckets', status=200)
-        assert len(resp.json['data']) == 1
-        assert resp.json['data'][0]['id'] == 'beers'
+        resp = self.app.get("/buckets", status=200)
+        assert len(resp.json["data"]) == 1
+        assert resp.json["data"][0]["id"] == "beers"
 
 
 class BucketCreationTest(BaseWebTest, unittest.TestCase):
     def test_buckets_can_be_created_with_post(self):
-        r = self.app.post_json('/buckets',
-                               MINIMALIST_BUCKET,
-                               headers=self.headers)
+        r = self.app.post_json("/buckets", MINIMALIST_BUCKET, headers=self.headers)
         self.assertEqual(r.status_code, 201)
 
     def test_bucket_id_can_be_specified_in_post(self):
-        bucket = 'blog'
-        r = self.app.post_json('/buckets',
-                               {'data': {'id': bucket}},
-                               headers=self.headers)
-        self.assertEqual(r.json['data']['id'], bucket)
+        bucket = "blog"
+        r = self.app.post_json("/buckets", {"data": {"id": bucket}}, headers=self.headers)
+        self.assertEqual(r.json["data"]["id"], bucket)
 
     def test_bucket_can_be_created_without_body_nor_contenttype(self):
         headers = {**self.headers}
         headers.pop("Content-Type")
-        self.app.put('/buckets/catalog', headers=headers)
+        self.app.put("/buckets/catalog", headers=headers)
 
 
 class BucketReadPermissionTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets'
-    record_url = '/buckets/beers'
+    collection_url = "/buckets"
+    record_url = "/buckets/beers"
 
     def setUp(self):
         super().setUp()
         bucket = {**MINIMALIST_BUCKET}
-        self.app.put_json(self.record_url,
-                          bucket,
-                          headers=self.headers)
+        self.app.put_json(self.record_url, bucket, headers=self.headers)
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         # Give the right to list buckets (for cls.principal and alice).
-        settings['kinto.bucket_read_principals'] = Authenticated
+        settings["kinto.bucket_read_principals"] = Authenticated
         return settings
 
     def test_bucket_collection_endpoint_lists_them_all_for_everyone(self):
-        resp = self.app.get(self.collection_url,
-                            headers=get_user_headers('alice'))
-        records = resp.json['data']
+        resp = self.app.get(self.collection_url, headers=get_user_headers("alice"))
+        records = resp.json["data"]
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['id'], 'beers')
+        self.assertEqual(records[0]["id"], "beers")
 
     def test_everyone_can_read_bucket_information(self):
-        resp = self.app.get(self.record_url, headers=get_user_headers('alice'))
-        record = resp.json['data']
-        self.assertEqual(record['id'], 'beers')
+        resp = self.app.get(self.record_url, headers=get_user_headers("alice"))
+        record = resp.json["data"]
+        self.assertEqual(record["id"], "beers")
 
 
 class BucketDeletionTest(BaseWebTest, unittest.TestCase):
 
-    bucket_url = '/buckets/beers'
-    collection_url = '/buckets/beers/collections/barley'
-    group_url = '/buckets/beers/groups/moderators'
+    bucket_url = "/buckets/beers"
+    collection_url = "/buckets/beers/collections/barley"
+    group_url = "/buckets/beers/groups/moderators"
 
     def setUp(self):
         # Create a bucket with some objects.
-        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json(self.group_url, MINIMALIST_GROUP,
-                          headers=self.headers)
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        resp = self.app.post_json(self.collection_url + '/records',
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        record_id = resp.json['data']['id']
-        self.previous_ts = resp.headers['ETag']
-        self.record_url = self.collection_url + '/records/{}'.format(record_id)
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(self.group_url, MINIMALIST_GROUP, headers=self.headers)
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
+        resp = self.app.post_json(
+            self.collection_url + "/records", MINIMALIST_RECORD, headers=self.headers
+        )
+        record_id = resp.json["data"]["id"]
+        self.previous_ts = resp.headers["ETag"]
+        self.record_url = self.collection_url + "/records/{}".format(record_id)
         # Delete the bucket.
         self.app.delete(self.bucket_url, headers=self.headers)
 
@@ -203,76 +176,66 @@ class BucketDeletionTest(BaseWebTest, unittest.TestCase):
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         # Give the permission to read, to get an explicit 404 once deleted.
-        settings['kinto.bucket_read_principals'] = cls.principal
+        settings["kinto.bucket_read_principals"] = cls.principal
         return settings
 
     def test_buckets_can_be_deleted_in_bulk(self):
-        self.app.put_json('/buckets/1', MINIMALIST_BUCKET,
-                          headers=get_user_headers('alice'))
-        self.app.put_json('/buckets/2', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/3', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.delete('/buckets', headers=self.headers)
-        self.app.get('/buckets/1', headers=self.headers, status=200)
-        self.app.get('/buckets/2', headers=self.headers, status=404)
-        self.app.get('/buckets/3', headers=self.headers, status=404)
+        self.app.put_json("/buckets/1", MINIMALIST_BUCKET, headers=get_user_headers("alice"))
+        self.app.put_json("/buckets/2", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json("/buckets/3", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.delete("/buckets", headers=self.headers)
+        self.app.get("/buckets/1", headers=self.headers, status=200)
+        self.app.get("/buckets/2", headers=self.headers, status=404)
+        self.app.get("/buckets/3", headers=self.headers, status=404)
 
     def test_unknown_bucket_raises_404(self):
-        resp = self.app.get('/buckets/2', headers=self.headers, status=404)
-        self.assertEqual(resp.json['details']['id'], '2')
-        self.assertEqual(resp.json['details']['resource_name'], 'bucket')
+        resp = self.app.get("/buckets/2", headers=self.headers, status=404)
+        self.assertEqual(resp.json["details"]["id"], "2")
+        self.assertEqual(resp.json["details"]["resource_name"], "bucket")
 
     def test_buckets_can_be_deleted(self):
-        self.app.get(self.bucket_url, headers=self.headers,
-                     status=404)
+        self.app.get(self.bucket_url, headers=self.headers, status=404)
 
     def test_every_collections_are_deleted_too(self):
-        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
-                          headers=self.headers)
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET, headers=self.headers)
         self.app.get(self.collection_url, headers=self.headers, status=404)
 
         # Verify tombstones
-        resp = self.app.get('{}/collections?_since=0'.format(self.bucket_url),
-                            headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 0)
+        resp = self.app.get(
+            "{}/collections?_since=0".format(self.bucket_url), headers=self.headers
+        )
+        self.assertEqual(len(resp.json["data"]), 0)
 
     def test_timestamps_are_refreshed_when_collection_is_recreated(self):
         # Kinto/kinto#1223
         # Recreate with same name.
-        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        resp = self.app.get(self.collection_url + '/records', headers=self.headers)
-        records_ts = resp.headers['ETag']
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
+        resp = self.app.get(self.collection_url + "/records", headers=self.headers)
+        records_ts = resp.headers["ETag"]
         self.assertNotEqual(self.previous_ts, records_ts)
 
     def test_every_groups_are_deleted_too(self):
-        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
-                          headers=self.headers)
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET, headers=self.headers)
         self.app.get(self.group_url, headers=self.headers, status=404)
         # Verify tombstones
-        resp = self.app.get('{}/groups?_since=0'.format(self.bucket_url),
-                            headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 0)
+        resp = self.app.get("{}/groups?_since=0".format(self.bucket_url), headers=self.headers)
+        self.assertEqual(len(resp.json["data"]), 0)
 
     def test_every_records_are_deleted_too(self):
-        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
         self.app.get(self.record_url, headers=self.headers, status=404)
 
         # Verify tombstones
-        resp = self.app.get('{}/records?_since=0'.format(self.collection_url),
-                            headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 0)
+        resp = self.app.get(
+            "{}/records?_since=0".format(self.collection_url), headers=self.headers
+        )
+        self.assertEqual(len(resp.json["data"]), 0)
 
     def test_can_be_created_after_deletion_with_if_none_match_star(self):
-        headers = {**self.headers, 'If-None-Match': '*'}
-        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET,
-                          headers=headers, status=201)
+        headers = {**self.headers, "If-None-Match": "*"}
+        self.app.put_json(self.bucket_url, MINIMALIST_BUCKET, headers=headers, status=201)
 
     def test_does_not_delete_buckets_with_similar_names(self):
         self.app.put("/buckets/a", headers=self.headers)

--- a/tests/test_views_collections.py
+++ b/tests/test_views_collections.py
@@ -2,202 +2,187 @@ import unittest
 
 from kinto.core.testing import get_user_headers
 
-from .support import (BaseWebTest, MINIMALIST_BUCKET,
-                      MINIMALIST_COLLECTION, MINIMALIST_RECORD)
+from .support import BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_COLLECTION, MINIMALIST_RECORD
 
 
 class CollectionViewTest(BaseWebTest, unittest.TestCase):
 
-    collections_url = '/buckets/beers/collections'
-    collection_url = '/buckets/beers/collections/barley'
+    collections_url = "/buckets/beers/collections"
+    collection_url = "/buckets/beers/collections/barley"
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        resp = self.app.put_json(self.collection_url,
-                                 MINIMALIST_COLLECTION,
-                                 headers=self.headers)
-        self.record = resp.json['data']
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        resp = self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
+        self.record = resp.json["data"]
 
     def test_collection_endpoint_lists_them_all(self):
         resp = self.app.get(self.collections_url, headers=self.headers)
-        records = resp.json['data']
+        records = resp.json["data"]
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['id'], 'barley')
+        self.assertEqual(records[0]["id"], "barley")
 
     def test_collections_can_be_put_with_simple_name(self):
-        self.assertEqual(self.record['id'], 'barley')
+        self.assertEqual(self.record["id"], "barley")
 
     def test_collections_name_should_be_simple(self):
-        self.app.put_json('/buckets/beers/collections/__barley__',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(
+            "/buckets/beers/collections/__barley__",
+            MINIMALIST_COLLECTION,
+            headers=self.headers,
+            status=400,
+        )
 
     def test_collections_should_reject_unaccepted_request_content_type(self):
-        headers = {**self.headers, 'Content-Type': 'text/plain'}
-        self.app.put('/buckets/beers/collections/barley',
-                     MINIMALIST_COLLECTION,
-                     headers=headers,
-                     status=415)
+        headers = {**self.headers, "Content-Type": "text/plain"}
+        self.app.put(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=headers, status=415
+        )
 
     def test_unknown_bucket_raises_403(self):
-        other_bucket = self.collections_url.replace('beers', 'sodas')
+        other_bucket = self.collections_url.replace("beers", "sodas")
         self.app.get(other_bucket, headers=self.headers, status=403)
 
     def test_unknown_collection_raises_404(self):
-        other_collection = self.collection_url.replace('barley', 'pills')
+        other_collection = self.collection_url.replace("barley", "pills")
         resp = self.app.get(other_collection, headers=self.headers, status=404)
-        self.assertEqual(resp.json['details']['id'], 'pills')
-        self.assertEqual(resp.json['details']['resource_name'], 'collection')
+        self.assertEqual(resp.json["details"]["id"], "pills")
+        self.assertEqual(resp.json["details"]["resource_name"], "collection")
 
     def test_collections_are_isolated_by_bucket(self):
-        other_bucket = self.collection_url.replace('beers', 'sodas')
-        self.app.put_json('/buckets/sodas',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
+        other_bucket = self.collection_url.replace("beers", "sodas")
+        self.app.put_json("/buckets/sodas", MINIMALIST_BUCKET, headers=self.headers)
         self.app.get(other_bucket, headers=self.headers, status=404)
 
     def test_create_permissions_can_be_added_on_collections(self):
-        collection = {**MINIMALIST_COLLECTION, 'permissions': {'record:create': ['fxa:user']}}
-        resp = self.app.put_json('/buckets/beers/collections/barley',
-                                 collection,
-                                 headers=self.headers,
-                                 status=200)
-        permissions = resp.json['permissions']
-        self.assertIn('fxa:user', permissions['record:create'])
+        collection = {**MINIMALIST_COLLECTION, "permissions": {"record:create": ["fxa:user"]}}
+        resp = self.app.put_json(
+            "/buckets/beers/collections/barley", collection, headers=self.headers, status=200
+        )
+        permissions = resp.json["permissions"]
+        self.assertIn("fxa:user", permissions["record:create"])
 
     def test_wrong_create_permissions_cannot_be_added_on_collections(self):
-        collection = {**MINIMALIST_COLLECTION, 'permissions': {'collection:create': ['fxa:user']}}
-        self.app.put_json('/buckets/beers/collections/barley',
-                          collection,
-                          headers=self.headers,
-                          status=400)
+        collection = {**MINIMALIST_COLLECTION, "permissions": {"collection:create": ["fxa:user"]}}
+        self.app.put_json(
+            "/buckets/beers/collections/barley", collection, headers=self.headers, status=400
+        )
 
     def test_collections_can_handle_arbitrary_attributes(self):
         fingerprint = "5866f245a00bb3a39100d31b2f14d453"
-        collection = {**MINIMALIST_COLLECTION, 'data': {'fingerprint': fingerprint}}
-        resp = self.app.put_json('/buckets/beers/collections/barley',
-                                 collection,
-                                 headers=self.headers,
-                                 status=200)
-        data = resp.json['data']
-        self.assertIn('fingerprint', data)
-        self.assertEqual(data['fingerprint'], fingerprint)
+        collection = {**MINIMALIST_COLLECTION, "data": {"fingerprint": fingerprint}}
+        resp = self.app.put_json(
+            "/buckets/beers/collections/barley", collection, headers=self.headers, status=200
+        )
+        data = resp.json["data"]
+        self.assertIn("fingerprint", data)
+        self.assertEqual(data["fingerprint"], fingerprint)
 
     def test_collections_can_be_filtered_by_arbitrary_attribute(self):
-        collection = {**MINIMALIST_COLLECTION, 'data': {'size': 3}}
-        self.app.put_json('/buckets/beers/collections/moderator',
-                          collection,
-                          headers=self.headers)
-        resp = self.app.get('/buckets/beers/collections?has_size=true&min_size=2',
-                            headers=self.headers)
-        data = resp.json['data']
+        collection = {**MINIMALIST_COLLECTION, "data": {"size": 3}}
+        self.app.put_json("/buckets/beers/collections/moderator", collection, headers=self.headers)
+        resp = self.app.get(
+            "/buckets/beers/collections?has_size=true&min_size=2", headers=self.headers
+        )
+        data = resp.json["data"]
         self.assertEqual(len(data), 1)
 
 
 class CollectionDeletionTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets/beers/collections/barley'
+    collection_url = "/buckets/beers/collections/barley"
 
     def setUp(self):
         super().setUp()
-        bucket = {**MINIMALIST_BUCKET,
-                  'permissions': {'collection:create': ['system.Everyone'],
-                                  'read': ['system.Everyone']}}
-        self.app.put_json('/buckets/beers', bucket,
-                          headers=self.headers)
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        resp = self.app.post_json(self.collection_url + '/records',
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        self.previous_ts = resp.headers['ETag']
-        record_id = resp.json['data']['id']
-        self.record_url = self.collection_url + '/records/{}'.format(record_id)
+        bucket = {
+            **MINIMALIST_BUCKET,
+            "permissions": {"collection:create": ["system.Everyone"], "read": ["system.Everyone"]},
+        }
+        self.app.put_json("/buckets/beers", bucket, headers=self.headers)
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
+        resp = self.app.post_json(
+            self.collection_url + "/records", MINIMALIST_RECORD, headers=self.headers
+        )
+        self.previous_ts = resp.headers["ETag"]
+        record_id = resp.json["data"]["id"]
+        self.record_url = self.collection_url + "/records/{}".format(record_id)
         self.app.delete(self.collection_url, headers=self.headers)
 
     def test_collections_can_be_deleted(self):
         self.app.get(self.collection_url, headers=self.headers, status=404)
 
     def test_collections_can_be_deleted_in_bulk(self):
-        alice_headers = get_user_headers('alice')
-        self.app.put_json('/buckets/beers/collections/1',
-                          MINIMALIST_COLLECTION, headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/2',
-                          MINIMALIST_COLLECTION, headers=alice_headers)
-        self.app.put_json('/buckets/beers/collections/3',
-                          MINIMALIST_COLLECTION, headers=alice_headers)
-        self.app.delete('/buckets/beers/collections',
-                        headers=alice_headers)
-        resp = self.app.get('/buckets/beers/collections', headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 1)
+        alice_headers = get_user_headers("alice")
+        self.app.put_json(
+            "/buckets/beers/collections/1", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        self.app.put_json(
+            "/buckets/beers/collections/2", MINIMALIST_COLLECTION, headers=alice_headers
+        )
+        self.app.put_json(
+            "/buckets/beers/collections/3", MINIMALIST_COLLECTION, headers=alice_headers
+        )
+        self.app.delete("/buckets/beers/collections", headers=alice_headers)
+        resp = self.app.get("/buckets/beers/collections", headers=self.headers)
+        self.assertEqual(len(resp.json["data"]), 1)
 
     def test_records_of_collection_are_deleted_too(self):
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
         self.app.get(self.record_url, headers=self.headers, status=404)
 
         # Verify tombstones
-        resp = self.app.get('{}/records?_since=0'.format(self.collection_url),
-                            headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 0)
+        resp = self.app.get(
+            "{}/records?_since=0".format(self.collection_url), headers=self.headers
+        )
+        self.assertEqual(len(resp.json["data"]), 0)
 
     def test_timestamps_are_refreshed_when_collection_is_recreated(self):
         # Kinto/kinto#1223
         # Recreate with same name.
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        resp = self.app.get(self.collection_url + '/records', headers=self.headers)
-        records_ts = resp.headers['ETag']
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=self.headers)
+        resp = self.app.get(self.collection_url + "/records", headers=self.headers)
+        records_ts = resp.headers["ETag"]
         self.assertNotEqual(self.previous_ts, records_ts)
 
     def test_can_be_created_after_deletion_with_if_none_match_star(self):
-        headers = {**self.headers, 'If-None-Match': '*'}
-        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION,
-                          headers=headers, status=201)
+        headers = {**self.headers, "If-None-Match": "*"}
+        self.app.put_json(self.collection_url, MINIMALIST_COLLECTION, headers=headers, status=201)
 
     def test_collection_permissions_are_removed_after_collection_deleted(self):
-        self.assertDictEqual(self.permission.get_object_permissions(
-                             self.collection_url), {})
+        self.assertDictEqual(self.permission.get_object_permissions(self.collection_url), {})
 
     def test_records_permissions_are_removed_after_collection_deleted(self):
-        self.assertDictEqual(self.permission.get_object_permissions(
-                             self.record_url), {})
+        self.assertDictEqual(self.permission.get_object_permissions(self.record_url), {})
 
 
 class CollectionCreationTest(BaseWebTest, unittest.TestCase):
 
-    collections_url = '/buckets/beers/collections'
+    collections_url = "/buckets/beers/collections"
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
 
     def test_collection_can_be_created_with_post(self):
-        r = self.app.post_json(self.collections_url,
-                               MINIMALIST_COLLECTION,
-                               headers=self.headers)
+        r = self.app.post_json(self.collections_url, MINIMALIST_COLLECTION, headers=self.headers)
         self.assertEqual(r.status_code, 201)
-        self.assertTrue(len(r.json['data']['id']) == 8)
+        self.assertTrue(len(r.json["data"]["id"]) == 8)
 
     def test_collection_can_be_specified_in_post(self):
-        collection = 'barley'
-        r = self.app.post_json(self.collections_url,
-                               {'data': {'id': collection}},
-                               headers=self.headers)
+        collection = "barley"
+        r = self.app.post_json(
+            self.collections_url, {"data": {"id": collection}}, headers=self.headers
+        )
         self.assertEqual(r.status_code, 201)
-        self.assertEqual(r.json['data']['id'], collection)
+        self.assertEqual(r.json["data"]["id"], collection)
 
     def test_collection_already_exists_post(self):
         collection = "barley"
-        self.app.post_json(self.collections_url,
-                           {'data': {'id': collection}},
-                           headers=self.headers)
-        r = self.app.post_json(self.collections_url,
-                               {'data': {'id': collection}},
-                               headers=self.headers)
-        self.assertEqual(r.json['data']['id'], collection)
+        self.app.post_json(
+            self.collections_url, {"data": {"id": collection}}, headers=self.headers
+        )
+        r = self.app.post_json(
+            self.collections_url, {"data": {"id": collection}}, headers=self.headers
+        )
+        self.assertEqual(r.json["data"]["id"], collection)
         self.assertEqual(r.status_code, 200)

--- a/tests/test_views_collections_cache.py
+++ b/tests/test_views_collections_cache.py
@@ -1,147 +1,140 @@
 from kinto.core.testing import unittest
 
-from .support import (BaseWebTest, MINIMALIST_BUCKET,
-                      MINIMALIST_COLLECTION, MINIMALIST_RECORD)
+from .support import BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_COLLECTION, MINIMALIST_RECORD
 
 
 class GlobalSettingsTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['kinto.record_cache_expires_seconds'] = 3600
-        settings['kinto.record_read_principals'] = 'system.Everyone'
+        settings["kinto.record_cache_expires_seconds"] = 3600
+        settings["kinto.record_read_principals"] = "system.Everyone"
         return settings
 
     def setUp(self):
         super().setUp()
-        self.create_bucket('blog')
-        self.app.put_json('/buckets/blog/collections/cached',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        r = self.app.post_json('/buckets/blog/collections/cached/records',
-                               MINIMALIST_RECORD,
-                               headers=self.headers)
-        self.record = r.json['data']
+        self.create_bucket("blog")
+        self.app.put_json(
+            "/buckets/blog/collections/cached", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        r = self.app.post_json(
+            "/buckets/blog/collections/cached/records", MINIMALIST_RECORD, headers=self.headers
+        )
+        self.record = r.json["data"]
 
     def test_expires_and_cache_control_headers_are_set(self):
-        url = '/buckets/blog/collections/cached/records'
+        url = "/buckets/blog/collections/cached/records"
         r = self.app.get(url)
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(r.headers["Cache-Control"], "max-age=3600")
 
-        r = self.app.get('{}/{}'.format(url, self.record['id']))
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')
+        r = self.app.get("{}/{}".format(url, self.record["id"]))
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(r.headers["Cache-Control"], "max-age=3600")
 
 
 class SpecificSettingsTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['kinto.blog.record_cache_expires_seconds'] = '30'
-        settings['kinto.browser.top500.record_cache_expires_seconds'] = '60'
+        settings["kinto.blog.record_cache_expires_seconds"] = "30"
+        settings["kinto.browser.top500.record_cache_expires_seconds"] = "60"
         return settings
 
     def setUp(self):
         super().setUp()
 
         def create_record_in_collection(bucket_id, collection_id):
-            bucket = {**MINIMALIST_BUCKET, 'permissions': {'read': ['system.Everyone']}}
-            self.app.put_json('/buckets/{}'.format(bucket_id),
-                              bucket, headers=self.headers)
-            collection_url = '/buckets/{}/collections/{}'.format(bucket_id, collection_id)
-            self.app.put_json(collection_url,
-                              MINIMALIST_COLLECTION,
-                              headers=self.headers)
-            r = self.app.post_json(collection_url + '/records',
-                                   MINIMALIST_RECORD,
-                                   headers=self.headers)
-            return r.json['data']
+            bucket = {**MINIMALIST_BUCKET, "permissions": {"read": ["system.Everyone"]}}
+            self.app.put_json("/buckets/{}".format(bucket_id), bucket, headers=self.headers)
+            collection_url = "/buckets/{}/collections/{}".format(bucket_id, collection_id)
+            self.app.put_json(collection_url, MINIMALIST_COLLECTION, headers=self.headers)
+            r = self.app.post_json(
+                collection_url + "/records", MINIMALIST_RECORD, headers=self.headers
+            )
+            return r.json["data"]
 
-        self.blog_record = create_record_in_collection('blog', 'cached')
-        self.app_record = create_record_in_collection('browser', 'top500')
+        self.blog_record = create_record_in_collection("blog", "cached")
+        self.app_record = create_record_in_collection("browser", "top500")
 
     def assertHasCache(self, url, age):
         r = self.app.get(url)
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'], 'max-age={}'.format(age))
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(r.headers["Cache-Control"], "max-age={}".format(age))
 
     def test_for_records_on_a_specific_bucket(self):
-        collection_url = '/buckets/blog/collections/cached/records'
+        collection_url = "/buckets/blog/collections/cached/records"
         self.assertHasCache(collection_url, 30)
-        record_url = '{}/{}'.format(collection_url, self.blog_record['id'])
+        record_url = "{}/{}".format(collection_url, self.blog_record["id"])
         self.assertHasCache(record_url, 30)
 
     def test_for_records_on_a_specific_collection(self):
-        collection_url = '/buckets/browser/collections/top500/records'
+        collection_url = "/buckets/browser/collections/top500/records"
         self.assertHasCache(collection_url, 60)
-        record_url = '{}/{}'.format(collection_url, self.app_record['id'])
+        record_url = "{}/{}".format(collection_url, self.app_record["id"])
         self.assertHasCache(record_url, 60)
 
 
 class CollectionExpiresTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {'read': ['system.Everyone']}}
-        self.app.put_json('/buckets/blog',
-                          bucket,
-                          headers=self.headers)
-        self.collection_url = '/buckets/blog/collections/cached'
-        self.app.put_json(self.collection_url,
-                          {'data': {'cache_expires': 3600}},
-                          headers=self.headers)
+        bucket = {**MINIMALIST_BUCKET, "permissions": {"read": ["system.Everyone"]}}
+        self.app.put_json("/buckets/blog", bucket, headers=self.headers)
+        self.collection_url = "/buckets/blog/collections/cached"
+        self.app.put_json(
+            self.collection_url, {"data": {"cache_expires": 3600}}, headers=self.headers
+        )
 
-        self.records_url = self.collection_url + '/records'
+        self.records_url = self.collection_url + "/records"
 
-        resp = self.app.post_json(self.records_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        self.record = resp.json['data']
-        self.record_url = '{}/{}'.format(self.records_url, self.record['id'])
+        resp = self.app.post_json(self.records_url, MINIMALIST_RECORD, headers=self.headers)
+        self.record = resp.json["data"]
+        self.record_url = "{}/{}".format(self.records_url, self.record["id"])
 
     def test_cache_expires_must_be_an_integer(self):
-        self.app.put_json(self.collection_url,
-                          {'data': {'cache_expires': 'abc'}},
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(
+            self.collection_url,
+            {"data": {"cache_expires": "abc"}},
+            headers=self.headers,
+            status=400,
+        )
 
     def test_expires_and_cache_control_are_not_set_if_authenticated(self):
         r = self.app.get(self.records_url, headers=self.headers)
-        self.assertNotIn('Expires', r.headers)
-        self.assertIn('Cache-Control', r.headers)
-        self.assertNotIn('max-age', r.headers['Cache-Control'])
+        self.assertNotIn("Expires", r.headers)
+        self.assertIn("Cache-Control", r.headers)
+        self.assertNotIn("max-age", r.headers["Cache-Control"])
 
     def test_expires_and_cache_control_are_set_on_records(self):
         r = self.app.get(self.records_url)
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(r.headers["Cache-Control"], "max-age=3600")
 
     def test_expires_and_cache_control_are_set_on_record(self):
         r = self.app.get(self.record_url)
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(r.headers["Cache-Control"], "max-age=3600")
 
     def test_cache_control_is_set_no_cache_if_zero(self):
-        self.app.put_json(self.collection_url,
-                          {'data': {'cache_expires': 0}},
-                          headers=self.headers)
+        self.app.put_json(
+            self.collection_url, {"data": {"cache_expires": 0}}, headers=self.headers
+        )
         r = self.app.get(self.records_url)
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'],
-                         'max-age=0, must-revalidate, no-cache, no-store')
-        self.assertEqual(r.headers['Pragma'], 'no-cache')
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(
+            r.headers["Cache-Control"], "max-age=0, must-revalidate, no-cache, no-store"
+        )
+        self.assertEqual(r.headers["Pragma"], "no-cache")
 
     def test_cache_control_on_collection_overrides_setting(self):
-        app = self.make_app(settings={
-            'kinto.record_cache_expires_seconds': 10,
-            'kinto.record_read_principals': 'system.Everyone'
-        })
-        app.put_json('/buckets/blog', MINIMALIST_BUCKET, headers=self.headers)
-        app.put_json(self.collection_url,
-                     {'data': {'cache_expires': 3600}},
-                     headers=self.headers)
+        app = self.make_app(
+            settings={
+                "kinto.record_cache_expires_seconds": 10,
+                "kinto.record_read_principals": "system.Everyone",
+            }
+        )
+        app.put_json("/buckets/blog", MINIMALIST_BUCKET, headers=self.headers)
+        app.put_json(self.collection_url, {"data": {"cache_expires": 3600}}, headers=self.headers)
         r = app.get(self.records_url)
-        self.assertIn('Expires', r.headers)
-        self.assertEqual(r.headers['Cache-Control'], 'max-age=3600')
+        self.assertIn("Expires", r.headers)
+        self.assertEqual(r.headers["Cache-Control"], "max-age=3600")

--- a/tests/test_views_contribute.py
+++ b/tests/test_views_contribute.py
@@ -4,10 +4,8 @@ from .support import BaseWebTest
 
 
 class ContributeViewTest(BaseWebTest, unittest.TestCase):
-
     def test_returns_info_about_project(self):
-        response = self.app.get('/contribute.json')
+        response = self.app.get("/contribute.json")
         keys = sorted(response.json.keys())
-        expected = ['description', 'keywords', 'name', 'participate',
-                    'repository', 'urls']
+        expected = ["description", "keywords", "name", "participate", "repository", "urls"]
         self.assertEqual(keys, expected)

--- a/tests/test_views_disable_default.py
+++ b/tests/test_views_disable_default.py
@@ -5,14 +5,14 @@ from .support import BaseWebTest
 
 class DisableDefaultBucketViewTest(BaseWebTest, unittest.TestCase):
 
-    test_url = '/buckets/default'
+    test_url = "/buckets/default"
 
     def test_returns_403_if_excluded_in_configuration(self):
-        extra = {'includes': ''}
+        extra = {"includes": ""}
         app = self.make_app(settings=extra)
         app.get(self.test_url, headers=self.headers, status=403)
 
     def test_returns_200_if_included_in_configuration(self):
-        extra = {'includes': 'kinto.plugins.default_bucket'}
+        extra = {"includes": "kinto.plugins.default_bucket"}
         app = self.make_app(settings=extra)
         app.get(self.test_url, headers=self.headers, status=200)

--- a/tests/test_views_groups.py
+++ b/tests/test_views_groups.py
@@ -2,256 +2,228 @@ import unittest
 from kinto.core.errors import ERRORS
 from kinto.core.testing import FormattedErrorMixin
 
-from .support import (BaseWebTest, MINIMALIST_BUCKET,
-                      MINIMALIST_GROUP)
+from .support import BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_GROUP
 
 
 class GroupViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets/beers/groups'
-    record_url = '/buckets/beers/groups/moderators'
+    collection_url = "/buckets/beers/groups"
+    record_url = "/buckets/beers/groups/moderators"
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        resp = self.app.put_json(self.record_url,
-                                 MINIMALIST_GROUP,
-                                 headers=self.headers)
-        self.record = resp.json['data']
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        resp = self.app.put_json(self.record_url, MINIMALIST_GROUP, headers=self.headers)
+        self.record = resp.json["data"]
 
     def test_collection_endpoint_lists_them_all(self):
         resp = self.app.get(self.collection_url, headers=self.headers)
-        records = resp.json['data']
+        records = resp.json["data"]
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['members'], ['fxa:user'])
+        self.assertEqual(records[0]["members"], ["fxa:user"])
 
     def test_groups_can_be_posted_without_id(self):
-        resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_GROUP,
-                                  headers=self.headers,
-                                  status=201)
-        self.assertIn('id', resp.json['data'])
-        self.assertEqual(resp.json['data']['members'], ['fxa:user'])
+        resp = self.app.post_json(
+            self.collection_url, MINIMALIST_GROUP, headers=self.headers, status=201
+        )
+        self.assertIn("id", resp.json["data"])
+        self.assertEqual(resp.json["data"]["members"], ["fxa:user"])
 
     def test_groups_can_be_put_with_empty_body(self):
-        self.app.put('/buckets/beers/groups/simple', headers=self.headers)
+        self.app.put("/buckets/beers/groups/simple", headers=self.headers)
 
     def test_groups_can_be_created_with_just_permissions(self):
-        group = {'permissions': {'write': ['github:me']}}
-        resp = self.app.put_json('/buckets/beers/groups/g',
-                                 group,
-                                 headers=self.headers)
-        self.assertNotIn('members', resp.json['data'])
+        group = {"permissions": {"write": ["github:me"]}}
+        resp = self.app.put_json("/buckets/beers/groups/g", group, headers=self.headers)
+        self.assertNotIn("members", resp.json["data"])
 
     def test_groups_can_be_create_without_members_attribute(self):
-        group = {'data': {'alias': 'admins'}}
-        resp = self.app.put_json(self.record_url,
-                                 group,
-                                 headers=self.headers)
-        self.assertEqual(resp.json['data']['members'], [])
+        group = {"data": {"alias": "admins"}}
+        resp = self.app.put_json(self.record_url, group, headers=self.headers)
+        self.assertEqual(resp.json["data"]["members"], [])
 
     def test_groups_can_be_patched_without_members_attribute(self):
-        group = {'data': {'alias': 'admins'}}
-        resp = self.app.patch_json(self.record_url,
-                                   group,
-                                   headers=self.headers)
-        self.assertEqual(resp.json['data']['members'], ['fxa:user'])
-        self.assertEqual(resp.json['data']['alias'], 'admins')
+        group = {"data": {"alias": "admins"}}
+        resp = self.app.patch_json(self.record_url, group, headers=self.headers)
+        self.assertEqual(resp.json["data"]["members"], ["fxa:user"])
+        self.assertEqual(resp.json["data"]["alias"], "admins")
 
     def test_groups_can_be_put_with_simple_name(self):
-        self.assertEqual(self.record['id'], 'moderators')
+        self.assertEqual(self.record["id"], "moderators")
 
     def test_groups_name_should_be_simple(self):
-        self.app.put_json('/buckets/beers/groups/__moderator__',
-                          MINIMALIST_GROUP,
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(
+            "/buckets/beers/groups/__moderator__",
+            MINIMALIST_GROUP,
+            headers=self.headers,
+            status=400,
+        )
 
     def test_groups_can_have_arbitrary_attributes(self):
         mailinglist = "kinto@mozilla.com"
-        group = {**MINIMALIST_GROUP, 'data': {**MINIMALIST_GROUP['data'],
-                                              'mailinglist': mailinglist}}
-        resp = self.app.put_json('/buckets/beers/groups/moderator',
-                                 group,
-                                 headers=self.headers)
-        data = resp.json['data']
-        self.assertIn('mailinglist', data)
-        self.assertEqual(data['mailinglist'], mailinglist)
+        group = {
+            **MINIMALIST_GROUP,
+            "data": {**MINIMALIST_GROUP["data"], "mailinglist": mailinglist},
+        }
+        resp = self.app.put_json("/buckets/beers/groups/moderator", group, headers=self.headers)
+        data = resp.json["data"]
+        self.assertIn("mailinglist", data)
+        self.assertEqual(data["mailinglist"], mailinglist)
 
     def test_groups_can_be_filtered_by_arbitrary_attribute(self):
-        group = {**MINIMALIST_GROUP, 'data': {**MINIMALIST_GROUP['data'], 'size': 3}}
-        self.app.put_json('/buckets/beers/groups/moderator',
-                          group,
-                          headers=self.headers)
-        resp = self.app.get('/buckets/beers/groups?has_size=true&min_size=2',
-                            headers=self.headers)
-        data = resp.json['data']
+        group = {**MINIMALIST_GROUP, "data": {**MINIMALIST_GROUP["data"], "size": 3}}
+        self.app.put_json("/buckets/beers/groups/moderator", group, headers=self.headers)
+        resp = self.app.get("/buckets/beers/groups?has_size=true&min_size=2", headers=self.headers)
+        data = resp.json["data"]
         self.assertEqual(len(data), 1)
 
     def test_groups_should_reject_unaccepted_request_content_type(self):
-        headers = {**self.headers, 'Content-Type': 'text/plain'}
-        self.app.put('/buckets/beers/groups/moderator',
-                     MINIMALIST_GROUP,
-                     headers=headers,
-                     status=415)
+        headers = {**self.headers, "Content-Type": "text/plain"}
+        self.app.put(
+            "/buckets/beers/groups/moderator", MINIMALIST_GROUP, headers=headers, status=415
+        )
 
     def test_unknown_bucket_raises_403(self):
-        other_bucket = self.collection_url.replace('beers', 'sodas')
+        other_bucket = self.collection_url.replace("beers", "sodas")
         self.app.get(other_bucket, headers=self.headers, status=403)
 
     def test_groups_are_isolated_by_bucket(self):
-        other_bucket = self.record_url.replace('beers', 'sodas')
-        self.app.put_json('/buckets/sodas',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
+        other_bucket = self.record_url.replace("beers", "sodas")
+        self.app.put_json("/buckets/sodas", MINIMALIST_BUCKET, headers=self.headers)
         self.app.get(other_bucket, headers=self.headers, status=404)
 
     def test_wrong_create_permissions_cannot_be_added_on_groups(self):
-        group = {**MINIMALIST_GROUP, 'permissions': {'group:create': ['fxa:user']}}
-        self.app.put_json('/buckets/beers/groups/moderator',
-                          group,
-                          headers=self.headers,
-                          status=400)
+        group = {**MINIMALIST_GROUP, "permissions": {"group:create": ["fxa:user"]}}
+        self.app.put_json(
+            "/buckets/beers/groups/moderator", group, headers=self.headers, status=400
+        )
 
     def test_recreate_group_after_deletion_returns_a_201(self):
-        self.app.put_json('/buckets/beers/groups/moderator',
-                          MINIMALIST_GROUP,
-                          headers=self.headers,
-                          status=201)
-        self.app.delete('/buckets/beers/groups/moderator',
-                        headers=self.headers,
-                        status=200)
-        self.app.put_json('/buckets/beers/groups/moderator',
-                          MINIMALIST_GROUP,
-                          headers=self.headers,
-                          status=201)
+        self.app.put_json(
+            "/buckets/beers/groups/moderator", MINIMALIST_GROUP, headers=self.headers, status=201
+        )
+        self.app.delete("/buckets/beers/groups/moderator", headers=self.headers, status=200)
+        self.app.put_json(
+            "/buckets/beers/groups/moderator", MINIMALIST_GROUP, headers=self.headers, status=201
+        )
 
     def test_group_doesnt_accept_system_Everyone(self):
-        group = {**MINIMALIST_GROUP, 'data': {'members': ['system.Everyone']}}
-        response = self.app.put_json('/buckets/beers/groups/moderator',
-                                     group,
-                                     headers=self.headers,
-                                     status=400)
+        group = {**MINIMALIST_GROUP, "data": {"members": ["system.Everyone"]}}
+        response = self.app.put_json(
+            "/buckets/beers/groups/moderator", group, headers=self.headers, status=400
+        )
         self.assertFormattedError(
-            response, 400, ERRORS.INVALID_PARAMETERS,
+            response,
+            400,
+            ERRORS.INVALID_PARAMETERS,
             "Invalid parameters",
-            "'system.Everyone' is not a valid user ID.")
+            "'system.Everyone' is not a valid user ID.",
+        )
 
     def test_group_doesnt_accept_groups_inside_groups(self):
-        group = {**MINIMALIST_GROUP, 'data': {'members': ['/buckets/beers/groups/administrators']}}
-        response = self.app.put_json('/buckets/beers/groups/moderator',
-                                     group,
-                                     headers=self.headers,
-                                     status=400)
+        group = {**MINIMALIST_GROUP, "data": {"members": ["/buckets/beers/groups/administrators"]}}
+        response = self.app.put_json(
+            "/buckets/beers/groups/moderator", group, headers=self.headers, status=400
+        )
         self.assertFormattedError(
-            response, 400, ERRORS.INVALID_PARAMETERS,
+            response,
+            400,
+            ERRORS.INVALID_PARAMETERS,
             "Invalid parameters",
-            "'/buckets/beers/groups/administrators' is not a valid user ID.")
+            "'/buckets/beers/groups/administrators' is not a valid user ID.",
+        )
 
 
 class GroupManagementTest(BaseWebTest, unittest.TestCase):
 
-    group_url = '/buckets/beers/groups/moderators'
+    group_url = "/buckets/beers/groups/moderators"
 
     def setUp(self):
         super().setUp()
-        self.create_bucket('beers')
+        self.create_bucket("beers")
 
     def test_groups_can_be_deleted(self):
-        self.create_group('beers', 'moderators')
+        self.create_group("beers", "moderators")
         self.app.delete(self.group_url, headers=self.headers)
-        self.app.get(self.group_url, headers=self.headers,
-                     status=404)
+        self.app.get(self.group_url, headers=self.headers, status=404)
 
     def test_unknown_group_raises_404(self):
-        other_group = self.group_url.replace('moderators', 'blah')
+        other_group = self.group_url.replace("moderators", "blah")
         resp = self.app.get(other_group, headers=self.headers, status=404)
-        self.assertEqual(resp.json['details']['id'], 'blah')
-        self.assertEqual(resp.json['details']['resource_name'], 'group')
+        self.assertEqual(resp.json["details"]["id"], "blah")
+        self.assertEqual(resp.json["details"]["resource_name"], "group")
 
     def test_group_is_removed_from_users_principals_on_group_deletion(self):
-        self.app.put_json(self.group_url, MINIMALIST_GROUP,
-                          headers=self.headers, status=201)
-        self.assertIn(self.group_url,
-                      self.permission.get_user_principals('fxa:user'))
+        self.app.put_json(self.group_url, MINIMALIST_GROUP, headers=self.headers, status=201)
+        self.assertIn(self.group_url, self.permission.get_user_principals("fxa:user"))
         self.app.delete(self.group_url, headers=self.headers, status=200)
-        self.assertNotIn(self.group_url,
-                         self.permission.get_user_principals('fxa:user'))
+        self.assertNotIn(self.group_url, self.permission.get_user_principals("fxa:user"))
 
     def test_group_is_removed_from_users_principals_on_groups_deletion(self):
-        self.create_group('beers', 'moderators', ['natim', 'fxa:me'])
-        self.create_group('beers', 'reviewers', ['natim', 'alexis'])
+        self.create_group("beers", "moderators", ["natim", "fxa:me"])
+        self.create_group("beers", "reviewers", ["natim", "alexis"])
 
-        self.app.delete('/buckets/beers/groups', headers=self.headers,
-                        status=200)
+        self.app.delete("/buckets/beers/groups", headers=self.headers, status=200)
 
-        self.assertEqual(self.permission.get_user_principals('fxa:me'), set())
-        self.assertEqual(self.permission.get_user_principals('natim'), set())
-        self.assertEqual(self.permission.get_user_principals('alexis'), set())
+        self.assertEqual(self.permission.get_user_principals("fxa:me"), set())
+        self.assertEqual(self.permission.get_user_principals("natim"), set())
+        self.assertEqual(self.permission.get_user_principals("alexis"), set())
 
     def test_group_is_added_to_user_principals_when_added_to_members(self):
-        self.create_group('beers', 'moderators', ['natim', 'mat'])
+        self.create_group("beers", "moderators", ["natim", "mat"])
 
-        self.app.get('/buckets/beers/groups', headers=self.headers, status=200)
-        self.assertEqual(self.permission.get_user_principals('natim'),
-                         {'/buckets/beers/groups/moderators'})
-        self.assertEqual(self.permission.get_user_principals('mat'),
-                         {'/buckets/beers/groups/moderators'})
+        self.app.get("/buckets/beers/groups", headers=self.headers, status=200)
+        self.assertEqual(
+            self.permission.get_user_principals("natim"), {"/buckets/beers/groups/moderators"}
+        )
+        self.assertEqual(
+            self.permission.get_user_principals("mat"), {"/buckets/beers/groups/moderators"}
+        )
 
     def test_group_is_added_to_user_principals_on_members_add_with_patch(self):
-        self.create_group('beers', 'moderators', ['natim', 'mat'])
-        group_url = '/buckets/beers/groups/moderators'
-        group = {'data': {'members': ['natim', 'mat', 'alice']}}
-        self.app.patch_json(group_url, group,
-                            headers=self.headers, status=200)
-        self.app.get('/buckets/beers/groups', headers=self.headers, status=200)
-        self.assertEqual(self.permission.get_user_principals('natim'),
-                         {group_url})
-        self.assertEqual(self.permission.get_user_principals('mat'),
-                         {group_url})
-        self.assertEqual(self.permission.get_user_principals('alice'),
-                         {group_url})
+        self.create_group("beers", "moderators", ["natim", "mat"])
+        group_url = "/buckets/beers/groups/moderators"
+        group = {"data": {"members": ["natim", "mat", "alice"]}}
+        self.app.patch_json(group_url, group, headers=self.headers, status=200)
+        self.app.get("/buckets/beers/groups", headers=self.headers, status=200)
+        self.assertEqual(self.permission.get_user_principals("natim"), {group_url})
+        self.assertEqual(self.permission.get_user_principals("mat"), {group_url})
+        self.assertEqual(self.permission.get_user_principals("alice"), {group_url})
 
     def test_group_member_removal_updates_user_principals(self):
-        self.create_group('beers', 'moderators', ['natim', 'mat'])
-        group_url = '/buckets/beers/groups/moderators'
-        group = {'data': {'members': ['mat']}}
-        self.app.put_json(group_url, group,
-                          headers=self.headers, status=200)
-        self.app.get('/buckets/beers/groups', headers=self.headers, status=200)
-        self.assertEqual(self.permission.get_user_principals('natim'), set())
-        self.assertEqual(self.permission.get_user_principals('mat'),
-                         {group_url})
+        self.create_group("beers", "moderators", ["natim", "mat"])
+        group_url = "/buckets/beers/groups/moderators"
+        group = {"data": {"members": ["mat"]}}
+        self.app.put_json(group_url, group, headers=self.headers, status=200)
+        self.app.get("/buckets/beers/groups", headers=self.headers, status=200)
+        self.assertEqual(self.permission.get_user_principals("natim"), set())
+        self.assertEqual(self.permission.get_user_principals("mat"), {group_url})
 
     def test_group_with_authenticated_is_added_to_everbody(self):
-        self.create_group('beers', 'reviewers', ['system.Authenticated'])
-        self.assertEqual(self.permission.get_user_principals('natim'),
-                         {'/buckets/beers/groups/reviewers'})
-        self.assertEqual(self.permission.get_user_principals('mat'),
-                         {'/buckets/beers/groups/reviewers'})
+        self.create_group("beers", "reviewers", ["system.Authenticated"])
+        self.assertEqual(
+            self.permission.get_user_principals("natim"), {"/buckets/beers/groups/reviewers"}
+        )
+        self.assertEqual(
+            self.permission.get_user_principals("mat"), {"/buckets/beers/groups/reviewers"}
+        )
 
     def test_group_member_removal_updates_user_principals_with_patch(self):
-        self.create_group('beers', 'moderators', ['natim', 'mat'])
-        group_url = '/buckets/beers/groups/moderators'
-        group = {'data': {'members': ['mat']}}
+        self.create_group("beers", "moderators", ["natim", "mat"])
+        group_url = "/buckets/beers/groups/moderators"
+        group = {"data": {"members": ["mat"]}}
         self.app.patch_json(group_url, group, headers=self.headers, status=200)
-        self.assertEqual(self.permission.get_user_principals('natim'), set())
-        self.assertEqual(self.permission.get_user_principals('mat'),
-                         {group_url})
+        self.assertEqual(self.permission.get_user_principals("natim"), set())
+        self.assertEqual(self.permission.get_user_principals("mat"), {group_url})
 
     def test_groups_can_be_created_after_deletion(self):
-        self.create_group('beers', 'moderators')
-        group_url = '/buckets/beers/groups/moderators'
+        self.create_group("beers", "moderators")
+        group_url = "/buckets/beers/groups/moderators"
         self.app.delete(group_url, headers=self.headers)
-        headers = {**self.headers, 'If-None-Match': '*'}
-        self.app.put_json(group_url, MINIMALIST_GROUP,
-                          headers=headers, status=201)
+        headers = {**self.headers, "If-None-Match": "*"}
+        self.app.put_json(group_url, MINIMALIST_GROUP, headers=headers, status=201)
 
     def test_groups_data_is_optional_with_patch(self):
-        valid = {'permissions': {'write': ['github:me']}}
-        self.app.put_json(self.group_url, MINIMALIST_GROUP,
-                          headers=self.headers)
-        self.app.patch_json(self.group_url,
-                            valid,
-                            headers=self.headers)
+        valid = {"permissions": {"write": ["github:me"]}}
+        self.app.put_json(self.group_url, MINIMALIST_GROUP, headers=self.headers)
+        self.app.patch_json(self.group_url, valid, headers=self.headers)

--- a/tests/test_views_hello.py
+++ b/tests/test_views_hello.py
@@ -6,78 +6,75 @@ from .support import BaseWebTest, MINIMALIST_BUCKET, MINIMALIST_GROUP
 
 
 class HelloViewTest(BaseWebTest, unittest.TestCase):
-
     def test_returns_info_about_url_and_version(self):
-        response = self.app.get('/')
-        self.assertEqual(response.json['project_name'], 'kinto')
-        self.assertEqual(response.json['project_version'], VERSION)
-        self.assertEqual(response.json['project_docs'],
-                         'https://kinto.readthedocs.io/')
-        self.assertEqual(response.json['url'], 'http://localhost/v1/')
+        response = self.app.get("/")
+        self.assertEqual(response.json["project_name"], "kinto")
+        self.assertEqual(response.json["project_version"], VERSION)
+        self.assertEqual(response.json["project_docs"], "https://kinto.readthedocs.io/")
+        self.assertEqual(response.json["url"], "http://localhost/v1/")
 
     def test_project_name_can_be_overriden(self):
-        settings = {'project_name': 'RemoteSettings'}
+        settings = {"project_name": "RemoteSettings"}
         app = self.make_app(settings=settings)
-        resp = app.get('/')
-        self.assertEqual(resp.json['project_name'], 'RemoteSettings')
+        resp = app.get("/")
+        self.assertEqual(resp.json["project_name"], "RemoteSettings")
 
     def test_hides_user_info_if_anonymous(self):
-        response = self.app.get('/')
-        self.assertNotIn('user', response.json)
+        response = self.app.get("/")
+        self.assertNotIn("user", response.json)
 
     def test_returns_user_id_if_authenticated(self):
-        response = self.app.get('/', headers=self.headers)
-        self.assertEqual(response.json['user']['id'], self.principal)
+        response = self.app.get("/", headers=self.headers)
+        self.assertEqual(response.json["user"]["id"], self.principal)
 
     def test_returns_user_principals_if_authenticated(self):
-        group_url = '/buckets/beers/groups/users'
+        group_url = "/buckets/beers/groups/users"
         group = {**MINIMALIST_GROUP}
-        group['data']['members'].append(self.principal)
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET, headers=self.headers)
+        group["data"]["members"].append(self.principal)
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
         self.app.put_json(group_url, group, headers=self.headers)
-        response = self.app.get('/', headers=self.headers).json['user']['principals']
-        principals = ('system.Everyone', 'system.Authenticated',
-                      group_url, self.principal)
+        response = self.app.get("/", headers=self.headers).json["user"]["principals"]
+        principals = ("system.Everyone", "system.Authenticated", group_url, self.principal)
         self.assertEqual(sorted(response), sorted(principals))
 
     def test_capability_is_exposed_if_setting_is_set(self):
-        settings = {'experimental_collection_schema_validation': True}
+        settings = {"experimental_collection_schema_validation": True}
         app = self.make_app(settings=settings)
-        resp = app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('schema', capabilities)
+        resp = app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("schema", capabilities)
         expected = {
             "description": "Validates collection records with JSON schemas.",
             "url": "https://kinto.readthedocs.io/en/latest/api/1.x/"
-                   "collections.html#collection-json-schema",
+            "collections.html#collection-json-schema",
         }
-        self.assertEqual(expected, capabilities['schema'])
+        self.assertEqual(expected, capabilities["schema"])
 
     def test_capability_is_exposed_if_setting_is_not_set(self):
         settings = self.get_app_settings()
-        settings['experimental_collection_schema_validation'] = False
+        settings["experimental_collection_schema_validation"] = False
         app = self.make_app(settings=settings)
-        resp = app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertNotIn('schema', capabilities)
+        resp = app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertNotIn("schema", capabilities)
 
     def test_permissions_capability_if_enabled(self):
-        settings = {'experimental_permissions_endpoint': True}
+        settings = {"experimental_permissions_endpoint": True}
         app = self.make_app(settings=settings)
-        resp = app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertIn('permissions_endpoint', capabilities)
+        resp = app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertIn("permissions_endpoint", capabilities)
         expected = {
             "description": "The permissions endpoint can be used to list "
-                           "all user objects permissions.",
+            "all user objects permissions.",
             "url": "https://kinto.readthedocs.io/en/latest/configuration/"
-                   "settings.html#activating-the-permissions-endpoint"
+            "settings.html#activating-the-permissions-endpoint",
         }
-        self.assertEqual(expected, capabilities['permissions_endpoint'])
+        self.assertEqual(expected, capabilities["permissions_endpoint"])
 
     def test_permissions_capability_if_not_enabled(self):
-        settings = {'experimental_permissions_endpoint': False}
+        settings = {"experimental_permissions_endpoint": False}
         app = self.make_app(settings=settings)
-        resp = app.get('/')
-        capabilities = resp.json['capabilities']
-        self.assertNotIn('permissions_endpoint', capabilities)
+        resp = app.get("/")
+        capabilities = resp.json["capabilities"]
+        self.assertNotIn("permissions_endpoint", capabilities)

--- a/tests/test_views_objects_permissions.py
+++ b/tests/test_views_objects_permissions.py
@@ -2,102 +2,95 @@ import unittest
 
 from kinto.core.testing import get_user_headers
 
-from .support import (BaseWebTest,
-                      MINIMALIST_BUCKET, MINIMALIST_COLLECTION,
-                      MINIMALIST_GROUP, MINIMALIST_RECORD)
+from .support import (
+    BaseWebTest,
+    MINIMALIST_BUCKET,
+    MINIMALIST_COLLECTION,
+    MINIMALIST_GROUP,
+    MINIMALIST_RECORD,
+)
 
 
 class PermissionsTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.alice_headers = {**cls.headers, **get_user_headers('alice')}
-        cls.bob_headers = {**cls.headers, **get_user_headers('bob')}
+        cls.alice_headers = {**cls.headers, **get_user_headers("alice")}
+        cls.bob_headers = {**cls.headers, **get_user_headers("bob")}
 
-        cls.alice_principal = ('basicauth:d5b0026601f1b251974e09548d44155e16'
-                               '812e3c64ff7ae053fe3542e2ca1570')
-        cls.bob_principal = ('basicauth:c031ced27503f788b102ca54269a062ec737'
-                             '94bb075154c74a0d4311e74ca8b6')
+        cls.alice_principal = (
+            "basicauth:d5b0026601f1b251974e09548d44155e16" "812e3c64ff7ae053fe3542e2ca1570"
+        )
+        cls.bob_principal = (
+            "basicauth:c031ced27503f788b102ca54269a062ec737" "94bb075154c74a0d4311e74ca8b6"
+        )
 
 
 class BucketPermissionsTest(PermissionsTest):
-
     def setUp(self):
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {'read': [self.alice_principal]}}
-        self.app.put_json('/buckets/sodas',
-                          bucket,
-                          headers=self.headers)
+        bucket = {**MINIMALIST_BUCKET, "permissions": {"read": [self.alice_principal]}}
+        self.app.put_json("/buckets/sodas", bucket, headers=self.headers)
 
     def test_creation_is_allowed_to_authenticated_by_default(self):
-        self.app.put_json('/buckets/beer',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beer", MINIMALIST_BUCKET, headers=self.headers)
 
     def test_current_user_receives_write_permission_on_creation(self):
-        resp = self.app.put_json('/buckets/beer',
-                                 MINIMALIST_BUCKET,
-                                 headers=self.headers)
-        permissions = resp.json['permissions']
-        self.assertIn(self.principal, permissions['write'])
+        resp = self.app.put_json("/buckets/beer", MINIMALIST_BUCKET, headers=self.headers)
+        permissions = resp.json["permissions"]
+        self.assertIn(self.principal, permissions["write"])
 
     def test_can_read_if_allowed(self):
-        self.app.get('/buckets/sodas',
-                     headers=self.alice_headers)
+        self.app.get("/buckets/sodas", headers=self.alice_headers)
 
     def test_cannot_write_if_not_allowed(self):
-        self.app.put_json('/buckets/sodas',
-                          MINIMALIST_BUCKET,
-                          headers=self.alice_headers,
-                          status=403)
+        self.app.put_json(
+            "/buckets/sodas", MINIMALIST_BUCKET, headers=self.alice_headers, status=403
+        )
 
     def test_permissions_are_not_returned_if_can_only_read(self):
-        resp = self.app.get('/buckets/sodas', headers=self.alice_headers)
-        self.assertEqual(resp.json['permissions'], {})
+        resp = self.app.get("/buckets/sodas", headers=self.alice_headers)
+        self.assertEqual(resp.json["permissions"], {})
 
     def test_permissions_are_returned_if_can_write(self):
-        resp = self.app.get('/buckets/sodas', headers=self.headers)
-        self.assertIn('write', resp.json['permissions'])
+        resp = self.app.get("/buckets/sodas", headers=self.headers)
+        self.assertIn("write", resp.json["permissions"])
 
 
 class CollectionPermissionsTest(PermissionsTest):
-
     def setUp(self):
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {
-            'read': [self.alice_principal],
-            'write': [self.bob_principal]
-        }}
-        self.app.put_json('/buckets/beer',
-                          bucket,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beer/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        bucket = {
+            **MINIMALIST_BUCKET,
+            "permissions": {"read": [self.alice_principal], "write": [self.bob_principal]},
+        }
+        self.app.put_json("/buckets/beer", bucket, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beer/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
 
     def test_passing_unicode_on_parent_id_is_supported(self):
-        self.app.get('/buckets/block%C2%93%C2%96sts/collections/barley',
-                     headers=self.alice_headers,
-                     status=403)
+        self.app.get(
+            "/buckets/block%C2%93%C2%96sts/collections/barley",
+            headers=self.alice_headers,
+            status=403,
+        )
 
     def test_read_is_allowed_if_read_on_bucket(self):
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=self.alice_headers)
+        self.app.get("/buckets/beer/collections/barley", headers=self.alice_headers)
 
     def test_read_is_allowed_if_write_on_bucket(self):
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=self.bob_headers)
+        self.app.get("/buckets/beer/collections/barley", headers=self.bob_headers)
 
     def test_cannot_read_if_not_allowed(self):
-        headers = {**self.headers, **get_user_headers('jean-louis')}
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=headers,
-                     status=403)
+        headers = {**self.headers, **get_user_headers("jean-louis")}
+        self.app.get("/buckets/beer/collections/barley", headers=headers, status=403)
 
     def test_cannot_write_if_not_allowed(self):
-        self.app.put_json('/buckets/beer/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.alice_headers,
-                          status=403)
+        self.app.put_json(
+            "/buckets/beer/collections/barley",
+            MINIMALIST_COLLECTION,
+            headers=self.alice_headers,
+            status=403,
+        )
 
     def test_permission_backend_prevent_sql_injections(self):
         self.app.get("/buckets/beer'", headers=self.headers, status=403)
@@ -112,194 +105,216 @@ class CollectionPermissionsTest(PermissionsTest):
 
 
 class GroupPermissionsTest(PermissionsTest):
-
     def setUp(self):
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {
-            'read': [self.alice_principal],
-            'write': [self.bob_principal]
-        }}
-        self.app.put_json('/buckets/beer',
-                          bucket,
-                          headers=self.headers)
+        bucket = {
+            **MINIMALIST_BUCKET,
+            "permissions": {"read": [self.alice_principal], "write": [self.bob_principal]},
+        }
+        self.app.put_json("/buckets/beer", bucket, headers=self.headers)
 
-        self.app.put_json('/buckets/beer/groups/moderators',
-                          MINIMALIST_GROUP,
-                          headers=self.headers)
+        self.app.put_json(
+            "/buckets/beer/groups/moderators", MINIMALIST_GROUP, headers=self.headers
+        )
 
     def test_creation_is_allowed_if_write_on_bucket(self):
-        self.app.post_json('/buckets/beer/groups',
-                           MINIMALIST_GROUP,
-                           headers=self.headers)
+        self.app.post_json("/buckets/beer/groups", MINIMALIST_GROUP, headers=self.headers)
 
     def test_read_is_allowed_if_read_on_bucket(self):
-        self.app.get('/buckets/beer/groups/moderators',
-                     headers=self.alice_headers)
+        self.app.get("/buckets/beer/groups/moderators", headers=self.alice_headers)
 
     def test_read_is_allowed_if_write_on_bucket(self):
-        self.app.get('/buckets/beer/groups/moderators',
-                     headers=self.bob_headers)
+        self.app.get("/buckets/beer/groups/moderators", headers=self.bob_headers)
 
     def test_cannot_read_if_not_allowed(self):
-        headers = {**self.headers, **get_user_headers('jean-louis')}
-        self.app.get('/buckets/beer/groups/moderators',
-                     headers=headers,
-                     status=403)
+        headers = {**self.headers, **get_user_headers("jean-louis")}
+        self.app.get("/buckets/beer/groups/moderators", headers=headers, status=403)
 
     def test_cannot_write_if_not_allowed(self):
-        self.app.put_json('/buckets/beer/groups/moderators',
-                          MINIMALIST_GROUP,
-                          headers=self.alice_headers,
-                          status=403)
+        self.app.put_json(
+            "/buckets/beer/groups/moderators",
+            MINIMALIST_GROUP,
+            headers=self.alice_headers,
+            status=403,
+        )
 
     def test_creation_is_forbidden_is_no_write_on_bucket(self):
-        self.app.post_json('/buckets/beer/groups',
-                           MINIMALIST_GROUP,
-                           headers=self.alice_headers,
-                           status=403)
+        self.app.post_json(
+            "/buckets/beer/groups", MINIMALIST_GROUP, headers=self.alice_headers, status=403
+        )
 
 
 class RecordPermissionsTest(PermissionsTest):
-
     def setUp(self):
-        bucket = {**MINIMALIST_BUCKET, 'permissions': {'write': [self.alice_principal]}}
-        self.app.put_json('/buckets/beer',
-                          bucket,
-                          headers=self.headers)
+        bucket = {**MINIMALIST_BUCKET, "permissions": {"write": [self.alice_principal]}}
+        self.app.put_json("/buckets/beer", bucket, headers=self.headers)
 
-        collection = {**MINIMALIST_COLLECTION, 'permissions': {'write': [self.bob_principal]}}
-        self.app.put_json('/buckets/beer/collections/barley',
-                          collection,
-                          headers=self.headers)
+        collection = {**MINIMALIST_COLLECTION, "permissions": {"write": [self.bob_principal]}}
+        self.app.put_json("/buckets/beer/collections/barley", collection, headers=self.headers)
 
     def test_creation_is_allowed_if_write_on_bucket(self):
-        self.app.post_json('/buckets/beer/collections/barley/records',
-                           MINIMALIST_RECORD,
-                           headers=self.alice_headers)
+        self.app.post_json(
+            "/buckets/beer/collections/barley/records",
+            MINIMALIST_RECORD,
+            headers=self.alice_headers,
+        )
 
     def test_creation_is_allowed_if_write_on_collection(self):
-        self.app.post_json('/buckets/beer/collections/barley/records',
-                           MINIMALIST_RECORD,
-                           headers=self.bob_headers)
+        self.app.post_json(
+            "/buckets/beer/collections/barley/records", MINIMALIST_RECORD, headers=self.bob_headers
+        )
 
     def test_creation_is_forbidden_is_no_write_on_bucket_nor_collection(self):
-        headers = {**self.headers, **get_user_headers('jean-louis')}
-        self.app.post_json('/buckets/beer/collections/barley/records',
-                           MINIMALIST_RECORD,
-                           headers=headers,
-                           status=403)
+        headers = {**self.headers, **get_user_headers("jean-louis")}
+        self.app.post_json(
+            "/buckets/beer/collections/barley/records",
+            MINIMALIST_RECORD,
+            headers=headers,
+            status=403,
+        )
 
     def test_record_permissions_are_modified_by_patch(self):
-        collection_url = '/buckets/beer/collections/barley/records'
-        resp = self.app.post_json(collection_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        record = resp.json['data']
-        resp = self.app.patch_json('{}/{}'.format(collection_url, record['id']),
-                                   {'permissions': {'read': ['fxa:user']}},
-                                   headers=self.headers)
-        self.assertIn('fxa:user', resp.json['permissions']['read'])
+        collection_url = "/buckets/beer/collections/barley/records"
+        resp = self.app.post_json(collection_url, MINIMALIST_RECORD, headers=self.headers)
+        record = resp.json["data"]
+        resp = self.app.patch_json(
+            "{}/{}".format(collection_url, record["id"]),
+            {"permissions": {"read": ["fxa:user"]}},
+            headers=self.headers,
+        )
+        self.assertIn("fxa:user", resp.json["permissions"]["read"])
 
 
 class ChildrenCreationTest(PermissionsTest):
     def setUp(self):
-        self.app.put_json('/buckets/create',
-                          {'permissions': {'group:create': ['system.Authenticated']}},
-                          headers=self.alice_headers)
-        self.app.put_json('/buckets/write',
-                          {'permissions': {'write': ['system.Authenticated']}},
-                          headers=self.alice_headers)
-        self.app.put_json('/buckets/read',
-                          {'permissions': {'read': ['system.Authenticated']}},
-                          headers=self.alice_headers)
-        for parent in ('create', 'write', 'read'):
-            self.app.put_json('/buckets/{}/groups/child'.format(parent),
-                              MINIMALIST_GROUP,
-                              headers=self.alice_headers)
-        self.bob_headers_safe_creation = dict({'If-None-Match': '*'},
-                                              **self.bob_headers)
+        self.app.put_json(
+            "/buckets/create",
+            {"permissions": {"group:create": ["system.Authenticated"]}},
+            headers=self.alice_headers,
+        )
+        self.app.put_json(
+            "/buckets/write",
+            {"permissions": {"write": ["system.Authenticated"]}},
+            headers=self.alice_headers,
+        )
+        self.app.put_json(
+            "/buckets/read",
+            {"permissions": {"read": ["system.Authenticated"]}},
+            headers=self.alice_headers,
+        )
+        for parent in ("create", "write", "read"):
+            self.app.put_json(
+                "/buckets/{}/groups/child".format(parent),
+                MINIMALIST_GROUP,
+                headers=self.alice_headers,
+            )
+        self.bob_headers_safe_creation = dict({"If-None-Match": "*"}, **self.bob_headers)
 
     def test_cannot_read_others_objects_if_only_allowed_to_create(self):
-        self.app.get('/buckets/create/groups/child', headers=self.bob_headers, status=403)
+        self.app.get("/buckets/create/groups/child", headers=self.bob_headers, status=403)
 
     def test_safe_creation_with_put_returns_412_if_allowed_to_create(self):
-        self.app.put_json('/buckets/create/groups/child',
-                          MINIMALIST_GROUP,
-                          headers=self.bob_headers_safe_creation, status=412)
+        self.app.put_json(
+            "/buckets/create/groups/child",
+            MINIMALIST_GROUP,
+            headers=self.bob_headers_safe_creation,
+            status=412,
+        )
 
     def test_safe_creation_with_post_returns_412_if_allowed_to_create(self):
-        self.app.post_json('/buckets/create/groups',
-                           {'data': {'id': 'child', 'members': []}},
-                           headers=self.bob_headers_safe_creation, status=412)
+        self.app.post_json(
+            "/buckets/create/groups",
+            {"data": {"id": "child", "members": []}},
+            headers=self.bob_headers_safe_creation,
+            status=412,
+        )
 
     def test_safe_creation_with_put_returns_412_if_allowed_to_write(self):
-        self.app.put_json('/buckets/write/groups/child',
-                          MINIMALIST_GROUP,
-                          headers=self.bob_headers_safe_creation, status=412)
+        self.app.put_json(
+            "/buckets/write/groups/child",
+            MINIMALIST_GROUP,
+            headers=self.bob_headers_safe_creation,
+            status=412,
+        )
 
     def test_safe_creation_with_post_returns_412_if_allowed_to_write(self):
-        self.app.post_json('/buckets/write/groups',
-                           {'data': {'id': 'child', 'members': []}},
-                           headers=self.bob_headers_safe_creation, status=412)
+        self.app.post_json(
+            "/buckets/write/groups",
+            {"data": {"id": "child", "members": []}},
+            headers=self.bob_headers_safe_creation,
+            status=412,
+        )
 
     def test_safe_creation_with_put_returns_403_if_only_allowed_to_read(self):
-        self.app.put_json('/buckets/read/groups/child',
-                          MINIMALIST_GROUP,
-                          headers=self.bob_headers_safe_creation, status=403)
+        self.app.put_json(
+            "/buckets/read/groups/child",
+            MINIMALIST_GROUP,
+            headers=self.bob_headers_safe_creation,
+            status=403,
+        )
 
     def test_safe_creation_with_post_returns_403_if_only_allowed_to_read(self):
-        self.app.post_json('/buckets/read/groups',
-                           {'data': {'id': 'child', 'members': []}},
-                           headers=self.bob_headers_safe_creation, status=403)
+        self.app.post_json(
+            "/buckets/read/groups",
+            {"data": {"id": "child", "members": []}},
+            headers=self.bob_headers_safe_creation,
+            status=403,
+        )
 
     def test_delete_returns_404_on_unknown_if_only_allowed_to_read(self):
-        self.app.delete('/buckets/read/groups/g1',
-                        headers=self.bob_headers,
-                        status=404)
+        self.app.delete("/buckets/read/groups/g1", headers=self.bob_headers, status=404)
 
     def test_patch_returns_404_on_unknown_if_only_allowed_to_read(self):
-        self.app.patch_json('/buckets/read/groups/g1',
-                            {'data': {'members': []}},
-                            headers=self.bob_headers,
-                            status=404)
+        self.app.patch_json(
+            "/buckets/read/groups/g1",
+            {"data": {"members": []}},
+            headers=self.bob_headers,
+            status=404,
+        )
 
 
 class ParentMetadataTest(PermissionsTest):
     def setUp(self):
-        self.app.put_json('/buckets/beer',
-                          {'permissions': {'collection:create': [self.bob_principal]}},
-                          headers=self.headers)
+        self.app.put_json(
+            "/buckets/beer",
+            {"permissions": {"collection:create": [self.bob_principal]}},
+            headers=self.headers,
+        )
 
-        self.app.put_json('/buckets/beer/collections/wheat', headers=self.headers)
-        self.app.put_json('/buckets/beer/collections/root', headers=self.headers)
+        self.app.put_json("/buckets/beer/collections/wheat", headers=self.headers)
+        self.app.put_json("/buckets/beer/collections/root", headers=self.headers)
 
-        self.app.put_json('/buckets/beer/collections/barley',
-                          {'permissions': {'record:create': [self.alice_principal]}},
-                          headers=self.bob_headers)
+        self.app.put_json(
+            "/buckets/beer/collections/barley",
+            {"permissions": {"record:create": [self.alice_principal]}},
+            headers=self.bob_headers,
+        )
 
     def test_parent_metadata_can_be_read_if_allowed_to_create_child(self):
-        self.app.get('/buckets/beer', headers=self.bob_headers)
-        self.app.get('/buckets/beer/collections/barley', headers=self.alice_headers)
+        self.app.get("/buckets/beer", headers=self.bob_headers)
+        self.app.get("/buckets/beer/collections/barley", headers=self.alice_headers)
 
     def test_parent_metadata_cannot_be_read_if_not_allowed_to_create_child(self):
-        self.app.get('/buckets/beer',
-                     headers=get_user_headers('jean:paul'),
-                     status=403)
-        self.app.get('/buckets/beer/collections/barley',
-                     headers=get_user_headers('mahmud:hatim'),
-                     status=403)
+        self.app.get("/buckets/beer", headers=get_user_headers("jean:paul"), status=403)
+        self.app.get(
+            "/buckets/beer/collections/barley",
+            headers=get_user_headers("mahmud:hatim"),
+            status=403,
+        )
 
     def test_list_can_be_obtained_if_allowed_to_create(self):
-        resp = self.app.get('/buckets/beer/collections', headers=self.bob_headers)
-        self.assertEqual(len(resp.json['data']), 1)
-        self.assertEqual(resp.json['data'][0]['id'], 'barley')
+        resp = self.app.get("/buckets/beer/collections", headers=self.bob_headers)
+        self.assertEqual(len(resp.json["data"]), 1)
+        self.assertEqual(resp.json["data"][0]["id"], "barley")
 
-        resp = self.app.get('/buckets/beer/collections/barley/records', headers=self.alice_headers)
-        self.assertEqual(resp.json['data'], [])
+        resp = self.app.get("/buckets/beer/collections/barley/records", headers=self.alice_headers)
+        self.assertEqual(resp.json["data"], [])
 
     def test_list_is_denied_if_not_allowed_to_create(self):
-        self.app.get('/buckets/beer/collections',
-                     headers=get_user_headers('jean:paul'),
-                     status=403)
-        self.app.get('/buckets/beer/collections/barley/records',
-                     headers=get_user_headers('mahmud:hatim'),
-                     status=403)
+        self.app.get(
+            "/buckets/beer/collections", headers=get_user_headers("jean:paul"), status=403
+        )
+        self.app.get(
+            "/buckets/beer/collections/barley/records",
+            headers=get_user_headers("mahmud:hatim"),
+            status=403,
+        )

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -2,199 +2,203 @@ import unittest
 
 from kinto.core.testing import get_user_headers
 
-from .support import (BaseWebTest, MINIMALIST_RECORD,
-                      MINIMALIST_GROUP, MINIMALIST_BUCKET,
-                      MINIMALIST_COLLECTION)
+from .support import (
+    BaseWebTest,
+    MINIMALIST_RECORD,
+    MINIMALIST_GROUP,
+    MINIMALIST_BUCKET,
+    MINIMALIST_COLLECTION,
+)
 
 
-RECORD_ID = 'd5db6e57-2c10-43e2-96c8-56602ef01435'
+RECORD_ID = "d5db6e57-2c10-43e2-96c8-56602ef01435"
 
 
 class PermissionsViewTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_permissions_endpoint'] = 'True'
+        settings["experimental_permissions_endpoint"] = "True"
         return settings
 
 
 class PermissionsUnauthenticatedViewTest(BaseWebTest, unittest.TestCase):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_permissions_endpoint'] = 'True'
-        settings['bucket_create_principals'] = 'system.Everyone'
+        settings["experimental_permissions_endpoint"] = "True"
+        settings["bucket_create_principals"] = "system.Everyone"
         return settings
 
     def setUp(self):
         super().setUp()
-        self.everyone_headers = get_user_headers('')
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.everyone_headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.everyone_headers)
-        self.app.put_json('/buckets/beers/groups/amateurs',
-                          MINIMALIST_GROUP,
-                          headers=self.everyone_headers)
-        self.app.put_json('/buckets/beers/groups/barley',
-                          MINIMALIST_GROUP,
-                          headers=self.everyone_headers)
-        self.app.put_json('/buckets/beers/collections/barley/records/{}'.format(RECORD_ID),
-                          MINIMALIST_RECORD,
-                          headers=self.everyone_headers)
+        self.everyone_headers = get_user_headers("")
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.everyone_headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley",
+            MINIMALIST_COLLECTION,
+            headers=self.everyone_headers,
+        )
+        self.app.put_json(
+            "/buckets/beers/groups/amateurs", MINIMALIST_GROUP, headers=self.everyone_headers
+        )
+        self.app.put_json(
+            "/buckets/beers/groups/barley", MINIMALIST_GROUP, headers=self.everyone_headers
+        )
+        self.app.put_json(
+            "/buckets/beers/collections/barley/records/{}".format(RECORD_ID),
+            MINIMALIST_RECORD,
+            headers=self.everyone_headers,
+        )
 
         # Other user.
-        self.app.put_json('/buckets/water', MINIMALIST_BUCKET,
-                          headers=get_user_headers('alice'))
+        self.app.put_json("/buckets/water", MINIMALIST_BUCKET, headers=get_user_headers("alice"))
 
     def test_permissions_list_entries_for_everyone(self):
-        resp = self.app.get('/permissions', headers=self.everyone_headers)
-        buckets = resp.json['data']
+        resp = self.app.get("/permissions", headers=self.everyone_headers)
+        buckets = resp.json["data"]
         self.assertEqual(len(buckets), 6)
 
-        uris = [bucket['uri'] for bucket in buckets]
-        self.assertEqual(sorted(uris), [
-            '/',
-            '/buckets/beers',
-            '/buckets/beers/collections/barley',
-            '/buckets/beers/collections/barley/records/{}'.format(RECORD_ID),
-            '/buckets/beers/groups/amateurs',
-            '/buckets/beers/groups/barley',
-        ])
+        uris = [bucket["uri"] for bucket in buckets]
+        self.assertEqual(
+            sorted(uris),
+            [
+                "/",
+                "/buckets/beers",
+                "/buckets/beers/collections/barley",
+                "/buckets/beers/collections/barley/records/{}".format(RECORD_ID),
+                "/buckets/beers/groups/amateurs",
+                "/buckets/beers/groups/barley",
+            ],
+        )
 
     def test_bucket_create_permission_exists(self):
-        resp = self.app.get('/permissions', headers=self.everyone_headers)
-        buckets = resp.json['data']
-        toplevel_bucket = [b for b in buckets if b['resource_name'] == 'root']
-        self.assertEqual(toplevel_bucket, [{
-            'permissions': ['bucket:create'],
-            'resource_name': 'root',
-            'uri': '/'}])
+        resp = self.app.get("/permissions", headers=self.everyone_headers)
+        buckets = resp.json["data"]
+        toplevel_bucket = [b for b in buckets if b["resource_name"] == "root"]
+        self.assertEqual(
+            toplevel_bucket,
+            [{"permissions": ["bucket:create"], "resource_name": "root", "uri": "/"}],
+        )
 
     def test_permissions_can_be_paginated(self):
         """Verify that pagination doesn't squash same IDs"""
         # kinto_http.js uses this sort of request when listing permissions
-        real_permissions = self.app.get('/permissions', headers=self.everyone_headers).json['data']
+        real_permissions = self.app.get("/permissions", headers=self.everyone_headers).json["data"]
 
         def sort_by_uri(l):
-            return sorted(l, key=lambda r: r['uri'])
+            return sorted(l, key=lambda r: r["uri"])
 
-        for order in ['id', '-id', 'uri', '-uri']:
+        for order in ["id", "-id", "uri", "-uri"]:
             for limit in range(1, 10):
                 with self.subTest(order=order, limit=limit):
                     records = []
-                    resp = self.app.get('/permissions?_sort={}&_limit={}'.format(order, limit),
-                                        headers=self.everyone_headers)
-                    records = records + resp.json['data']
-                    while 'Next-Page' in resp.headers:
-                        next_url = resp.headers['Next-Page'][len('http://localhost/v1'):]
+                    resp = self.app.get(
+                        "/permissions?_sort={}&_limit={}".format(order, limit),
+                        headers=self.everyone_headers,
+                    )
+                    records = records + resp.json["data"]
+                    while "Next-Page" in resp.headers:
+                        next_url = resp.headers["Next-Page"][len("http://localhost/v1") :]
                         resp = self.app.get(next_url, headers=self.everyone_headers)
-                        records = records + resp.json['data']
+                        records = records + resp.json["data"]
 
-                    self.assertEqual(sort_by_uri(real_permissions),
-                                     sort_by_uri(records))
+                    self.assertEqual(sort_by_uri(real_permissions), sort_by_uri(records))
 
     def test_object_details_are_provided(self):
-        resp = self.app.get('/permissions', headers=self.everyone_headers)
-        entries = resp.json['data']
+        resp = self.app.get("/permissions", headers=self.everyone_headers)
+        entries = resp.json["data"]
         for entry in entries:
-            if entry['resource_name'] == 'record':
+            if entry["resource_name"] == "record":
                 record_permission = entry
-        self.assertEqual(record_permission['record_id'], RECORD_ID)
-        self.assertEqual(record_permission['collection_id'], 'barley')
-        self.assertEqual(record_permission['bucket_id'], 'beers')
+        self.assertEqual(record_permission["record_id"], RECORD_ID)
+        self.assertEqual(record_permission["collection_id"], "barley")
+        self.assertEqual(record_permission["bucket_id"], "beers")
 
 
 class EntriesTest(PermissionsViewTest):
-
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/groups/amateurs',
-                          MINIMALIST_GROUP,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley/records/{}'.format(RECORD_ID),
-                          MINIMALIST_RECORD,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        self.app.put_json("/buckets/beers/groups/amateurs", MINIMALIST_GROUP, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley/records/{}".format(RECORD_ID),
+            MINIMALIST_RECORD,
+            headers=self.headers,
+        )
 
         # Other user.
-        self.app.put_json('/buckets/water', MINIMALIST_BUCKET,
-                          headers=get_user_headers('alice'))
+        self.app.put_json("/buckets/water", MINIMALIST_BUCKET, headers=get_user_headers("alice"))
 
     def test_permissions_list_entries_for_current_principal(self):
-        resp = self.app.get('/permissions', headers=self.headers)
-        permissions = resp.json['data']
+        resp = self.app.get("/permissions", headers=self.headers)
+        permissions = resp.json["data"]
         self.assertEqual(len(permissions), 5)
 
     def test_permissions_can_be_listed_anonymously(self):
-        self.app.patch_json('/buckets/beers/collections/barley',
-                            {'permissions': {'write': ['system.Everyone']}},
-                            headers=self.headers)
-        resp = self.app.get('/permissions')
-        permissions = resp.json['data']
+        self.app.patch_json(
+            "/buckets/beers/collections/barley",
+            {"permissions": {"write": ["system.Everyone"]}},
+            headers=self.headers,
+        )
+        resp = self.app.get("/permissions")
+        permissions = resp.json["data"]
         self.assertEqual(len(permissions), 1)
 
     def test_implicit_permissions_are_explicited(self):
-        resp = self.app.get('/permissions', headers=get_user_headers('alice'))
-        permissions = resp.json['data']
+        resp = self.app.get("/permissions", headers=get_user_headers("alice"))
+        permissions = resp.json["data"]
         bucket_permissions = permissions[0]
-        self.assertEqual(sorted(bucket_permissions['permissions']),
-                         ['collection:create',
-                          'group:create',
-                          'read',
-                          'read:attributes',
-                          'write'])
+        self.assertEqual(
+            sorted(bucket_permissions["permissions"]),
+            ["collection:create", "group:create", "read", "read:attributes", "write"],
+        )
 
     def test_object_details_are_provided(self):
-        resp = self.app.get('/permissions', headers=self.headers)
-        entries = resp.json['data']
+        resp = self.app.get("/permissions", headers=self.headers)
+        entries = resp.json["data"]
         for entry in entries:
-            if entry['resource_name'] == 'record':
+            if entry["resource_name"] == "record":
                 record_permission = entry
-        self.assertEqual(record_permission['record_id'], RECORD_ID)
-        self.assertEqual(record_permission['collection_id'], 'barley')
-        self.assertEqual(record_permission['bucket_id'], 'beers')
+        self.assertEqual(record_permission["record_id"], RECORD_ID)
+        self.assertEqual(record_permission["collection_id"], "barley")
+        self.assertEqual(record_permission["bucket_id"], "beers")
 
     def test_permissions_list_can_be_filtered(self):
-        resp = self.app.get('/permissions?in_resource_name=bucket,collection',
-                            headers=self.headers)
-        permissions = resp.json['data']
+        resp = self.app.get(
+            "/permissions?in_resource_name=bucket,collection", headers=self.headers
+        )
+        permissions = resp.json["data"]
         self.assertEqual(len(permissions), 2)
 
     def test_filtering_with_unknown_field_is_not_supported(self):
-        self.app.get('/permissions?movie=bourne',
-                     headers=self.headers,
-                     status=400)
+        self.app.get("/permissions?movie=bourne", headers=self.headers, status=400)
 
     def test_permissions_fields_can_be_selected(self):
-        resp = self.app.get('/permissions?_fields=uri',
-                            headers=self.headers)
-        self.assertNotIn('resource_name', resp.json['data'][0])
+        resp = self.app.get("/permissions?_fields=uri", headers=self.headers)
+        self.assertNotIn("resource_name", resp.json["data"][0])
 
     def test_permissions_list_can_be_paginated(self):
-        resp = self.app.get('/permissions?_limit=2',
-                            headers=self.headers)
-        self.assertEqual(resp.headers['Total-Records'], '5')
-        self.assertIn('Next-Page', resp.headers)
-        self.assertEqual(len(resp.json['data']), 2)
+        resp = self.app.get("/permissions?_limit=2", headers=self.headers)
+        self.assertEqual(resp.headers["Total-Records"], "5")
+        self.assertIn("Next-Page", resp.headers)
+        self.assertEqual(len(resp.json["data"]), 2)
 
     def test_permissions_list_do_not_crash_with_preconditions(self):
-        headers = {'If-None-Match': '"123"', **self.headers}
-        self.app.get('/permissions', headers=headers)
+        headers = {"If-None-Match": '"123"', **self.headers}
+        self.app.get("/permissions", headers=headers)
 
     def test_permissions_can_be_paginated(self):
         for i in range(10):
-            self.app.put_json('/buckets/beers/collections/barley/records/r-{}'.format(i),
-                              MINIMALIST_RECORD,
-                              headers=self.headers)
-        resp = self.app.get('/permissions?resource_name=record&_limit=7', headers=self.headers)
+            self.app.put_json(
+                "/buckets/beers/collections/barley/records/r-{}".format(i),
+                MINIMALIST_RECORD,
+                headers=self.headers,
+            )
+        resp = self.app.get("/permissions?resource_name=record&_limit=7", headers=self.headers)
         page1 = resp.json["data"]
         next_page = resp.headers["Next-Page"].replace("http://localhost/v1", "")
         resp = self.app.get(next_page, headers=self.headers)
@@ -203,11 +207,14 @@ class EntriesTest(PermissionsViewTest):
 
     def test_permissions_can_be_paginated_with_uri_in_sorting(self):
         for i in range(10):
-            self.app.put_json('/buckets/beers/collections/barley/records/r-{}'.format(i),
-                              MINIMALIST_RECORD,
-                              headers=self.headers)
-        resp = self.app.get('/permissions?resource_name=record&_limit=7&_sort=uri',
-                            headers=self.headers)
+            self.app.put_json(
+                "/buckets/beers/collections/barley/records/r-{}".format(i),
+                MINIMALIST_RECORD,
+                headers=self.headers,
+            )
+        resp = self.app.get(
+            "/permissions?resource_name=record&_limit=7&_sort=uri", headers=self.headers
+        )
         page1 = resp.json["data"]
         next_page = resp.headers["Next-Page"].replace("http://localhost/v1", "")
         resp = self.app.get(next_page, headers=self.headers)
@@ -216,140 +223,153 @@ class EntriesTest(PermissionsViewTest):
 
 
 class GroupsPermissionTest(PermissionsViewTest):
-
     def setUp(self):
         super().setUp()
 
-        self.admin_headers = get_user_headers('admin')
-        self.admin_principal = self.app.get('/', headers=self.admin_headers).json['user']['id']
+        self.admin_headers = get_user_headers("admin")
+        self.admin_principal = self.app.get("/", headers=self.admin_headers).json["user"]["id"]
 
-        self.app.put_json('/buckets/beers',
-                          {'permissions': {'write': ['/buckets/beers/groups/admins']}},
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/groups/admins',
-                          {'data': {'members': [self.admin_principal]}},
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers",
+            {"permissions": {"write": ["/buckets/beers/groups/admins"]}},
+            headers=self.headers,
+        )
+        self.app.put_json(
+            "/buckets/beers/groups/admins",
+            {"data": {"members": [self.admin_principal]}},
+            headers=self.headers,
+        )
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
 
-        self.app.put_json('/buckets/sodas',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/groups/admins',
-                          {'data': {'members': [self.admin_principal]}},
-                          headers=self.headers)
-        self.app.put_json('/buckets/sodas/collections/sprite',
-                          {'permissions': {'read': ['/buckets/beers/groups/admins']}},
-                          headers=self.headers)
+        self.app.put_json("/buckets/sodas", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/groups/admins",
+            {"data": {"members": [self.admin_principal]}},
+            headers=self.headers,
+        )
+        self.app.put_json(
+            "/buckets/sodas/collections/sprite",
+            {"permissions": {"read": ["/buckets/beers/groups/admins"]}},
+            headers=self.headers,
+        )
 
     def test_permissions_granted_via_groups_are_listed(self):
-        resp = self.app.get('/permissions', headers=self.admin_headers)
-        buckets = [e for e in resp.json['data'] if e['resource_name'] == 'bucket']
-        self.assertEqual(buckets[0]['id'], 'beers')
-        self.assertIn('write', buckets[0]['permissions'])
+        resp = self.app.get("/permissions", headers=self.admin_headers)
+        buckets = [e for e in resp.json["data"] if e["resource_name"] == "bucket"]
+        self.assertEqual(buckets[0]["id"], "beers")
+        self.assertIn("write", buckets[0]["permissions"])
 
-        collections = [e for e in resp.json['data'] if e['resource_name'] == 'collection']
-        self.assertEqual(collections[0]['id'], 'sprite')
-        self.assertEqual(collections[0]['bucket_id'], 'sodas')
-        self.assertIn('read', collections[0]['permissions'])
+        collections = [e for e in resp.json["data"] if e["resource_name"] == "collection"]
+        self.assertEqual(collections[0]["id"], "sprite")
+        self.assertEqual(collections[0]["bucket_id"], "sodas")
+        self.assertIn("read", collections[0]["permissions"])
 
     def test_permissions_inherited_are_not_listed(self):
-        resp = self.app.get('/permissions', headers=self.admin_headers)
-        collections = [e for e in resp.json['data']
-                       # top level '/' does not have an id
-                       if e['uri'] != '/'
-                       if e['bucket_id'] == 'beers' and e['resource_name'] == 'collection']
+        resp = self.app.get("/permissions", headers=self.admin_headers)
+        collections = [
+            e
+            for e in resp.json["data"]
+            # top level '/' does not have an id
+            if e["uri"] != "/"
+            if e["bucket_id"] == "beers" and e["resource_name"] == "collection"
+        ]
         self.assertEqual(len(collections), 0)
 
 
 class SettingsPermissionsTest(PermissionsViewTest):
 
-    admin_headers = get_user_headers('admin')
-    admin_principal = 'basicauth:bb7fe7b98e759578ef0de85b546dd57d21fe1e399390ad8dafc9886043a00e5c'  # NOQA
+    admin_headers = get_user_headers("admin")
+    admin_principal = (
+        "basicauth:bb7fe7b98e759578ef0de85b546dd57d21fe1e399390ad8dafc9886043a00e5c"
+    )  # NOQA
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['bucket_write_principals'] = 'system.Authenticated'
-        settings['group_create_principals'] = cls.admin_principal
-        settings['collection_write_principals'] = 'system.Authenticated'
-        settings['record_create_principals'] = '/buckets/beers/groups/admins'
+        settings["bucket_write_principals"] = "system.Authenticated"
+        settings["group_create_principals"] = cls.admin_principal
+        settings["collection_write_principals"] = "system.Authenticated"
+        settings["record_create_principals"] = "/buckets/beers/groups/admins"
         return settings
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET, headers=self.headers)
-        self.app.put_json('/buckets/beers/groups/admins',
-                          {'data': {'members': [self.admin_principal]}},
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/groups/admins",
+            {"data": {"members": [self.admin_principal]}},
+            headers=self.headers,
+        )
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
 
     def test_bucket_write_taken_into_account(self):
-        resp = self.app.get('/permissions', headers=get_user_headers("any"))
-        buckets = [e for e in resp.json['data'] if e['resource_name'] == 'bucket']
-        self.assertEqual(buckets[0]['id'], 'beers')
-        self.assertIn('write', buckets[0]['permissions'])
+        resp = self.app.get("/permissions", headers=get_user_headers("any"))
+        buckets = [e for e in resp.json["data"] if e["resource_name"] == "bucket"]
+        self.assertEqual(buckets[0]["id"], "beers")
+        self.assertIn("write", buckets[0]["permissions"])
 
     def test_collection_create_taken_into_account(self):
-        resp = self.app.get('/permissions', headers=self.admin_headers)
-        buckets = [e for e in resp.json['data'] if e['resource_name'] == 'bucket']
-        self.assertEqual(buckets[0]['id'], 'beers')
-        self.assertIn('group:create', buckets[0]['permissions'])
+        resp = self.app.get("/permissions", headers=self.admin_headers)
+        buckets = [e for e in resp.json["data"] if e["resource_name"] == "bucket"]
+        self.assertEqual(buckets[0]["id"], "beers")
+        self.assertIn("group:create", buckets[0]["permissions"])
 
     def test_collection_write_taken_into_account(self):
-        resp = self.app.get('/permissions', headers=get_user_headers("any"))
-        collections = [e for e in resp.json['data'] if e['resource_name'] == 'collection']
-        self.assertEqual(collections[0]['id'], 'barley')
-        self.assertIn('write', collections[0]['permissions'])
+        resp = self.app.get("/permissions", headers=get_user_headers("any"))
+        collections = [e for e in resp.json["data"] if e["resource_name"] == "collection"]
+        self.assertEqual(collections[0]["id"], "barley")
+        self.assertIn("write", collections[0]["permissions"])
 
     def test_record_create_taken_into_account(self):
-        resp = self.app.get('/permissions', headers=self.admin_headers)
-        collections = [e for e in resp.json['data'] if e['resource_name'] == 'collection']
-        self.assertEqual(collections[0]['id'], 'barley')
-        self.assertIn('record:create', collections[0]['permissions'])
+        resp = self.app.get("/permissions", headers=self.admin_headers)
+        collections = [e for e in resp.json["data"] if e["resource_name"] == "collection"]
+        self.assertEqual(collections[0]["id"], "barley")
+        self.assertIn("record:create", collections[0]["permissions"])
 
     def test_settings_permissions_are_merged_with_perms_backend(self):
-        self.app.patch_json('/buckets/beers',
-                            {'permissions': {'collection:create': [self.admin_principal]}},
-                            headers=self.headers)
-        self.app.patch_json('/buckets/beers/collections/barley',
-                            {'permissions': {'read': [self.admin_principal]}},
-                            headers=self.headers)
+        self.app.patch_json(
+            "/buckets/beers",
+            {"permissions": {"collection:create": [self.admin_principal]}},
+            headers=self.headers,
+        )
+        self.app.patch_json(
+            "/buckets/beers/collections/barley",
+            {"permissions": {"read": [self.admin_principal]}},
+            headers=self.headers,
+        )
 
-        resp = self.app.get('/permissions', headers=self.admin_headers)
+        resp = self.app.get("/permissions", headers=self.admin_headers)
 
-        buckets = [e for e in resp.json['data'] if e['resource_name'] == 'bucket']
-        self.assertEqual(buckets[0]['id'], 'beers')
-        self.assertIn('group:create', buckets[0]['permissions'])
-        self.assertIn('collection:create', buckets[0]['permissions'])
+        buckets = [e for e in resp.json["data"] if e["resource_name"] == "bucket"]
+        self.assertEqual(buckets[0]["id"], "beers")
+        self.assertIn("group:create", buckets[0]["permissions"])
+        self.assertIn("collection:create", buckets[0]["permissions"])
 
-        collections = [e for e in resp.json['data'] if e['resource_name'] == 'collection']
-        self.assertEqual(collections[0]['id'], 'barley')
-        self.assertIn('record:create', collections[0]['permissions'])
-        self.assertIn('read', collections[0]['permissions'])
+        collections = [e for e in resp.json["data"] if e["resource_name"] == "collection"]
+        self.assertEqual(collections[0]["id"], "barley")
+        self.assertIn("record:create", collections[0]["permissions"])
+        self.assertIn("read", collections[0]["permissions"])
 
 
 class DeletedObjectsTest(PermissionsViewTest):
-
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/groups/admins',
-                          MINIMALIST_GROUP,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley/records/vieuxsinge',
-                          MINIMALIST_RECORD,
-                          headers=self.headers)
-        self.app.delete('/buckets/beers', headers=self.headers)
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json("/buckets/beers/groups/admins", MINIMALIST_GROUP, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        self.app.put_json(
+            "/buckets/beers/collections/barley/records/vieuxsinge",
+            MINIMALIST_RECORD,
+            headers=self.headers,
+        )
+        self.app.delete("/buckets/beers", headers=self.headers)
 
     def test_deleted_objects_are_not_listed(self):
-        resp = self.app.get('/permissions', headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 1)
+        resp = self.app.get("/permissions", headers=self.headers)
+        self.assertEqual(len(resp.json["data"]), 1)

--- a/tests/test_views_records.py
+++ b/tests/test_views_records.py
@@ -5,441 +5,340 @@ from unittest import mock
 
 from kinto.core.testing import get_user_headers
 
-from .support import (BaseWebTest, MINIMALIST_RECORD,
-                      MINIMALIST_GROUP, MINIMALIST_BUCKET,
-                      MINIMALIST_COLLECTION)
+from .support import (
+    BaseWebTest,
+    MINIMALIST_RECORD,
+    MINIMALIST_GROUP,
+    MINIMALIST_BUCKET,
+    MINIMALIST_COLLECTION,
+)
 
 
 class RecordsViewTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets/beers/collections/barley/records'
-    _record_url = '/buckets/beers/collections/barley/records/{}'
+    collection_url = "/buckets/beers/collections/barley/records"
+    _record_url = "/buckets/beers/collections/barley/records/{}"
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers)
-        self.record = resp.json['data']
-        self.record_url = self._record_url.format(self.record['id'])
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        resp = self.app.post_json(self.collection_url, MINIMALIST_RECORD, headers=self.headers)
+        self.record = resp.json["data"]
+        self.record_url = self._record_url.format(self.record["id"])
 
     def test_records_can_be_accessed_by_id(self):
         self.app.get(self.record_url, headers=self.headers)
 
     def test_unknown_bucket_raises_403(self):
-        other_bucket = self.collection_url.replace('beers', 'sodas')
+        other_bucket = self.collection_url.replace("beers", "sodas")
         self.app.get(other_bucket, headers=self.headers, status=403)
 
     def test_unknown_collection_raises_404(self):
-        other_collection = self.collection_url.replace('barley', 'pills')
+        other_collection = self.collection_url.replace("barley", "pills")
         resp = self.app.get(other_collection, headers=self.headers, status=404)
-        self.assertEqual(resp.json['details']['id'], 'pills')
-        self.assertEqual(resp.json['details']['resource_name'], 'collection')
+        self.assertEqual(resp.json["details"]["id"], "pills")
+        self.assertEqual(resp.json["details"]["resource_name"], "collection")
 
     def test_unknown_record_raises_404(self):
-        other_record = self.record_url.replace(self.record['id'], self.record['id']+'blah')
+        other_record = self.record_url.replace(self.record["id"], self.record["id"] + "blah")
         response = self.app.get(other_record, headers=self.headers, status=404)
-        self.assertEqual(response.json['details']['id'], self.record['id']+'blah')
-        self.assertEqual(response.json['details']['resource_name'], 'record')
+        self.assertEqual(response.json["details"]["id"], self.record["id"] + "blah")
+        self.assertEqual(response.json["details"]["resource_name"], "record")
 
     def test_unknown_collection_does_not_query_timestamp(self):
-        other_collection = self.collection_url.replace('barley', 'pills')
-        patch = mock.patch.object(self.app.app.registry.storage,
-                                  'collection_timestamp')
+        other_collection = self.collection_url.replace("barley", "pills")
+        patch = mock.patch.object(self.app.app.registry.storage, "collection_timestamp")
         self.addCleanup(patch.stop)
         mocked = patch.start()
         self.app.get(other_collection, headers=self.headers, status=404)
         self.assertFalse(mocked.called)
 
     def test_parent_collection_and_bucket_are_fetched_only_once_in_batch(self):
-        batch = {'requests': []}
+        batch = {"requests": []}
         nb_create = 25
         for i in range(nb_create):
-            request = {'method': 'POST',
-                       'path': self.collection_url,
-                       'body': MINIMALIST_RECORD}
-            batch['requests'].append(request)
+            request = {"method": "POST", "path": self.collection_url, "body": MINIMALIST_RECORD}
+            batch["requests"].append(request)
 
-        with mock.patch.object(self.storage, 'get',
-                               wraps=self.storage.get) as patched:
-            self.app.post_json('/batch', batch, headers=self.headers)
+        with mock.patch.object(self.storage, "get", wraps=self.storage.get) as patched:
+            self.app.post_json("/batch", batch, headers=self.headers)
             self.assertEqual(patched.call_count, 1)
 
     def test_individual_collections_can_be_deleted(self):
         resp = self.app.get(self.collection_url, headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 1)
+        self.assertEqual(len(resp.json["data"]), 1)
         self.app.delete(self.collection_url, headers=self.headers)
         resp = self.app.get(self.collection_url, headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 0)
+        self.assertEqual(len(resp.json["data"]), 0)
 
     def test_records_can_be_added_to_collections(self):
         response = self.app.get(self.record_url, headers=self.headers)
-        record = response.json['data']
-        del record['id']
-        del record['last_modified']
-        self.assertEqual(record, MINIMALIST_RECORD['data'])
+        record = response.json["data"]
+        del record["id"]
+        del record["last_modified"]
+        self.assertEqual(record, MINIMALIST_RECORD["data"])
 
     def test_records_are_isolated_by_bucket_and_by_collection(self):
         # By collection.
-        self.app.put_json('/buckets/beers/collections/pills',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
-        other_collection = self.record_url.replace('barley', 'pills')
+        self.app.put_json(
+            "/buckets/beers/collections/pills", MINIMALIST_BUCKET, headers=self.headers
+        )
+        other_collection = self.record_url.replace("barley", "pills")
         self.app.get(other_collection, headers=self.headers, status=404)
 
         # By bucket.
-        self.app.put_json('/buckets/sodas',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/sodas/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        other_bucket = self.record_url.replace('beers', 'sodas')
+        self.app.put_json("/buckets/sodas", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/sodas/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        other_bucket = self.record_url.replace("beers", "sodas")
         self.app.get(other_bucket, headers=self.headers, status=404)
 
         # By bucket and by collection.
-        self.app.put_json('/buckets/be',
-                          MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/be/collections/ba',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        other = self.record_url.replace('barley', 'ba').replace('beers', 'be')
+        self.app.put_json("/buckets/be", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/be/collections/ba", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        other = self.record_url.replace("barley", "ba").replace("beers", "be")
         self.app.get(other, headers=self.headers, status=404)
 
     def test_a_collection_named_group_do_not_interfere_with_groups(self):
         # Create a group.
-        self.app.put_json('/buckets/beers/groups/test',
-                          MINIMALIST_GROUP,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beers/groups/test", MINIMALIST_GROUP, headers=self.headers)
         # Create a record in a collection named "group".
-        self.app.put_json('/buckets/beers/collections/groups',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        collection_group = self.collection_url.replace('barley', 'groups')
-        self.app.post_json(collection_group,
-                           MINIMALIST_RECORD,
-                           headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/groups", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        collection_group = self.collection_url.replace("barley", "groups")
+        self.app.post_json(collection_group, MINIMALIST_RECORD, headers=self.headers)
         # There is still only one group.
-        resp = self.app.get('/buckets/beers/groups', headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 1)
+        resp = self.app.get("/buckets/beers/groups", headers=self.headers)
+        self.assertEqual(len(resp.json["data"]), 1)
 
     def test_records_can_be_filtered_on_any_field(self):
-        self.app.post_json(self.collection_url,
-                           MINIMALIST_RECORD,
-                           headers=self.headers)
-        response = self.app.get(self.collection_url + '?unknown=1',
-                                headers=self.headers)
-        self.assertEqual(len(response.json['data']), 0)
+        self.app.post_json(self.collection_url, MINIMALIST_RECORD, headers=self.headers)
+        response = self.app.get(self.collection_url + "?unknown=1", headers=self.headers)
+        self.assertEqual(len(response.json["data"]), 0)
 
     def test_records_can_be_sorted_on_any_field(self):
         for i in range(3):
-            record = {**MINIMALIST_RECORD, 'data': {
-                **MINIMALIST_RECORD['data'],
-                'name': 'Stout {}'.format(i)}
+            record = {
+                **MINIMALIST_RECORD,
+                "data": {**MINIMALIST_RECORD["data"], "name": "Stout {}".format(i)},
             }
-            self.app.post_json(self.collection_url,
-                               record,
-                               headers=self.headers)
+            self.app.post_json(self.collection_url, record, headers=self.headers)
 
-        response = self.app.get(self.collection_url + '?_sort=-name',
-                                headers=self.headers)
-        names = [i['name'] for i in response.json['data']]
-        self.assertEqual(names,
-                         ['Stout 2', 'Stout 1', 'Stout 0', 'Hulled Barley'])
+        response = self.app.get(self.collection_url + "?_sort=-name", headers=self.headers)
+        names = [i["name"] for i in response.json["data"]]
+        self.assertEqual(names, ["Stout 2", "Stout 1", "Stout 0", "Hulled Barley"])
 
     def test_wrong_create_permissions_cannot_be_added_on_records(self):
-        record = {**MINIMALIST_RECORD, 'permissions': {'record:create': ['fxa:user']}}
-        self.app.put_json(self.record_url,
-                          record,
-                          headers=self.headers,
-                          status=400)
+        record = {**MINIMALIST_RECORD, "permissions": {"record:create": ["fxa:user"]}}
+        self.app.put_json(self.record_url, record, headers=self.headers, status=400)
 
     def test_create_a_record_update_collection_timestamp(self):
-        collection_resp = self.app.get(self.collection_url,
-                                       headers=self.headers)
-        old_timestamp = int(json.loads(collection_resp.headers['ETag']))
-        self.app.post_json(self.collection_url,
-                           MINIMALIST_RECORD,
-                           headers=self.headers,
-                           status=201)
-        collection_resp = self.app.get(self.collection_url,
-                                       headers=self.headers)
-        new_timestamp = int(json.loads(collection_resp.headers['ETag']))
+        collection_resp = self.app.get(self.collection_url, headers=self.headers)
+        old_timestamp = int(json.loads(collection_resp.headers["ETag"]))
+        self.app.post_json(
+            self.collection_url, MINIMALIST_RECORD, headers=self.headers, status=201
+        )
+        collection_resp = self.app.get(self.collection_url, headers=self.headers)
+        new_timestamp = int(json.loads(collection_resp.headers["ETag"]))
         assert old_timestamp < new_timestamp
 
     def test_create_a_record_without_id_generates_a_uuid(self):
-        resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers,
-                                  status=201)
-        regexp = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
-                            r'[0-9a-f]{4}-[0-9a-f]{12}$')
-        self.assertTrue(regexp.match(resp.json['data']['id']))
+        resp = self.app.post_json(
+            self.collection_url, MINIMALIST_RECORD, headers=self.headers, status=201
+        )
+        regexp = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-" r"[0-9a-f]{4}-[0-9a-f]{12}$")
+        self.assertTrue(regexp.match(resp.json["data"]["id"]))
 
     def test_create_a_record_with_an_id_uses_it(self):
-        record = {'data': dict(id='a-simple-id', **MINIMALIST_RECORD['data'])}
-        resp = self.app.post_json(self.collection_url,
-                                  record,
-                                  headers=self.headers,
-                                  status=201)
-        self.assertEqual(resp.json['data']['id'], 'a-simple-id')
+        record = {"data": dict(id="a-simple-id", **MINIMALIST_RECORD["data"])}
+        resp = self.app.post_json(self.collection_url, record, headers=self.headers, status=201)
+        self.assertEqual(resp.json["data"]["id"], "a-simple-id")
 
     def test_create_a_record_with_an_existing_id_returns_existing(self):
-        resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers,
-                                  status=201)
-        existing_id = resp.json['data']['id']
-        record = {'data': {'id': existing_id, 'stars': 8}}
-        resp = self.app.post_json(self.collection_url,
-                                  record,
-                                  headers=self.headers,
-                                  status=200)
-        self.assertNotIn('stars', resp.json['data'])
+        resp = self.app.post_json(
+            self.collection_url, MINIMALIST_RECORD, headers=self.headers, status=201
+        )
+        existing_id = resp.json["data"]["id"]
+        record = {"data": {"id": existing_id, "stars": 8}}
+        resp = self.app.post_json(self.collection_url, record, headers=self.headers, status=200)
+        self.assertNotIn("stars", resp.json["data"])
 
     def test_create_a_record_with_existing_from_someone_else_gives_403(self):
-        resp = self.app.post_json(self.collection_url,
-                                  MINIMALIST_RECORD,
-                                  headers=self.headers,
-                                  status=201)
-        existing_id = resp.json['data']['id']
-        record = {'data': {'id': existing_id, 'stars': 8}}
-        resp = self.app.post_json(self.collection_url,
-                                  record,
-                                  headers=get_user_headers('tartanpion'),
-                                  status=403)
+        resp = self.app.post_json(
+            self.collection_url, MINIMALIST_RECORD, headers=self.headers, status=201
+        )
+        existing_id = resp.json["data"]["id"]
+        record = {"data": {"id": existing_id, "stars": 8}}
+        resp = self.app.post_json(
+            self.collection_url, record, headers=get_user_headers("tartanpion"), status=403
+        )
 
     def test_update_a_record_update_collection_timestamp(self):
-        collection_resp = self.app.get(self.collection_url,
-                                       headers=self.headers)
-        old_timestamp = int(json.loads(collection_resp.headers['ETag']))
-        self.app.put_json(self.record_url,
-                          MINIMALIST_RECORD,
-                          headers=self.headers,
-                          status=200)
-        collection_resp = self.app.get(self.collection_url,
-                                       headers=self.headers)
-        new_timestamp = int(json.loads(collection_resp.headers['ETag']))
+        collection_resp = self.app.get(self.collection_url, headers=self.headers)
+        old_timestamp = int(json.loads(collection_resp.headers["ETag"]))
+        self.app.put_json(self.record_url, MINIMALIST_RECORD, headers=self.headers, status=200)
+        collection_resp = self.app.get(self.collection_url, headers=self.headers)
+        new_timestamp = int(json.loads(collection_resp.headers["ETag"]))
         assert old_timestamp < new_timestamp
 
     def test_delete_a_record_update_collection_timestamp(self):
-        collection_resp = self.app.get(self.collection_url,
-                                       headers=self.headers)
-        old_timestamp = int(json.loads(collection_resp.headers['ETag']))
-        self.app.delete(self.record_url,
-                        headers=self.headers,
-                        status=200)
-        collection_resp = self.app.get(self.collection_url,
-                                       headers=self.headers)
-        new_timestamp = int(json.loads(collection_resp.headers['ETag']))
+        collection_resp = self.app.get(self.collection_url, headers=self.headers)
+        old_timestamp = int(json.loads(collection_resp.headers["ETag"]))
+        self.app.delete(self.record_url, headers=self.headers, status=200)
+        collection_resp = self.app.get(self.collection_url, headers=self.headers)
+        new_timestamp = int(json.loads(collection_resp.headers["ETag"]))
         assert old_timestamp < new_timestamp
 
     def test_record_is_accessible_by_group_member(self):
         # access as aaron
-        self.aaron_headers = {**self.headers, **get_user_headers('aaron')}
+        self.aaron_headers = {**self.headers, **get_user_headers("aaron")}
 
-        resp = self.app.get('/',
-                            headers=self.aaron_headers,
-                            status=200)
+        resp = self.app.get("/", headers=self.aaron_headers, status=200)
 
-        self.create_group('beers', 'brewers', [resp.json['user']['id']])
-        record = {**MINIMALIST_RECORD, 'permissions': {'read': ['/buckets/beers/groups/brewers']}}
-        self.app.put_json(self.record_url,
-                          record,
-                          headers=self.headers,
-                          status=200)
+        self.create_group("beers", "brewers", [resp.json["user"]["id"]])
+        record = {**MINIMALIST_RECORD, "permissions": {"read": ["/buckets/beers/groups/brewers"]}}
+        self.app.put_json(self.record_url, record, headers=self.headers, status=200)
 
-        self.app.get(self.record_url,
-                     headers=self.aaron_headers,
-                     status=200)
+        self.app.get(self.record_url, headers=self.aaron_headers, status=200)
 
     def test_records_should_reject_unaccepted_request_content_type(self):
-        headers = {**self.headers, 'Content-Type': 'text/plain'}
-        self.app.put(self.record_url,
-                     MINIMALIST_RECORD,
-                     headers=headers,
-                     status=415)
+        headers = {**self.headers, "Content-Type": "text/plain"}
+        self.app.put(self.record_url, MINIMALIST_RECORD, headers=headers, status=415)
 
     def test_records_should_reject_unaccepted_client_accept(self):
-        headers = {**self.headers, 'Accept': 'text/plain'}
-        self.app.get(self.record_url,
-                     MINIMALIST_RECORD,
-                     headers=headers,
-                     status=406)
+        headers = {**self.headers, "Accept": "text/plain"}
+        self.app.get(self.record_url, MINIMALIST_RECORD, headers=headers, status=406)
 
     def test_records_should_accept_client_accept(self):
-        headers = {**self.headers, 'Accept': '*/*'}
-        self.app.get(self.record_url,
-                     MINIMALIST_RECORD,
-                     headers=headers,
-                     status=200)
+        headers = {**self.headers, "Accept": "*/*"}
+        self.app.get(self.record_url, MINIMALIST_RECORD, headers=headers, status=200)
 
     def test_records_can_be_created_after_deletion(self):
-        self.app.delete(self.record_url,
-                        headers=self.headers,
-                        status=200)
-        headers = {**self.headers, 'If-None-Match': '*'}
-        self.app.put_json(self.record_url, MINIMALIST_RECORD,
-                          headers=headers, status=201)
+        self.app.delete(self.record_url, headers=self.headers, status=200)
+        headers = {**self.headers, "If-None-Match": "*"}
+        self.app.put_json(self.record_url, MINIMALIST_RECORD, headers=headers, status=201)
 
 
 class RecordsViewMergeTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets/beers/collections/barley/records'
-    _record_url = '/buckets/beers/collections/barley/records/{}'
+    collection_url = "/buckets/beers/collections/barley/records"
+    _record_url = "/buckets/beers/collections/barley/records/{}"
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        record = {**MINIMALIST_RECORD, 'data': {'grain': {'one': 1}}}
-        resp = self.app.post_json(self.collection_url, record,
-                                  headers=self.headers)
-        self.record = resp.json['data']
-        self.record_url = self._record_url.format(self.record['id'])
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        record = {**MINIMALIST_RECORD, "data": {"grain": {"one": 1}}}
+        resp = self.app.post_json(self.collection_url, record, headers=self.headers)
+        self.record = resp.json["data"]
+        self.record_url = self._record_url.format(self.record["id"])
 
     def test_merge_patch(self):
-        headers = {**self.headers, 'Content-Type': 'application/merge-patch+json'}
-        json = {'data': {'grain': {'two': 2}}}
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=headers,
-                                   status=200)
-        self.assertEqual(resp.json['data']['grain']['one'], 1)
-        self.assertEqual(resp.json['data']['grain']['two'], 2)
+        headers = {**self.headers, "Content-Type": "application/merge-patch+json"}
+        json = {"data": {"grain": {"two": 2}}}
+        resp = self.app.patch_json(self.record_url, json, headers=headers, status=200)
+        self.assertEqual(resp.json["data"]["grain"]["one"], 1)
+        self.assertEqual(resp.json["data"]["grain"]["two"], 2)
 
     def test_merge_patch_remove_nones(self):
-        headers = {**self.headers, 'Content-Type': 'application/merge-patch+json'}
-        json = {'data': {'grain': {'one': None}}}
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=headers,
-                                   status=200)
-        self.assertNotIn('one', resp.json['data']['grain'])
+        headers = {**self.headers, "Content-Type": "application/merge-patch+json"}
+        json = {"data": {"grain": {"one": None}}}
+        resp = self.app.patch_json(self.record_url, json, headers=headers, status=200)
+        self.assertNotIn("one", resp.json["data"]["grain"])
 
     def test_merge_patch_permissions(self):
-        headers = {**self.headers, 'Content-Type': 'application/merge-patch+json'}
+        headers = {**self.headers, "Content-Type": "application/merge-patch+json"}
 
         # Add perms
-        json = {'permissions': {'read': ['bad_guys'], 'write': ['good_guys']}}
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=headers,
-                                   status=200)
-        result = resp.json['permissions']
+        json = {"permissions": {"read": ["bad_guys"], "write": ["good_guys"]}}
+        resp = self.app.patch_json(self.record_url, json, headers=headers, status=200)
+        result = resp.json["permissions"]
 
-        self.assertIn('write', result)
-        self.assertIn('read', result)
-        self.assertIn('bad_guys', result['read'])
-        self.assertIn('good_guys', result['write'])
+        self.assertIn("write", result)
+        self.assertIn("read", result)
+        self.assertIn("bad_guys", result["read"])
+        self.assertIn("good_guys", result["write"])
 
         # Remove perms
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=headers,
-                                   status=200)
+        resp = self.app.patch_json(self.record_url, json, headers=headers, status=200)
 
-        json = {'permissions': {'read': None, 'write': ['good_guys']}}
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=headers,
-                                   status=200)
-        result = resp.json['permissions']
+        json = {"permissions": {"read": None, "write": ["good_guys"]}}
+        resp = self.app.patch_json(self.record_url, json, headers=headers, status=200)
+        result = resp.json["permissions"]
 
-        self.assertIn('write', result)
-        self.assertNotIn('read', result)
-        self.assertIn('good_guys', result['write'])
+        self.assertIn("write", result)
+        self.assertNotIn("read", result)
+        self.assertIn("good_guys", result["write"])
 
 
 class RecordsViewPatchTest(BaseWebTest, unittest.TestCase):
 
-    collection_url = '/buckets/beers/collections/barley/records'
-    _record_url = '/buckets/beers/collections/barley/records/{}'
+    collection_url = "/buckets/beers/collections/barley/records"
+    _record_url = "/buckets/beers/collections/barley/records/{}"
 
     def setUp(self):
         super().setUp()
-        self.patch_headers = {**self.headers, 'Content-Type': 'application/json-patch+json'}
+        self.patch_headers = {**self.headers, "Content-Type": "application/json-patch+json"}
 
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
-        record = {**MINIMALIST_RECORD, 'permissions': {
-            'read': ['alice', 'carla'],
-            'write': ['bob']
-        }}
-        resp = self.app.post_json(self.collection_url,
-                                  record,
-                                  headers=self.headers)
-        self.record = resp.json['data']
-        self.record_url = self._record_url.format(self.record['id'])
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
+        record = {
+            **MINIMALIST_RECORD,
+            "permissions": {"read": ["alice", "carla"], "write": ["bob"]},
+        }
+        resp = self.app.post_json(self.collection_url, record, headers=self.headers)
+        self.record = resp.json["data"]
+        self.record_url = self._record_url.format(self.record["id"])
 
     def test_patch_add_permissions(self):
-        json = [{'op': 'add', 'path': '/permissions/read/me', 'value': 'me'}]
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=self.patch_headers,
-                                   status=200)
+        json = [{"op": "add", "path": "/permissions/read/me", "value": "me"}]
+        resp = self.app.patch_json(self.record_url, json, headers=self.patch_headers, status=200)
 
-        perms = resp.json['permissions']
-        self.assertIn('me', perms['read'])
-        self.assertIn('alice', perms['read'])
+        perms = resp.json["permissions"]
+        self.assertIn("me", perms["read"])
+        self.assertIn("alice", perms["read"])
 
     def test_patch_update_permissions(self):
-        json = [{'op': 'add', 'path': '/permissions/read', 'value': ['me']}]
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=self.patch_headers,
-                                   status=200)
+        json = [{"op": "add", "path": "/permissions/read", "value": ["me"]}]
+        resp = self.app.patch_json(self.record_url, json, headers=self.patch_headers, status=200)
 
-        perms = resp.json['permissions']
-        self.assertIn('me', perms['read'])
-        self.assertNotIn(('alice', 'bob'), perms['read'])
+        perms = resp.json["permissions"]
+        self.assertIn("me", perms["read"])
+        self.assertNotIn(("alice", "bob"), perms["read"])
 
     def test_patch_remove_permissions(self):
-        json = [{'op': 'remove', 'path': '/permissions/read/alice'}]
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=self.patch_headers,
-                                   status=200)
-        perms = resp.json['permissions']
-        self.assertNotIn('alice', perms['read'])
+        json = [{"op": "remove", "path": "/permissions/read/alice"}]
+        resp = self.app.patch_json(self.record_url, json, headers=self.patch_headers, status=200)
+        perms = resp.json["permissions"]
+        self.assertNotIn("alice", perms["read"])
 
     def test_patch_move_permissions(self):
-        json = [
-            {'op': 'move', 'from': '/permissions/read/alice',
-                           'path': '/data/old'}
-        ]
-        resp = self.app.patch_json(self.record_url,
-                                   json,
-                                   headers=self.patch_headers,
-                                   status=200)
+        json = [{"op": "move", "from": "/permissions/read/alice", "path": "/data/old"}]
+        resp = self.app.patch_json(self.record_url, json, headers=self.patch_headers, status=200)
 
-        perms = resp.json['permissions']
-        data = resp.json['data']
-        self.assertNotIn('alice', perms['read'])
-        self.assertEqual('alice', data['old'])
+        perms = resp.json["permissions"]
+        data = resp.json["data"]
+        self.assertNotIn("alice", perms["read"])
+        self.assertEqual("alice", data["old"])
 
     def test_patch_raises_400_on_wrong_path(self):
-        json = [{'op': 'add', 'path': '/permissions/destroy/me'}]
-        self.app.patch_json(self.record_url,
-                            json,
-                            headers=self.patch_headers,
-                            status=400)
+        json = [{"op": "add", "path": "/permissions/destroy/me"}]
+        self.app.patch_json(self.record_url, json, headers=self.patch_headers, status=400)
 
 
 class RecordsViewFilterTest(BaseWebTest, unittest.TestCase):
-    collection_url = '/buckets/beers/collections/barley/records'
+    collection_url = "/buckets/beers/collections/barley/records"
 
     RECORDS = [
         {
@@ -459,26 +358,21 @@ class RecordsViewFilterTest(BaseWebTest, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.app.put_json('/buckets/beers', MINIMALIST_BUCKET,
-                          headers=self.headers)
-        self.app.put_json('/buckets/beers/collections/barley',
-                          MINIMALIST_COLLECTION,
-                          headers=self.headers)
+        self.app.put_json("/buckets/beers", MINIMALIST_BUCKET, headers=self.headers)
+        self.app.put_json(
+            "/buckets/beers/collections/barley", MINIMALIST_COLLECTION, headers=self.headers
+        )
 
         for record in self.RECORDS:
-            self.app.post_json(self.collection_url,
-                               {"data": record},
-                               headers=self.headers)
+            self.app.post_json(self.collection_url, {"data": record}, headers=self.headers)
 
     def test_records_can_be_filtered_using_json(self):
-        response = self.app.get(self.collection_url + '?flavor="strawberry"',
-                                headers=self.headers)
-        assert len(response.json['data']) == 1
-        assert response.json['data'][0]['id'] == 'strawberry'
+        response = self.app.get(self.collection_url + '?flavor="strawberry"', headers=self.headers)
+        assert len(response.json["data"]) == 1
+        assert response.json["data"][0]["id"] == "strawberry"
 
     def test_records_can_be_filtered_with_object(self):
         query = self.collection_url + '?attributes={"ibu": 25, "seen_on": "2017-06-01"}'
-        response = self.app.get(query,
-                                headers=self.headers)
-        assert len(response.json['data']) == 1
-        assert response.json['data'][0]['id'] == 'strawberry'
+        response = self.app.get(query, headers=self.headers)
+        assert len(response.json["data"]) == 1
+        assert response.json["data"][0]["id"] == "strawberry"

--- a/tests/test_views_schema_collection.py
+++ b/tests/test_views_schema_collection.py
@@ -3,100 +3,89 @@ from kinto.core.testing import unittest
 from .support import BaseWebTest
 
 
-BUCKET_URL = '/buckets/blog'
-COLLECTION_URL = '/buckets/blog/collections/articles'
+BUCKET_URL = "/buckets/blog"
+COLLECTION_URL = "/buckets/blog/collections/articles"
 
 
 SCHEMA = {
-    'title': 'Collection schema',
-    'type': 'object',
-    'required': ['displayFields'],
-    'properties': {
-        'uiSchema': {
-            'type': 'object'
-        },
-        'displayFields': {
-            'type': 'array',
-            'items': {
-                'type': 'string'
-            },
-        },
+    "title": "Collection schema",
+    "type": "object",
+    "required": ["displayFields"],
+    "properties": {
+        "uiSchema": {"type": "object"},
+        "displayFields": {"type": "array", "items": {"type": "string"}},
     },
 }
 
-VALID_COLLECTION = {'uiSchema': {'schema': {'ui:widget': 'hidden'}}, 'displayFields': ['name']}
+VALID_COLLECTION = {"uiSchema": {"schema": {"ui:widget": "hidden"}}, "displayFields": ["name"]}
 
 
 class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
     def test_schema_should_be_json_schema(self):
-        newschema = {**SCHEMA, 'type': 'Washmachine'}
-        resp = self.app.put_json(BUCKET_URL, {'data': {'collection:schema': newschema}},
-                                 headers=self.headers, status=400)
+        newschema = {**SCHEMA, "type": "Washmachine"}
+        resp = self.app.put_json(
+            BUCKET_URL,
+            {"data": {"collection:schema": newschema}},
+            headers=self.headers,
+            status=400,
+        )
         error_msg = "'Washmachine' is not valid under any of the given schemas"
-        self.assertIn(error_msg, resp.json['message'])
+        self.assertIn(error_msg, resp.json["message"])
 
     def test_records_are_not_invalid_if_do_not_match_schema(self):
-        self.app.put_json(BUCKET_URL, {'data': {'collection:schema': SCHEMA}},
-                          headers=self.headers)
-        self.app.put_json(COLLECTION_URL, {'data': {'displayFields': 42}},
-                          headers=self.headers, status=201)
+        self.app.put_json(
+            BUCKET_URL, {"data": {"collection:schema": SCHEMA}}, headers=self.headers
+        )
+        self.app.put_json(
+            COLLECTION_URL, {"data": {"displayFields": 42}}, headers=self.headers, status=201
+        )
 
 
 class BaseWebTestWithSchema(BaseWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_collection_schema_validation'] = 'True'
+        settings["experimental_collection_schema_validation"] = "True"
         return settings
 
 
 class CollectionValidationTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(BUCKET_URL,
-                                 {'data': {'collection:schema': SCHEMA}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            BUCKET_URL, {"data": {"collection:schema": SCHEMA}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_empty_metadata_can_be_validated(self):
-        self.app.post_json(BUCKET_URL + '/collections',
-                           headers=self.headers,
-                           status=400)
-        self.app.post_json(BUCKET_URL + '/collections',
-                           {'data': {}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(BUCKET_URL + "/collections", headers=self.headers, status=400)
+        self.app.post_json(
+            BUCKET_URL + "/collections", {"data": {}}, headers=self.headers, status=400
+        )
 
     def test_collections_are_valid_if_match_schema(self):
-        self.app.put_json(COLLECTION_URL,
-                          {'data': VALID_COLLECTION},
-                          headers=self.headers,
-                          status=201)
+        self.app.put_json(
+            COLLECTION_URL, {"data": VALID_COLLECTION}, headers=self.headers, status=201
+        )
 
     def test_collections_are_invalid_if_do_not_match_schema(self):
-        self.app.put_json(COLLECTION_URL,
-                          {'data': {'displayFields': 42}},
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(
+            COLLECTION_URL, {"data": {"displayFields": 42}}, headers=self.headers, status=400
+        )
 
 
-SCHEMA_UNRESOLVABLE = {
-    'properties': {
-        'displayFields': {'$ref': '#/definitions/displayFields'}
-    },
-}
+SCHEMA_UNRESOLVABLE = {"properties": {"displayFields": {"$ref": "#/definitions/displayFields"}}}
 
 
 class CollectionUnresolvableTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(BUCKET_URL,
-                                 {'data': {'collection:schema': SCHEMA_UNRESOLVABLE}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            BUCKET_URL, {"data": {"collection:schema": SCHEMA_UNRESOLVABLE}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_unresolvable_errors_handled(self):
-        self.app.put_json(COLLECTION_URL,
-                          {'data': {'displayFields': 42}},
-                          headers=self.headers, status=400)
+        self.app.put_json(
+            COLLECTION_URL, {"data": {"displayFields": 42}}, headers=self.headers, status=400
+        )

--- a/tests/test_views_schema_group.py
+++ b/tests/test_views_schema_group.py
@@ -3,100 +3,74 @@ from kinto.core.testing import unittest
 from .support import BaseWebTest
 
 
-BUCKET_URL = '/buckets/blog'
-GROUP_URL = '/buckets/blog/groups/tarnac-nine'
+BUCKET_URL = "/buckets/blog"
+GROUP_URL = "/buckets/blog/groups/tarnac-nine"
 
 
 SCHEMA = {
-    'title': 'Group schema',
-    'type': 'object',
-    'required': ['phone'],
-    'properties': {
-        'phone': {
-            'type': 'string'
-        },
-        'members': {
-            'type': 'array',
-            'items': {
-                'type': 'string'
-            },
-        },
+    "title": "Group schema",
+    "type": "object",
+    "required": ["phone"],
+    "properties": {
+        "phone": {"type": "string"},
+        "members": {"type": "array", "items": {"type": "string"}},
     },
 }
 
-VALID_GROUP = {'members': ['oidc:coupat'], 'phone': '+33688776655'}
+VALID_GROUP = {"members": ["oidc:coupat"], "phone": "+33688776655"}
 
 
 class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
     def test_schema_should_be_json_schema(self):
-        newschema = {**SCHEMA, 'type': 'Washmachine'}
-        resp = self.app.put_json(BUCKET_URL, {'data': {'group:schema': newschema}},
-                                 headers=self.headers, status=400)
+        newschema = {**SCHEMA, "type": "Washmachine"}
+        resp = self.app.put_json(
+            BUCKET_URL, {"data": {"group:schema": newschema}}, headers=self.headers, status=400
+        )
         error_msg = "'Washmachine' is not valid under any of the given schemas"
-        self.assertIn(error_msg, resp.json['message'])
+        self.assertIn(error_msg, resp.json["message"])
 
     def test_group_are_not_invalid_if_do_not_match_schema(self):
-        self.app.put_json(BUCKET_URL, {'data': {'group:schema': SCHEMA}},
-                          headers=self.headers)
-        self.app.put_json(GROUP_URL, {'data': {'phone': 42}},
-                          headers=self.headers, status=201)
+        self.app.put_json(BUCKET_URL, {"data": {"group:schema": SCHEMA}}, headers=self.headers)
+        self.app.put_json(GROUP_URL, {"data": {"phone": 42}}, headers=self.headers, status=201)
 
 
 class BaseWebTestWithSchema(BaseWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_collection_schema_validation'] = 'True'
+        settings["experimental_collection_schema_validation"] = "True"
         return settings
 
 
 class CollectionValidationTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(BUCKET_URL,
-                                 {'data': {'group:schema': SCHEMA}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            BUCKET_URL, {"data": {"group:schema": SCHEMA}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_empty_metadata_can_be_validated(self):
-        self.app.post_json(BUCKET_URL + '/groups',
-                           headers=self.headers,
-                           status=400)
-        self.app.post_json(BUCKET_URL + '/groups',
-                           {'data': {}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(BUCKET_URL + "/groups", headers=self.headers, status=400)
+        self.app.post_json(BUCKET_URL + "/groups", {"data": {}}, headers=self.headers, status=400)
 
     def test_groups_are_valid_if_match_schema(self):
-        self.app.put_json(GROUP_URL,
-                          {'data': VALID_GROUP},
-                          headers=self.headers,
-                          status=201)
+        self.app.put_json(GROUP_URL, {"data": VALID_GROUP}, headers=self.headers, status=201)
 
     def test_groups_are_invalid_if_do_not_match_schema(self):
-        self.app.put_json(GROUP_URL,
-                          {'data': {'phone': 42}},
-                          headers=self.headers,
-                          status=400)
+        self.app.put_json(GROUP_URL, {"data": {"phone": 42}}, headers=self.headers, status=400)
 
 
-SCHEMA_UNRESOLVABLE = {
-    'properties': {
-        'phone': {'$ref': '#/definitions/phone'}
-    },
-}
+SCHEMA_UNRESOLVABLE = {"properties": {"phone": {"$ref": "#/definitions/phone"}}}
 
 
 class CollectionUnresolvableTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(BUCKET_URL,
-                                 {'data': {'group:schema': SCHEMA_UNRESOLVABLE}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            BUCKET_URL, {"data": {"group:schema": SCHEMA_UNRESOLVABLE}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_unresolvable_errors_handled(self):
-        self.app.put_json(GROUP_URL,
-                          {'data': {'phone': 42}},
-                          headers=self.headers, status=400)
+        self.app.put_json(GROUP_URL, {"data": {"phone": 42}}, headers=self.headers, status=400)

--- a/tests/test_views_schema_record.py
+++ b/tests/test_views_schema_record.py
@@ -3,9 +3,9 @@ from kinto.core.testing import unittest
 from .support import BaseWebTest
 
 
-BUCKET_URL = '/buckets/blog'
-COLLECTION_URL = '/buckets/blog/collections/articles'
-RECORDS_URL = '/buckets/blog/collections/articles/records'
+BUCKET_URL = "/buckets/blog"
+COLLECTION_URL = "/buckets/blog/collections/articles"
+RECORDS_URL = "/buckets/blog/collections/articles/records"
 
 
 SCHEMA = {
@@ -16,55 +16,48 @@ SCHEMA = {
         "body": {"type": "string"},
         "file": {
             "type": "object",
-            "properties": {
-                "size": {
-                    "type": "number",
-                },
-                "name": {
-                    "type": "string",
-                }
-            },
+            "properties": {"size": {"type": "number"}, "name": {"type": "string"}},
         },
     },
-    "required": ["title"]
+    "required": ["title"],
 }
 
-VALID_RECORD = {'title': 'About us', 'body': '<h1>About</h1>'}
+VALID_RECORD = {"title": "About us", "body": "<h1>About</h1>"}
 
 
 class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
     def test_schema_should_be_json_schema(self):
-        newschema = {**SCHEMA, 'type': 'Washmachine'}
+        newschema = {**SCHEMA, "type": "Washmachine"}
         self.app.put(BUCKET_URL, headers=self.headers)
         self.app.put(COLLECTION_URL, headers=self.headers)
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': newschema}},
-                                 headers=self.headers,
-                                 status=400)
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": newschema}}, headers=self.headers, status=400
+        )
         error_msg = "'Washmachine' is not valid under any of the given schemas"
-        self.assertIn(error_msg, resp.json['message'])
+        self.assertIn(error_msg, resp.json["message"])
 
     def test_records_are_not_invalid_if_do_not_match_schema(self):
         self.app.put_json(BUCKET_URL, headers=self.headers)
         self.app.put(COLLECTION_URL, headers=self.headers)
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': SCHEMA}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": SCHEMA}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
-        resp = self.app.post_json(RECORDS_URL,
-                                  {'data': {'body': '<h1>Without title</h1>'}},
-                                  headers=self.headers,
-                                  status=201)
-        self.assertNotIn('schema', resp.json['data'])
+        resp = self.app.post_json(
+            RECORDS_URL,
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=201,
+        )
+        self.assertNotIn("schema", resp.json["data"])
 
 
 class BaseWebTestWithSchema(BaseWebTest):
-
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        settings['experimental_collection_schema_validation'] = 'True'
+        settings["experimental_collection_schema_validation"] = "True"
         return settings
 
     def setUp(self):
@@ -75,332 +68,297 @@ class BaseWebTestWithSchema(BaseWebTest):
 
 class MissingSchemaTest(BaseWebTestWithSchema, unittest.TestCase):
     def test_attribute_is_none_if_no_schema_defined(self):
-        resp = self.app.get(COLLECTION_URL,
-                            headers=self.headers)
-        self.assertIsNone(resp.json['data'].get(''))
+        resp = self.app.get(COLLECTION_URL, headers=self.headers)
+        self.assertIsNone(resp.json["data"].get(""))
 
     def test_accepts_any_kind_of_record(self):
-        record = {'title': 'Troll'}
-        self.app.post_json(RECORDS_URL,
-                           {'data': record},
-                           headers=self.headers,
-                           status=201)
-        record = {'author': {'age': 32, 'status': 'captain'}}
-        self.app.post_json(RECORDS_URL,
-                           {'data': record},
-                           headers=self.headers,
-                           status=201)
+        record = {"title": "Troll"}
+        self.app.post_json(RECORDS_URL, {"data": record}, headers=self.headers, status=201)
+        record = {"author": {"age": 32, "status": "captain"}}
+        self.app.post_json(RECORDS_URL, {"data": record}, headers=self.headers, status=201)
 
 
 class InvalidSchemaTest(BaseWebTestWithSchema, unittest.TestCase):
     def test_schema_should_be_json_schema(self):
-        newschema = {**SCHEMA, 'type': 'Washmachine'}
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': newschema}},
-                                 headers=self.headers,
-                                 status=400)
+        newschema = {**SCHEMA, "type": "Washmachine"}
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": newschema}}, headers=self.headers, status=400
+        )
         error_msg = "'Washmachine' is not valid under any of the given schemas"
-        self.assertIn(error_msg, resp.json['message'])
+        self.assertIn(error_msg, resp.json["message"])
 
     def test_extra_unknown_required_property(self):
         schema = {**SCHEMA, "required": ["unknown"]}
-        self.app.put_json(COLLECTION_URL,
-                          {'data': {'schema': schema}},
-                          headers=self.headers)
+        self.app.put_json(COLLECTION_URL, {"data": {"schema": schema}}, headers=self.headers)
 
-        record = {'title': 'bug 1243'}
-        r = self.app.post_json(RECORDS_URL,
-                               {'data': record},
-                               headers=self.headers,
-                               status=400)
+        record = {"title": "bug 1243"}
+        r = self.app.post_json(RECORDS_URL, {"data": record}, headers=self.headers, status=400)
         self.assertEqual("'unknown' is a required property", r.json["message"])
 
         # With bug Kinto/kinto#1243, the second call would crash.
-        self.app.post_json(RECORDS_URL,
-                           {'data': record},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(RECORDS_URL, {"data": record}, headers=self.headers, status=400)
 
 
 class RecordsValidationTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': SCHEMA}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": SCHEMA}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_empty_record_can_be_validated(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(RECORDS_URL, {"data": {}}, headers=self.headers, status=400)
 
     def test_records_are_valid_if_match_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': VALID_RECORD},
-                           headers=self.headers,
-                           status=201)
+        self.app.post_json(RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers, status=201)
 
     def test_records_are_invalid_if_do_not_match_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'body': '<h1>Without title</h1>'}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=400,
+        )
 
     def test_records_are_validated_on_patch(self):
-        resp = self.app.post_json(RECORDS_URL,
-                                  {'data': VALID_RECORD},
-                                  headers=self.headers,
-                                  status=201)
-        record_id = resp.json['data']['id']
-        self.app.patch_json('{}/{}'.format(RECORDS_URL, record_id),
-                            {'data': {'title': 3.14}},
-                            headers=self.headers,
-                            status=400)
+        resp = self.app.post_json(
+            RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers, status=201
+        )
+        record_id = resp.json["data"]["id"]
+        self.app.patch_json(
+            "{}/{}".format(RECORDS_URL, record_id),
+            {"data": {"title": 3.14}},
+            headers=self.headers,
+            status=400,
+        )
 
     def test_records_are_validated_on_put(self):
-        resp = self.app.post_json(RECORDS_URL,
-                                  {'data': VALID_RECORD},
-                                  headers=self.headers,
-                                  status=201)
-        record_id = resp.json['data']['id']
-        self.app.put_json('{}/{}'.format(RECORDS_URL, record_id),
-                          {'data': {'body': '<h1>Without title</h1>'}},
-                          headers=self.headers,
-                          status=400)
+        resp = self.app.post_json(
+            RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers, status=201
+        )
+        record_id = resp.json["data"]["id"]
+        self.app.put_json(
+            "{}/{}".format(RECORDS_URL, record_id),
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=400,
+        )
 
     def test_validation_error_response_provides_details(self):
-        resp = self.app.post_json(RECORDS_URL,
-                                  {'data': {'body': '<h1>Without title</h1>'}},
-                                  headers=self.headers,
-                                  status=400)
-        self.assertIn("'title' is a required property", resp.json['message'])
-        self.assertEqual(resp.json['details'][0]['name'], 'title')
+        resp = self.app.post_json(
+            RECORDS_URL,
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=400,
+        )
+        self.assertIn("'title' is a required property", resp.json["message"])
+        self.assertEqual(resp.json["details"][0]["name"], "title")
 
     def test_validation_error_response_provides_details_and_path(self):
-        resp = self.app.post_json(RECORDS_URL,
-                                  {'data': {
-                                      'title': 'Some title',
-                                      'file': {
-                                          'size': "hi!",
-                                      }
-                                  }},
-                                  headers=self.headers,
-                                  status=400)
-        self.assertIn("size in body: 'hi!' is not of type 'number'", resp.json['message'])
-        self.assertEqual(resp.json['details'][0]['name'], 'size')
+        resp = self.app.post_json(
+            RECORDS_URL,
+            {"data": {"title": "Some title", "file": {"size": "hi!"}}},
+            headers=self.headers,
+            status=400,
+        )
+        self.assertIn("size in body: 'hi!' is not of type 'number'", resp.json["message"])
+        self.assertEqual(resp.json["details"][0]["name"], "size")
 
     def test_records_of_other_bucket_are_not_impacted(self):
-        self.app.put_json('/buckets/cms', headers=self.headers)
-        self.app.put_json('/buckets/cms/collections/articles',
-                          headers=self.headers)
-        self.app.post_json('/buckets/cms/collections/articles/records',
-                           {'data': {'body': '<h1>Without title</h1>'}},
-                           headers=self.headers)
+        self.app.put_json("/buckets/cms", headers=self.headers)
+        self.app.put_json("/buckets/cms/collections/articles", headers=self.headers)
+        self.app.post_json(
+            "/buckets/cms/collections/articles/records",
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+        )
 
     def test_records_receive_the_schema_as_attribute(self):
-        resp = self.app.post_json(RECORDS_URL,
-                                  {'data': VALID_RECORD},
-                                  headers=self.headers,
-                                  status=201)
-        self.assertEqual(resp.json['data']['schema'],
-                         self.collection['last_modified'])
+        resp = self.app.post_json(
+            RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers, status=201
+        )
+        self.assertEqual(resp.json["data"]["schema"], self.collection["last_modified"])
 
     def test_records_can_filtered_by_schema_version(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': VALID_RECORD},
-                           headers=self.headers)
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': SCHEMA}},
-                                 headers=self.headers)
-        schema_version = resp.json['data']['last_modified']
-        self.app.post_json(RECORDS_URL,
-                           {'data': VALID_RECORD},
-                           headers=self.headers)
+        self.app.post_json(RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers)
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": SCHEMA}}, headers=self.headers
+        )
+        schema_version = resp.json["data"]["last_modified"]
+        self.app.post_json(RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers)
 
-        resp = self.app.get(RECORDS_URL + '?min_schema={}'.format(schema_version),
-                            headers=self.headers)
-        self.assertEqual(len(resp.json['data']), 1)
+        resp = self.app.get(
+            RECORDS_URL + "?min_schema={}".format(schema_version), headers=self.headers
+        )
+        self.assertEqual(len(resp.json["data"]), 1)
 
 
 class ExtraPropertiesValidationTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        schema = {**SCHEMA, 'additionalProperties': False}
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': schema}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        schema = {**SCHEMA, "additionalProperties": False}
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": schema}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_record_can_be_validated_on_post(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': VALID_RECORD},
-                           headers=self.headers)
+        self.app.post_json(RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers)
 
     def test_record_can_be_validated_on_put(self):
-        record_id = '5443d83f-852a-481a-8e9d-5aa804b05b08'
-        self.app.put_json('{}/{}'.format(RECORDS_URL, record_id),
-                          {'data': VALID_RECORD},
-                          headers=self.headers)
+        record_id = "5443d83f-852a-481a-8e9d-5aa804b05b08"
+        self.app.put_json(
+            "{}/{}".format(RECORDS_URL, record_id), {"data": VALID_RECORD}, headers=self.headers
+        )
 
     def test_records_are_validated_on_patch(self):
-        record_id = '5443d83f-852a-481a-8e9d-5aa804b05b08'
-        record_url = '{}/{}'.format(RECORDS_URL, record_id)
-        resp = self.app.put_json(record_url,
-                                 {'data': VALID_RECORD},
-                                 headers=self.headers)
-        record = resp.json['data']
-        assert 'schema' in record
-        record['title'] = 'hey'
-        self.app.patch_json(record_url,
-                            {'data': record},
-                            headers=self.headers)
+        record_id = "5443d83f-852a-481a-8e9d-5aa804b05b08"
+        record_url = "{}/{}".format(RECORDS_URL, record_id)
+        resp = self.app.put_json(record_url, {"data": VALID_RECORD}, headers=self.headers)
+        record = resp.json["data"]
+        assert "schema" in record
+        record["title"] = "hey"
+        self.app.patch_json(record_url, {"data": record}, headers=self.headers)
 
     def test_additional_properties_are_rejected(self):
-        record_id = '5443d83f-852a-481a-8e9d-5aa804b05b08'
-        record = {**VALID_RECORD, 'extra': 'blah!'}
-        resp = self.app.put_json('{}/{}'.format(RECORDS_URL, record_id),
-                                 {'data': record},
-                                 headers=self.headers,
-                                 status=400)
-        assert "'extra' was unexpected)" in resp.json['message']
+        record_id = "5443d83f-852a-481a-8e9d-5aa804b05b08"
+        record = {**VALID_RECORD, "extra": "blah!"}
+        resp = self.app.put_json(
+            "{}/{}".format(RECORDS_URL, record_id),
+            {"data": record},
+            headers=self.headers,
+            status=400,
+        )
+        assert "'extra' was unexpected)" in resp.json["message"]
 
 
 class InternalRequiredProperties(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
         # See bug Kinto/kinto#1244
-        schema = {**SCHEMA, 'required': ['id', 'schema', 'last_modified']}
-        self.app.put_json(COLLECTION_URL,
-                          {'data': {'schema': schema}},
-                          headers=self.headers)
+        schema = {**SCHEMA, "required": ["id", "schema", "last_modified"]}
+        self.app.put_json(COLLECTION_URL, {"data": {"schema": schema}}, headers=self.headers)
 
     def test_record_can_be_validated_with_minimum_fields(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {}},
-                           headers=self.headers)
+        self.app.post_json(RECORDS_URL, {"data": {}}, headers=self.headers)
 
     def test_record_can_be_validated_with_every_fields(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'id': 'abc', 'last_modified': 1234,
-                                     'schema': 42, 'title': 'b', 'name': 'n'}},
-                           headers=self.headers)
+        self.app.post_json(
+            RECORDS_URL,
+            {
+                "data": {
+                    "id": "abc",
+                    "last_modified": 1234,
+                    "schema": 42,
+                    "title": "b",
+                    "name": "n",
+                }
+            },
+            headers=self.headers,
+        )
 
     def test_record_can_be_validated_with_id_and_last_modified(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'id': 'abc', 'last_modified': 1234}},
-                           headers=self.headers)
+        self.app.post_json(
+            RECORDS_URL, {"data": {"id": "abc", "last_modified": 1234}}, headers=self.headers
+        )
 
     def test_record_validation_can_reject_records(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'id': 'abc', 'last_modified': 1234,
-                                     'body': 2}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {"id": "abc", "last_modified": 1234, "body": 2}},
+            headers=self.headers,
+            status=400,
+        )
 
 
 class BucketRecordSchema(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.app.put_json(BUCKET_URL,
-                          {'data': {'record:schema': SCHEMA}},
-                          headers=self.headers)
+        self.app.put_json(BUCKET_URL, {"data": {"record:schema": SCHEMA}}, headers=self.headers)
 
     def test_records_are_valid_if_match_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': VALID_RECORD},
-                           headers=self.headers,
-                           status=201)
+        self.app.post_json(RECORDS_URL, {"data": VALID_RECORD}, headers=self.headers, status=201)
 
     def test_records_are_validated_on_batch(self):
-        resp = self.app.post_json("/batch", {
-            'defaults': {
-                'path': RECORDS_URL,
-                'method': 'POST',
+        resp = self.app.post_json(
+            "/batch",
+            {
+                "defaults": {"path": RECORDS_URL, "method": "POST"},
+                "requests": [
+                    {"body": {"data": VALID_RECORD}},
+                    {"body": {"data": {"body": "<h1>Without title</h1>"}}},
+                ],
             },
-            'requests': [{
-                'body': {'data': VALID_RECORD},
-              }, {
-                'body': {'data': {'body': '<h1>Without title</h1>'}},
-            }]
-        }, headers=self.headers)
-        assert resp.json['responses'][0]['status'] == 201
-        assert resp.json['responses'][1]['status'] == 400
+            headers=self.headers,
+        )
+        assert resp.json["responses"][0]["status"] == 201
+        assert resp.json["responses"][1]["status"] == 400
 
     def test_records_are_invalid_if_do_not_match_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'body': '<h1>Without title</h1>'}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=400,
+        )
 
 
 class BothBucketAndCollectionSchemas(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.app.put_json(COLLECTION_URL,
-                          {'data': {'schema': SCHEMA}},
-                          headers=self.headers)
-        other_schema = {
-            "type": "object",
-            "properties": {
-                "filters": {"type": "string"},
-            },
-        }
-        self.app.put_json(BUCKET_URL,
-                          {'data': {'record:schema': other_schema}},
-                          headers=self.headers)
+        self.app.put_json(COLLECTION_URL, {"data": {"schema": SCHEMA}}, headers=self.headers)
+        other_schema = {"type": "object", "properties": {"filters": {"type": "string"}}}
+        self.app.put_json(
+            BUCKET_URL, {"data": {"record:schema": other_schema}}, headers=self.headers
+        )
 
     def test_records_are_valid_if_match_both_schemas(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'filters': '1 == 1', **VALID_RECORD}},
-                           headers=self.headers,
-                           status=201)
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {"filters": "1 == 1", **VALID_RECORD}},
+            headers=self.headers,
+            status=201,
+        )
 
     def test_records_are_invalid_if_do_not_match_collection_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'body': '<h1>Without title</h1>'}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=400,
+        )
 
     def test_records_are_invalid_if_do_not_match_bucket_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'filters': 42, **VALID_RECORD}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {"filters": 42, **VALID_RECORD}},
+            headers=self.headers,
+            status=400,
+        )
 
 
-SCHEMA_UNRESOLVABLE = {
-    'properties': {
-        'title': {'$ref': '#/definitions/title'}
-    },
-}
+SCHEMA_UNRESOLVABLE = {"properties": {"title": {"$ref": "#/definitions/title"}}}
 
 
 class RecordsUnresolvableTest(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        resp = self.app.put_json(COLLECTION_URL,
-                                 {'data': {'schema': SCHEMA_UNRESOLVABLE}},
-                                 headers=self.headers)
-        self.collection = resp.json['data']
+        resp = self.app.put_json(
+            COLLECTION_URL, {"data": {"schema": SCHEMA_UNRESOLVABLE}}, headers=self.headers
+        )
+        self.collection = resp.json["data"]
 
     def test_unresolvable_errors_handled(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'title': 'b'}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(RECORDS_URL, {"data": {"title": "b"}}, headers=self.headers, status=400)
 
 
 class BucketUnresolvableRecordSchema(BaseWebTestWithSchema, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.app.put_json(BUCKET_URL,
-                          {'data': {'record:schema': SCHEMA_UNRESOLVABLE}},
-                          headers=self.headers)
+        self.app.put_json(
+            BUCKET_URL, {"data": {"record:schema": SCHEMA_UNRESOLVABLE}}, headers=self.headers
+        )
 
     def test_records_are_valid_if_match_schema(self):
-        self.app.post_json(RECORDS_URL,
-                           {'data': {'title': 'b'}},
-                           headers=self.headers,
-                           status=400)
+        self.app.post_json(RECORDS_URL, {"data": {"title": "b"}}, headers=self.headers, status=400)

--- a/tox.ini
+++ b/tox.ini
@@ -42,3 +42,4 @@ deps =
 
 [flake8]
 max-line-length = 99
+ignore = E203, E266, E501, W503

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,12 @@ deps =
     statsd
 install_command = pip install {opts} {packages}
 
-[testenv:flake8]
-commands = flake8 kinto tests docs/conf.py
+[testenv:lint]
+commands = therapist run --use-tracked-files kinto tests docs/conf.py
 deps =
-    setuptools<36
+    -rlint-requirements.txt
     flake8
+    setuptools<36
 
 [testenv:py35-raw]
 passenv = TRAVIS

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-raw,py35,py36,py37,flake8
+envlist = py35-raw,py35,py36,py37,lint
 skip_missing_interpreters = True
 
 [testenv]
@@ -20,8 +20,6 @@ install_command = pip install {opts} {packages}
 commands = therapist run --use-tracked-files kinto tests docs/conf.py
 deps =
     -rlint-requirements.txt
-    flake8
-    setuptools<36
 
 [testenv:py35-raw]
 passenv = TRAVIS


### PR DESCRIPTION
Letting black run over everything

- [ ] Add documentation.
- [ ] Add a changelog entry.
- [x] Add your name in the contributors file.

So in light of my other pull request I suggested that we run black over everything and @leplatrem seemed to be in favor so here we are.

I figured it would be best if we did this before adding all the type annotations to not have too many changes at once.

I let black run over everything, adding a pre-commit (https://pre-commit.com) config file as well as a config file for black.

I also had to add an ignore E203 in order for flake8 to be happy.

If this is okay then I would still have to add some documentation on how to set things up for development but I do think the result is actually quite nice!

Thoughts?