### PR TITLE
Observe request summary, size, and duration with labels

### DIFF
--- a/kinto/__init__.py
+++ b/kinto/__init__.py
@@ -38,6 +38,7 @@ DEFAULT_SETTINGS = {
     "record_id_generator": "kinto.views.RelaxedUUID",
     "project_name": "kinto",
     "admin_assets_path": None,
+    "metrics_matchdict_fields": ["bucket_id", "collection_id", "group_id", "record_id"],
 }
 
 

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -96,6 +96,7 @@ DEFAULT_SETTINGS = {
     "statsd_backend": "kinto.core.statsd",
     "statsd_prefix": "kinto.core",
     "statsd_url": None,
+    "metrics_matchdict_fields": [],
     "storage_backend": "",
     "storage_url": "",
     "storage_max_fetch_size": 10000,

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -489,6 +489,13 @@ def setup_metrics(config):
             ],
         )
 
+        # Observe response size.
+        metrics_service.observe(
+            "request_size",
+            len(request.response.body or b""),
+            labels=[("endpoint", utils.strip_uri_prefix(request.path))],
+        )
+
         # Count authentication verifications.
         if hasattr(request, "authn_type"):
             metrics_service.count(f"authn_type.{request.authn_type}")

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -479,6 +479,16 @@ def setup_metrics(config):
             auth, user_id = user_id.split(":")
             metrics_service.count("users", unique=[("auth", auth), ("userid", user_id)])
 
+        # Count served requests.
+        metrics_service.count(
+            "request_summary",
+            unique=[
+                ("method", request.method.lower()),
+                ("endpoint", utils.strip_uri_prefix(request.path)),
+                ("status", str(request.response.status_code)),
+            ],
+        )
+
         # Count authentication verifications.
         if hasattr(request, "authn_type"):
             metrics_service.count(f"authn_type.{request.authn_type}")

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -479,6 +479,21 @@ def setup_metrics(config):
             auth, user_id = user_id.split(":")
             metrics_service.count("users", unique=[("auth", auth), ("userid", user_id)])
 
+        # Add extra labels to metrics, based on fields extracted from the request matchdict.
+        metrics_matchdict_fields = aslist(settings["metrics_matchdict_fields"])
+        # Turn the `id` field of object endpoints into `{resource}_id` (eg. `mushroom_id`, `bucket_id`)
+        enhanced_matchdict = dict(request.matchdict or {})
+        try:
+            enhanced_matchdict[request.current_resource_name + "_id"] = enhanced_matchdict.get(
+                "id", ""
+            )
+        except AttributeError:
+            # Not on a resource.
+            pass
+        metrics_matchdict_labels = [
+            (field, enhanced_matchdict.get(field, "")) for field in metrics_matchdict_fields
+        ]
+
         # Count served requests.
         metrics_service.count(
             "request_summary",
@@ -486,7 +501,8 @@ def setup_metrics(config):
                 ("method", request.method.lower()),
                 ("endpoint", utils.strip_uri_prefix(request.path)),
                 ("status", str(request.response.status_code)),
-            ],
+            ]
+            + metrics_matchdict_labels,
         )
 
         try:
@@ -495,7 +511,8 @@ def setup_metrics(config):
             metrics_service.observe(
                 "request_duration",
                 duration,
-                labels=[("endpoint", utils.strip_uri_prefix(request.path))],
+                labels=[("endpoint", utils.strip_uri_prefix(request.path))]
+                + metrics_matchdict_labels,
             )
         except AttributeError:  # pragma: no cover
             # Logging was not setup in this Kinto app (unlikely but possible)
@@ -505,7 +522,7 @@ def setup_metrics(config):
         metrics_service.observe(
             "request_size",
             len(request.response.body or b""),
-            labels=[("endpoint", utils.strip_uri_prefix(request.path))],
+            labels=[("endpoint", utils.strip_uri_prefix(request.path))] + metrics_matchdict_labels,
         )
 
         # Count authentication verifications.

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -489,6 +489,18 @@ def setup_metrics(config):
             ],
         )
 
