### PR TITLE
Escape regex characters in object search pattern (#2676)

### DIFF
--- a/kinto/core/permission/memory.py
+++ b/kinto/core/permission/memory.py
@@ -103,7 +103,7 @@ class Permission(PermissionBase):
         else:
             for pattern, perm in bound_permissions:
                 id_match = ".*" if with_children else "[^/]+"
-                regexp = re.compile(f"^{pattern.replace('*', id_match)}$")
+                regexp = re.compile(f"^{re.escape(pattern).replace('*', id_match)}$")
                 for key, value in self._store.items():
                     if key.endswith(perm):
                         object_id = key.split(":")[1]

--- a/tests/core/resource/test_object_permissions.py
+++ b/tests/core/resource/test_object_permissions.py
@@ -76,6 +76,20 @@ class ObtainObjectPermissionTest(PermissionTest):
         self.assertEqual(result["permissions"], {})
 
 
+class GetObjectsPermissionTest(PermissionTest):
+    def setUp(self):
+        super().setUp()
+        self.object_id = ")EFg9=)%5E(M~%2037"
+        self.object_uri = "/articles/{}".format(self.object_id)
+        self.perm = "read"
+        self.permission.add_principal_to_ace(self.object_uri, self.perm, "account:readonly")
+
+    def test_get_objects_permissions_escapes_regex_chars_in_id(self):
+        principals = self.permission.get_object_permission_principals(self.object_uri, self.perm)
+        result = self.permission.get_accessible_objects(principals, [(self.object_uri, self.perm)])
+        self.assertEqual(result, {self.object_uri: {self.perm}})
+
+
 class SpecifyObjectPermissionTest(PermissionTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Fixes #2676

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [x] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
