### PR TITLE
Add cache-control headers to version prefix redirects (fixes #2874)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 14.5.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**New feature**
+
+- Add ``kinto.version_prefix_redirect_ttl_seconds`` setting in order to send ``Cache-Control`` response headers on version prefix redirects (fixes #2874)
 
 
 14.4.1 (2021-09-20)

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -1064,27 +1064,30 @@ If set to ``0`` then the resource becomes uncacheable (``no-cache``).
 Project information
 ===================
 
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| Setting name                          | Default                                    | What does it do?                                                         |
-+=======================================+============================================+==========================================================================+
-| kinto.version_json_path               | ``./version.json``                         | Location of the file containing the information to be shown in the       |
-|                                       |                                            | :ref:`version endpoint <api-utilities-version>`.                         |
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| kinto.error_info_link                 | ``https://github.com/kinto/kinto/issues/`` | The HTTP link returned when uncaught errors are triggered on the server. |
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| kinto.project_docs                    | ``https://kinto.readthedocs.io``           | The URL where the documentation of the Kinto instance can be found. Will |
-|                                       |                                            | be returned in :ref:`the hello view <api-utilities>`.                    |
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| kinto.project_name                    | ``kinto``                                  | The name of your project (powered by Kinto)                              |
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| kinto.project_version                 | ``''``                                     | The version of the project. Will be returned in :ref:`the hello view     |
-|                                       |                                            | <api-utilities>`. By default, this is the major version of Kinto.        |
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
-| kinto.version_prefix_redirect_enabled | ``True``                                   | By default, all endpoints exposed by Kinto are prefixed by a             |
-|                                       |                                            | :ref:`version number <api-versioning>`. If this flag is enabled, the     |
-|                                       |                                            | server will redirect all requests not matching the supported version     |
-|                                       |                                            | to the supported one.                                                    |
-+---------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| Setting name                                    | Default                                    | What does it do?                                                         |
++=================================================+============================================+==========================================================================+
+| kinto.version_json_path                         | ``./version.json``                         | Location of the file containing the information to be shown in the       |
+|                                                 |                                            | :ref:`version endpoint <api-utilities-version>`.                         |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| kinto.error_info_link                           | ``https://github.com/kinto/kinto/issues/`` | The HTTP link returned when uncaught errors are triggered on the server. |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| kinto.project_docs                              | ``https://kinto.readthedocs.io``           | The URL where the documentation of the Kinto instance can be found. Will |
+|                                                 |                                            | be returned in :ref:`the hello view <api-utilities>`.                    |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| kinto.project_name                              | ``kinto``                                  | The name of your project (powered by Kinto)                              |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| kinto.project_version                           | ``''``                                     | The version of the project. Will be returned in :ref:`the hello view     |
+|                                                 |                                            | <api-utilities>`. By default, this is the major version of Kinto.        |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| kinto.version_prefix_redirect_enabled           | ``True``                                   | By default, all endpoints exposed by Kinto are prefixed by a             |
+|                                                 |                                            | :ref:`version number <api-versioning>`. If this flag is enabled, the     |
+|                                                 |                                            | server will redirect all requests not matching the supported version     |
+|                                                 |                                            | to the supported one.                                                    |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
+| kinto.version_prefix_redirect_ttl_seconds       | ``-1``                                     | Seconds specified in cache control headers on version prefix redirects.  |
+|                                                 |                                            | Set to ``-1`` to disable, and ``0``  to send ``no-cache`` explicitly.    |
++-------------------------------------------------+--------------------------------------------+--------------------------------------------------------------------------+
 
 Example:
 

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -83,6 +83,7 @@ DEFAULT_SETTINGS = {
     "project_version": "",
     "readonly": False,
     "retry_after_seconds": 30,
+    "version_prefix_redirect_ttl_seconds": -1,
     "settings_prefix": "",
     "statsd_backend": "kinto.core.statsd",
     "statsd_prefix": "kinto.core",

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -74,6 +74,7 @@ def setup_version_redirection(config):
     settings = config.get_settings()
     redirect_enabled = settings["version_prefix_redirect_enabled"]
     version_prefix_redirection_enabled = asbool(redirect_enabled)
+    cache_seconds = int(settings["version_prefix_redirect_ttl_seconds"])
 
     route_prefix = config.route_prefix
     config.registry.route_prefix = route_prefix
@@ -91,7 +92,10 @@ def setup_version_redirection(config):
 
         querystring = request.url[(request.url.rindex(request.path) + len(request.path)) :]
         redirect = f"/{route_prefix}{request.path}{querystring}"
-        raise HTTPTemporaryRedirect(redirect)
+        resp = HTTPTemporaryRedirect(redirect)
+        if cache_seconds >= 0:
+            resp.cache_expires(cache_seconds)
+        raise resp
 
     # Disable the route prefix passed by the app.
     config.route_prefix = None

--- a/tests/core/test_views_errors.py
+++ b/tests/core/test_views_errors.py
@@ -313,6 +313,13 @@ class RedirectViewTest(FormattedErrorMixin, BaseWebTest, unittest.TestCase):
         resp = self.app.options("/", headers=headers, status=200)
         self.assertIn("Access-Control-Allow-Origin", resp.headers)
 
+    def test_redirects_sends_cache_control_headers(self):
+        app = self.make_app({"version_prefix_redirect_ttl_seconds": 3600})
+        resp = app.get("/", status=307)
+        self.assertIn("Expires", resp.headers)
+        self.assertIn("Cache-Control", resp.headers)
+        self.assertEqual(resp.headers["Cache-Control"], "max-age=3600")
+
     def test_do_not_redirect_to_version_if_disabled_in_settings(self):
         # GET on the hello view.
         app = self.make_app({"version_prefix_redirect_enabled": False})


### PR DESCRIPTION
Fixes #2874

- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] ~~If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.~~  Decided that it was a bit too level. Maybe?
