### PR TITLE
Read admin assets version from configured folder

### DIFF
--- a/docs/kinto-admin.rst
+++ b/docs/kinto-admin.rst
@@ -11,6 +11,7 @@ configuration, a Web admin UI is available at ``/v1/admin/``.
 +=========================+==========+=================================================+
 | kinto.admin_assets_path | None     | Absolute path to the Admin UI assets files.     |
 |                         |          | The folder must contain an ``index.html`` file. |
+|                         |          | and a ``VERSION`` file.                         |
 +-------------------------+----------+-------------------------------------------------+
 
 

--- a/kinto/plugins/admin/__init__.py
+++ b/kinto/plugins/admin/__init__.py
@@ -6,11 +6,16 @@ from pyramid.static import static_view
 from .views import admin_home_view
 
 
-VERSION_FILE_PATH = Path(__file__).parent / "VERSION"
-
-
 def includeme(config):
-    admin_version = VERSION_FILE_PATH.read_text().strip()
+    admin_assets_path = config.registry.settings["admin_assets_path"]
+    if not admin_assets_path:
+        # Use bundled admin.
+        admin_assets_path = "kinto.plugins.admin:build"
+        version_file_parent = Path(__file__).parent
+    else:
+        version_file_parent = Path(admin_assets_path)
+
+    admin_version = (version_file_parent / "VERSION").read_text().strip()
 
     # Expose capability.
     config.add_api_capability(
@@ -23,9 +28,6 @@ def includeme(config):
     config.add_route("admin_home", "/admin/")
     config.add_view(admin_home_view, route_name="admin_home")
 
-    admin_assets_path = (
-        config.registry.settings["admin_assets_path"] or "kinto.plugins.admin:build"
-    )
     build_dir = static_view(admin_assets_path, use_subpath=True)
     config.add_route("catchall_static", "/admin/*subpath")
     config.add_view(build_dir, route_name="catchall_static")

--- a/tests/plugins/test_admin.py
+++ b/tests/plugins/test_admin.py
@@ -75,25 +75,31 @@ class AdminViewTest(BaseWebTest, unittest.TestCase):
 
 class OverriddenAdminViewTest(BaseWebTest, unittest.TestCase):
     @classmethod
+    def make_app(cls, *args, **kwargs):
+        cls.tmp_dir = tempfile.TemporaryDirectory()
+        with open(os.path.join(cls.tmp_dir.name, "VERSION"), "w") as f:
+            f.write("42.0.0")
+        with open(os.path.join(cls.tmp_dir.name, "index.html"), "w") as f:
+            f.write("mine!")
+        with open(os.path.join(cls.tmp_dir.name, "script.js"), "w") as f:
+            f.write("kiddy")
+        return super().make_app(*args, **kwargs)
+
+    @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         cls.tmp_dir.cleanup()
 
     @classmethod
     def get_app_settings(cls, extras=None):
-        cls.tmp_dir = tempfile.TemporaryDirectory()
-
         settings = super().get_app_settings(extras)
         settings["includes"] = "kinto.plugins.admin"
         settings["admin_assets_path"] = cls.tmp_dir.name
         return settings
 
-    def setUp(self) -> None:
-        super().setUp()
-        with open(os.path.join(self.tmp_dir.name, "index.html"), "w") as f:
-            f.write("mine!")
-        with open(os.path.join(self.tmp_dir.name, "script.js"), "w") as f:
-            f.write("kiddy")
+    def test_admin_capability_reads_version_from_configured_folder(self):
+        resp = self.app.get("/")
+        self.assertEqual(resp.json["capabilities"]["admin"]["version"], "42.0.0")
 
     def test_admin_ui_is_served_from_configured_folder(self):
         resp = self.app.get("/admin/")


### PR DESCRIPTION
Without this, the exposed capabilities shows the bundled version and not the overriden assets versions.

This introduces a breaking change, since the plugin will fail without this `VERSION` file.
