### PR TITLE
Reapply CORS on EOL response

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -197,7 +197,7 @@ def _end_of_life_tween_factory(handler, registry):
             )
 
         errors.send_alert(request, eos_message, url=eos_url, code=code)
-        return request.response
+        return utils.reapply_cors(request, request.response)
 
     return eos_tween
 


### PR DESCRIPTION
This PR reapplies CORS headers to EOL responses. This enables browser clients to properly read EOL responses and react accordingly.

I'm not sure if there are any security implications, so please let me know if that's the case!
