### PR TITLE
Keep warning level for server-side logging

### DIFF
--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -104,7 +104,7 @@ class AuthorizationPolicy:
                 allowed = context.check_permission(principals, bound_perms)
 
         if not allowed:
-            logger.warning(
+            logger.info(
                 "Permission %r on %r not granted to %r.",
                 permission,
                 object_id,

--- a/kinto/core/errors.py
+++ b/kinto/core/errors.py
@@ -205,7 +205,7 @@ def request_GET(request):
     except UnicodeDecodeError:
         querystring = request.environ.get("QUERY_STRING", "")
         logger = logging.getLogger(__name__)
-        logger.warning("Error decoding QUERY_STRING: %s" % request.environ)
+        logger.info("Error decoding QUERY_STRING: %s" % request.environ)
         raise http_error(
             httpexceptions.HTTPBadRequest(),
             errno=ERRORS.INVALID_PARAMETERS,

--- a/tests/core/test_authorization.py
+++ b/tests/core/test_authorization.py
@@ -185,7 +185,7 @@ class AuthorizationPolicyTest(unittest.TestCase):
         userid = "portier:yourself"
         object_id = "/articles/43/comments/2"
         perm = "read"
-        mocked.warning.assert_called_with(
+        mocked.info.assert_called_with(
             "Permission %r on %r not granted to %r.",
             perm,
             object_id,


### PR DESCRIPTION
We shouldn't use warnings for concerns that apply to the request. 

Warnings should be used to warn developers/admins of potential issues on the service, not on malformed requests 