### PR TITLE
Parse large exponents as strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ This document describes changes between each past release.
 
 - History entries datetimes now carry timezone information
 - Fix ``kinto init`` command (#2375)
-- Fix issue parsing certain strings in URL query parameters
+- Fix float strings parsing in certain URL query parameters. (#2392)
 
 **Internal Changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This document describes changes between each past release.
 
 - History entries datetimes now carry timezone information
 - Fix ``kinto init`` command (#2375)
+- Fix issue parsing certain strings in URL query parameters
 
 **Internal Changes**
 

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -1,6 +1,7 @@
 import collections
 import hashlib
 import hmac
+import math
 import os
 import re
 import time
@@ -110,7 +111,9 @@ def native_value(value):
     """
     if isinstance(value, str):
         try:
-            value = json.loads(value)
+            parsed_value = json.loads(value)
+            if parsed_value != math.inf:
+                value = parsed_value
         except ValueError:
             return value
     return value

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -82,7 +82,7 @@ class NativeValueTest(unittest.TestCase):
 
     def test_bad_string_values(self):
         self.assertEqual(native_value("\u0000"), "\x00")
-    
+
     def test_infinite_strings(self):
         self.assertEqual(native_value("803E5708"), "803E5708")
         self.assertEqual(native_value("Infinity"), "Infinity")

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -82,6 +82,10 @@ class NativeValueTest(unittest.TestCase):
 
     def test_bad_string_values(self):
         self.assertEqual(native_value("\u0000"), "\x00")
+    
+    def test_infinite_strings(self):
+        self.assertEqual(native_value("803E5708"), "803E5708")
+        self.assertEqual(native_value("Infinity"), "Infinity")
 
 
 class StripWhitespaceTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #2312 

- [ ] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.

This PR updates the `native_value` utility function to return the original string for values that parse to `Infinity` based on the JSON spec. This allows strings like `803E5708` which were being parsed to `803×10^5708` (which is just `Infinity` in JSON).