### PR TITLE
Add a new ``kinto.admin_assets_path`` to specify the location of the Admin UI assets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 16.3.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+**New features**
+
+- Add a new ``kinto.admin_assets_path`` setting to specify the location on the Admin UI assets.
 
 
 16.2.3 (2023-12-05)

--- a/docs/kinto-admin.rst
+++ b/docs/kinto-admin.rst
@@ -6,6 +6,13 @@ Kinto Admin
 When the built-in plugin ``kinto.plugins.admin`` is enabled in
 configuration, a Web admin UI is available at ``/v1/admin/``.
 
++-------------------------+----------+-------------------------------------------------+
+| Setting name            | Default  | What does it do?                                |
++=========================+==========+=================================================+
+| kinto.admin_assets_path | None     | Absolute path to the Admin UI assets files.     |
+|                         |          | The folder must contain an ``index.html`` file. |
++-------------------------+----------+-------------------------------------------------+
+
 
 * `See dedicated repo <https://github.com/Kinto/kinto-admin/>`_
 

--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -37,6 +37,7 @@ DEFAULT_SETTINGS = {
     "group_id_generator": "kinto.views.NameGenerator",
     "record_id_generator": "kinto.views.RelaxedUUID",
     "project_name": "kinto",
+    "admin_assets_path": None,
 }
 
 

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -201,6 +201,10 @@ kinto.bucket_create_principals = account:admin
 # kinto.group_id_generator = name_generator.GroupGenerator
 # kinto.record_id_generator = name_generator.RecordGenerator
 
+# Kinto admin
+# Absolute path to UI assets
+# kinto.admin_assets_path = /app/kinto/plugins/admin/build/
+
 # Enabling or disabling endpoints
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#enabling-or-disabling-endpoints
 #

--- a/kinto/plugins/admin/__init__.py
+++ b/kinto/plugins/admin/__init__.py
@@ -23,7 +23,10 @@ def includeme(config):
     config.add_route("admin_home", "/admin/")
     config.add_view(admin_home_view, route_name="admin_home")
 
-    build_dir = static_view("kinto.plugins.admin:build", use_subpath=True)
+    admin_assets_path = (
+        config.registry.settings["admin_assets_path"] or "kinto.plugins.admin:build"
+    )
+    build_dir = static_view(admin_assets_path, use_subpath=True)
     config.add_route("catchall_static", "/admin/*subpath")
     config.add_view(build_dir, route_name="catchall_static")
 

--- a/kinto/plugins/admin/views.py
+++ b/kinto/plugins/admin/views.py
@@ -15,12 +15,11 @@ def admin_home_view(request):
 
     This requires the Admin UI to be built with ``ASSET_PATH="/v1/admin/"``.
     """
-    admin_assets_path = request.registry.settings["admin_assets_path"]
-    if not admin_assets_path:
-        # Default location of the Admin UI is relative to this plugin source folder,
-        # as built with the ``make build-kinto-admin`` command.
-        admin_assets_path = os.path.join(HERE, "build")
-
+    # Default location of the Admin UI is relative to this plugin source folder,
+    # as built with the ``make build-kinto-admin`` command.
+    admin_assets_path = request.registry.settings["admin_assets_path"] or os.path.join(
+        HERE, "build"
+    )
     try:
         with open(os.path.join(admin_assets_path, "index.html")) as f:
             page_content = f.read()

--- a/kinto/plugins/admin/views.py
+++ b/kinto/plugins/admin/views.py
@@ -9,11 +9,23 @@ HERE = os.path.dirname(__file__)
 # Configured home page
 @cache_forever
 def admin_home_view(request):
+    """
+    This view reads the ``index.html`` file from the Admin assets path folder
+    and serves it.
+
+    This requires the Admin UI to be built with ``ASSET_PATH="/v1/admin/"``.
+    """
+    admin_assets_path = request.registry.settings["admin_assets_path"]
+    if not admin_assets_path:
+        # Default location of the Admin UI is relative to this plugin source folder,
+        # as built with the ``make build-kinto-admin`` command.
+        admin_assets_path = os.path.join(HERE, "build")
+
     try:
-        with open(os.path.join(HERE, "build/index.html")) as f:
+        with open(os.path.join(admin_assets_path, "index.html")) as f:
             page_content = f.read()
     except FileNotFoundError:  # pragma: no cover
-        with open(os.path.join(HERE, "public/help.html")) as f:
+        with open(os.path.join(HERE, "public", "help.html")) as f:
             page_content = f.read()
 
     # Add Content-Security-Policy HTTP response header to protect against XSS:

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -201,6 +201,10 @@ kinto.bucket_create_principals = account:admin
 # kinto.group_id_generator = name_generator.GroupGenerator
 # kinto.record_id_generator = name_generator.RecordGenerator
 
+# Kinto admin
+# Absolute path to UI assets
+# kinto.admin_assets_path = /app/kinto/plugins/admin/build/
+
 # Enabling or disabling endpoints
 # https://kinto.readthedocs.io/en/latest/configuration/settings.html#enabling-or-disabling-endpoints
 #


### PR DESCRIPTION
- [x] Add documentation.
- [x] Add tests.
- [x] Add a changelog entry.
- [x] Add your name in the contributors file.
- [x] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/master/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/master/docs/api/index.rst)
- [x] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/master/kinto/config/kinto.tpl) file with it.
