### PR TITLE
Generate changelog from Github releases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 
 This document describes changes between each past release.
 
+>= 16.4.0
+---------
+
+Since 16.4.0, the `changelog in our documentation <https://docs.kinto-storage.org/en/stable/changelog.html>`_ is automatically generated from our `Github releases <https://github.com/Kinto/kinto/releases>`_
+
+
 16.3.0 (2024-01-12)
 -------------------
 
@@ -27,7 +33,7 @@ This document describes changes between each past release.
 16.2.2 (2023-11-21)
 -------------------
 
-- Upgraded Kinto Admin to `v2.1.0 <https://github.com/Kinto/kinto-admin/releases/tag/v2.1.0>`_  
+- Upgraded Kinto Admin to `v2.1.0 <https://github.com/Kinto/kinto-admin/releases/tag/v2.1.0>`_
 
 
 16.2.1 (2023-09-13)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,7 @@
-.. include:: ../CHANGELOG.rst
+Changelog
+=========
+
+.. changelog::
+    :changelog-url: https://docs.kinto-storage.org/en/stable/changelog.html
+    :github: https://github.com/Kinto/kinto/releases/
+    :pypi: https://pypi.org/project/kinto/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinxcontrib.httpdomain",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
+    "sphinx_github_changelog",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -168,6 +169,10 @@ intersphinx_mapping = {
     "cornice": ("https://cornice.readthedocs.io/en/latest/", None),
     "pyramid": ("https://pyramid.readthedocs.io/en/latest/", None),
 }
+
+# -- Changelog
+
+sphinx_github_changelog_token = os.getenv("SPHINX_GITHUB_CHANGELOG_TOKEN")
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ Sphinx==7.2.6
 sphinx_rtd_theme==2.0.0
 docutils==0.20.1
 sphinxcontrib-httpdomain==1.8.1
+sphinx-github-changelog==1.2.1
 kinto
 mock==5.1.0
 webtest==3.0.0


### PR DESCRIPTION
With this change, we won't need to update the `CHANGELOG.rst` file before each release, and will allow us to tag new releases from the Github releases page (with one-click 😎 )

<img width="1015" alt="Screenshot 2024-01-22 at 14 19 10" src="https://github.com/Kinto/kinto/assets/546692/f38c1041-db96-4d3a-a63b-4a445430099f">
