### PR TITLE
Add setting to set prefix on Prometheus metrics

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -503,6 +503,8 @@ Prometheus metrics can be enabled with (disabled by default):
 
     kinto.includes = kinto.plugins.prometheus
 
+    # kinto.prometheus_prefix = kinto-prod
+
 Metrics can then be crawled from the ``/__metrics__`` endpoint.
 
 

--- a/tests/plugins/test_prometheus.py
+++ b/tests/plugins/test_prometheus.py
@@ -141,3 +141,19 @@ class ServiceTest(PrometheusWebTest):
 
         resp = self.app.get("/__metrics__")
         self.assertIn('kintoprod_mushrooms_total{species="boletus"} 1.0', resp.text)
+
+
+@skip_if_no_prometheus
+class PrometheusNoPrefixTest(PrometheusWebTest):
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings["project_name"] = "Some Project"
+        settings["prometheus_prefix"] = ""
+        return settings
+
+    def test_metrics_have_no_prefix(self):
+        self.app.app.registry.metrics.observe("price", 111)
+
+        resp = self.app.get("/__metrics__")
+        self.assertIn("TYPE price summary", resp.text)


### PR DESCRIPTION
It will use the `project_name` setting by default (eg. `Remote Settings PROD` -> `remotesettingsprod_`)
And can be set explicitly with `kinto.prometheus_prefix = ""` or `kinto.prometheus_prefix = "kinto"`