### PR TITLE
Fallback to jsonschema DraftV4 in case Draftv7 is not available

### DIFF
--- a/kinto/schema_validation.py
+++ b/kinto/schema_validation.py
@@ -1,5 +1,10 @@
 import colander
-from jsonschema import Draft7Validator, ValidationError, SchemaError, RefResolutionError, validate
+from jsonschema import ValidationError, SchemaError, RefResolutionError, validate
+try:
+    from jsonschema import Draft7Validator as DraftValidator
+except ImportError:
+    from jsonschema import Draft4Validator as DraftValidator
+
 from pyramid.settings import asbool
 
 from kinto.core import utils
@@ -27,7 +32,7 @@ class JSONSchemaMapping(colander.SchemaNode):
 
 def check_schema(data):
     try:
-        Draft7Validator.check_schema(data)
+        DraftValidator.check_schema(data)
     except SchemaError as e:
         message = e.path.pop() + e.message
         raise ValidationError(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ idna==2.7
 iso8601==0.1.12
 jsonpatch==1.23
 jsonpointer==2.0
-jsonschema==3.0.0a3
+jsonschema==2.6.0
 logging-color-formatter==1.0.2
 newrelic==4.8.0.110
 PasteDeploy==2.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     py.test {posargs}
 deps =
     bravado_core
-    jsonschema==3.0.0a3
+    jsonschema==2.6.0
     pytest==3.3.2
     pytest-cache
     pytest-cover


### PR DESCRIPTION
Fixes #1916

@chartjes Is this the dependency error you had?


- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
