### PR TITLE
[security] Fix pagination leaking between collections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ This document describes changes between each past release.
 - Update Kinto OpenID plugin to redirect with a base64 JSON encoded token. (#1988).
   *This will work with kinto-admin 1.23*
 
+**Bug fixes**
+
+- **security**: Fix a pagination bug in the PostgreSQL backend that could leak records between collections
+
 **Internal changes**
 
 - Upgrade kinto-admin to v1.23.0

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -420,7 +420,7 @@ class Storage(StorageBase, MigratorMixin):
              WHERE id = :object_id
                AND parent_id = :parent_id
                AND resource_name = :resource_name
-               AND deleted = FALSE
+               AND NOT deleted
             RETURNING as_epoch(last_modified) AS last_modified;
             """
         else:
@@ -429,7 +429,7 @@ class Storage(StorageBase, MigratorMixin):
             WHERE id = :object_id
                AND parent_id = :parent_id
                AND resource_name = :resource_name
-               AND deleted = FALSE
+               AND NOT deleted
             RETURNING as_epoch(last_modified) AS last_modified;
             """
         deleted_data = self.json.dumps(dict([(deleted_field, True)]))
@@ -476,7 +476,7 @@ class Storage(StorageBase, MigratorMixin):
                     FROM objects
                     WHERE {parent_id_filter}
                           {resource_name_filter}
-                          AND deleted = FALSE
+                          AND NOT deleted
                           {conditions_filter}
                           {pagination_rules}
                     {sorting}
@@ -498,7 +498,7 @@ class Storage(StorageBase, MigratorMixin):
                     FROM objects
                     WHERE {parent_id_filter}
                           {resource_name_filter}
-                          AND deleted = FALSE
+                          AND NOT deleted
                           {conditions_filter}
                           {pagination_rules}
                     {sorting}
@@ -546,7 +546,7 @@ class Storage(StorageBase, MigratorMixin):
 
         if pagination_rules:
             sql, holders = self._format_pagination(pagination_rules, id_field, modified_field)
-            safeholders["pagination_rules"] = f"AND {sql}"
+            safeholders["pagination_rules"] = f"AND ({sql})"
             placeholders.update(**holders)
 
         # Limit the number of results (pagination).
@@ -748,7 +748,7 @@ class Storage(StorageBase, MigratorMixin):
 
         if pagination_rules:
             sql, holders = self._format_pagination(pagination_rules, id_field, modified_field)
-            safeholders["pagination_rules"] = f"AND {sql}"
+            safeholders["pagination_rules"] = f"AND ({sql})"
             placeholders.update(**holders)
 
         # Limit the number of results (pagination).


### PR DESCRIPTION
Note: kinto < 12 is not affected

Bug introduced in 2fd5cbc15 (#1931)

The SQL generated was missing parenthesis:

![screenshot from 2019-01-25 16-54-43](https://user-images.githubusercontent.com/546692/51759005-7c72f480-20c7-11e9-8866-7d854e01b384.png)
