### PR TITLE
Allow dots in records IDs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ This document describes changes between each past release.
 11.1.0 (unreleased)
 -------------------
 
+**API**
+
+- Allow dots (``.``) in records IDs
+
+API is now at version **1.21**. See `API changelog`_.
+
 **New features**
 
 - Add ability to configure the ``project_name`` in settings, shown in the `root URL <https://kinto.readthedocs.io/en/stable/api/1.x/utilities.html#get>`_ (fixes #1809)

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,6 +11,12 @@ API
 Changelog
 ---------
 
+1.21 (unreleased)
+'''''''''''''''''
+
+- Allow dots (``.``) in records IDs
+
+
 1.20 (2018-06-07)
 '''''''''''''''''
 

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -13,7 +13,7 @@ from kinto.authorization import RouteFactory
 __version__ = pkg_resources.get_distribution(__package__).version
 
 # Implemented HTTP API Version
-HTTP_API_VERSION = '1.20'
+HTTP_API_VERSION = '1.21'
 
 # Main kinto logger
 logger = logging.getLogger(__name__)

--- a/kinto/views/__init__.py
+++ b/kinto/views/__init__.py
@@ -19,7 +19,7 @@ class NameGenerator(generators.Generator):
 class RelaxedUUID(generators.UUID4):
     """A generator that generates UUIDs but accepts any string.
     """
-    regexp = generators.Generator.regexp
+    regexp = r'^[a-zA-Z0-9][a-zA-Z0-9\\._-]*$'  # same as `generators.Generator` with dots.
 
 
 def object_exists_or_404(request, collection_id, object_id, parent_id=''):

--- a/tests/test_views_records.py
+++ b/tests/test_views_records.py
@@ -160,6 +160,20 @@ class RecordsViewTest(BaseWebTest, unittest.TestCase):
                           headers=self.headers,
                           status=400)
 
+    def test_records_ids_do_not_allow_every_character(self):
+        record = {"data": {"id": "bad:id:format"}}
+        self.app.post_json(self.collection_url,
+                           record,
+                           headers=self.headers,
+                           status=400)
+
+    def test_records_ids_can_contain_some_specific_characters(self):
+        record = {"data": {"id": "this_is.Like-A-Domain.fr"}}
+        self.app.post_json(self.collection_url,
+                           record,
+                           headers=self.headers,
+                           status=201)
+
     def test_create_a_record_update_collection_timestamp(self):
         collection_resp = self.app.get(self.collection_url,
                                        headers=self.headers)


### PR DESCRIPTION
What do you think about making such a change?

(*It would serve a very specific use-case that we have: use domain names as records IDs.*)
