### PR TITLE
Fix typos on the Overview page

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -74,6 +74,7 @@ Contributors
 * PeriGK <per.gkolias@gmail.com>
 * Peter Bengtsson <mail@peterbe.com>
 * Peter Rassias <ubcpeter@hotmail.com>
+* Ravi Kalsi <jadeleafmoon@gmail.com>
 * realsumit <sumitsarinofficial@gmail.com>
 * Rektide <rektide@voodoowarez.com>
 * Rémy Hubscher <rhubscher@mozilla.com>

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -48,8 +48,8 @@ Use cases
 - **Offline-first applications**: data can also be stored locally and published later.
 - **Build collaborative applications** with real time updates and fine-grained permissions.
 - **Synchronise application data** between different devices.
-- **Content delivery**: manage remote content or configuration for your apps via an administration UI
-- **Data collection**: easily collect structured data from surveys, forms, analytics.
+- **Content delivery**: manage remote content or configuration for your apps via an administration UI.
+- **Data collection**: easily collect structured data from surveys, forms, and analytics.
 - **Store encrypted data** at a location users can control, ensuring better privacy and security.
 
 .. note::

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -186,7 +186,7 @@ Key features
 | <https://kintojs.readthedocs.io>`_            | <kinto-admin>`                                      |
 +-----------------------------------------------+-----------------------------------------------------+
 | |logo-history|                                | |logo-livesync|                                     |
-| :ref:`History of changes and authorship       | Live :ref:`Push notifications                       |
+| :ref:`History of changes and authorship       | :ref:`Live push notifications                       |
 | <api-history>`                                | <tutorials>`                                        |
 +-----------------------------------------------+-----------------------------------------------------+
 | |logo-attachment|                             | |logo-signature|                                    |

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -246,7 +246,7 @@ For example, when a record is created or updated in a particular collection.
 
 It can send a notification to clients using `WebSockets <https://en.wikipedia.org/wiki/WebSocket>`_
 or fill a queue of messages in `Redis <http://redis.io/>`_ or execute any custom code of your choice,
-like for sending emails or pinging a third-party. For example, at Mozilla, Push notifications are sent to millions of clients using `kinto-megaphone <https://github.com/Kinto/kinto-megaphone>`_.
+like for sending emails or pinging a third party. For example, at Mozilla, push notifications are sent to millions of clients using `kinto-megaphone <https://github.com/Kinto/kinto-megaphone>`_.
 
 
 See :ref:`our tutorials <tutorials>` for more in-depth information on

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -20,7 +20,7 @@ Why use Kinto?
 It's hard for frontend developers to respect user privacy when building applications
 that work offline, store data remotely, and synchronise across devices.
 Existing solutions either rely on big corporations that crave user data, or require
-a non-trivial amount of time and expertise to setup a new server for every new project.
+a considerable amount of time and expertise to setup a new server for every new project.
 
 We want to help developers focus on the frontend, and we don't want the challenge
 of storing user data to get in their way. The path between a new idea and deploying to

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -18,9 +18,9 @@ Why use Kinto?
     Don't build silos. Decentralize the Web!
 
 It's hard for frontend developers to respect user privacy when building applications
-that work offline, store data remotely, and synchronise across devices.
+that work offline, store data remotely and synchronise across devices.
 Existing solutions either rely on big corporations that crave user data, or require
-a considerable amount of time and expertise to setup a new server for every new project.
+a considerable amount of time and expertise to set up a new server for every new project.
 
 We want to help developers focus on the frontend, and we don't want the challenge
 of storing user data to get in their way. The path between a new idea and deploying to
@@ -30,7 +30,7 @@ Also, we believe data belongs to the users, and not necessarily to the applicati
 Applications should be decoupled from the storage location, and users should be
 able to choose where their personal data is stored.
 
-The backend can often be universal, generic and resusable. We envision mutualisation
+The backend can often be universal, generic, and resusable. We envision mutualisation
 of services and self-hosting: the backend is deployed, secured and scaled
 only once for several applications.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -31,7 +31,7 @@ Applications should be decoupled from the storage location, and users should be
 able to choose where their personal data is stored.
 
 The backend can often be universal, generic, and resusable. We envision mutualisation
