### PR TITLE
Fix documentation about disabling endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 14.3.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Documentation**
+
+- Fix documentation about disabling endpoints (#2794)
 
 
 14.2.0 (2021-02-22)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -98,6 +98,7 @@ Contributors
 * Tiberiu Ichim <@tiberiuichim>
 * Vamsi Sangam <vamsisangam@live.com>
 * Varna Suresh <varna96@gmail.com>
+* Vincent Fretin <@vincentfretin>
 * Vitor Falcao <vitor.falcaor@gmail.com>
 * Wil Clouser <wclouser@mozilla.com>
 * Yann Klis <yann.klis@gmail.com>

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -995,23 +995,17 @@ To do so, a setting key must be defined for the disabled resources endpoints::
 
 Where:
 
-- **endpoint_type** is either ``collection`` (plural, e.g. ``/buckets``) or ``record`` (single, e.g. ``/buckets/abc``);
+- **endpoint_type** is either ``plural`` (e.g. ``/buckets``) or ``object`` (e.g. ``/buckets/abc``);
 - **resource_name** is the name of the resource (e.g. ``bucket``, ``group``, ``collection``, ``record``);
 - **method** is the http method (in lower case) (e.g. ``get``, ``post``, ``put``, ``patch``, ``delete``).
-
-.. important::
-
-    These settings are confusing because of the naming used in ``kinto.core``.
-    Especially ``collection`` and ``record`` are endpoint types in ``kinto.core`` and resource names in Kinto.
-    We want to solve this in #710.
 
 For example, to disable the POST on the list of buckets and DELETE on single records, the
 following setting should be declared in the ``.ini`` file:
 
 .. code-block:: ini
 
-    kinto.collection_bucket_post_enabled = false
-    kinto.record_record_delete_enabled = false
+    kinto.plural_bucket_post_enabled = false
+    kinto.object_record_delete_enabled = false
 
 
 Activating the permissions endpoint

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -200,16 +200,14 @@ kinto.bucket_create_principals = account:admin
 # Enabling or disabling endpoints
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#enabling-or-disabling-endpoints
 #
-# This is a rather confusing setting due to naming conventions used in kinto.core
-# For a more in depth explanation, refer to https://github.com/Kinto/kinto/issues/710
 # kinto.endpoint_type_resource_name_method_enabled = false
 # Where:
-# endpoint_type: is either ``collection`` (plural, e.g. ``/buckets``) or ``record`` (single, e.g. ``/buckets/abc``);
+# endpoint_type: is either ``plural`` (e.g. ``/buckets``) or ``object`` (e.g. ``/buckets/abc``);
 # resource_name: is the name of the resource (e.g. ``bucket``, ``group``, ``collection``, ``record``);
 # method: is the http method (in lower case) (e.g. ``get``, ``post``, ``put``, ``patch``, ``delete``).
 # For example, to disable the POST on the list of buckets and DELETE on single records
-# kinto.collection_bucket_post_enabled = false
-# kinto.record_record_delete_enabled = false
+# kinto.plural_bucket_post_enabled = false
+# kinto.object_record_delete_enabled = false
 
 # [uwsgi]
 # wsgi-file = app.wsgi


### PR DESCRIPTION
I was trying to disable listing records following the documentation 
https://docs.kinto-storage.org/en/latest/configuration/settings.html#enabling-or-disabling-endpoints
but couldn't make it work. In the end I added a print in `kinto/core/resource/viewset.py` to list what conf it tried, here the list:

plural_account_head_enabled
plural_account_get_enabled
plural_account_post_enabled
plural_account_delete_enabled
object_account_get_enabled
object_account_put_enabled
object_account_patch_enabled
object_account_delete_enabled
object_user-data_delete_enabled
plural_bucket_head_enabled
plural_bucket_get_enabled
plural_bucket_post_enabled
plural_bucket_delete_enabled
object_bucket_get_enabled
object_bucket_put_enabled
object_bucket_patch_enabled
object_bucket_delete_enabled
plural_collection_head_enabled
plural_collection_get_enabled
plural_collection_post_enabled
plural_collection_delete_enabled
object_collection_get_enabled
object_collection_put_enabled
object_collection_patch_enabled
object_collection_delete_enabled
plural_group_head_enabled
plural_group_get_enabled
plural_group_post_enabled
plural_group_delete_enabled
object_group_get_enabled
object_group_put_enabled
object_group_patch_enabled
object_group_delete_enabled
plural_permissions_head_enabled
plural_permissions_get_enabled
plural_record_head_enabled
plural_record_get_enabled
plural_record_post_enabled
plural_record_delete_enabled
object_record_get_enabled
object_record_put_enabled
object_record_patch_enabled
object_record_delete_enabled

This seems to have changed with #710

Using `kinto.plural_record_get_enabled = false` works.
```
curl --silent http://0.0.0.0:8888/v1/buckets/mybucket/collections/mycollection/records |python -mjson.tool
{
    "code": 405,
    "errno": 115,
    "error": "Method Not Allowed",
    "message": "Method not allowed on this endpoint."
}
```
