### PR TITLE
Introducing Kinto Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Kinto
 =====
 
-|coc| |gitter| |readthedocs| |pypi| |ci| |main-coverage|
+|coc| |gitter| |readthedocs| |pypi| |ci| |main-coverage| |gurubase|
 
 .. |coc| image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
     :target: https://github.com/Kinto/kinto/blob/main/.github/CODE_OF_CONDUCT.md
@@ -25,6 +25,8 @@ Kinto
 .. |pypi| image:: https://img.shields.io/pypi/v/kinto.svg
     :target: https://pypi.python.org/pypi/kinto
 
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Kinto%20Guru-006BFF
+    :target: https://gurubase.io/g/kinto
 
 Kinto is a minimalist JSON storage service with synchronisation and sharing abilities.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Kinto Guru](https://gurubase.io/g/kinto) to Gurubase. Kinto Guru uses the data from this repo and data from the [docs](https://docs.kinto-storage.org/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Kinto Guru", which highlights that Kinto now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Kinto Guru in Gurubase, just let me know that's totally fine.
