### PR TITLE
Fix crash in the /permissions endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 14.7.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug Fixes**
+
+- Fix crash in ``/permissions`` endpoint when a setting is misinterpreted as resource permission (e.g. ``signer.auto_create_resources_principals``)
 
 
 14.6.0 (2021-11-16)

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -25,10 +25,12 @@ def allowed_from_settings(settings, principals):
     """
     potential_settings = {tuple(k.split("_")): v for k, v in settings.items()}
     perms_settings = {
-        k: aslist(v) for k, v in potential_settings.items() if len(k) == 3 and k[2] == "principals"
+        k[:2]: aslist(v)  # ("bucket", "write"), ["account:admin"]
+        for k, v in potential_settings.items()
+        if len(k) == 3 and k[2] == "principals"  # bucket_write_principals = ...
     }
     from_settings = {}
-    for (resource_name, permission, _), allowed_principals in perms_settings.items():
+    for (resource_name, permission), allowed_principals in perms_settings.items():
         # Keep the known permissions only.
         if resource_name not in PERMISSIONS_INHERITANCE_TREE.keys():
             continue

--- a/kinto/views/permissions.py
+++ b/kinto/views/permissions.py
@@ -23,10 +23,12 @@ def allowed_from_settings(settings, principals):
 
     XXX: This helper will be useful for Kinto/kinto#894
     """
-    perms_settings = {k: aslist(v) for k, v in settings.items() if k.endswith("_principals")}
+    potential_settings = {tuple(k.split("_")): v for k, v in settings.items()}
+    perms_settings = {
+        k: aslist(v) for k, v in potential_settings.items() if len(k) == 3 and k[2] == "principals"
+    }
     from_settings = {}
-    for key, allowed_principals in perms_settings.items():
-        resource_name, permission, _ = key.split("_")
+    for (resource_name, permission, _), allowed_principals in perms_settings.items():
         # Keep the known permissions only.
         if resource_name not in PERMISSIONS_INHERITANCE_TREE.keys():
             continue

--- a/tests/test_views_permissions.py
+++ b/tests/test_views_permissions.py
@@ -375,3 +375,18 @@ class DeletedObjectsTest(PermissionsViewTest):
     def test_deleted_objects_are_not_listed(self):
         resp = self.app.get("/permissions", headers=self.headers)
         self.assertEqual(len(resp.json["data"]), 1)
+
+
+class IgnoredSettingsTest(PermissionsViewTest):
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings["signer.auto_create_resources_principals"] = "system.Authenticated"
+        return settings
+
+    def test_unrecognized_settings_are_ignored(self):
+        resp = self.app.get("/permissions", headers=self.headers)
+        self.assertEqual(
+            resp.json["data"],
+            [{"permissions": ["bucket:create"], "resource_name": "root", "uri": "/"}],
+        )


### PR DESCRIPTION
Prevent all settings ending with _principals to be interpreted as
resource permissions settings.

- [ ] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
