### PR TITLE
Remove `auth` parameter from postgresql/memory storage backends

### DIFF
--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -148,13 +148,13 @@ class Storage(MemoryBasedStorage):
         self.readonly = readonly
         self.flush()
 
-    def flush(self, auth=None):
+    def flush(self):
         self._store = tree()
         self._cemetery = tree()
         self._timestamps = defaultdict(dict)
 
     @synchronized
-    def resource_timestamp(self, resource_name, parent_id, auth=None):
+    def resource_timestamp(self, resource_name, parent_id):
         ts = self._timestamps[parent_id].get(resource_name)
         if ts is not None:
             return ts
@@ -187,7 +187,6 @@ class Storage(MemoryBasedStorage):
         id_generator=None,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         id_generator = id_generator or self.id_generator
         obj = {**obj}
@@ -217,7 +216,6 @@ class Storage(MemoryBasedStorage):
         object_id,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         objects = self._store[parent_id][resource_name]
         if object_id not in objects:
@@ -234,7 +232,6 @@ class Storage(MemoryBasedStorage):
         obj,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         obj = {**obj}
         obj[id_field] = object_id
@@ -256,7 +253,6 @@ class Storage(MemoryBasedStorage):
         with_deleted=True,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
         last_modified=None,
     ):
         existing = self.get(resource_name, parent_id, object_id)
@@ -288,7 +284,6 @@ class Storage(MemoryBasedStorage):
         before=None,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         parent_id_match = re.compile(parent_id.replace("*", ".*"))
         by_parent_id = {
@@ -326,7 +321,6 @@ class Storage(MemoryBasedStorage):
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
         objects = _get_objects_by_parent_id(self._store, parent_id, resource_name)
 
@@ -361,7 +355,6 @@ class Storage(MemoryBasedStorage):
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
         objects = _get_objects_by_parent_id(self._store, parent_id, resource_name)
         _, count = self.extract_object_set(
@@ -387,7 +380,6 @@ class Storage(MemoryBasedStorage):
         with_deleted=True,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
         objects = _get_objects_by_parent_id(self._store, parent_id, resource_name, with_meta=True)
         objects, count = self.extract_object_set(

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -179,7 +179,7 @@ class Storage(StorageBase, MigratorMixin):
             MAX_FLUSHABLE_SCHEMA_VERSION = 20
             return MAX_FLUSHABLE_SCHEMA_VERSION
 
-    def flush(self, auth=None):
+    def flush(self):
         """Delete objects from tables without destroying schema.
 
         This is used in test suites as well as in the flush plugin.
@@ -192,7 +192,7 @@ class Storage(StorageBase, MigratorMixin):
             conn.execute(query)
         logger.debug("Flushed PostgreSQL storage tables")
 
-    def resource_timestamp(self, resource_name, parent_id, auth=None):
+    def resource_timestamp(self, resource_name, parent_id):
         query_existing = """
         WITH existing_timestamps AS (
           -- Timestamp of latest object.
@@ -256,7 +256,6 @@ class Storage(StorageBase, MigratorMixin):
         id_generator=None,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         id_generator = id_generator or self.id_generator
         obj = {**obj}
@@ -328,7 +327,6 @@ class Storage(StorageBase, MigratorMixin):
         object_id,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         query = """
         SELECT as_epoch(last_modified) AS last_modified, data
@@ -360,7 +358,6 @@ class Storage(StorageBase, MigratorMixin):
         obj,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
 
         # Remove redundancy in data field
@@ -407,7 +404,6 @@ class Storage(StorageBase, MigratorMixin):
         with_deleted=True,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
         last_modified=None,
     ):
         if with_deleted:
@@ -466,7 +462,6 @@ class Storage(StorageBase, MigratorMixin):
         with_deleted=True,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
         if with_deleted:
             query = """
@@ -574,7 +569,6 @@ class Storage(StorageBase, MigratorMixin):
         before=None,
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
-        auth=None,
     ):
         delete_tombstones = """
         DELETE
@@ -631,7 +625,6 @@ class Storage(StorageBase, MigratorMixin):
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
 
         query = """
@@ -658,7 +651,6 @@ class Storage(StorageBase, MigratorMixin):
             id_field=id_field,
             modified_field=modified_field,
             deleted_field=deleted_field,
-            auth=auth,
         )
 
         if len(rows) == 0:
@@ -680,7 +672,6 @@ class Storage(StorageBase, MigratorMixin):
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
 
         query = """
@@ -699,7 +690,6 @@ class Storage(StorageBase, MigratorMixin):
             id_field=id_field,
             modified_field=modified_field,
             deleted_field=deleted_field,
-            auth=auth,
         )
         return rows[0]["total_count"]
 
@@ -716,7 +706,6 @@ class Storage(StorageBase, MigratorMixin):
         id_field=DEFAULT_ID_FIELD,
         modified_field=DEFAULT_MODIFIED_FIELD,
         deleted_field=DEFAULT_DELETED_FIELD,
-        auth=None,
     ):
 
         # Unsafe strings escaped by PostgreSQL


### PR DESCRIPTION
Removed `auth` param from postgresq/memory backends that was already droped from base class.
kinto_redis required this changes too
