### PR TITLE
Add explicit Sentry logging integration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 16.0.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**New features**
+
+- Send logging warnings to Sentry, with logging debugs as breadcrumbs. Configure levels with ``kinto.sentry_breadcrumbs_min_level`` and ``kinto.sentry_events_min_level`` settings.
 
 
 16.0.0 (2023-05-30)

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -409,6 +409,10 @@ Sentry reporting can be enabled via the following settings:
     kinto.sentry_dsn = https://userid@o1.ingest.sentry.io/1
     kinto.sentry_env = stage
 
+    # Integrate logging with Sentry.
+    # kinto.sentry_breadcrumbs_min_level = 10 # DEBUG
+    # kinto.sentry_events_min_level = 30 # WARNING
+
 Or the equivalent environment variables:
 
 ::

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -89,6 +89,8 @@ DEFAULT_SETTINGS = {
     "settings_prefix": "",
     "sentry_dsn": None,
     "sentry_env": None,
+    "sentry_breadcrumbs_min_level": logging.DEBUG,
+    "sentry_events_min_level": logging.WARNING,
     "statsd_backend": "kinto.core.statsd",
     "statsd_prefix": "kinto.core",
     "statsd_url": None,

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -29,6 +29,7 @@ except ImportError:  # pragma: no cover
     ProfilerMiddleware = False
 try:
     import sentry_sdk
+    from sentry_sdk.integrations.logging import LoggingIntegration
     from sentry_sdk.integrations.pyramid import PyramidIntegration
     from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 except ImportError:  # pragma: no cover
@@ -284,11 +285,19 @@ def setup_sentry(config):
         if env:
             env_options["environment"] = env
 
+        breadcrumbs_level = settings["sentry_breadcrumbs_min_level"]
+        events_level = settings["sentry_events_min_level"]
         sentry_sdk.init(
             dsn,
             integrations=[
                 PyramidIntegration(),
                 SqlalchemyIntegration(),
+                LoggingIntegration(
+                    # Capture debug and above as breadcrumbs
+                    level=breadcrumbs_level,
+                    # Send warnings and above as events
+                    event_level=events_level,
+                ),
             ],
             **env_options,
         )

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -293,9 +293,9 @@ def setup_sentry(config):
                 PyramidIntegration(),
                 SqlalchemyIntegration(),
                 LoggingIntegration(
-                    # Capture debug and above as breadcrumbs
+                    # Logs to be captured as breadcrumbs (debug and above by default)
                     level=breadcrumbs_level,
-                    # Send warnings and above as events
+                    # Logs to be catpured as events (warning and above by default)
                     event_level=events_level,
                 ),
             ],


### PR DESCRIPTION
Since https://github.com/Kinto/kinto/pull/3055 the logging messages do not seem to be sent to Sentry anymore.

This adds the logging integration explicitly, and adds settings to adjust levels