### PR TITLE
Pin swagger-spec-validator

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,7 @@ pytest-sugar==0.9.2
 pytest-watch==4.2.0
 SQLAlchemy==1.2.14
 python-memcached==1.59
+swagger-spec-validator==2.4.1
 tox==3.5.3
 WebTest==2.0.32
 werkzeug==0.14.1


### PR DESCRIPTION
dev-requirements.txt doesn't look like it's exhaustive, and let's not
try to make it be right now, but there's an incompatibility here between
bravado-core, swagger-spec-validator, and jsonschema. We'll just force
this version because it's annoyed enough of us.

Fixes #1922.

- (n/a) Add documentation.
- (n/a) Add tests.
- (n/a) Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
