### PR TITLE
Travis CI: The sudo tag is deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,10 @@ matrix:
   include:
     - python: 3.7
       dist: xenial
-      sudo: true
       env:
         - TOX_ENV=py37
     - python: 3.7
       dist: xenial
-      sudo: true
       env: ENV=functional
       before_install:
         - make install-dev
@@ -45,7 +43,6 @@ matrix:
         - make functional
     - python: 3.7
       dist: xenial
-      sudo: true
       env:
         - ENV=build-kinto-admin
       script: make build-kinto-admin


### PR DESCRIPTION
[Travis are now recommending removing __sudo__](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

Fixes #

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
