### PR TITLE
Don't duplicate logger messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 13.7.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix messages duplication in logs (#2513)
 
 
 13.6.5 (2020-03-31)

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -255,6 +255,7 @@ handlers = console
 level = DEBUG
 handlers = console
 qualname = kinto
+propagate = 0
 
 [handler_console]
 class = StreamHandler

--- a/tests/functional.ini
+++ b/tests/functional.ini
@@ -59,6 +59,7 @@ handlers = console
 level = DEBUG
 handlers =
 qualname = kinto
+propagate = 0
 
 [handler_console]
 class = StreamHandler

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -255,6 +255,7 @@ handlers = console
 level = DEBUG
 handlers = console
 qualname = kinto
+propagate = 0
 
 [handler_console]
 class = StreamHandler


### PR DESCRIPTION
Current log messages in console handler looks like:
```
Running kinto 13.6.5. 
Running kinto 13.6.5. 
...
"OPTIONS /v1/contenttypes?match_path=*&_sort=-last_modified&_limit=100" 200 (1 ms)  agent=Mozilla/5.0 (X11; Linux x86_64; rv:76.0) Gecko/20100101 Firefox/76.0 errno=0 lang=ru,en;q=0.7,en-US;q=0.3 time=2020-05-26T10:23:20.969000
Created new connection <connection object at 0x7f22b3f862a0; dsn: 'dbname=oasis_main', closed: 0> 
Created new connection <connection object at 0x7f22b3f862a0; dsn: 'dbname=oasis_main', closed: 0> 
Created new connection <connection object at 0x7f22b3f91040; dsn: 'dbname=oasis_main', closed: 0> 
Created new connection <connection object at 0x7f22b3f91040; dsn: 'dbname=oasis_main', closed: 0> 
Connection <connection object at 0x7f22b3f862a0; dsn: 'dbname=oasis_main', closed: 0> checked out from pool 
...
```
after turn off `propagate`, all works as expected
