### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install virtualenv
+        run: pip install virtualenv
+
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -18,7 +18,9 @@ jobs:
           python-version: "3.x"
 
       - name: Install virtualenv
-        run: pip install virtualenv
+        run: |
+          pip install virtualenv
+          virtualenv --python=python3 .venv
 
       - uses: actions/setup-node@v1
         with:
@@ -26,10 +28,13 @@ jobs:
 
       - name: Print environment
         run: |
+          source .venv/bin/activate
           python --version
           pip --version
           node --version
           npm --version
 
       - name: make build-kinto-admin
-        run: make build-kinto-admin
+        run: |
+          source .venv/bin/activate
+          make build-kinto-admin

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Kinto Admin
+jobs:
+  chore:
+    name: Build Kinto Admin
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14.x"
+
+      - name: Print environment
+        run: |
+          python --version
+          pip --version
+          node --version
+          npm --version
+
+      - name: make build-kinto-admin
+        run: make build-kinto-admin

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install virtualenv
+        run: pip install virtualenv
+
       - name: Print environment
         run: |
           python --version

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,17 @@ jobs:
           python-version: "3.x"
 
       - name: Install virtualenv
-        run: pip install virtualenv
+        run: |
+          pip install virtualenv
+          virtualenv --python=python3 .venv
 
       - name: Print environment
         run: |
+          source .venv/bin/activate
           python --version
           pip --version
 
       - name: make docs
-        run: make docs
+        run: |
+          source .venv/bin/activate
+          make docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Docs
+jobs:
+  chore:
+    name: Validate docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Print environment
+        run: |
+          python --version
+          pip --version
+
+      - name: make docs
+        run: make docs

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install virtualenv
+        run: pip install virtualenv
+
       - name: Print environment
         run: |
           python --version

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Functional Testing
+jobs:
+  chore:
+    name: Functional
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Print environment
+        run: |
+          python --version
+          pip --version
+
+      - name: Install dependencies
+        run: |
+          make install-dev
+          make install-postgres
+
+      - name: Create database
+        run: |
+          psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres
+
+      - name: Start Kinto
+        run: make runkinto & sleep 5
+
+      - name: Functional Tests
+        run: make functional

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -48,6 +48,8 @@ jobs:
           make install-postgres
 
       - name: Create database
+        env:
+          PGPASSWORD: postgres
         run: |
           psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres -h localhost
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create database
         run: |
-          psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres
+          psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres -h localhost
 
       - name: Start Kinto
         run: |

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -31,15 +31,19 @@ jobs:
           python-version: "3.x"
 
       - name: Install virtualenv
-        run: pip install virtualenv
+        run: |
+          pip install virtualenv
+          virtualenv --python=python3 .venv
 
       - name: Print environment
         run: |
+          source .venv/bin/activate
           python --version
           pip --version
 
       - name: Install dependencies
         run: |
+          source .venv/bin/activate
           make install-dev
           make install-postgres
 
@@ -48,7 +52,11 @@ jobs:
           psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres
 
       - name: Start Kinto
-        run: make runkinto & sleep 5
+        run: |
+          source .venv/bin/activate
+          make runkinto & sleep 5
 
       - name: Functional Tests
-        run: make functional
+        run: |
+          source .venv/bin/activate
+          make functional

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,12 +18,17 @@ jobs:
           python-version: "3.x"
 
       - name: Install virtualenv
-        run: pip install virtualenv
+        run: |
+          pip install virtualenv
+          virtualenv --python=python3 .venv
+          source .venv/bin/activate
 
       - name: Print environment
         run: |
           python --version
           pip --version
+          which python
+          which pip
 
       - name: make lint
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install virtualenv
+        run: pip install virtualenv
+
       - name: Print environment
         run: |
           python --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,14 +21,16 @@ jobs:
         run: |
           pip install virtualenv
           virtualenv --python=python3 .venv
-          source .venv/bin/activate
 
       - name: Print environment
         run: |
+          source .venv/bin/activate
           python --version
           pip --version
           which python
           which pip
 
       - name: make lint
