### PR TITLE
Fix exception in in-memory permission backend (fixes #2687)

### DIFF
--- a/kinto/core/permission/memory.py
+++ b/kinto/core/permission/memory.py
@@ -98,8 +98,9 @@ class Permission(PermissionBase):
         candidates = []
         if bound_permissions is None:
             for key, value in self._store.items():
-                _, object_id, permission = key.split(":", 2)
-                candidates.append((object_id, permission, value))
+                if key.startswith("permission:"):
+                    _, object_id, permission = key.split(":", 2)
+                    candidates.append((object_id, permission, value))
         else:
             for pattern, perm in bound_permissions:
                 id_match = ".*" if with_children else "[^/]+"

--- a/kinto/core/permission/testing.py
+++ b/kinto/core/permission/testing.py
@@ -344,6 +344,12 @@ class PermissionTest:
         )
         self.assertEqual(sorted(per_object_ids.keys()), ["/url/a", "/url/a/id/1", "/url/a/id/2"])
 
+    def test_accessible_objects_with_user_principle(self):
+        self.permission.add_user_principal("user1", "group")
+        self.permission.add_principal_to_ace("id1", "write", "user1")
+        per_object_ids = self.permission.get_accessible_objects(["user1"])
+        self.assertEqual(sorted(per_object_ids.keys()), ["id1"])
+
     #
     # get_object_permissions()
     #


### PR DESCRIPTION
Fix an exception in the in-memory permission backend when user principles exist, and get_accessible_objects is called without bound permissions.

Fixes #2687.

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it.
