### PR TITLE
Require one of the jsonschema 3 releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = [
     "cornice",
     "cornice_swagger >= 0.5.1",
     "dockerflow",
-    "jsonschema >= 3",
+    "jsonschema >= 3.0.0a1",
     "jsonpatch",
     "logging-color-formatter >= 1.0.1",  # Message interpolations.
     "python-dateutil",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = [
     "cornice",
     "cornice_swagger >= 0.5.1",
     "dockerflow",
-    "jsonschema >= 2.9.9",
+    "jsonschema >= 3",
     "jsonpatch",
     "logging-color-formatter >= 1.0.1",  # Message interpolations.
     "python-dateutil",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = [
     "cornice",
     "cornice_swagger >= 0.5.1",
     "dockerflow",
-    "jsonschema",
+    "jsonschema >= 2.9.9",
     "jsonpatch",
     "logging-color-formatter >= 1.0.1",  # Message interpolations.
     "python-dateutil",

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
 install_command = pip install {opts} {packages}
 
 [testenv:lint]
+pip_pre=true
 commands = therapist run --use-tracked-files kinto tests docs/conf.py
 deps =
     -rlint-requirements.txt
@@ -37,6 +38,7 @@ deps =
     werkzeug
 
 [testenv:docs]
+pip_pre=true
 commands = sphinx-build -a -W -n -b html -d docs/_build/doctrees docs docs/_build/html
 deps =
     -rdocs/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
 install_command = pip install {opts} {packages}
 
 [testenv:lint]
+# XXX: To be removed once jsonschema 3 is released (#1900)
 pip_pre=true
 commands = therapist run --use-tracked-files kinto tests docs/conf.py
 deps =
@@ -38,6 +39,7 @@ deps =
     werkzeug
 
 [testenv:docs]
+# XXX: To be removed once jsonschema 3 is released (#1900)
 pip_pre=true
 commands = sphinx-build -a -W -n -b html -d docs/_build/doctrees docs docs/_build/html
 deps =


### PR DESCRIPTION
We use Draft7Validator, which doesn't exist in the 2.6 series.

I believe this is why projects depending on this one have started to fail builds -- see https://github.com/mozilla-services/kinto-dist/pull/391 and https://github.com/Kinto/kinto-http.js/pull/317.