### PR TITLE
Test package description formatting in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,3 +32,8 @@ jobs:
         run: |
           source .venv/bin/activate
           make docs
+
+      - name: Package description
+        run: |
+          source .venv/bin/activate
+          make test-description

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 14.7.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Internal Changes**
+
+- Test package description formatting in CI
 
 
 14.6.1 (2022-02-03)

--- a/Makefile
+++ b/Makefile
@@ -131,3 +131,6 @@ docs: install-docs
 
 build:
 	docker build --pull -t kinto/kinto-server:latest .
+
+test-description: install-dev
+	$(VENV)/bin/longtest --headless

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,5 +14,5 @@ therapist==2.2.0
 tox==3.24.5
 WebTest==3.0.0
 wheel==0.37.1
-zest.releaser==6.22.2
+zest.releaser==7.0.0a2
 zope.sqlalchemy==1.6


### PR DESCRIPTION
Currently we include the CHANGELOG and README in the Python package description.

When pushing a release to Pypi, the server will return a 400 if the package description does not render properly (rst formatting etc.)

In order to avoid discovering issue at the moment of pushing the release to Pypi, let's add a CI job to verify it. This is globally equivalent to add linting to a rst document that concatenates README.rst, CHANGELOG.rst, and CONTRIBUTORS.rst