### PR TITLE
Updated Error on Version File Missing

### DIFF
--- a/kinto/core/views/version.py
+++ b/kinto/core/views/version.py
@@ -46,4 +46,4 @@ def version_view(request):
                 version_view.__json__ = json.load(f)
                 return version_view.__json__  # First one wins.
 
-    raise httpexceptions.HTTPNotFound()
+    raise FileNotFoundError("Version file missing")


### PR DESCRIPTION
4XX errors are client errors. In that case, if the file is not on the server, the client is not guilty