### PR TITLE
Fix SQLAlchemy integration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 15.1.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Bug Fixes**
+
+- Use correct import path for SQLAlchemy Sentry integration
 
 
 15.1.0 (2023-02-08)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help:
 
 all: install
 install: $(INSTALL_STAMP)
-$(INSTALL_STAMP): $(PYTHON) setup.py requirements.txt
+$(INSTALL_STAMP): $(PYTHON) setup.py requirements.txt setup.cfg
 	$(VENV)/bin/pip install -U pip
 	$(VENV)/bin/pip install -Ue . -c requirements.txt
 	touch $(INSTALL_STAMP)

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -28,7 +28,8 @@ except ImportError:  # pragma: no cover
     ProfilerMiddleware = False
 try:
     import sentry_sdk
-    from sentry_sdk.integrations.pyramid import PyramidIntegration, SqlalchemyIntegration
+    from sentry_sdk.integrations.pyramid import PyramidIntegration
+    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 except ImportError:  # pragma: no cover
     sentry_sdk = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ postgresql =
     zope.sqlalchemy
 monitoring =
     newrelic
-    sentry-sdk
+    sentry-sdk[sqlalchemy]
     statsd
     werkzeug
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/dev-requirements.txt
     psycopg2
     newrelic
-    sentry-sdk
+    sentry-sdk[sqlalchemy]
     statsd
 install_command = pip install {opts} {packages} -c{toxinidir}/requirements.txt
 


### PR DESCRIPTION
Looking at [the docs](https://docs.sentry.io/platforms/python/guides/pyramid/configuration/integrations/sqlalchemy/), I think this is the main change we needed to enable the SQLAlchemy integration:

```diff
- from sentry_sdk.integrations.pyramid import PyramidIntegration, SqlalchemyIntegration
+ from sentry_sdk.integrations.pyramid import PyramidIntegration
+ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
```
