### PR TITLE
Adjusting CORS logic to return the first match instead of sent Origin

### DIFF
--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -262,8 +262,9 @@ def reapply_cors(request, response):
             settings = request.registry.settings
             allowed_origins = set(aslist(settings["cors_origins"]))
             required_origins = {"*", origin}
-            if allowed_origins.intersection(required_origins):
-                response.headers["Access-Control-Allow-Origin"] = origin
+            matches = allowed_origins.intersection(required_origins)
+            if matches:
+                response.headers["Access-Control-Allow-Origin"] = matches.pop()
 
         # Import service here because kinto.core import utils
         from kinto.core import Service

--- a/tests/core/resource/test_views_cors.py
+++ b/tests/core/resource/test_views_cors.py
@@ -44,9 +44,16 @@ class CORSOriginHeadersTest(BaseWebTest, unittest.TestCase):
         response = self.app.delete(self.get_item_url(), headers=self.headers)
         self.assertIn("Access-Control-Allow-Origin", response.headers)
 
+    def test_present_on_specified_domain(self):
+        with mock.patch.dict(
+            self.app.app.registry.settings, [("cors_origins", ["foo.bar", "notmyidea.org"])]
+        ):
+            response = self.app.get("/unknown", headers=self.headers, status=404)
+            self.assertEqual(response.headers["Access-Control-Allow-Origin"], "notmyidea.org")
+
     def test_present_on_unknown_url(self):
         response = self.app.get("/unknown", headers=self.headers, status=404)
-        self.assertEqual(response.headers["Access-Control-Allow-Origin"], "notmyidea.org")
+        self.assertEqual(response.headers["Access-Control-Allow-Origin"], "*")
 
     def test_not_present_on_unknown_url_if_setting_does_not_match(self):
         with mock.patch.dict(self.app.app.registry.settings, [("cors_origins", "daybed.io")]):


### PR DESCRIPTION
Adjusting `reapply_cors` logic to return the first match instead of the domain provided. This fixes an issue where we want to always return `*`. 

- [x] Add tests.
