### PR TITLE
Add assertDatetimeAlmostEqual helper for comparing datetime objects.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
+13.3.0 (unreleased)
+-------------------
+
+- Nothing changed yet.
+
+
 13.2.0 (2019-06-18)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,6 @@ This document describes changes between each past release.
 - Upgrade kinto-admin to v1.24.1
 
 
-
 13.2.0 (2019-06-18)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 13.3.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+-  Fix intermittent failure when comparing timestamps in ConfigTest (fixes #2129)
 
 
 13.2.0 (2019-06-18)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -73,6 +73,7 @@ Contributors
 * realsumit <sumitsarinofficial@gmail.com>
 * Rektide <rektide@voodoowarez.com>
 * Rémy Hubscher <rhubscher@mozilla.com>
+* Renisha Nellums <r.nellums@gmail.com>
 * Ricardo <@rkleine>
 * Rodolphe Quiédeville <rodolphe@quiedeville.org>
 * Sahil Dua <sahildua2305@gmail.com>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = kinto
-version = 13.2.0
+version = 13.3.0.dev0
 description = Kinto Web Service - Store, Sync, Share, and Self-Host.
 long_description = file: README.rst, CHANGELOG.rst, CONTRIBUTORS.rst
 license = Apache License (2.0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,13 +11,27 @@ from kinto import __version__
 
 
 class ConfigTest(unittest.TestCase):
-    def _assertDatetimeAlmostEqual(self, s1, s2):
-        """Assert that two date strings are almost equal."""
+    def _assertTimestampStringsAlmostEqual(
+            self, s1, s2, delta=timedelta(seconds=1)):
+        """Assert that two timestamp strings are almost equal, within a
+        specified timedelta.
+
+        :param s1: a string representing a timestamp with the format
+            format %a, %d %b %Y %H:%M:%S %z
+        :param s2: a string representing a timestamp with the format
+            format %a, %d %b %Y %H:%M:%S %z
+        :param delta: timedelta, default is 1 second
+        :returns: True, if time between s1 and s2 is less than delta.
+            False, otherwise.
+
+        """
         s1 = datetime.strptime(s1, "%a, %d %b %Y %H:%M:%S %z")
         s2 = datetime.strptime(s2, "%a, %d %b %Y %H:%M:%S %z")
-        return self.assertTrue(
-            abs(s1 - s2) < timedelta(seconds=1),
-            f"Delta between {s1} and {s2} is greater than 1 second",
+
+        return self.assertLessEqual(
+            abs(s1 - s2), delta,
+            f"Delta between {s1} and {s2} is {s1 - s2}. Expected difference "
+            f"to be less than or equal to {delta}"
         )
 
     def test_transpose_parameters_into_template(self):
@@ -99,7 +113,7 @@ class ConfigTest(unittest.TestCase):
             },
         )
 
-        self._assertDatetimeAlmostEqual(
+        self._assertTimestampStringsAlmostEqual(
             strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
             kwargs["config_file_timestamp"],  # actual
         )
@@ -129,7 +143,7 @@ class ConfigTest(unittest.TestCase):
             },
         )
 
-        self._assertDatetimeAlmostEqual(
+        self._assertTimestampStringsAlmostEqual(
             strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
             kwargs["config_file_timestamp"],  # actual
         )
@@ -159,7 +173,7 @@ class ConfigTest(unittest.TestCase):
             },
         )
 
-        self._assertDatetimeAlmostEqual(
+        self._assertTimestampStringsAlmostEqual(
             strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
             kwargs["config_file_timestamp"],  # actual
         )
@@ -187,7 +201,7 @@ class ConfigTest(unittest.TestCase):
             },
         )
 
-        self._assertDatetimeAlmostEqual(
+        self._assertTimestampStringsAlmostEqual(
             strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
             kwargs["config_file_timestamp"],  # actual
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import codecs
 import os
 import tempfile
 import unittest
+from datetime import datetime, timedelta
 from time import strftime
 from unittest import mock
 
@@ -10,6 +11,16 @@ from kinto import __version__
 
 
 class ConfigTest(unittest.TestCase):
+
+    def _assertDatetimeAlmostEqual(self, s1, s2):
+        """Assert that two date strings are almost equal."""
+        s1 = datetime.strptime(s1, "%a, %d %b %Y %H:%M:%S %z")
+        s2 = datetime.strptime(s2, "%a, %d %b %Y %H:%M:%S %z")
+        return self.assertTrue(
+            abs(s1-s2) < timedelta(seconds=1),
+            f"Delta beteen {s1} and {s2} is greater than 1 second"
+        )
+
     def test_transpose_parameters_into_template(self):
         self.maxDiff = None
         template = "kinto.tpl"
@@ -85,8 +96,13 @@ class ConfigTest(unittest.TestCase):
                 "cache_url": postgresql_url,
                 "permission_url": postgresql_url,
                 "kinto_version": __version__,
-                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+                "config_file_timestamp": mock.ANY,
             },
+        )
+
+        self._assertDatetimeAlmostEqual(
+            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
+            kwargs["config_file_timestamp"]          # actual
         )
 
     @mock.patch("kinto.config.render_template")
@@ -110,8 +126,13 @@ class ConfigTest(unittest.TestCase):
                 "cache_url": cache_url,
                 "permission_url": postgresql_url,
                 "kinto_version": __version__,
