### PR TITLE
Fix Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PORT 8888
 # dependencies all at once to build a small image.
 RUN \
     apt-get update && \
-    apt-get install -y gcc libpq5 curl libssl-dev libffi-dev libpq-dev gnupg2 && \
+    apt-get install -y g++ gcc libpq5 curl libssl-dev libffi-dev libpq-dev gnupg2 && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y nodejs && \
     cd kinto/plugins/admin && npm install && npm run build && \
@@ -22,7 +22,7 @@ RUN \
     pip3 install kinto-attachment kinto-emailer kinto-elasticsearch kinto-portier kinto-redis && \
     pip3 install httpie && \
     kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory && \
-    apt-get purge -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs && \
+    apt-get purge -y -qq g++ gcc libssl-dev libffi-dev libpq-dev curl nodejs && \
     apt-get autoremove -y -qq && \
     apt-get clean -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,18 @@ ENV PORT 8888
 # Install build dependencies, build the virtualenv and remove build
 # dependencies all at once to build a small image.
 RUN \
-    apt-get update; \
-    apt-get install -y gcc libpq5 curl libssl-dev libffi-dev libpq-dev gnupg2; \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
-    apt-get install -y nodejs; \
-    cd kinto/plugins/admin; npm install; npm run build; \
-    pip3 install --upgrade pip; \
-    pip3 install -e /app[postgresql,memcached,monitoring] -c /app/requirements.txt; \
-    pip3 install kinto-attachment kinto-emailer kinto-elasticsearch kinto-portier kinto-redis; \
-    pip3 install httpie; \
-    kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory; \
-    apt-get purge -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs; \
-    apt-get autoremove -y -qq; \
+    apt-get update && \
+    apt-get install -y gcc libpq5 curl libssl-dev libffi-dev libpq-dev gnupg2 && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get install -y nodejs && \
+    cd kinto/plugins/admin && npm install && npm run build && \
+    pip3 install --upgrade pip && \
+    pip3 install -e /app[postgresql,memcached,monitoring] -c /app/requirements.txt && \
+    pip3 install kinto-attachment kinto-emailer kinto-elasticsearch kinto-portier kinto-redis && \
+    pip3 install httpie && \
+    kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory && \
+    apt-get purge -y -qq gcc libssl-dev libffi-dev libpq-dev curl nodejs && \
+    apt-get autoremove -y -qq && \
     apt-get clean -y
 
 USER app


### PR DESCRIPTION
@magopian reported that nightly builds of our Docker container on DockerHub are breaking with an error similar to https://github.com/mozilla-services/kinto-dist/pull/1332. It seems like `cc1plus` is not installed and that's causing breakage. I'm not sure when `ujson` started hard-requiring C++ -- it seems like `double-conversion` has been in here for a couple of years -- or why we have gotten away without it for so long.

- (n/a) Add documentation.
- (n/a) Add tests.
- (n/a) Add a changelog entry.
- [X] Add your name in the contributors file.
- (n/a) If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- (n/a) If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.

