### PR TITLE
feat: allow env-var based email config

### DIFF
--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -36,6 +36,11 @@ DEFAULT_SETTINGS = {
     "group_id_generator": "kinto.views.NameGenerator",
     "record_id_generator": "kinto.views.RelaxedUUID",
     "project_name": "kinto",
+    "mail.host": "localhost",
+    "mail.port": 25,
+    "mail.default_sender": None,
+    "mail.username": None,
+    "mail.password": None,
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/Kinto/kinto-emailer/issues/233

Hi, i'm not sure this is the way to fix it, but this allow to use environment variables to configure pyramid email settings

I can now use these variables without any ini file : 

```sh
MAIL_DEFAULT_SENDER=toto@toto.com
MAIL_HOST=smtp.orange.fr
MAIL_PORT=25
```

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
