### PR TITLE
Don't native value

### DIFF
--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -125,7 +125,9 @@ def read_env(key, value):
     :returns: the value from environment, coerced to python type
     """
     envkey = key.replace(".", "_").replace("-", "_").upper()
-    return native_value(os.getenv(envkey, value))
+    if envkey in os.environ:
+        return native_value(os.environ[envkey])
+    return value
 
 
 def encode64(content, encoding="utf-8"):

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -229,6 +229,17 @@ class ApplicationWrapperTest(unittest.TestCase):
         self.assertNotIn("myapp.http_host", settings)
         self.assertEqual(settings["http_host"], "localhost:8888")
 
+    def test_load_default_settings_doesnt_parse_version(self):
+        config = mock.MagicMock()
+
+        settings = {'settings_prefix': 'myapp'}
+
+        config.get_settings.return_value = settings
+        initialization.load_default_settings(
+            config, {'http_api_version': '1.20'})
+
+        self.assertEqual(settings['http_api_version'], '1.20')
+
 
 class StatsDConfigurationTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Part of https://github.com/Kinto/kinto-http.js/issues/311 is due to the fact that the `http_api_version` (which is currently `1.20`) is understood as `1.2`. This PR adds a test to demonstrate the problem and offers the first thing I thought of as a solution. Unfortunately I'm not sure the solution is worth pursuing, because it means that settings read from .ini files are always strings. This means we need to update places where we access settings to explicitly convert them to numbers or something.

Another alternative might be to just represent the `http_api_version` as `"1.20"`, which is maybe more honest anyhow?