-of services and self-hosting: the backend is deployed, secured and scaled
+of services and self-hosting: the backend is deployed, secured, and scaled
 only once for several applications.
 
 
@@ -46,11 +46,11 @@ Use cases
 - **Applications as static files**: just host your apps on GitHub pages, your backend storage
   is elsewhere!
 - **Offline-first applications**: data can also be stored locally and published later.
-- **Build collaborative applications** with real time updates and fine-grained permissions.
+- **Build collaborative applications** with real-time updates and fine-grained permissions.
 - **Synchronise application data** between different devices.
 - **Content delivery**: manage remote content or configuration for your apps via an administration UI.
 - **Data collection**: easily collect structured data from surveys, forms, and analytics.
-- **Store encrypted data** at a location users can control, ensuring better privacy and security.
+- **Store encrypted data** at a location that users can control, ensuring better privacy and security.
 
 .. note::
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -26,9 +26,9 @@ We want to help developers focus on the frontend, and we don't want the challeng
 of storing user data to get in their way. The path between a new idea and deploying to
 production should be short!
 
-Also, we believe data belong to the users, and not necessarily to the application authors.
+Also, we believe data belongs to the users, and not necessarily to the application authors.
 Applications should be decoupled from the storage location, and users should be
-able to choose where their personal data are stored.
+able to choose where their personal data is stored.
 
 The backend can often be universal, generic and resuable. We envision mutualisation
 of services and self-hosting: the backend is deployed, secured and scaled

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -17,7 +17,7 @@ Why use Kinto?
 
     Don't build silos. Redecentralize the Web!
 
-It's hard for frontend developers to respect users privacy when building applications
+It's hard for frontend developers to respect user privacy when building applications
 that work offline, store data remotely, and synchronise across devices.
 Existing solutions either rely on big corporations that crave user data, or require
 a non-trivial amount of time and expertise to setup a new server for every new project.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -15,7 +15,7 @@ abilities. It is meant to be **easy to use** and **easy to self-host**.
 Why use Kinto?
 ==============
 
-    Don't build silos. Redecentralize the Web!
+    Don't build silos. Decentralize the Web!
 
 It's hard for frontend developers to respect user privacy when building applications
 that work offline, store data remotely, and synchronise across devices.
@@ -30,7 +30,7 @@ Also, we believe data belongs to the users, and not necessarily to the applicati
 Applications should be decoupled from the storage location, and users should be
 able to choose where their personal data is stored.
 
-The backend can often be universal, generic and resuable. We envision mutualisation
+The backend can often be universal, generic and resusable. We envision mutualisation
 of services and self-hosting: the backend is deployed, secured and scaled
 only once for several applications.
 
@@ -43,7 +43,7 @@ Use cases
 - **A generic Web database**: JSON store for mobile and Web apps, games, or IoT...
 - **Quickly prototype frontend applications**: don't lose time with server stuff,
   the backend for your next single page app is already there.
-- **Applications as static files**: just host your apps on GitHub pages, your storage backend
+- **Applications as static files**: just host your apps on GitHub pages, your backend storage
   is elsewhere!
 - **Offline-first applications**: data can also be stored locally and published later.
 - **Build collaborative applications** with real time updates and fine-grained permissions.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -76,8 +76,8 @@ to work completely offline and synchronise data when online.
 
 It's even possible for data to be encrypted on the client to keep user data safe on the server.
 
-The ecosystem of plugins provide advanced features like history tracking, specific authentication,
-push notifications, file attachments...
+The ecosystem of plugins provides advanced features such as history tracking, specific authentication,
+push notifications, and file attachments.
 
 
 Key features


### PR DESCRIPTION
Fixes #

- [x] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [x] Add your name in the contributors file.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [x] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.

## Features

**Status: Corrections are complete. PR ready for review**

Made corrections such as fixing typos and other grammatical errors found on the [Kinto Overview](https://docs.kinto-storage.org/en/stable/overview.html) page. Getting the first impression right is important!

## Notes

I made a few corrections so far, and found at least ten more changes to make. 

Before continuing, I want to make sure I'm correctly following Kinto's [Contribution Guidelines](https://github.com/Kinto/kinto/blob/master/CONTRIBUTING.md).
When complete, I will make a note in the comments sections of this PR.