### PR TITLE
Add request filter if server is configured as readonly

### DIFF
--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -54,6 +54,7 @@ DEFAULT_SETTINGS = {
     "initialization_sequence": (
         "kinto.core.initialization.setup_request_bound_data",
         "kinto.core.initialization.setup_json_serializer",
+        "kinto.core.initialization.restrict_http_methods_if_readonly",
         "kinto.core.initialization.setup_csp_headers",
         "kinto.core.initialization.setup_logging",
         "kinto.core.initialization.setup_storage",

--- a/tests/core/testplugin/__init__.py
+++ b/tests/core/testplugin/__init__.py
@@ -15,5 +15,38 @@ def attachment_post(request):
     return {"ok": True}
 
 
+log = Service(
+    name="log",
+    description="Test endpoint without permissions",
+    path="/log",
+)
+
+
+@log.get()
+def log_get(request):
+    return {}
+
+
+@log.post()
+def log_post(request):
+    return {}
+
+
+@log.delete()
+def log_delete(request):
+    return {}
+
+
+@log.put()
+def log_put(request):
+    return {}
+
+
+@log.patch()
+def log_patch(request):
+    return {}
+
+
 def includeme(config):
     config.add_cornice_service(attachment)
+    config.add_cornice_service(log)


### PR DESCRIPTION
The `readonly` setting is only leveraged in `kinto.core` Resources. With this change, services that are defined ad-hoc do not have to explicitly check for this setting.