-        run: make lint
+        run: |
+          source .venv/bin/activate
+          make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,6 @@ jobs:
           source .venv/bin/activate
           python --version
           pip --version
-          which python
-          which pip
 
       - name: make lint
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Lint
+jobs:
+  chore:
+    name: Lint and check format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Print environment
+        run: |
+          python --version
+          pip --version
+
+      - name: make lint
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ on:
       - master
   pull_request:
 
-name: Functional Testing
+name: Unit Testing
 jobs:
   chore:
-    name: Functional
+    name: Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,74 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Functional Testing
+jobs:
+  chore:
+    name: Functional
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toxenv: [py36, py36-raw, py37, py38, py39]
+        include:
+          - toxenv: py36
+            python-version: "3.6"
+          - toxenv: py36-raw
+            python-version: "3.6"
+          - toxenv: py37
+            python-version: "3.7"
+          - toxenv: py38
+            python-version: "3.8"
+          - toxenv: py39
+            python-version: "3.9"
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install virtualenv
+        run: |
+          pip install virtualenv
+          virtualenv --python=python3 .venv
+
+      - name: Print environment
+        run: |
+          source .venv/bin/activate
+          python --version
+          pip --version
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          make install-dev
+          make install-postgres
+          pip install tox
+
+      - name: Create database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres -h localhost
+
+      - name: Tox
+        run: |
+          source .venv/bin/activate
+          tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,15 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      memcached:
+        image: memcached
+        options: >-
+          --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 11211:11211
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOX_ENV=py36
   - TOX_ENV=py36-raw
 install:
+  - pip install -U pip
   - pip install tox
 before_script:
   - echo "Pull request ${TRAVIS_PULL_REQUEST}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 install:
   - pip install -U pip
   - pip install tox
+  - pip install -U virtualenv
 before_script:
   - echo "Pull request ${TRAVIS_PULL_REQUEST}"
   - sudo sed -i "s/fsync/#fsync/" /etc/postgresql/9.5/main/postgresql.conf

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.16
-Sphinx==3.3.1
+Sphinx==3.0.3
 sphinx_rtd_theme==0.5.0
 sphinxcontrib-httpdomain==1.7.0
 kinto

--- a/kinto/core/storage/testing.py
+++ b/kinto/core/storage/testing.py
@@ -5,7 +5,7 @@ from pyramid import testing
 
 from kinto.core import utils
 from kinto.core.storage import MISSING, Filter, Sort, exceptions, heartbeat
-from kinto.core.testing import DummyRequest, ThreadMixin, skip_if_travis
+from kinto.core.testing import DummyRequest, ThreadMixin, skip_if_ci
 
 OBJECT_ID = "472be9ec-26fe-461b-8282-9c4e4b207ab3"
 
@@ -782,7 +782,7 @@ class TimestampsTest:
         after = self.storage.resource_timestamp(**self.storage_kw)
         self.assertTrue(before < after)
 
-    @skip_if_travis
+    @skip_if_ci
     def test_timestamps_are_unique(self):  # pragma: no cover
         obtained = []
 

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -12,7 +12,9 @@ from kinto.core import DEFAULT_SETTINGS, statsd
 from kinto.core.storage import generators
 from kinto.core.utils import encode64, follow_subrequest, memcache, sqlalchemy
 
-skip_if_travis = unittest.skipIf("TRAVIS" in os.environ, "travis")
+skip_if_travis = unittest.skipIf(
+    "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ, "travis"
+)
 skip_if_no_postgresql = unittest.skipIf(sqlalchemy is None, "postgresql is not installed.")
 skip_if_no_memcached = unittest.skipIf(memcache is None, "memcached is not installed.")
 skip_if_no_statsd = unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -12,9 +12,7 @@ from kinto.core import DEFAULT_SETTINGS, statsd
 from kinto.core.storage import generators
 from kinto.core.utils import encode64, follow_subrequest, memcache, sqlalchemy
 
