### PR TITLE
Add Python 3.9 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
       dist: xenial
       env:
         - TOX_ENV=py38
+    - python: 3.9
+      dist: xenial
+      env:
+        - TOX_ENV=py39
     - python: 3.7
       dist: xenial
       env: ENV=functional

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py36-raw,py37,py38
+envlist = py36,py36-raw,py37,py38,py39
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This PR adds CI support for Python 3.9,

Currently blocked on Travis adding support for Python 3.9.