-                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+                "config_file_timestamp": mock.ANY,
             },
+        )
+
+        self._assertDatetimeAlmostEqual(
+            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
+            kwargs["config_file_timestamp"]          # actual
         )
 
     @mock.patch("kinto.config.render_template")
@@ -135,8 +156,13 @@ class ConfigTest(unittest.TestCase):
                 "cache_url": redis_url + "/2",
                 "permission_url": redis_url + "/3",
                 "kinto_version": __version__,
-                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+                "config_file_timestamp": mock.ANY,
             },
+        )
+
+        self._assertDatetimeAlmostEqual(
+            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
+            kwargs["config_file_timestamp"]          # actual
         )
 
     @mock.patch("kinto.config.render_template")
@@ -158,8 +184,13 @@ class ConfigTest(unittest.TestCase):
                 "cache_url": "",
                 "permission_url": "",
                 "kinto_version": __version__,
-                "config_file_timestamp": strftime("%a, %d %b %Y %H:%M:%S %z"),
+                "config_file_timestamp": mock.ANY,
             },
+        )
+
+        self._assertDatetimeAlmostEqual(
+            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
+            kwargs["config_file_timestamp"]          # actual
         )
 
     def test_render_template_works_with_file_in_cwd(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,8 +17,8 @@ class ConfigTest(unittest.TestCase):
         s1 = datetime.strptime(s1, "%a, %d %b %Y %H:%M:%S %z")
         s2 = datetime.strptime(s2, "%a, %d %b %Y %H:%M:%S %z")
         return self.assertTrue(
-            abs(s1-s2) < timedelta(seconds=1),
-            f"Delta beteen {s1} and {s2} is greater than 1 second"
+            abs(s1 - s2) < timedelta(seconds=1),
+            f"Delta between {s1} and {s2} is greater than 1 second"
         )
 
     def test_transpose_parameters_into_template(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,8 +11,7 @@ from kinto import __version__
 
 
 class ConfigTest(unittest.TestCase):
-    def _assertTimestampStringsAlmostEqual(
-            self, s1, s2, delta=timedelta(seconds=1)):
+    def _assertTimestampStringsAlmostEqual(self, s1, s2, delta=timedelta(seconds=1)):
         """Assert that two timestamp strings are almost equal, within a
         specified timedelta.
 
@@ -29,9 +28,10 @@ class ConfigTest(unittest.TestCase):
         s2 = datetime.strptime(s2, "%a, %d %b %Y %H:%M:%S %z")
 
         return self.assertLessEqual(
-            abs(s1 - s2), delta,
+            abs(s1 - s2),
+            delta,
             f"Delta between {s1} and {s2} is {s1 - s2}. Expected difference "
-            f"to be less than or equal to {delta}"
+            f"to be less than or equal to {delta}",
         )
 
     def test_transpose_parameters_into_template(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,14 +11,13 @@ from kinto import __version__
 
 
 class ConfigTest(unittest.TestCase):
-
     def _assertDatetimeAlmostEqual(self, s1, s2):
         """Assert that two date strings are almost equal."""
         s1 = datetime.strptime(s1, "%a, %d %b %Y %H:%M:%S %z")
         s2 = datetime.strptime(s2, "%a, %d %b %Y %H:%M:%S %z")
         return self.assertTrue(
             abs(s1 - s2) < timedelta(seconds=1),
-            f"Delta between {s1} and {s2} is greater than 1 second"
+            f"Delta between {s1} and {s2} is greater than 1 second",
         )
 
     def test_transpose_parameters_into_template(self):
@@ -101,8 +100,8 @@ class ConfigTest(unittest.TestCase):
         )
 
         self._assertDatetimeAlmostEqual(
-            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
-            kwargs["config_file_timestamp"]          # actual
+            strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
+            kwargs["config_file_timestamp"],  # actual
         )
 
     @mock.patch("kinto.config.render_template")
@@ -131,8 +130,8 @@ class ConfigTest(unittest.TestCase):
         )
 
         self._assertDatetimeAlmostEqual(
-            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
-            kwargs["config_file_timestamp"]          # actual
+            strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
+            kwargs["config_file_timestamp"],  # actual
         )
 
     @mock.patch("kinto.config.render_template")
@@ -161,8 +160,8 @@ class ConfigTest(unittest.TestCase):
         )
 
         self._assertDatetimeAlmostEqual(
-            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
-            kwargs["config_file_timestamp"]          # actual
+            strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
+            kwargs["config_file_timestamp"],  # actual
         )
 
     @mock.patch("kinto.config.render_template")
@@ -189,8 +188,8 @@ class ConfigTest(unittest.TestCase):
         )
 
         self._assertDatetimeAlmostEqual(
-            strftime("%a, %d %b %Y %H:%M:%S %z"),    # expected
-            kwargs["config_file_timestamp"]          # actual
+            strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
+            kwargs["config_file_timestamp"],  # actual
         )
 
     def test_render_template_works_with_file_in_cwd(self):
@@ -210,6 +209,6 @@ class ConfigTest(unittest.TestCase):
                 "permission_url": "",
                 "kinto_version": "",
                 "config_file_timestamp": "",
-            }
+            },
         )
         self.assertTrue(os.path.exists(os.path.join(temp_path, "kinto.ini")))


### PR DESCRIPTION
Fixes #2129

- [n/a] Add documentation.
- [n/a] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [n/a] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [n/a] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
