### PR TITLE
Fix memory permission implementation of remove_principal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ This document describes changes between each past release.
 
 - Like query now returns 400 when a non string value is used. (#1899)
 - Record ID is validated if explicitly mentioned in the collection schema (#1942)
+- The Memory permission backend implementation of ``remove_principal``
+  is now less generous with what it removes (#1955).
 
 **Internal changes**
 

--- a/kinto/core/permission/memory.py
+++ b/kinto/core/permission/memory.py
@@ -48,7 +48,9 @@ class Permission(PermissionBase):
 
     @synchronized
     def remove_principal(self, principal):
-        for user_principals in self._store.values():
+        for key, user_principals in self._store.items():
+            if not key.startswith("user:"):
+                continue
             try:
                 user_principals.remove(principal)
             except KeyError:

--- a/kinto/core/permission/testing.py
+++ b/kinto/core/permission/testing.py
@@ -141,6 +141,17 @@ class PermissionTest:
         retrieved = self.permission.get_user_principals(user_id2)
         self.assertEqual(retrieved, {principal2})
 
+    def test_cannot_remove_principal_from_objects(self):
+        object_id = "/buckets/some-bucket"
+        user_id = "user"
+        principal = "readers-group"
+        self.permission.add_principal_to_ace(object_id, "read", principal)
+        self.permission.add_user_principal(user_id, principal)
+        self.permission.remove_principal(principal)
+
+        retrieved = self.permission.get_object_permissions(object_id)
+        self.assertEqual(retrieved, {"read": set([principal])})
+
     def test_authenticated_is_returned_for_everybody(self):
         user_id = "foo"
         principal = "bar"


### PR DESCRIPTION
Fixes #1955.

- (n/a) Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- (n/a) Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
