### PR TITLE
run tests on python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
             python-version: "3.9"
           - toxenv: py10
             python-version: "3.10"
+          - toxenv: py11
+            python-version: "3.11"
 
     services:
       postgres:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py38-raw,py39,py10
+envlist = py37,py38,py38-raw,py39,py10,py11
 skip_missing_interpreters = True
 requires =
     virtualenv >= 20.2.2


### PR DESCRIPTION
This PR adds Python 3.11 to the Unit Testing matrix.