### PR TITLE
Encode token in base64 for url safety.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,13 @@ Changelog
 
 This document describes changes between each past release.
 
-12.1.0 (unreleased)
+13.0.0 (unreleased)
 -------------------
 
+**Breaking changes**
+
 - Update Kinto OpenID plugin to redirect with a base64 JSON encoded token. (#1988)
+  This will work with kinto-admin 1.23
 
 
 12.0.0 (2019-01-10)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 12.1.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update Kinto OpenID plugin to redirect with a base64 JSON encoded token. (#1988)
 
 
 12.0.0 (2019-01-10)

--- a/docs/api/1.x/openid.rst
+++ b/docs/api/1.x/openid.rst
@@ -134,7 +134,7 @@ The ``parseToken()`` function scans the location hash to read the Identity Provi
         // No token in URL bar.
         return null;
       }
-      const tokens = tokensExtract[1];
+      const tokens = atob(tokensExtract[1]);
       const parsed = JSON.parse(tokens);
       return parsed;
     }
@@ -157,7 +157,7 @@ When the user clicks the login button, the browser will follow a sequence of red
 #. Auth0 redirects to Kinto with the *state* and a *code* `<http://localhost:8888/v1/openid/auth0/token?code=lWpsu9VoHLJEVyy1&state=3a309f5baba>`_
 #. Kinto checks that the *state* matches
 #. Kinto trades the *code* against the ID and Access tokens
-#. Kinto redirects back to the Single Page App appending the JSON encoded ID and Access tokens to the callback URL provided at step 2 `<http://localhost:3000/#provider=auth0&tokens={"access_token":"tY6um989...jfcer","id_token":"eyJ0eXAiOiJ...KV1QiL.ojkhgwRVH...UG8JGRENNF.Es8...DK10","expires_in":86400,"token_type":"Bearer"}>`_
+#. Kinto redirects back to the Single Page App appending the JSON encoded ID and Access tokens to the callback URL provided at step 2 `<http://localhost:3000/#provider=auth0&tokens=eyJhY2Nlc3NfdG9rZW4iOiJ0WTZ1bTk4OS4uLmpmY2VyIiwiaWRfdG9rZW4iOiJleUowZVhBaU9pSi4uLktWMVFpTC5vamtoZ3dSVkguLi5VRzhKR1JFTk5GLkVzOC4uLkRLMTAiLCJleHBpcmVzX2luIjo4NjQwMCwidG9rZW5fdHlwZSI6IkJlYXJlciJ9>`_
 #. JavaScript code parses the location hash and reads the ID and Access tokens
 
 The JavaScript app can now use the Access token to make authenticated calls to the Kinto server, and read the user info from the ID token fields. See :github:`demo <leplatrem/kinto-oidc-demo>`.

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -189,5 +189,5 @@ def get_token(request):
     # (eg. callback=`http://localhost:3000/#tokens=`)
     token_info = resp.text.encode("utf-8")
     encoded_token = base64.b64encode(token_info)
-    redirect = callback + urllib.parse.quote(encoded_token.decode('utf-8'))
+    redirect = callback + urllib.parse.quote(encoded_token.decode("utf-8"))
     raise httpexceptions.HTTPTemporaryRedirect(redirect)

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -1,3 +1,4 @@
+import base64
 import urllib.parse
 
 import colander
@@ -186,5 +187,7 @@ def get_token(request):
 
     # The IdP response is forwarded to the client in the querystring/location hash.
     # (eg. callback=`http://localhost:3000/#tokens=`)
-    redirect = callback + urllib.parse.quote(resp.text)
+    token_info = resp.text.encode("utf-8")
+    encoded_token = base64.b64encode(token_info)
+    redirect = callback + urllib.parse.quote(encoded_token.decode('utf-8'))
     raise httpexceptions.HTTPTemporaryRedirect(redirect)

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -316,4 +316,4 @@ class TokenViewTest(OpenIDWebTest):
                 "/openid/auth0/token", params={"code": "abc", "state": "key"}, status=307
             )
         location = resp.headers["Location"]
-        assert location == "http://ui/#token=%7B%22access_token%22%3A%20%22token%22%7D"
+        assert location == "http://ui/#token=eyJhY2Nlc3NfdG9rZW4iOiAidG9rZW4ifQ%3D%3D"


### PR DESCRIPTION
Refs: https://github.com/Kinto/kinto-admin/pull/715

Encode the openid payload as base64 in order to make it URL-safe

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.