### PR TITLE
If Content-Type cannot be read, it leads to a CORS error.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fix unexpected exception in ``/__version__`` endpoint
-- Add ``Content-Type`` to default_cors_headers (fixes #2220)
+- Add ``Content-Type`` to default_cors_headers (refs #2220)
 
 
 13.2.2 (2019-07-04)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document describes changes between each past release.
 **Bug fixes**
 
 - Fix unexpected exception in ``/__version__`` endpoint
+- Add ``Content-Type`` to default_cors_headers (fixes #2220)
 
 
 13.2.2 (2019-07-04)

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -110,8 +110,7 @@ class Service(CorniceService):
     patching the default cornice service (which would impact other uses of it)
     """
 
-    default_cors_headers = ("Backoff", "Retry-After", "Alert",
-                            "Content-Length", "Content-Type")
+    default_cors_headers = ("Backoff", "Retry-After", "Alert", "Content-Length", "Content-Type")
 
     def error_handler(self, request):
         return errors.json_error_handler(request)

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -110,7 +110,8 @@ class Service(CorniceService):
     patching the default cornice service (which would impact other uses of it)
     """
 
-    default_cors_headers = ("Backoff", "Retry-After", "Alert", "Content-Length")
+    default_cors_headers = ("Backoff", "Retry-After", "Alert",
+                            "Content-Length", "Content-Type")
 
     def error_handler(self, request):
         return errors.json_error_handler(request)

--- a/tests/core/resource/test_views_cors.py
+++ b/tests/core/resource/test_views_cors.py
@@ -129,6 +129,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
                 "Next-Page",
                 "Retry-After",
                 "Content-Length",
+                "Content-Type",
                 "Cache-Control",
                 "Expires",
                 "Pragma",
@@ -148,6 +149,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
                 "Total-Objects",
                 "Total-Records",
                 "Content-Length",
+                "Content-Type",
                 "Cache-Control",
                 "Expires",
                 "Next-Page",
@@ -157,7 +159,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
 
     def test_hello_endpoint_exposes_only_minimal_set_of_headers(self):
         self.assert_expose_headers(
-            "GET", "/", ["Alert", "Backoff", "Retry-After", "Content-Length"]
+            "GET", "/", ["Alert", "Backoff", "Retry-After", "Content-Type", "Content-Length"]
         )
 
     def test_object_get_exposes_only_used_headers(self):
@@ -174,6 +176,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
                 "Retry-After",
                 "Last-Modified",
                 "Content-Length",
+                "Content-Type",
                 "Cache-Control",
                 "Expires",
                 "Pragma",
@@ -185,7 +188,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
         self.assert_expose_headers(
             "POST_JSON",
             "/mushrooms",
-            ["Alert", "Backoff", "Retry-After", "Content-Length"],
+            ["Alert", "Backoff", "Retry-After", "Content-Length", "Content-Type"],
             body=body,
         )
 
@@ -194,7 +197,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
         self.assert_expose_headers(
             "PUT_JSON",
             "/mushrooms/wrong=ids",
-            ["Alert", "Backoff", "Retry-After", "Content-Length"],
+            ["Alert", "Backoff", "Retry-After", "Content-Length", "Content-Type"],
             body=body,
             status=400,
         )
@@ -203,7 +206,7 @@ class CORSExposeHeadersTest(BaseWebTest, unittest.TestCase):
         self.assert_expose_headers(
             "PUT_JSON",
             "/unknown",
-            ["Alert", "Backoff", "Retry-After", "Content-Length"],
+            ["Alert", "Backoff", "Retry-After", "Content-Length", "Content-Type"],
             status=404,
         )
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)

Allow CORS to read Content-Type

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [x] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
