### PR TITLE
Revert "Bump sphinx from 3.0.3 to 3.3.1"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.16
-Sphinx==3.3.1
+Sphinx==3.0.3
 sphinx_rtd_theme==0.5.0
 sphinxcontrib-httpdomain==1.7.0
 kinto


### PR DESCRIPTION
Reverts Kinto/kinto#2657

It looks like there's an issue generating docs using recent versions of `sphinx`. This PR reverts to the last known working version since it look like this PR was merged with the docs tests failing.