### PR TITLE
Replace IRC and Slack badges with Gitter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,14 @@
 Kinto
 =====
 
-|coc| |irc| |slack| |readthedocs| |pypi| |travis| |master-coverage|
+|coc| |gitter| |readthedocs| |pypi| |travis| |master-coverage|
 
 .. |coc| image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
     :target: https://github.com/Kinto/kinto/blob/master/CODE_OF_CONDUCT.md
     :alt: Code of conduct
 
-.. |irc| image:: https://img.shields.io/badge/Live%20chat-%23kinto%20on%20freenode-blue.svg
-    :target: https://kiwiirc.com/client/irc.freenode.net/?#kinto
-
-.. |slack| image:: https://img.shields.io/badge/slack-kinto-e01865.svg
-    :target: https://slack.kinto-storage.org/
+.. |gitter| image:: https://badges.gitter.im/Kinto/kinto.svg
+    :target: https://gitter.im/Kinto/kinto
 
 .. |travis| image:: https://travis-ci.org/Kinto/kinto.svg?branch=master
     :target: https://travis-ci.org/Kinto/kinto


### PR DESCRIPTION
Replacing the README Slack and IRC badges with Gitter.

It looks like this is the only repo with a chat-related badge, but let me know if you'd like me to add them to other READMEs!