+        try:
+            current = utils.msec_time()
+            duration = current - request._received_at
+            metrics_service.observe(
+                "request_duration",
+                duration,
+                labels=[("endpoint", utils.strip_uri_prefix(request.path))],
+            )
+        except AttributeError:  # pragma: no cover
+            # Logging was not setup in this Kinto app (unlikely but possible)
+            pass
+
         # Observe response size.
         metrics_service.observe(
             "request_size",

--- a/kinto/core/metrics.py
+++ b/kinto/core/metrics.py
@@ -50,6 +50,9 @@ class NoOpMetricsService:
     def timer(self, key):
         return NoOpTimer()
 
+    def observe(self, key, value, labels=[]):
+        pass
+
     def count(self, key, count=1, unique=None):
         pass
 

--- a/kinto/core/metrics.py
+++ b/kinto/core/metrics.py
@@ -16,6 +16,11 @@ class IMetricsService(Interface):
         Watch execution time.
         """
 
+    def observe(self, key, value, labels=[]):
+        """
+        Observe a give `value` for the specified `key`.
+        """
+
     def count(key, count=1, unique=None):
         """
         Count occurrences. If `unique` is set, overwrites the counter value

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -173,7 +173,7 @@ def includeme(config):
     config.add_view(metrics_view, route_name="prometheus_metrics")
 
     # Reinitialize the registry on initialization.
-    # This is mainly useful in tests, where we plugins is included
+    # This is mainly useful in tests, where the plugin is included
     # several times with different settings.
     registry = get_registry()
     for collector in _METRICS.values():

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -172,4 +172,15 @@ def includeme(config):
     config.add_route("prometheus_metrics", "/__metrics__")
     config.add_view(metrics_view, route_name="prometheus_metrics")
 
+    # Reinitialize the registry on initialization.
+    # This is mainly useful in tests, where we plugins is included
+    # several times with different settings.
+    registry = get_registry()
+    for collector in _METRICS.values():
+        try:
+            registry.unregister(collector)
+        except KeyError:  # pragma: no cover
+            pass
+    _METRICS.clear()
+
     config.registry.registerUtility(PrometheusService(), metrics.IMetricsService)

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -82,6 +82,28 @@ class PrometheusService:
 
         return Timer(_METRICS[key])
 
+    def observe(self, key, value, labels=[]):
+        global _METRICS
+
+        if key not in _METRICS:
+            _METRICS[key] = prometheus_module.Summary(
+                _fix_metric_name(key),
+                f"Summary of {key}",
+                labelnames=[label_name for label_name, _ in labels],
+                registry=get_registry(),
+            )
+
+        if not isinstance(_METRICS[key], prometheus_module.Summary):
+            raise RuntimeError(
+                f"Metric {key} already exists with different type ({_METRICS[key]})"
+            )
+
+        m = _METRICS[key]
+        if labels:
+            m = m.labels(*(label_value for _, label_value in labels))
+
+        m.observe(value)
+
     def count(self, key, count=1, unique=None):
         global _METRICS
 

--- a/kinto/plugins/statsd.py
+++ b/kinto/plugins/statsd.py
@@ -21,6 +21,9 @@ class StatsDService:
     def timer(self, key):
         return self._client.timer(key)
 
+    def observe(self, key, value, labels=[]):
+        return self._client.gauge(key, value)
+
     def count(self, key, count=1, unique=None):
         if unique is None:
             return self._client.incr(key, count=count)

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -411,6 +411,15 @@ class MetricsConfigurationTest(unittest.TestCase):
         app.get("/")
         self.assertFalse(self.mocked.count.called)
 
+    def test_statsd_counts_endpoints(self):
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
+        app = webtest.TestApp(self.config.make_wsgi_app())
+        app.get("/v0/__heartbeat__")
+        self.mocked().count.assert_any_call(
+            "request_summary",
+            unique=[("method", "get"), ("endpoint", "/__heartbeat__"), ("status", "200")],
+        )
+
     def test_statsd_counts_views_and_methods(self):
         kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -420,6 +420,16 @@ class MetricsConfigurationTest(unittest.TestCase):
             unique=[("method", "get"), ("endpoint", "/__heartbeat__"), ("status", "200")],
         )
 
