### PR TITLE
Fix typo in accounts.rst

### DIFF
--- a/docs/api/1.x/accounts.rst
+++ b/docs/api/1.x/accounts.rst
@@ -280,7 +280,7 @@ For example, create somebody else account:
 
 ::
 
-    $ echo '{"data": {"id": "sam-body", password": "else"}}' | http POST http://localhost:8888/v1/accounts --auth admin:s3cr3t
+    $ echo '{"data": {"id": "sam-body", "password": "else"}}' | http POST http://localhost:8888/v1/accounts --auth admin:s3cr3t
 
 List accounts:
 


### PR DESCRIPTION
Saw a typo in the `accounts.rst` doc. And I followed the "edit on github" link from readthedocs and it worked!
Well, at least, partially: it brought me on the tag hash, and it's not possible to edit from there, I had to change the hash to `master` to be able to edit in github's ui.
