### PR TITLE
Loosen up CSP in admin plugin (fixes #2000)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 13.0.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Loosen up the Content-Security policies in the Kinto Admin plugin to prevent Webpack inline script to be rejected (fixes #2000)
 
 
 13.0.0 (2019-01-25)

--- a/kinto/plugins/admin/public/index.html
+++ b/kinto/plugins/admin/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Enable CSP to protect against XSS : only allow from local domain -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src data: 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src data: 'self'; script-src 'self' 'unsafe-inline'">
     <link rel="shortcut icon" href="favicon.png" type="image/png" />
     <title>Kinto Administration</title>
   </head>


### PR DESCRIPTION
Fixes #2000 

This is how I fixed it.

There might be better options using nounces or hashes, but since we use `react-scripts` I could not find anything obvious.
If we consider this as a temporary solution, we should open another issue..