### PR TITLE
Decouple `kinto-redis` from this repository

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -37,7 +37,7 @@ Creates a configuration file that works out of the box.
 
     optional arguments:
       -h, --help         show this help message and exit
-      --backend BACKEND  {memory,redis,postgresql}
+      --backend BACKEND  {memory,postgresql}
 
 
 .. note::

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -908,6 +908,10 @@ the *event_handlers* setting, which takes a list of aliases.
 In the example below, the Redis listener is activated and will send events
 data in the ``queue`` Redis list.
 
+.. note::
+
+    Install the `kinto-redis package <https://github.com/Kinto/kinto-redis>`_ first.
+
 .. code-block:: ini
 
     kinto.event_listeners = redis

--- a/docs/tutorials/install.rst
+++ b/docs/tutorials/install.rst
@@ -290,7 +290,7 @@ During the installation, you will be asked which backend you would like to use:
 
 ::
 
-    $ Select the backend you would like to use: (1 - postgresql, 2 - redis, default - memory)
+    $ Select the backend you would like to use: (1 - postgresql, default - memory)
 
 If you don't know, just push "enter" to choose the default Memory backend.
 You can always change your backend selection

--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -77,14 +77,14 @@ def main(args=None):
         if command == "init":
             subparser.add_argument(
                 "--backend",
-                help="{memory,redis,postgresql}",
+                help="{memory,postgresql}",
                 dest="backend",
                 required=False,
                 default=None,
             )
             subparser.add_argument(
                 "--cache-backend",
-                help="{memory,redis,postgresql,memcached}",
+                help="{memory,postgresql,memcached}",
                 dest="cache-backend",
                 required=False,
                 default=None,
@@ -162,11 +162,11 @@ def main(args=None):
             while True:
                 prompt = (
                     "Select the backend you would like to use: "
-                    "(1 - postgresql, 2 - redis, default - memory) "
+                    "(1 - postgresql, default - memory) "
                 )
                 answer = input(prompt).strip()
                 try:
-                    backends = {"1": "postgresql", "2": "redis", "": "memory"}
+                    backends = {"1": "postgresql", "": "memory"}
                     backend = backends[answer]
                     break
                 except KeyError:
@@ -176,14 +176,13 @@ def main(args=None):
             while True:
                 prompt = (
                     "Select the cache backend you would like to use: "
-                    "(1 - postgresql, 2 - redis, 3 - memcached, default - memory) "
+                    "(1 - postgresql, 2 - memcached, default - memory) "
                 )
                 answer = input(prompt).strip()
                 try:
                     cache_backends = {
                         "1": "postgresql",
-                        "2": "redis",
-                        "3": "memcached",
+                        "2": "memcached",
                         "": "memory",
                     }
                     cache_backend = cache_backends[answer]
@@ -201,11 +200,6 @@ def main(args=None):
                 subprocess.check_call(
                     [sys.executable, "-m", "pip", "install", "kinto[postgresql]"]
                 )
-        elif backend == "redis" or cache_backend == "redis":
-            try:
-                import kinto_redis  # NOQA
-            except ImportError:
-                subprocess.check_call([sys.executable, "-m", "pip", "install", "kinto[redis]"])
         elif cache_backend == "memcached":
             try:
                 import memcache  # NOQA

--- a/kinto/config/__init__.py
+++ b/kinto/config/__init__.py
@@ -29,7 +29,6 @@ def render_template(template, destination, **kwargs):
 
 
 postgresql_url = "postgresql://postgres:postgres@localhost/postgres"
-redis_url = "redis://localhost:6379"
 
 backend_to_values = {
     "postgresql": {
@@ -37,12 +36,6 @@ backend_to_values = {
         "storage_url": postgresql_url,
         "permission_backend": "kinto.core.permission.postgresql",
         "permission_url": postgresql_url,
-    },
-    "redis": {
-        "storage_backend": "kinto_redis.storage",
-        "storage_url": redis_url + "/1",
-        "permission_backend": "kinto_redis.permission",
-        "permission_url": redis_url + "/3",
     },
     "memory": {
         "storage_backend": "kinto.core.storage.memory",
@@ -54,7 +47,6 @@ backend_to_values = {
 
 cache_backend_to_values = {
     "postgresql": {"cache_backend": "kinto.core.cache.postgresql", "cache_url": postgresql_url},
-    "redis": {"cache_backend": "kinto_redis.cache", "cache_url": redis_url + "/2"},
     "memcached": {
         "cache_backend": "kinto.core.cache.memcached",
         "cache_url": "127.0.0.1:11211 127.0.0.2:11211",

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,8 +67,6 @@ console_scripts =
     kinto = kinto.__main__:main
 
 [options.extras_require]
-redis =
-    kinto_redis
 memcached =
     python-memcached
 postgresql =

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,63 +158,6 @@ class ConfigTest(unittest.TestCase):
         )
 
     @mock.patch("kinto.config.render_template")
-    def test_init_redis_values(self, mocked_render_template):
-        config.init("kinto.ini", backend="redis", cache_backend="redis")
-
-        args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
-
-        redis_url = "redis://localhost:6379"
-        self.maxDiff = None  # See the full diff in case of error
-        self.assertDictEqual(
-            kwargs,
-            {
-                "host": "127.0.0.1",
-                "secret": kwargs["secret"],
-                "bucket_id_salt": kwargs["bucket_id_salt"],
-                "storage_backend": "kinto_redis.storage",
-                "cache_backend": "kinto_redis.cache",
-                "permission_backend": "kinto_redis.permission",
-                "storage_url": redis_url + "/1",
-                "cache_url": redis_url + "/2",
-                "permission_url": redis_url + "/3",
-                "kinto_version": __version__,
-                "config_file_timestamp": mock.ANY,
-            },
-        )
-
-        self._assertTimestampStringsAlmostEqual(
-            strftime("%a, %d %b %Y %H:%M:%S %z"),  # expected
-            kwargs["config_file_timestamp"],  # actual
-        )
-
-    @mock.patch("kinto.config.render_template")
-    def test_init_postgresql_redis_values(self, mocked_render_template):
-        config.init("kinto.ini", backend="postgresql", cache_backend="redis")
-
-        args, kwargs = list(mocked_render_template.call_args)
-        self.assertEqual(args, ("kinto.tpl", "kinto.ini"))
-
-        redis_url = "redis://localhost:6379"
-        self.maxDiff = None  # See the full diff in case of error
-        self.assertDictEqual(
-            kwargs,
-            {
-                "host": "127.0.0.1",
-                "secret": kwargs["secret"],
-                "bucket_id_salt": kwargs["bucket_id_salt"],
-                "storage_backend": "kinto.core.storage.postgresql",
-                "cache_backend": "kinto_redis.cache",
-                "permission_backend": "kinto.core.permission.postgresql",
-                "storage_url": "postgresql://postgres:postgres@localhost/postgres",
-                "cache_url": redis_url + "/2",
-                "permission_url": "postgresql://postgres:postgres@localhost/postgres",
-                "kinto_version": __version__,
-                "config_file_timestamp": mock.ANY,
-            },
-        )
-
-    @mock.patch("kinto.config.render_template")
     def test_init_memory_values(self, mocked_render_template):
         config.init("kinto.ini", backend="memory", cache_backend="memory")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,28 +44,28 @@ class TestMain(unittest.TestCase):
             assert "{} already exists.".format(TEMP_KINTO_INI) in content
 
     def test_cli_init_asks_for_backend_if_not_specified(self):
-        with mock.patch("kinto.__main__.input", create=True, return_value="2"):
+        with mock.patch("kinto.__main__.input", create=True, return_value="1"):
             res = main(["init", "--ini", TEMP_KINTO_INI])
             assert res == 0
         with open(TEMP_KINTO_INI) as f:
             content = f.read()
-        assert "redis" in content
+        assert "postgresql" in content
 
     def test_cli_init_asks_until_backend_is_valid(self):
-        with mock.patch("kinto.__main__.input", create=True, side_effect=["10", "2", "2"]):
+        with mock.patch("kinto.__main__.input", create=True, side_effect=["10", "1", "1"]):
             res = main(["init", "--ini", TEMP_KINTO_INI])
             assert res == 0
             with open(TEMP_KINTO_INI) as f:
                 content = f.read()
-            assert "redis" in content
+            assert "postgresql" in content
 
     def test_cli_init_asks_until_cache_backend_is_valid(self):
-        with mock.patch("kinto.__main__.input", create=True, side_effect=["2", "21", "2"]):
+        with mock.patch("kinto.__main__.input", create=True, side_effect=["1", "10", "2"]):
             res = main(["init", "--ini", TEMP_KINTO_INI])
             assert res == 0
             with open(TEMP_KINTO_INI) as f:
                 content = f.read()
-            assert "redis" in content
+            assert "memcached" in content
 
     def test_fails_if_not_enough_args(self):
         with mock.patch("sys.stderr", new_callable=StringIO) as mock_stderr:
@@ -92,24 +92,6 @@ class TestMain(unittest.TestCase):
                     assert res == 0
                     assert mocked_pip.call_count == 1
 
-    def test_cli_init_installs_redis_dependencies_if_needed(self):
-        realimport = builtins.__import__
-
-        def redis_missing(name, *args, **kwargs):
-            if name == "kinto_redis":
-                raise ImportError()
-            else:
-                return realimport(name, *args, **kwargs)
-
-        with mock.patch("builtins.__import__", side_effect=redis_missing):
-            with mock.patch(
-                "kinto.__main__.subprocess.check_call", return_value=None
-            ) as mocked_pip:
-                with mock.patch("kinto.__main__.input", create=True, return_value="2"):
-                    res = main(["init", "--ini", TEMP_KINTO_INI])
-                    assert res == 0
-                    assert mocked_pip.call_count == 1
-
     def test_cli_init_installs_memcached_dependencies_if_needed(self):
         realimport = builtins.__import__
 
@@ -123,7 +105,7 @@ class TestMain(unittest.TestCase):
             with mock.patch(
                 "kinto.__main__.subprocess.check_call", return_value=None
             ) as mocked_pip:
-                with mock.patch("kinto.__main__.input", create=True, return_value="3"):
+                with mock.patch("kinto.__main__.input", create=True, return_value="2"):
                     res = main(["init", "--ini", TEMP_KINTO_INI, "--backend", "memory"])
                     assert res == 0
                     assert mocked_pip.call_count == 1


### PR DESCRIPTION
In order to make sure we don't offer features that are unstable or outdated, I would prefer to decouple kinto-redis from this project, because it is not actively maintained (last commit 3 years ago). 

Our team at Mozilla is the only group of folks who still actively maintains kinto. And since kinto-redis is not used in our production service anymore, it is not in the bag of things we maintain.

It does not mean it is not supported, it is probably stable and will run as expected. If you want to use it, you have to set it up yourself, since `kinto init`won't propose the option anymore. That's why I mark this PR as breaking change.

