### PR TITLE
Force labels on pull-requests, and add sections in generated changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "breaking-change"
+    - title: Bug Fixes
+      labels:
+        - "bug"
+    - title: New Features
+      labels:
+        - "enhancement"
+    - title: Documentation
+      labels:
+        - "documentation"
+    - title: Dependency Updates
+      labels:
+        - "dependencies"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,0 +1,14 @@
+name: Force pull-requests label(s)
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+jobs:
+  pr-has-label:
+    name: Will be skipped if labelled
+    runs-on: ubuntu-latest
+    if: ${{ join(github.event.pull_request.labels.*.name, ', ') == '' }}
+    steps:
+      - run: |
+          echo 'Pull-request must have at least one label'
+          exit 1


### PR DESCRIPTION
This allows us to keep sections in the auto-generated changelog, and forces us to add labels to our pull-requests