### PR TITLE
#1508 - fix json_error_handler behaviour in case field name is index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fixed two potential bugs relating to mutable default values.
+- Fix crash on validating records with errors in arrays (#1508)
 - Fix crash on deleting multiple accounts (#2009)
 
 **Internal changes**

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -29,6 +29,7 @@ Contributors
 * Éric Lemoine <eric.lemoine@gmail.com>
 * Ethan Glasser-Camp <ethan@betacantrips.com>
 * Étienne <@Étienne>
+* Eugene Kulak <kulak.eugene@gmail.com>
 * Fil <fil@rezo.net>
 * FooBarQuaxx
 * Francisco J. Piedrahita <@fpiedrah>

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -148,7 +148,7 @@ def json_error_handler(request):
         description = error["description"].decode("utf-8")
 
     if name is not None:
-        if name in description:
+        if str(name) in description:
             message = description
         else:
             message = "{name} in {location}: {description}".format_map(error)

--- a/tests/test_views_schema_record.py
+++ b/tests/test_views_schema_record.py
@@ -19,6 +19,10 @@ SCHEMA = {
             "type": "object",
             "properties": {"size": {"type": "number"}, "name": {"type": "string"}},
         },
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"}
+        }
     },
     "required": ["title"],
 }
@@ -121,6 +125,14 @@ class RecordsValidationTest(BaseWebTestWithSchema, unittest.TestCase):
         self.app.post_json(
             RECORDS_URL,
             {"data": {"body": "<h1>Without title</h1>"}},
+            headers=self.headers,
+            status=400,
+        )
+
+    def test_records_are_invalid_if_do_not_match_schema_in_array(self):
+        self.app.post_json(
+            RECORDS_URL,
+            {"data": {**VALID_RECORD, 'tags': [0]}},
             headers=self.headers,
             status=400,
         )

--- a/tests/test_views_schema_record.py
+++ b/tests/test_views_schema_record.py
@@ -19,10 +19,7 @@ SCHEMA = {
             "type": "object",
             "properties": {"size": {"type": "number"}, "name": {"type": "string"}},
         },
-        "tags": {
-            "type": "array",
-            "items": {"type": "string"}
-        }
+        "tags": {"type": "array", "items": {"type": "string"}},
     },
     "required": ["title"],
 }
@@ -131,10 +128,7 @@ class RecordsValidationTest(BaseWebTestWithSchema, unittest.TestCase):
 
     def test_records_are_invalid_if_do_not_match_schema_in_array(self):
         self.app.post_json(
-            RECORDS_URL,
-            {"data": {**VALID_RECORD, 'tags': [0]}},
-            headers=self.headers,
-            status=400,
+            RECORDS_URL, {"data": {**VALID_RECORD, "tags": [0]}}, headers=self.headers, status=400
         )
 
     def test_records_are_validated_on_patch(self):


### PR DESCRIPTION
Fixes #1508 

- [ ] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
