### PR TITLE
Update tests to pass on Windows

### DIFF
--- a/tests/core/test_storage_migrations.py
+++ b/tests/core/test_storage_migrations.py
@@ -45,11 +45,11 @@ class MigratorTest(unittest.TestCase):
 
         self.migrator.create_or_migrate_schema()
         sql_called = execute_sql.call_args_list[-3][0][0]
-        self.assertIn("migrations/migration_003_004.sql", sql_called)
+        self.assertIn(os.path.join("migrations", "migration_003_004.sql"), sql_called)
         sql_called = execute_sql.call_args_list[-2][0][0]
-        self.assertIn("migrations/migration_004_005.sql", sql_called)
+        self.assertIn(os.path.join("migrations", "migration_004_005.sql"), sql_called)
         sql_called = execute_sql.call_args_list[-1][0][0]
-        self.assertIn("migrations/migration_005_006.sql", sql_called)
+        self.assertIn(os.path.join("migrations", "migration_005_006.sql"), sql_called)
 
     def test_migration_files_are_listed_if_ran_with_dry_run(self, execute_sql):
         self._walk_from_3_to_6()
@@ -57,10 +57,10 @@ class MigratorTest(unittest.TestCase):
         with mock.patch("kinto.core.storage.postgresql.migrator.logger") as mocked:
             self.migrator.create_or_migrate_schema(dry_run=True)
 
-        output = "".join([repr(call) for call in mocked.info.call_args_list])
-        self.assertIn("migrations/migration_003_004.sql", output)
-        self.assertIn("migrations/migration_004_005.sql", output)
-        self.assertIn("migrations/migration_005_006.sql", output)
+        output = "".join([repr(call) for call in mocked.info.call_args_list]).replace("\\\\", "\\")
+        self.assertIn(os.path.join("migrations", "migration_003_004.sql"), output)
+        self.assertIn(os.path.join("migrations", "migration_004_005.sql"), output)
+        self.assertIn(os.path.join("migrations", "migration_005_006.sql"), output)
 
     def test_migration_fails_if_intermediary_version_is_missing(self, execute_sql):
         with mock.patch.object(self.migrator, "get_installed_version") as current:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,14 +12,15 @@ from io import StringIO
 from kinto import __version__ as kinto_version
 from kinto.__main__ import main, DEFAULT_LOG_FORMAT
 
-_, TEMP_KINTO_INI = tempfile.mkstemp(prefix="kinto_config", suffix=".ini")
+fd, TEMP_KINTO_INI = tempfile.mkstemp(prefix="kinto_config", suffix=".ini")
+os.fdopen(fd).close()
 
 
 class TestMain(unittest.TestCase):
     def setUp(self):
         try:
             os.remove(TEMP_KINTO_INI)
-        except OSError:
+        except FileNotFoundError:
             pass
 
     def test_cli_init_generates_configuration(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,9 @@ from kinto import __version__ as kinto_version
 from kinto.__main__ import main, DEFAULT_LOG_FORMAT
 
 fd, TEMP_KINTO_INI = tempfile.mkstemp(prefix="kinto_config", suffix=".ini")
+# The above call to mkstemp returns a handle to an open file. On Windows,
+# attempting to call os.remove on this file will result in an error unless it is
+# manually closed.
 os.fdopen(fd).close()
 
 


### PR DESCRIPTION
This PR makes some small modifications to the tests so that they pass when run on Windows.

## Windows Path Separators 

On Windows, the path separator is the `\` character, as opposed to `/` on *nix/macOS. I modified the tests that were explicitly using the `/` character to use `os.path.join` instead.

## Manually close temp file from `mkstemp`

According to the Python documentation, `tempfile.mkstemp` [returns an OS-level handle to an open file](https://docs.python.org/3.7/library/tempfile.html#tempfile.mkstemp). On Windows, when the `setUp` function was called to remove the temporary file between tests, it was throwing an error that the file couldn't be removed since it was in use by another process. This PR adds a call to `os.fdopen().close()` to explicitly close the open file handler before beginning the tests. It also adjusts the exception to allow only `FileNotFoundError` as opposed to allowing any `OSError`.

After these changes I'm pleased to say that all the tests pass on Windows! :tada: