### PR TITLE
Updated postgresql install instructions for MacOS

### DIFF
--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -35,7 +35,11 @@ On RedHat / Fedora / Mint based systems::
 
     $ yum install postgresql-devel
 
-On Mac OS X, `install a server or use port <http://superuser.com/questions/296873/install-libpq-dev-on-mac-os>`_.
+On MacOS::
+
+    $ brew install postgresql
+
+See also `install a server or use port <http://superuser.com/questions/296873/install-libpq-dev-on-mac-os>`_.
 
 Install PostgreSQL Python Dependencies
 --------------------------------------


### PR DESCRIPTION
Added `brew` command to install postgresql on MacOS, analogous to the preceding Linux commands.

Fixes #

- [x] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