+    def test_statsd_observe_request_size(self):
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
+        app = webtest.TestApp(self.config.make_wsgi_app())
+        app.get("/v0/__heartbeat__")
+        self.mocked().observe.assert_any_call(
+            "request_size",
+            len("{}"),
+            labels=[("endpoint", "/__heartbeat__")],
+        )
+
     def test_statsd_counts_views_and_methods(self):
         kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -430,6 +430,16 @@ class MetricsConfigurationTest(unittest.TestCase):
             labels=[("endpoint", "/__heartbeat__")],
         )
 
+    def test_statsd_observe_request_duration(self):
+        kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
+        app = webtest.TestApp(self.config.make_wsgi_app())
+        app.get("/v0/__heartbeat__")
+        self.mocked().observe.assert_any_call(
+            "request_duration",
+            mock.ANY,
+            labels=[("endpoint", "/__heartbeat__")],
+        )
+
     def test_statsd_counts_views_and_methods(self):
         kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())

--- a/tests/plugins/test_statsd.py
+++ b/tests/plugins/test_statsd.py
@@ -31,6 +31,11 @@ class StatsdClientTest(unittest.TestCase):
         self.mocked_client = patch.start()
         self.addCleanup(patch.stop)
 
+    def test_observe_a_single_value(self):
+        with mock.patch.object(self.client, "_client") as mocked_client:
+            self.client.observe("size", 3.14)
+            mocked_client.gauge.assert_called_with("size", 3.14)
+
     def test_count_increments_the_counter_for_key(self):
         with mock.patch.object(self.client, "_client") as mocked_client:
             self.client.count("click")

--- a/tests/test_views_metrics.py
+++ b/tests/test_views_metrics.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest import mock
+
+from kinto.core.testing import skip_if_no_prometheus
+
+from .support import BaseWebTest
+
+
+@skip_if_no_prometheus
+class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings["includes"] += "\nkinto.plugins.prometheus"
+        return settings
+
+    def setUp(self):
+        super().setUp()
+        patch = mock.patch("kinto.plugins.prometheus.PrometheusService")
+        self.mocked = patch.start()
+        self.addCleanup(patch.stop)
+
+    def test_metrics_have_matchdict_labels(self):
+        self.app.put("/buckets/beers", headers=self.headers)
+        self.app.put("/buckets/beers/groups/amateurs", headers=self.headers)
+        self.app.put("/buckets/beers/collections/barley", headers=self.headers)
+        self.app.put("/buckets/beers/collections/barley/records/abc", headers=self.headers)
+
+        resp = self.app.get("/__metrics__")
+        self.assertIn(
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="/buckets/beers",group_id="",record_id=""}',
+            resp.text,
+        )
+        self.assertIn(
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="/buckets/beers/groups/amateurs",group_id="amateurs",record_id=""}',
+            resp.text,
+        )
+        self.assertIn(
+            'request_summary_total{bucket_id="beers",collection_id="barley",endpoint="/buckets/beers/collections/barley",group_id="",method="put",record_id="",status="201"}',
+            resp.text,
+        )
+        self.assertIn(
+            'request_duration_sum{bucket_id="beers",collection_id="barley",endpoint="/buckets/beers/collections/barley/records/abc",group_id="",record_id="abc"}',
+            resp.text,
+        )


### PR DESCRIPTION
Based on #3459 

@ahoneiser Now that Kinto has Prometheus support, we can count things with more details. Do you have any suggestion?