### PR TITLE
Build admin plugin in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - sudo /etc/init.d/postgresql restart
   - psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres
   - make version-file
+  - make build-kinto-admin
 script:
   - tox -e $TOX_ENV
 after_success:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,12 @@ Before doing so, here are a few guidelines:
   [license](https://github.com/Kinto/kinto/blob/master/LICENSE).
 * Use pull-requests early so it's open for discussion, even if your
   contribution isn't ready yet.
-* All pull requests should include tests, they help us avoiding regressions in
+* All pull requests should include tests, as they help us avoid regressions in
   our code.
 * A pull-request adding functionality should also update the documentation
   accordingly.
-* [TravisCI integration tests](https://travis-ci.org/Kinto/kinto) should be
+* [Travis CI integration tests](https://travis-ci.org/Kinto/kinto) should be
   green.
 * If you're interested, you can also check the [contributing
   documentation](https://kinto.readthedocs.io/en/latest/community.html#how-to-contribute)
-  which goes into more details.
+  guide which goes into more details.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,4 @@ kinto-redis==1.3.0
 mock==2.0.0
 webtest==2.0.32
 cornice==3.4.2
-pyramid==1.9.2
+pyramid==1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ plaster==1.0
 plaster-pastedeploy==0.6
 psycopg2==2.7.5
 pycparser==2.19
-pyramid==1.9.2
+pyramid==1.10
 pyramid-multiauth==0.9.0
 pyramid-tm==2.2.1
 python-dateutil==2.7.5


### PR DESCRIPTION
Fixes #1707.
I tried to add a `make` task which also tests the plugin by running `react-scripts test`, but that failed and I didn't have the time to look into it. This should probably be fixed and tested in CI in the future.

- [x] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
