### PR TITLE
Drop support of Python 3.7 (end-of-life 2023-06-27)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,21 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toxenv: [py37, py38, py38-raw, py39]
+        toxenv: [py38, py39, py310, py311, py311-raw]
         include:
-          - toxenv: py37
-            python-version: "3.7"
           - toxenv: py38
-            python-version: "3.8"
-          - toxenv: py38-raw
             python-version: "3.8"
           - toxenv: py39
             python-version: "3.9"
-          - toxenv: py10
+          - toxenv: py310
             python-version: "3.10"
-          - toxenv: py11
+          - toxenv: py311
             python-version: "3.11"
-
+          - toxenv: py311-raw
+            python-version: "3.11"
     services:
       postgres:
         image: postgres

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 15.1.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**Breaking Changes**
+
+- Drop support of Python 3.7 (end-of-life 2023-06-27)
 
 
 15.1.1 (2023-02-09)

--- a/README.rst
+++ b/README.rst
@@ -38,5 +38,5 @@ Kinto is a minimalist JSON storage service with synchronisation and sharing abil
 Requirements
 ------------
 
-* **Python**: 3.7+
+* **Python**: 3.8+
 * **Backends**: In-memory (development), PostgreSQL 9.5+ (production)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,10 @@ keywords = web sync json storage services
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: WSGI :: Application

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py38-raw,py39,py10,py11
+envlist = py38,py39,py310,py311,py311-raw
 skip_missing_interpreters = True
 requires =
     virtualenv >= 20.2.2
@@ -17,7 +17,7 @@ deps =
     statsd
 install_command = pip install {opts} {packages} -c{toxinidir}/requirements.txt
 
-[testenv:py38-raw]
+[testenv:py311-raw]
 passenv = CI
 commands =
     python --version


### PR DESCRIPTION
Dropping 3.7 before its end of life isn't great, but we already have a few dependencies that start requiring 3.8+ https://github.com/Kinto/kinto/pull/3089