### PR TITLE
Enable GitHub action build and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64
           tags: elswork/kinto:1.0.0, elswork/kinto:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           tags: elswork/kinto:1.0.0, elswork/kinto:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  # push:
+  #   branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    #environment: elsworkEnvironment
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3.1.0
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Make Buildx
+        run: make build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
           tags: elswork/kinto:1.0.0, elswork/kinto:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Build & Publish
 
 # Controls when the workflow will run
 on:
@@ -40,5 +40,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Make Buildx
-        run: make build
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: elswork/kinto:latest, elswork/kinto:1.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: elswork/kinto:latest, elswork/kinto:1.0.0
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          tags: elswork/kinto:1.0.0, elswork/kinto:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,11 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Build & Publish
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  # push:
-  #   branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   docker:
     runs-on: ubuntu-latest
-    #environment: elsworkEnvironment
     steps:
       -
         name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,16 +33,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Login to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: elswork/kinto:1.0.0, elswork/kinto:latest
+          tags: kinto/kinto-server:14.4.0, kinto/kinto-server:latest


### PR DESCRIPTION
Add a GitHub action Workflow that build and publish Kinto docker images in DockerHub.
You only need to add required secrets in the repository and launch the workflow from action workflow trigger button.
Then you will get arm64 and amd64 images in your DockerHub like this:
https://hub.docker.com/r/elswork/kinto/tags