### PR TITLE
Add ability to disable explicit permissions at object level (ref #893)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ This document describes changes between each past release.
 14.0.2 (unreleased)
 -------------------
 
+**New feature**
+
+- Add ability to disable explicit permissions at object level (ref #893). Use ``kinto.explicit_permissions = false`` to only rely on inherited permissions (see settings docs)
+
 **Internal Changes**
 
 - Distinguish readonly errors in storage backend (``kinto.core.storage.exceptions.ReadonlyError``)

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -44,6 +44,7 @@ DEFAULT_SETTINGS = {
     "eos": None,
     "eos_message": None,
     "eos_url": None,
+    "explicit_permissions": True,
     "error_info_link": "https://github.com/Kinto/kinto/issues/",
     "http_host": None,
     "http_scheme": None,
@@ -155,7 +156,7 @@ def includeme(config):
     config.registry.heartbeats = {}
 
     # Public settings registry.
-    config.registry.public_settings = {"batch_max_requests", "readonly"}
+    config.registry.public_settings = {"batch_max_requests", "readonly", "explicit_permissions"}
 
     # Directive to declare arbitrary API capabilities.
     def add_api_capability(config, identifier, description="", url="", **kw):

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -15,6 +15,7 @@ from pyramid.httpexceptions import (
     HTTPServiceUnavailable,
 )
 from pyramid.security import Everyone
+from pyramid.settings import asbool
 
 from kinto.core import Service
 from kinto.core.errors import ERRORS, http_error, raise_invalid, request_GET, send_alert
@@ -209,6 +210,7 @@ class Resource:
                 parent_id=parent_id,
                 current_principal=current_principal,
                 prefixed_principals=request.prefixed_principals,
+                explicit_perm=asbool(request.registry.settings["explicit_permissions"]),
             )
 
         # Initialize timestamp as soon as possible.

--- a/kinto/core/resource/model.py
+++ b/kinto/core/resource/model.py
@@ -35,6 +35,7 @@ class Model:
         parent_id="",
         current_principal=None,
         prefixed_principals=None,
+        explicit_perm=True,
     ):
         """
         :param storage: an instance of storage
@@ -44,6 +45,12 @@ class Model:
 
         :param str resource_name: the resource name
         :param str parent_id: the default parent id
+        :param bool explicit_perm:
+            Without explicit permissions, the ACLs on the object will
+            fully depend on the inherited permission tree (eg. read/write on parent).
+            This basically means that if user loose the permission on the
+            parent, they also loose the permission on children.
+            See https://github.com/Kinto/kinto/issues/893
         """
         self.storage = storage
         self.permission = permission
@@ -52,6 +59,7 @@ class Model:
         self.resource_name = resource_name
         self.current_principal = current_principal
         self.prefixed_principals = prefixed_principals
+        self.explicit_perm = explicit_perm
 
         # Object permission id.
         self.get_permission_object_id = None
@@ -81,7 +89,8 @@ class Model:
 
     def _allow_write(self, perm_object_id):
         """Helper to give the ``write`` permission to the current user."""
-        self.permission.add_principal_to_ace(perm_object_id, "write", self.current_principal)
+        if self.explicit_perm:
+            self.permission.add_principal_to_ace(perm_object_id, "write", self.current_principal)
 
     def get_objects(
         self,

--- a/tests/core/resource/test_base.py
+++ b/tests/core/resource/test_base.py
@@ -27,7 +27,7 @@ class ResourceTest(BaseTest):
 
         excepted_exc = httpexceptions.HTTPServiceUnavailable
 
-        request.registry.settings = {"readonly": "true"}
+        request.registry.settings = {"readonly": "true", "explicit_permissions": "true"}
         with mock.patch.object(
             request.registry.storage,
             "resource_timestamp",

--- a/tests/core/test_views_hello.py
+++ b/tests/core/test_views_hello.py
@@ -32,7 +32,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_public_settings_are_shown_in_view(self):
         response = self.app.get("/")
         settings = response.json["settings"]
-        expected = {"batch_max_requests": 25, "readonly": False}
+        expected = {"batch_max_requests": 25, "readonly": False, "explicit_permissions": True}
         self.assertEqual(expected, settings)
 
     def test_public_settings_can_be_set_from_registry(self):


### PR DESCRIPTION
Ref #893 

I'm looking at our DB in prod, and the `history` plugin combined with our explicit permissions system adds around 5K rows every month. And most of them are for permissions on the history entries (99.17% of 1M+ rows)

``` 
[kintoprod] # SELECT COUNT(*) FROM access_control_entries WHERE object_id LIKE '/buckets/%/history/%';
  count  
---------
 1165553
(1 row)

Time: 663,572 ms
[kintoprod] # SELECT COUNT(*) FROM access_control_entries WHERE object_id NOT LIKE '/buckets/%/history/%';
 count 
-------
  9715
(1 row)


``` 

This is not ideal, and it makes the [permission endpoint]() super slow of course (used in Kinto Admin to list accessible/writable objects on the server).

Introducing a new setting to disable explicit permissions is a cheap and simple way to overcome this issue. @Natim what do you think of the approach? (I will add tests of course)



