### PR TITLE
Remove `record` field from UnicityError exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document describes changes between each past release.
 **Breaking changes**
 
 - Remove Python 3.5 support and upgrade to Python 3.6. (#1886)
+- Remove `record` from UnicityError class (#1919). This enabled us to fix #1545.
 
 **Internal changes**
 

--- a/kinto/core/storage/exceptions.py
+++ b/kinto/core/storage/exceptions.py
@@ -36,8 +36,7 @@ class UnicityError(IntegrityError):
 
     """
 
-    def __init__(self, field, record, *args, **kwargs):
+    def __init__(self, field, *args, **kwargs):
         self.field = field
-        self.record = record
-        self.msg = f"{field} is not unique: {record}"
+        self.msg = f"{field} is not unique"
         super().__init__(*args, **kwargs)

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -286,25 +286,17 @@ class Storage(StorageBase, MigratorMixin):
         # safe. We add a constant "inserted" field to know whether we
         # need to throw or not.
         query = """
-        WITH create_record AS (
-            INSERT INTO records (id, parent_id, collection_id, data, last_modified, deleted)
-            VALUES (:object_id, :parent_id,
-                    :collection_id, (:data)::JSONB,
-                    from_epoch(:last_modified),
-                    FALSE)
-            ON CONFLICT (id, parent_id, collection_id) DO UPDATE
-            SET last_modified = from_epoch(:last_modified),
-                data = (:data)::JSONB,
-                deleted = FALSE
-            WHERE records.deleted = TRUE
-            RETURNING id, data, last_modified
-        )
-        SELECT id, data, as_epoch(last_modified) AS last_modified, TRUE AS inserted
-            FROM create_record
-        UNION ALL
-        SELECT id, data, as_epoch(last_modified) AS last_modified, FALSE AS inserted FROM records
-        WHERE id = :object_id AND parent_id = :parent_id AND collection_id = :collection_id
-        LIMIT 1;
+        INSERT INTO records (id, parent_id, collection_id, data, last_modified, deleted)
+        VALUES (:object_id, :parent_id,
+                :collection_id, (:data)::JSONB,
+                from_epoch(:last_modified),
+                FALSE)
+        ON CONFLICT (id, parent_id, collection_id) DO UPDATE
+        SET last_modified = from_epoch(:last_modified),
+            data = (:data)::JSONB,
+            deleted = FALSE
+        WHERE records.deleted = TRUE
+        RETURNING id, data, as_epoch(last_modified) AS last_modified;
         """
 
         safe_holders = {}
@@ -319,11 +311,8 @@ class Storage(StorageBase, MigratorMixin):
             result = conn.execute(query % safe_holders, placeholders)
             inserted = result.fetchone()
 
-        if not inserted["inserted"]:
-            record = inserted["data"]
-            record[id_field] = inserted["id"]
-            record[modified_field] = inserted["last_modified"]
-            raise exceptions.UnicityError(id_field, record)
+        if not inserted:
+            raise exceptions.UnicityError(id_field)
 
         record[modified_field] = inserted["last_modified"]
         return record

--- a/kinto/plugins/default_bucket/__init__.py
+++ b/kinto/plugins/default_bucket/__init__.py
@@ -96,9 +96,9 @@ def resource_create_object(request, resource_cls, uri):
     data = {"id": obj_id}
     try:
         obj = resource.model.create_record(data)
-    except UnicityError as e:
+    except UnicityError:
         # The record already exists; skip running events
-        return e.record
+        return {}
 
     # Since the current request is not a resource (but a straight Service),
     # we simulate a request on a resource.


### PR DESCRIPTION
This isn't super important for any of our uses and it is a lot of work
to try to retrieve it. Let's just commit to breaking the API.

Fixes #1525.

- [ ] Add documentation.
- [ ] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
