### PR TITLE
Fix modification of mutable default value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,9 @@ This document describes changes between each past release.
 13.1.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
 
+- Fixed two potential bugs relating to mutable default values.
 
 13.0.1 (2019-01-29)
 -------------------
@@ -27,7 +28,6 @@ This document describes changes between each past release.
 
 **Bug fixes**
 
-- Fixed two potential bugs relating to mutable default values.
 - **security**: Fix a pagination bug in the PostgreSQL backend that could leak records between collections
 
 **Internal changes**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ This document describes changes between each past release.
 - Update Kinto OpenID plugin to redirect with a base64 JSON encoded token. (#1988).
   *This will work with kinto-admin 1.23*
 
-**Bug Fixes**
+**Bug fixes**
 
 - Fixed two potential bugs relating to mutable default values.
 - **security**: Fix a pagination bug in the PostgreSQL backend that could leak records between collections

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 - Update Kinto OpenID plugin to redirect with a base64 JSON encoded token. (#1988).
   *This will work with kinto-admin 1.23*
 
+**Bug Fixes**
+
+- Fixed two potential bugs relating to mutable default values.
+
 **Internal changes**
 
 - Upgrade kinto-admin to v1.23.0

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -86,6 +86,7 @@ Contributors
 * Surya Prashanth <prashantsurya@ymail.com>
 * SwhGo_oN <@swhgoon>
 * Tarek Ziade <tarek@mozilla.com>
+* Taus Brock-Nannestad <taus@semmle.com>
 * Taylor Zane Glaeser <tzglaeser@gmail.com>
 * Thomas Dressler <Thomas.Dressler1@gmail.com>
 * Tiberiu Ichim <@tiberiuichim>

--- a/kinto/schema_validation.py
+++ b/kinto/schema_validation.py
@@ -68,7 +68,9 @@ def validate(data, schema):
     return _schema_cache[cache_key].validate(data)
 
 
-def validate_schema(data, schema, id_field, ignore_fields=[]):
+def validate_schema(data, schema, id_field, ignore_fields=None):
+    if ignore_fields is None:
+        ignore_fields = []
     # Only ignore the `id` field if the schema does not explicitly mention it.
     if id_field not in schema.get("properties", {}):
         ignore_fields += (id_field,)

--- a/kinto/schema_validation.py
+++ b/kinto/schema_validation.py
@@ -106,12 +106,15 @@ def validate_schema(data, schema, id_field, ignore_fields=None):
         raise e
 
 
-def validate_from_bucket_schema_or_400(data, resource_name, request, id_field, ignore_fields=[]):
+def validate_from_bucket_schema_or_400(data, resource_name, request, id_field, ignore_fields=None):
     """Lookup in the parent objects if a schema was defined for this resource.
 
     If the schema validation feature is enabled, if a schema is/are defined, and if the
     data does not validate it/them, then it raises a 400 exception.
     """
+    if ignore_fields is None:
+        ignore_fields = []
+
     settings = request.registry.settings
     schema_validation = "experimental_collection_schema_validation"
     # If disabled from settings, do nothing.

--- a/tests/test_views_schema_record.py
+++ b/tests/test_views_schema_record.py
@@ -1,4 +1,5 @@
 from kinto.core.testing import unittest
+from kinto.schema_validation import validate_schema
 
 from .support import BaseWebTest
 
@@ -51,6 +52,9 @@ class DeactivatedSchemaTest(BaseWebTest, unittest.TestCase):
             status=201,
         )
         self.assertNotIn("schema", resp.json["data"])
+
+    def test_validate_schema(self):
+        validate_schema(VALID_RECORD, SCHEMA, id_field="id")
 
 
 class BaseWebTestWithSchema(BaseWebTest):


### PR DESCRIPTION
Hi,

I came across what I think is a bug when looking at the alerts for this project on [LGTM.com](https://LGTM.com) (full disclosure: I work on the Python analysis there).

Essentially, default parameter values in Python are shared between all invocations of a function. This means that if a default value is mutable, and if it is modified inside the function, then that modification will be in effect the next time the function is called, and this is rarely what we want. 

In this particular case, the default value for `ignore_fields` will contain all of the `id_fields` encountered so far, and I'm guessing this is not the intended behaviour.

(If I'm mistaken, please do let me know! We're always interested in improving our analysis and eliminating false positives.)

You can see the original alert on LGTM.com here: https://lgtm.com/projects/g/Kinto/kinto/alerts/?mode=tree&ruleFocus=4840097

Cheers,
    Taus

(I will leave these bits below unfilled until you've determined whether this is actually a bug fix or not...)

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
