### PR TITLE
Fix #3008: Wait for Postgres before starting Kinto container in docker-compose

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -109,3 +109,4 @@ Contributors
 * Fabian Chong <@feiming>
 * Dan Milgram <danm@intervivo.com>
 * Dex Devlon <@bxff>
+* Varun Koranne <@varun-dhruv>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       POSTGRES_NAME: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   cache:
     image: memcached:1
   web:
@@ -14,8 +19,10 @@ services:
       dockerfile: Dockerfile
     image: kinto/kinto-server:latest
     depends_on:
-    - db
-    - cache
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_started
     ports:
     - "8888:8888"
     environment:


### PR DESCRIPTION
Fixes #

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