-skip_if_travis = unittest.skipIf(
-    "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ, "travis"
-)
+skip_if_travis = unittest.skipIf("CI" in os.environ, "travis")
 skip_if_no_postgresql = unittest.skipIf(sqlalchemy is None, "postgresql is not installed.")
 skip_if_no_memcached = unittest.skipIf(memcache is None, "memcached is not installed.")
 skip_if_no_statsd = unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -12,7 +12,7 @@ from kinto.core import DEFAULT_SETTINGS, statsd
 from kinto.core.storage import generators
 from kinto.core.utils import encode64, follow_subrequest, memcache, sqlalchemy
 
-skip_if_travis = unittest.skipIf("CI" in os.environ, "travis")
+skip_if_ci = unittest.skipIf("CI" in os.environ, "travis")
 skip_if_no_postgresql = unittest.skipIf(sqlalchemy is None, "postgresql is not installed.")
 skip_if_no_memcached = unittest.skipIf(memcache is None, "memcached is not installed.")
 skip_if_no_statsd = unittest.skipIf(not statsd.statsd_module, "statsd is not installed.")

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ requires =
 
 [testenv]
 passenv = TRAVIS CI
+setenv =
+    PIP_USE_DEPRECATED = legacy-resolver
 commands =
     python --version
     py.test --cov-report term-missing --cov-branch --cov-fail-under 100 --cov kinto {posargs}
@@ -15,10 +17,12 @@ deps =
     newrelic
     raven
     statsd
-install_command = pip install --use-deprecated legacy-resolver {opts} {packages} -c{toxinidir}/requirements.txt
+install_command = pip install {opts} {packages} -c{toxinidir}/requirements.txt
 
 [testenv:py36-raw]
 passenv = TRAVIS CI
+setenv =
+    PIP_USE_DEPRECATED = legacy-resolver
 commands =
     python --version
     py.test {posargs}
@@ -30,4 +34,4 @@ deps =
 #   pytest-sugar
     webtest
     werkzeug
-install_command = pip install --use-deprecated legacy-resolver {opts} {packages} -c{toxinidir}/requirements.txt
+install_command = pip install {opts} {packages} -c{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py36,py36-raw,py37,py38,py39
 skip_missing_interpreters = True
+requires =
+    virtualenv >= 20.2.2
 
 [testenv]
 passenv = TRAVIS CI

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py36,py36-raw,py37,py38,py39
 skip_missing_interpreters = True
 
 [testenv]
-passenv = TRAVIS
+passenv = TRAVIS CI
 commands =
     python --version
     py.test --cov-report term-missing --cov-branch --cov-fail-under 100 --cov kinto {posargs}
@@ -16,7 +16,7 @@ deps =
 install_command = pip install --use-deprecated legacy-resolver {opts} {packages} -c{toxinidir}/requirements.txt
 
 [testenv:py36-raw]
-passenv = TRAVIS
+passenv = TRAVIS CI
 commands =
     python --version
     py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     newrelic
     raven
     statsd
-install_command = pip install {opts} {packages} -c{toxinidir}/requirements.txt
+install_command = pip install --use-deprecated legacy-resolver {opts} {packages} -c{toxinidir}/requirements.txt
 
 [testenv:py36-raw]
 passenv = TRAVIS
@@ -28,4 +28,4 @@ deps =
 #   pytest-sugar
     webtest
     werkzeug
-install_command = pip install {opts} {packages} -c{toxinidir}/requirements.txt
+install_command = pip install --use-deprecated legacy-resolver {opts} {packages} -c{toxinidir}/requirements.txt


### PR DESCRIPTION
As discussed in #2643, this PR mirrors the CI steps we're currently performing in Travis to GitHub Actions.

This PR makes the following changes:
- pip now installs using the [legacy resolver](https://pip.pypa.io/en/stable/user_guide/#resolver-changes-2020), which matches the installation behavior it used prior to the 20.3 upgrade released earlier this month. There are some incompatibilities in our dependencies, so I'm hoping that those get resolved by the time the legacy resolver is deprecated in January.
- Sphinx has been downgraded to the last known working version, 3.0.3.
- The latest versions of pip and virtualenv are installed into the environment prior to tox being run

In addition to the above changes, this PR adds GitHub Actions workflows mirroring the things we're currently doing in Travis.