### PR TITLE
Distinguish readonly errors in storage backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 14.0.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Internal Changes**
+
+- Distinguish readonly errors in storage backend (``kinto.core.storage.exceptions.ReadonlyError``)
 
 
 14.0.1 (2020-09-09)

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -235,10 +235,7 @@ class Resource:
         """
         try:
             return self.model.timestamp()
-        except storage_exceptions.BackendError as e:
-            is_readonly = self.request.registry.settings["readonly"]
-            if not is_readonly:
-                raise e
+        except storage_exceptions.ReadonlyError as e:
             # If the instance is configured to be readonly, and if the
             # resource is empty, the backend will try to bump the timestamp.
             # It fails if the configured db user has not write privileges.

--- a/kinto/core/resource/model.py
+++ b/kinto/core/resource/model.py
@@ -61,7 +61,9 @@ class Model:
 
         :param str parent_id: optional filter for parent id
         :rtype: int
+
         """
+        raise ValueError("poppp")
         parent_id = parent_id or self.parent_id
         return self.storage.resource_timestamp(
             resource_name=self.resource_name, parent_id=parent_id

--- a/kinto/core/resource/model.py
+++ b/kinto/core/resource/model.py
@@ -63,7 +63,6 @@ class Model:
         :rtype: int
 
         """
-        raise ValueError("poppp")
         parent_id = parent_id or self.parent_id
         return self.storage.resource_timestamp(
             resource_name=self.resource_name, parent_id=parent_id

--- a/kinto/core/storage/exceptions.py
+++ b/kinto/core/storage/exceptions.py
@@ -20,6 +20,7 @@ class ReadonlyError(BackendError):
     """An error raised when a write operation is attempted on a
     read-only instance.
     """
+
     pass
 
 

--- a/kinto/core/storage/exceptions.py
+++ b/kinto/core/storage/exceptions.py
@@ -16,6 +16,13 @@ class BackendError(Exception):
         super().__init__(message, *args, **kwargs)
 
 
+class ReadonlyError(BackendError):
+    """An error raised when a write operation is attempted on a
+    read-only instance.
+    """
+    pass
+
+
 class RecordNotFoundError(Exception):
     """Deprecated exception name."""
 

--- a/kinto/core/storage/memory.py
+++ b/kinto/core/storage/memory.py
@@ -150,7 +150,7 @@ class Storage(MemoryBasedStorage):
             return ts
         if self.readonly:
             error_msg = "Cannot initialize empty resource timestamp when running in readonly."
-            raise exceptions.BackendError(message=error_msg)
+            raise exceptions.ReadonlyError(message=error_msg)
         return self.bump_and_store_timestamp(resource_name, parent_id)
 
     def bump_and_store_timestamp(

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -233,7 +233,7 @@ class Storage(StorageBase, MigratorMixin):
             if self.readonly:
                 if existing_ts is None:
                     error_msg = (
-                        "Cannot initialize empty resource timestamp " "when running in readonly."
+                        "Cannot initialize empty resource timestamp when running in readonly."
                     )
                     raise exceptions.ReadonlyError(message=error_msg)
                 obj = row

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -235,7 +235,7 @@ class Storage(StorageBase, MigratorMixin):
                     error_msg = (
                         "Cannot initialize empty resource timestamp " "when running in readonly."
                     )
-                    raise exceptions.BackendError(message=error_msg)
+                    raise exceptions.ReadonlyError(message=error_msg)
                 obj = row
             else:
                 create_result = conn.execute(

--- a/tests/core/resource/test_base.py
+++ b/tests/core/resource/test_base.py
@@ -31,7 +31,7 @@ class ResourceTest(BaseTest):
         with mock.patch.object(
             request.registry.storage,
             "resource_timestamp",
-            side_effect=storage_exceptions.BackendError,
+            side_effect=storage_exceptions.ReadonlyError,
         ):
             with self.assertRaises(excepted_exc) as cm:
                 self.resource_class(request)


### PR DESCRIPTION
While working on https://github.com/Kinto/kinto-changes/pull/210 I realized we didn't have specific exceptions for the readonly errors.