### PR TITLE
Use postgresql:// instead postgres://

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,10 @@ This document describes changes between each past release.
 - Like query now returns 400 when a non string value is used. (#1899)
 - Record ID is validated if explicitly mentioned in the collection schema (#1942)
 
+**Documentation**
+
+- Change PostgreSQL backend URLs to be ``postgresql://`` instead of the deprecated ``postgres://``
+
 **Internal changes**
 
 - Remove depreciation warning for ``mapping`` (#1904)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ web:
     KINTO_CACHE_BACKEND: kinto.core.cache.memcached
     KINTO_CACHE_HOSTS: cache:11211 cache:11212
     KINTO_STORAGE_BACKEND: kinto.core.storage.postgresql
-    KINTO_STORAGE_URL: postgres://postgres:postgres@db/postgres
+    KINTO_STORAGE_URL: postgresql://postgres:postgres@db/postgres
     KINTO_PERMISSION_BACKEND: kinto.core.permission.postgresql
-    KINTO_PERMISSION_URL: postgres://postgres:postgres@db/postgres
+    KINTO_PERMISSION_URL: postgresql://postgres:postgres@db/postgres

--- a/docs/configuration/production.rst
+++ b/docs/configuration/production.rst
@@ -130,11 +130,11 @@ Select your database server address, name and user by editing the configuration 
 .. code-block:: python
 
     kinto.storage_backend = kinto.core.storage.postgresql
-    kinto.storage_url = postgres://dbuser:dbpassword@localhost/dbname
+    kinto.storage_url = postgresql://dbuser:dbpassword@localhost/dbname
     kinto.cache_backend = kinto.core.cache.postgresql
-    kinto.cache_url = postgres://dbuser:dbpassword@localhost/dbname
+    kinto.cache_url = postgresql://dbuser:dbpassword@localhost/dbname
     kinto.permission_backend = kinto.core.permission.postgresql
-    kinto.permission_url = postgres://dbuser:dbpassword@localhost/dbname
+    kinto.permission_url = postgresql://dbuser:dbpassword@localhost/dbname
 
 
 Creating tables and indices

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -104,7 +104,7 @@ Storage
 |                              |                               |                                                                          |
 +------------------------------+-------------------------------+--------------------------------------------------------------------------+
 | kinto.storage_url            | ``''``                        | The URL to use to authenticate to the storage backend. e.g.              |
-|                              |                               | ``redis://localhost:6378/1`` or ``postgres://user:pass@database/db``     |
+|                              |                               | ``redis://localhost:6378/1`` or ``postgresql://user:pass@database/db``     |
 +------------------------------+-------------------------------+--------------------------------------------------------------------------+
 | kinto.storage_max_fetch_size | ``10000``                     | The maximum number of items that can be returned by one request to the   |
 |                              |                               | storage backend. If no pagination is enabled, this is the maximum number |
@@ -127,7 +127,7 @@ Storage
 .. code-block:: ini
 
     kinto.storage_backend = kinto.core.storage.postgresql
-    kinto.storage_url = postgres://postgres:postgres@localhost/postgres
+    kinto.storage_url = postgresql://postgres:postgres@localhost/postgres
 
     # Safety limit while fetching from storage
     # kinto.storage_max_fetch_size = 10000
@@ -146,7 +146,7 @@ Cache
 |                            |                             |                                                                              |
 +----------------------------+-----------------------------+------------------------------------------------------------------------------+
 | kinto.cache_url            | ``''``                      | The URL to use to authenticate to the cache backend. e.g.                    |
-|                            |                             | ``redis://localhost:6378/1`` or ``postgres://user:pass@database/db``         |
+|                            |                             | ``redis://localhost:6378/1`` or ``postgresql://user:pass@database/db``         |
 +----------------------------+-----------------------------+------------------------------------------------------------------------------+
 | kinto.cache_prefix         | ``''``                      | A prefix added to each key. Useful when having multiple Kinto using the same |
 |                            |                             | cache database.                                                              |
@@ -172,7 +172,7 @@ Cache
 .. code-block:: ini
 
     kinto.cache_backend = kinto.core.cache.postgresql
-    kinto.cache_url = postgres://postgres:postgres@localhost/postgres
+    kinto.cache_url = postgresql://postgres:postgres@localhost/postgres
 
     # Control number of pooled connections
     # kinto.cache_pool_size = 50
@@ -214,7 +214,7 @@ Permissions
 .. code-block:: ini
 
     kinto.permission_backend = kinto.core.permission.postgresql
-    kinto.permission_url = postgres://postgres:postgres@localhost/postgres
+    kinto.permission_url = postgresql://postgres:postgres@localhost/postgres
 
     # Control number of pooled connections
     # kinto.permission_pool_size = 50

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -104,7 +104,7 @@ Storage
 |                              |                               |                                                                          |
 +------------------------------+-------------------------------+--------------------------------------------------------------------------+
 | kinto.storage_url            | ``''``                        | The URL to use to authenticate to the storage backend. e.g.              |
-|                              |                               | ``redis://localhost:6378/1`` or ``postgresql://user:pass@database/db``     |
+|                              |                               | ``redis://localhost:6378/1`` or ``postgresql://user:pass@database/db``   |
 +------------------------------+-------------------------------+--------------------------------------------------------------------------+
 | kinto.storage_max_fetch_size | ``10000``                     | The maximum number of items that can be returned by one request to the   |
 |                              |                               | storage backend. If no pagination is enabled, this is the maximum number |
@@ -146,7 +146,7 @@ Cache
 |                            |                             |                                                                              |
 +----------------------------+-----------------------------+------------------------------------------------------------------------------+
 | kinto.cache_url            | ``''``                      | The URL to use to authenticate to the cache backend. e.g.                    |
-|                            |                             | ``redis://localhost:6378/1`` or ``postgresql://user:pass@database/db``         |
+|                            |                             | ``redis://localhost:6378/1`` or ``postgresql://user:pass@database/db``       |
 +----------------------------+-----------------------------+------------------------------------------------------------------------------+
 | kinto.cache_prefix         | ``''``                      | A prefix added to each key. Useful when having multiple Kinto using the same |
 |                            |                             | cache database.                                                              |

--- a/docs/core/resource.rst
+++ b/docs/core/resource.rst
@@ -185,7 +185,7 @@ As an example, let's build a code that will copy a collection into another:
     config = Configurator(settings=DEFAULT_SETTINGS)
     config.add_settings({
         'kinto.storage_backend': 'kinto.core.storage.postgresql'
-        'kinto.storage_url': 'postgres://user:pass@db.server.lan:5432/dbname'
+        'kinto.storage_url': 'postgresql://user:pass@db.server.lan:5432/dbname'
     })
     kinto.core.initialize(config, '0.0.1')
 

--- a/docs/tutorials/install.rst
+++ b/docs/tutorials/install.rst
@@ -92,7 +92,7 @@ For example, using an environment file:
     KINTO_USERID_HMAC_SECRET = tr0ub4d@ur
     KINTO_BATCH_MAX_REQUESTS = 200
     # KINTO_STORAGE_BACKEND = kinto.core.storage.postgresql
-    # KINTO_STORAGE_URL = postgres://user:pass@localhost/kintodb
+    # KINTO_STORAGE_URL = postgresql://user:pass@localhost/kintodb
 
 And running the container with:
 
@@ -167,11 +167,11 @@ Note that with the above example,``config/kinto.ini`` must define the following 
 ::
 
     kinto.cache_backend = kinto.core.cache.postgresql
-    kinto.cache_url = postgres://postgres:postgres@db/postgres
+    kinto.cache_url = postgresql://postgres:postgres@db/postgres
     kinto.storage_backend = kinto.core.storage.postgresql
-    kinto.storage_url = postgres://postgres:postgres@db/postgres
+    kinto.storage_url = postgresql://postgres:postgres@db/postgres
     kinto.permission_backend = kinto.core.permission.postgresql
-    kinto.permission_url = postgres://postgres:postgres@db/postgres
+    kinto.permission_url = postgresql://postgres:postgres@db/postgres
 
 .. _run-kinto-python:
 

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -31,7 +31,7 @@ def render_template(template, destination, **kwargs):
 
 def get_cache_backend_url(cache_be_value):
     if cache_be_value == "kinto.core.cache.postgresql":
-        url = "postgres://postgres:postgres@localhost/postgres"
+        url = "postgresql://postgres:postgres@localhost/postgres"
     elif cache_be_value == "kinto.core.cache.redis":
         url = "redis://localhost:6379/2"
     elif cache_be_value == "kinto.core.cache.memcached":
@@ -56,7 +56,7 @@ def init(config_file, backend, cache_backend, host="127.0.0.1"):
     cache_backend_url = get_cache_backend_url(values["cache_backend"])
 
     if backend == "postgresql":
-        postgresql_url = "postgres://postgres:postgres@localhost/postgres"
+        postgresql_url = "postgresql://postgres:postgres@localhost/postgres"
         values["storage_url"] = postgresql_url
         values["cache_url"] = cache_backend_url
         values["permission_url"] = postgresql_url

--- a/kinto/core/cache/postgresql/__init__.py
+++ b/kinto/core/cache/postgresql/__init__.py
@@ -18,7 +18,7 @@ class Cache(CacheBase):
 
     Database location URI can be customized::
 
-        kinto.cache_url = postgres://user:pass@db.server.lan:5432/dbname
+        kinto.cache_url = postgresql://user:pass@db.server.lan:5432/dbname
 
     Alternatively, username and password could also rely on system user ident
     or even specified in :file:`~/.pgpass` (*see PostgreSQL documentation*).

--- a/kinto/core/permission/postgresql/__init__.py
+++ b/kinto/core/permission/postgresql/__init__.py
@@ -22,7 +22,7 @@ class Permission(PermissionBase, MigratorMixin):
 
     Database location URI can be customized::
 
-        kinto.permission_url = postgres://user:pass@db.server.lan:5432/dbname
+        kinto.permission_url = postgresql://user:pass@db.server.lan:5432/dbname
 
     Alternatively, username and password could also rely on system user ident
     or even specified in :file:`~/.pgpass` (*see PostgreSQL documentation*).

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -32,7 +32,7 @@ class Storage(StorageBase, MigratorMixin):
 
     Database location URI can be customized::
 
-        kinto.storage_url = postgres://user:pass@db.server.lan:5432/dbname
+        kinto.storage_url = postgresql://user:pass@db.server.lan:5432/dbname
 
     Alternatively, username and password could also rely on system user ident
     or even specified in :file:`~/.pgpass` (*see PostgreSQL documentation*).

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -116,7 +116,7 @@ class PostgreSQLCacheTest(CacheTest, unittest.TestCase):
     settings = {
         "cache_backend": "kinto.core.cache.postgresql",
         "cache_pool_size": 10,
-        "cache_url": "postgres://postgres:postgres@localhost:5432/testdb",
+        "cache_url": "postgresql://postgres:postgres@localhost:5432/testdb",
         "cache_prefix": "",
     }
 

--- a/tests/core/test_permission.py
+++ b/tests/core/test_permission.py
@@ -55,7 +55,7 @@ class PostgreSQLPermissionTest(PermissionTest, unittest.TestCase):
     settings = {
         "permission_backend": "kinto.core.permission.postgresql",
         "permission_pool_size": 10,
-        "permission_url": "postgres://postgres:postgres@localhost:5432/testdb",
+        "permission_url": "postgresql://postgres:postgres@localhost:5432/testdb",
     }
 
     def setUp(self):

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -138,7 +138,7 @@ class PostgreSQLStorageTest(StorageTest, unittest.TestCase):
         "storage_max_fetch_size": 10000,
         "storage_backend": "kinto.core.storage.postgresql",
         "storage_poolclass": "sqlalchemy.pool.StaticPool",
-        "storage_url": "postgres://postgres:postgres@localhost:5432/testdb",
+        "storage_url": "postgresql://postgres:postgres@localhost:5432/testdb",
         "storage_strict_json": True,
     }
 

--- a/tests/functional.ini
+++ b/tests/functional.ini
@@ -13,12 +13,12 @@ use = egg:kinto
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
 #
 kinto.storage_backend = kinto.core.storage.postgresql
-kinto.storage_url = postgres://postgres:postgres@localhost/testdb
+kinto.storage_url = postgresql://postgres:postgres@localhost/testdb
 kinto.cache_backend = kinto.core.cache.postgresql
-kinto.cache_url = postgres://postgres:postgres@localhost/testdb
+kinto.cache_url = postgresql://postgres:postgres@localhost/testdb
 # kinto.cache_max_size_bytes = 524288
 kinto.permission_backend = kinto.core.permission.postgresql
-kinto.permission_url = postgres://postgres:postgres@localhost/testdb
+kinto.permission_url = postgresql://postgres:postgres@localhost/testdb
 
 #
 # Auth configuration.

--- a/tests/plugins/test_quotas.py
+++ b/tests/plugins/test_quotas.py
@@ -72,7 +72,7 @@ class QuotaWebTest(support.BaseWebTest, unittest.TestCase):
 
         # Setup the postgresql backend for transaction support.
         settings["storage_backend"] = "kinto.core.storage.postgresql"
-        db = "postgres://postgres:postgres@localhost/testdb"
+        db = "postgresql://postgres:postgres@localhost/testdb"
         settings["storage_url"] = db
         settings["permission_backend"] = "kinto.core.permission.postgresql"
         settings["permission_url"] = db

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,7 +71,7 @@ class ConfigTest(unittest.TestCase):
         args, kwargs = list(mocked_render_template.call_args)
         self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
 
-        postgresql_url = "postgres://postgres:postgres@localhost/postgres"
+        postgresql_url = "postgresql://postgres:postgres@localhost/postgres"
         self.assertDictEqual(
             kwargs,
             {
@@ -95,7 +95,7 @@ class ConfigTest(unittest.TestCase):
         args, kwargs = list(mocked_render_template.call_args)
         self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
 
-        postgresql_url = "postgres://postgres:postgres@localhost/postgres"
+        postgresql_url = "postgresql://postgres:postgres@localhost/postgres"
         cache_url = "127.0.0.1:11211 127.0.0.2:11211"
         self.assertDictEqual(
             kwargs,


### PR DESCRIPTION
Removes the warning:

```
SADeprecationWarning: The 'postgres' dialect name has been renamed to 'postgresql'
```