### PR TITLE
Enable pip cache in all workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        with:
+          cache: pip
 
       - name: make lint
         run: make lint
@@ -69,7 +71,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: pyproject.toml
 
       - name: Create database
         env:
@@ -103,10 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
+
       - name: Install coveralls
         run: pip install coveralls
+
       - name: Coveralls Finished
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -135,6 +136,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        with:
+          cache: pip
 
       - name: Print environment
         run: |
@@ -169,6 +172,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        with:
+          cache: pip
 
       - uses: actions/setup-node@v4
         with:
@@ -210,6 +215,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        with:
+          cache: pip
 
       - name: Print environment
         run: |


### PR DESCRIPTION
According to [`setup-python` docs](https://github.com/actions/setup-python#caching-packages-dependencies), the cache is not enabled by default.