### PR TITLE
Update `Dockerfile` & `docker-compose` for faster, usable builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,26 @@
-db:
-  image: postgres
-  environment:
-    POSTGRES_USER: postgres
-    POSTGRES_PASSWORD: postgres
-cache:
-  image: library/memcached
-web:
-  image: kinto/kinto-server
-  links:
-   - db
-   - cache
-  ports:
-   - "8888:8888"
-  environment:
-    KINTO_CACHE_BACKEND: kinto.core.cache.memcached
-    KINTO_CACHE_HOSTS: cache:11211 cache:11212
-    KINTO_STORAGE_BACKEND: kinto.core.storage.postgresql
-    KINTO_STORAGE_URL: postgresql://postgres:postgres@db/postgres
-    KINTO_PERMISSION_BACKEND: kinto.core.permission.postgresql
-    KINTO_PERMISSION_URL: postgresql://postgres:postgres@db/postgres
+version: "3"
+services:
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_NAME: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+  cache:
+    image: memcached:1
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+    - db
+    - cache
+    ports:
+    - "8888:8888"
+    environment:
+      KINTO_CACHE_BACKEND: kinto.core.cache.memcached
+      KINTO_CACHE_HOSTS: cache:11211 cache:11212
+      KINTO_STORAGE_BACKEND: kinto.core.storage.postgresql
+      KINTO_STORAGE_URL: postgresql://postgres:postgres@db/postgres
+      KINTO_PERMISSION_BACKEND: kinto.core.permission.postgresql
+      KINTO_PERMISSION_URL: postgresql://postgres:postgres@db/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: kinto/kinto-server:latest
     depends_on:
     - db
     - cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jsonpatch==1.32
 jsonschema==4.4.0
 logging-color-formatter==1.0.2
 newrelic==7.2.4.171
-psycopg2-binary==2.9.3
+psycopg2==2.9.3
 pyramid==2.0
 pyramid-mailer==0.15.1
 pyramid-multiauth==1.0.1


### PR DESCRIPTION
This PR:
- Converts the Dockerfile to a multistage build

This is so that we can cache the layers responsible for building `kinto-admin` and installing the dependencies `kinto` relies on to build itself. This also leads to an overall smaller image by the end of the build.

Before:
- Build time (no cache): ~5m 30s
- Build time after minimal code change: ~5m 30s
- Image size: 638MB

After
- Build time (no cache): ~2m 30s
- Build time after minimal code change: ~8s
- Image size: 256MB

It also:
- Upgrades Node from version 10 (which was breaking the build) to version 16 (LTS)
- Modifies the `docker-compose` file to be usable again, since services must be nested under a top-level `services` key