### PR TITLE
Prevents merging of `ResourceChanged` events if they are emitted in cascade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ This document describes changes between each past release.
 14.7.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug Fixes**
+
+- Prevents merging of `ResourceChanged` events if they were triggered from
+  events listeners (cascade) (see mozilla/remote-settings#203)
 
 
 14.7.1 (2022-03-30)

--- a/kinto/core/events.py
+++ b/kinto/core/events.py
@@ -94,7 +94,7 @@ class EventCollector(object):
         self.event_dict = OrderedDict()
         """The events as collected so far.
 
-        The key of the event_dict is a triple (cascade_level, resource_name,
+        The key of the event_dict is a quadruple (cascade_level, resource_name,
         parent_id, action). The value is a triple (impacted, request,
         payload). If the same (cascade_level, resource_name, parent_id, action) is
         encountered, we just extend the existing impacted with the new

--- a/kinto/core/events.py
+++ b/kinto/core/events.py
@@ -84,13 +84,19 @@ class EventCollector(object):
     fewer events.
     """
 
-    def __init__(self):
+    def __init__(self, cascade_level=1):
+        self.cascade_level = cascade_level
+        """Current level of event cascade. When we start consuming the
+        gathered events, we increment it. This way, events emitted from
+        events listeners (cascade) are not merged with upstream ones.
+        """
+
         self.event_dict = OrderedDict()
         """The events as collected so far.
 
-        The key of the event_dict is a triple (resource_name,
+        The key of the event_dict is a triple (cascade_level, resource_name,
         parent_id, action). The value is a triple (impacted, request,
-        payload). If the same (resource_name, parent_id, action) is
+        payload). If the same (cascade_level, resource_name, parent_id, action) is
         encountered, we just extend the existing impacted with the new
         impacted. N.B. this means all values in the payload must not
         be specific to a single impacted_object. See
@@ -99,7 +105,7 @@ class EventCollector(object):
         """
 
     def add_event(self, resource_name, parent_id, action, payload, impacted, request):
-        key = (resource_name, parent_id, action)
+        key = (self.cascade_level, resource_name, parent_id, action)
         if key not in self.event_dict:
             value = (payload, impacted, request)
             self.event_dict[key] = value
@@ -119,6 +125,8 @@ class EventCollector(object):
         Items yielded will be of a tuple suitable for using as
         arguments to EventCollector.add_event.
         """
+        # Since we start consuming the gathered events, we increment the cascade level.
+        self.cascade_level += 1
         return EventCollectorDrain(self)
 
 
@@ -213,9 +221,9 @@ def get_resource_events(request, after_commit=False):
     by_resource = request.bound_data.get("resource_events", EventCollector())
     afterwards = EventCollector()
 
-    for event_call in by_resource.drain():
-        afterwards.add_event(*event_call)
-        (_, _, action, payload, impacted, request) = event_call
+    for event in by_resource.drain():
+        (_, resource_name, parent_id, action, payload, impacted, request) = event
+        afterwards.add_event(resource_name, parent_id, action, payload, impacted, request)
 
         if after_commit:
             if action == ACTIONS.READ:

--- a/tests/core/resource/test_events.py
+++ b/tests/core/resource/test_events.py
@@ -400,7 +400,7 @@ class CascadingEventsTest(BaseEventTest, unittest.TestCase):
             resource_changed_events[1].impacted_objects[0]["new"]["name"], "de New York"
         )
 
-    def test_cascading_events_are_merged(self):
+    def test_cascading_events_are_merged_in_after_resourced_changed(self):
         self.app.post_json(self.plural_url, self.body, headers=self.headers, status=201)
         relevant_events = [e for e in self.events if isinstance(e, AfterResourceChanged)]
         self.assertEqual(len(relevant_events), 1)
@@ -428,7 +428,7 @@ class BatchCascadeEventsTest(BaseEventTest, unittest.TestCase):
                 event.request, parent_id, event.payload["timestamp"], {"foo": "42"}, ACTIONS.UPDATE
             )
 
-    def test_cascading_events_are_not_merged_if_issuer_differs(self):
+    def test_cascading_events_are_not_merged(self):
         resp = self.app.post_json(self.plural_url, self.body, headers=self.headers)
         existing = resp.json["data"]
         before = len(self.events)


### PR DESCRIPTION
This wlil change the way cascading events are grouped together. 

Before, we would group all cascading events together, as long as they were for the same (resource name, parent id, action). When grouping events, some information is lost (we keep only payload and merge the list of impacted objects), including the `user_id` that triggered the event. This caused us issues because we were unable to distinguish events triggered by the plugin itself, from events triggered by users. See mozilla/remote-settings#203

Now, we prevent grouping of cascading events. Events triggered from events listeners won't be grouped with upstream events. To accomplish this, we increment a cascade_level state variable when we start consuming the list of events to be triggered, and use it in the grouping key.
