### PR TITLE
Vendor `cornice` and `cornice.ext.swagger`

### DIFF
--- a/constraints.in
+++ b/constraints.in
@@ -1,7 +1,6 @@
 # main dependencies
 bcrypt
 colander
-cornice
 cornice_swagger
 dockerflow
 jsonschema

--- a/constraints.in
+++ b/constraints.in
@@ -1,7 +1,6 @@
 # main dependencies
 bcrypt
 colander
-cornice_swagger
 dockerflow
 jsonschema
 jsonpatch

--- a/constraints.txt
+++ b/constraints.txt
@@ -31,9 +31,7 @@ colander==2.0
 colorama==0.4.6
     # via logging-color-formatter
 cornice==6.0.1
-    # via
-    #   -r constraints.in
-    #   cornice-swagger
+    # via cornice-swagger
 cornice-swagger==1.0.1
     # via -r constraints.in
 coverage==7.6.4
@@ -45,9 +43,7 @@ execnet==2.0.2
 fqdn==1.5.1
     # via jsonschema
 greenlet==3.1.1
-    # via
-    #   playwright
-    #   sqlalchemy
+    # via playwright
 hupper==1.12
     # via pyramid
 idna==3.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -25,15 +25,9 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
     # via requests
 colander==2.0
-    # via
-    #   -r constraints.in
-    #   cornice-swagger
+    # via -r constraints.in
 colorama==0.4.6
     # via logging-color-formatter
-cornice==6.0.1
-    # via cornice-swagger
-cornice-swagger==1.0.1
-    # via -r constraints.in
 coverage==7.6.4
     # via pytest-cov
 dockerflow==2024.4.2
@@ -107,7 +101,6 @@ pyproject-hooks==1.0.0
 pyramid==2.0.2
     # via
     #   -r constraints.in
-    #   cornice
     #   pyramid-mailer
     #   pyramid-multiauth
     #   pyramid-tm
@@ -168,7 +161,6 @@ simplejson==3.19.2
 six==1.16.0
     # via
     #   bravado-core
-    #   cornice-swagger
     #   python-dateutil
     #   rfc3339-validator
 soupsieve==2.5
@@ -207,9 +199,7 @@ urllib3==2.2.2
     #   requests
     #   sentry-sdk
 venusian==3.1.0
-    # via
-    #   cornice
-    #   pyramid
+    # via pyramid
 waitress==3.0.2
     # via
     #   -r constraints.in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ nitpick_ignore = [
     ("py:class", "str"),
     ("py:class", "tuple"),
     ("py:class", "Exception"),
-    ("py:class", "cornice.Service"),
+    ("py:class", "kinto.core.cornice.Service"),
     # Member autodoc fails with those:
     # kinto.core.resource.schema
     ("py:class", "Integer"),
@@ -163,7 +163,6 @@ def setup(app):
 
 intersphinx_mapping = {
     "colander": ("https://colander.readthedocs.io/en/latest/", None),
-    "cornice": ("https://cornice.readthedocs.io/en/latest/", None),
     "pyramid": ("https://pyramid.readthedocs.io/en/latest/", None),
 }
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,6 @@ sphinx-github-changelog==1.4.0
 kinto
 mock==5.1.0
 webtest==3.0.4
-cornice==6.1.0
 pyramid==2.0.2
 python-rapidjson==1.20
 SQLAlchemy==2.0.38

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -104,7 +104,7 @@ You might get some error like::
     File "./kinto/__init__.py", line 4, in <module>
       import kinto.core
     File "./kinto/core/__init__.py", line 5, in <module>
-      from cornice import Service as CorniceService
+      from kinto.core.cornice import Service as CorniceService
   ImportError: No module named cornice
   unable to load app 0 (mountpoint='') (callable not found or import error)
 

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -4,11 +4,11 @@ import logging
 import tempfile
 
 import pkg_resources
-from cornice import Service as CorniceService
 from dockerflow import logging as dockerflow_logging
 from pyramid.settings import aslist
 
 from kinto.core import errors, events
+from kinto.core.cornice import Service as CorniceService
 from kinto.core.initialization import (  # NOQA
     initialize,
     install_middlewares,

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -186,10 +186,10 @@ def includeme(config):
     config.add_request_method(events.notify_resource_event, name="notify_resource_event")
 
     # Setup cornice.
-    config.include("cornice")
+    config.include("kinto.core.cornice")
 
     # Setup cornice api documentation
-    config.include("cornice_swagger")
+    config.include("kinto.core.cornice_swagger")
 
     # Per-request transaction.
     config.include("pyramid_tm")

--- a/kinto/core/cornice/__init__.py
+++ b/kinto/core/cornice/__init__.py
@@ -4,21 +4,21 @@
 import logging
 from functools import partial
 
-import pkg_resources
-from cornice.errors import Errors  # NOQA
-from cornice.pyramidhook import (
+from pyramid.events import NewRequest
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.settings import asbool, aslist
+
+from kinto.core.cornice.errors import Errors  # NOQA
+from kinto.core.cornice.pyramidhook import (
     handle_exceptions,
     register_resource_views,
     register_service_views,
     wrap_request,
 )
-from cornice.renderer import CorniceRenderer
-from cornice.service import Service  # NOQA
-from cornice.util import ContentTypePredicate, current_service
-from pyramid.events import NewRequest
-from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound
-from pyramid.security import NO_PERMISSION_REQUIRED
-from pyramid.settings import asbool, aslist
+from kinto.core.cornice.renderer import CorniceRenderer
+from kinto.core.cornice.service import Service  # NOQA
+from kinto.core.cornice.util import ContentTypePredicate, current_service
 
 
 logger = logging.getLogger("cornice")

--- a/kinto/core/cornice/__init__.py
+++ b/kinto/core/cornice/__init__.py
@@ -1,0 +1,95 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import logging
+from functools import partial
+
+import pkg_resources
+from cornice.errors import Errors  # NOQA
+from cornice.pyramidhook import (
+    handle_exceptions,
+    register_resource_views,
+    register_service_views,
+    wrap_request,
+)
+from cornice.renderer import CorniceRenderer
+from cornice.service import Service  # NOQA
+from cornice.util import ContentTypePredicate, current_service
+from pyramid.events import NewRequest
+from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.settings import asbool, aslist
+
+
+logger = logging.getLogger("cornice")
+# Module version, as defined in PEP-0396.
+__version__ = pkg_resources.get_distribution(__package__).version
+
+
+def set_localizer_for_languages(event, available_languages, default_locale_name):
+    """
+    Sets the current locale based on the incoming Accept-Language header, if
+    present, and sets a localizer attribute on the request object based on
+    the current locale.
+
+    To be used as an event handler, this function needs to be partially applied
+    with the available_languages and default_locale_name arguments. The
+    resulting function will be an event handler which takes an event object as
+    its only argument.
+    """
+    request = event.request
+    if request.accept_language:
+        accepted = request.accept_language.lookup(available_languages, default=default_locale_name)
+        request._LOCALE_ = accepted
+
+
+def setup_localization(config):
+    """
+    Setup localization based on the available_languages and
+    pyramid.default_locale_name settings.
+
+    These settings are named after suggestions from the "Internationalization
+    and Localization" section of the Pyramid documentation.
+    """
+    try:
+        config.add_translation_dirs("colander:locale/")
+        settings = config.get_settings()
+        available_languages = aslist(settings["available_languages"])
+        default_locale_name = settings.get("pyramid.default_locale_name", "en")
+        set_localizer = partial(
+            set_localizer_for_languages,
+            available_languages=available_languages,
+            default_locale_name=default_locale_name,
+        )
+        config.add_subscriber(set_localizer, NewRequest)
+    except ImportError:  # pragma: no cover
+        # add_translation_dirs raises an ImportError if colander is not
+        # installed
+        pass
+
+
+def includeme(config):
+    """Include the Cornice definitions"""
+    # attributes required to maintain services
+    config.registry.cornice_services = {}
+
+    settings = config.get_settings()
+
+    # localization request subscriber must be set before first call
+    # for request.localizer (in wrap_request)
+    if settings.get("available_languages"):
+        setup_localization(config)
+
+    config.add_directive("add_cornice_service", register_service_views)
+    config.add_directive("add_cornice_resource", register_resource_views)
+    config.add_subscriber(wrap_request, NewRequest)
+    config.add_renderer("cornicejson", CorniceRenderer())
+    config.add_view_predicate("content_type", ContentTypePredicate)
+    config.add_request_method(current_service, reify=True)
+
+    if asbool(settings.get("handle_exceptions", True)):
+        config.add_view(handle_exceptions, context=Exception, permission=NO_PERMISSION_REQUIRED)
+        config.add_view(handle_exceptions, context=HTTPNotFound, permission=NO_PERMISSION_REQUIRED)
+        config.add_view(
+            handle_exceptions, context=HTTPForbidden, permission=NO_PERMISSION_REQUIRED
+        )

--- a/kinto/core/cornice/__init__.py
+++ b/kinto/core/cornice/__init__.py
@@ -22,8 +22,6 @@ from pyramid.settings import asbool, aslist
 
 
 logger = logging.getLogger("cornice")
-# Module version, as defined in PEP-0396.
-__version__ = pkg_resources.get_distribution(__package__).version
 
 
 def set_localizer_for_languages(event, available_languages, default_locale_name):

--- a/kinto/core/cornice/cors.py
+++ b/kinto/core/cornice/cors.py
@@ -1,0 +1,144 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import fnmatch
+import functools
+
+from pyramid.settings import asbool
+
+
+CORS_PARAMETERS = (
+    "cors_headers",
+    "cors_enabled",
+    "cors_origins",
+    "cors_credentials",
+    "cors_max_age",
+    "cors_expose_all_headers",
+)
+
+
+def get_cors_preflight_view(service):
+    """Return a view for the OPTION method.
+
+    Checks that the User-Agent is authorized to do a request to the server, and
+    to this particular service, and add the various checks that are specified
+    in http://www.w3.org/TR/cors/#resource-processing-model.
+    """
+
+    def _preflight_view(request):
+        response = request.response
+        origin = request.headers.get("Origin")
+        supported_headers = service.cors_supported_headers_for()
+
+        if not origin:
+            request.errors.add("header", "Origin", "this header is mandatory")
+
+        requested_method = request.headers.get("Access-Control-Request-Method")
+        if not requested_method:
+            request.errors.add(
+                "header", "Access-Control-Request-Method", "this header is mandatory"
+            )
+
+        if not (requested_method and origin):
+            return
+
+        requested_headers = request.headers.get("Access-Control-Request-Headers", ())
+
+        if requested_headers:
+            requested_headers = map(str.strip, requested_headers.split(","))
+
+        if requested_method not in service.cors_supported_methods:
+            request.errors.add("header", "Access-Control-Request-Method", "Method not allowed")
+
+        if not service.cors_expose_all_headers:
+            for h in requested_headers:
+                if h.lower() not in [s.lower() for s in supported_headers]:
+                    request.errors.add(
+                        "header", "Access-Control-Request-Headers", 'Header "%s" not allowed' % h
+                    )
+
+        supported_headers = set(supported_headers) | set(requested_headers)
+
+        response.headers["Access-Control-Allow-Headers"] = ",".join(supported_headers)
+
+        response.headers["Access-Control-Allow-Methods"] = ",".join(service.cors_supported_methods)
+
+        max_age = service.cors_max_age_for(requested_method)
+        if max_age is not None:
+            response.headers["Access-Control-Max-Age"] = str(max_age)
+
+        return None
+
+    return _preflight_view
+
+
+def _get_method(request):
+    """Return what's supposed to be the method for CORS operations.
+    (e.g if the verb is options, look at the A-C-Request-Method header,
+    otherwise return the HTTP verb).
+    """
+    if request.method == "OPTIONS":
+        method = request.headers.get("Access-Control-Request-Method", request.method)
+    else:
+        method = request.method
+    return method
+
+
+def ensure_origin(service, request, response=None, **kwargs):
+    """Ensure that the origin header is set and allowed."""
+    response = response or request.response
+
+    # Don't check this twice.
+    if not request.info.get("cors_checked", False):
+        method = _get_method(request)
+
+        origin = request.headers.get("Origin")
+
+        if not origin:
+            always_cors = asbool(request.registry.settings.get("cornice.always_cors"))
+            # With this setting, if the service origins has "*", then
+            # always return CORS headers.
+            origins = getattr(service, "cors_origins", [])
+            if always_cors and "*" in origins:
+                origin = "*"
+
+        if origin:
+            if not any([fnmatch.fnmatchcase(origin, o) for o in service.cors_origins_for(method)]):
+                request.errors.add("header", "Origin", "%s not allowed" % origin)
+            elif service.cors_support_credentials_for(method):
+                response.headers["Access-Control-Allow-Origin"] = origin
+            else:
+                if any([o == "*" for o in service.cors_origins_for(method)]):
+                    response.headers["Access-Control-Allow-Origin"] = "*"
+                else:
+                    response.headers["Access-Control-Allow-Origin"] = origin
+        request.info["cors_checked"] = True
+    return response
+
+
+def get_cors_validator(service):
+    return functools.partial(ensure_origin, service)
+
+
+def apply_cors_post_request(service, request, response):
+    """Handles CORS-related post-request things.
+
+    Add some response headers, such as the Expose-Headers and the
+    Allow-Credentials ones.
+    """
+    response = ensure_origin(service, request, response)
+    method = _get_method(request)
+
+    if (
+        service.cors_support_credentials_for(method)
+        and "Access-Control-Allow-Credentials" not in response.headers
+    ):
+        response.headers["Access-Control-Allow-Credentials"] = "true"
+
+    if request.method != "OPTIONS":
+        # Which headers are exposed?
+        supported_headers = service.cors_supported_headers_for(request.method)
+        if supported_headers:
+            response.headers["Access-Control-Expose-Headers"] = ", ".join(supported_headers)
+
+    return response

--- a/kinto/core/cornice/errors.py
+++ b/kinto/core/cornice/errors.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
+
+from pyramid.i18n import TranslationString
+
+
+class Errors(list):
+    """Holds Request errors"""
+
+    def __init__(self, status=400, localizer=None):
+        self.status = status
+        self.localizer = localizer
+        super(Errors, self).__init__()
+
+    def add(self, location, name=None, description=None, **kw):
+        """Registers a new error."""
+        allowed = ("body", "querystring", "url", "header", "path", "cookies", "method")
+        if location != "" and location not in allowed:
+            raise ValueError("%r not in %s" % (location, allowed))
+
+        if isinstance(description, TranslationString) and self.localizer:
+            description = self.localizer.translate(description)
+
+        self.append(dict(location=location, name=name, description=description, **kw))
+
+    @classmethod
+    def from_json(cls, string):
+        """Transforms a json string into an `Errors` instance"""
+        obj = json.loads(string.decode())
+        return Errors.from_list(obj.get("errors", []))
+
+    @classmethod
+    def from_list(cls, obj):
+        """Transforms a python list into an `Errors` instance"""
+        errors = Errors()
+        for error in obj:
+            errors.add(**error)
+        return errors

--- a/kinto/core/cornice/pyramidhook.py
+++ b/kinto/core/cornice/pyramidhook.py
@@ -1,0 +1,372 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import copy
+import functools
+import itertools
+
+from cornice.cors import (
+    CORS_PARAMETERS,
+    apply_cors_post_request,
+    get_cors_preflight_view,
+    get_cors_validator,
+)
+from cornice.errors import Errors
+from cornice.service import decorate_view
+from cornice.util import (
+    content_type_matches,
+    current_service,
+    is_string,
+    match_accept_header,
+    match_content_type_header,
+    to_list,
+)
+from pyramid.exceptions import PredicateMismatch
+from pyramid.httpexceptions import (
+    HTTPException,
+    HTTPMethodNotAllowed,
+    HTTPNotAcceptable,
+    HTTPUnsupportedMediaType,
+)
+from pyramid.security import NO_PERMISSION_REQUIRED
+
+
+def get_fallback_view(service):
+    """Fallback view for a given service, called when nothing else matches.
+
+    This method provides the view logic to be executed when the request
+    does not match any explicitly-defined view.  Its main responsibility
+    is to produce an accurate error response, such as HTTPMethodNotAllowed,
+    HTTPNotAcceptable or HTTPUnsupportedMediaType.
+    """
+
+    def _fallback_view(request):
+        # Maybe we failed to match any definitions for the request method?
+        if request.method not in service.defined_methods:
+            response = HTTPMethodNotAllowed()
+            response.allow = service.defined_methods
+            raise response
+        # Maybe we failed to match an acceptable content-type?
+        # First search all the definitions to find the acceptable types.
+        # XXX: precalculate this like the defined_methods list?
+        acceptable = []
+        supported_contenttypes = []
+        for method, _, args in service.definitions:
+            if method != request.method:
+                continue
+
+            if "accept" in args:
+                acceptable.extend(service.get_acceptable(method, filter_callables=True))
+                acceptable.extend(request.info.get("acceptable", []))
+                acceptable = list(set(acceptable))
+
+                # Now check if that was actually the source of the problem.
+                if not request.accept.acceptable_offers(offers=acceptable):
+                    request.errors.add(
+                        "header",
+                        "Accept",
+                        "Accept header should be one of {0}".format(acceptable).encode("ascii"),
+                    )
+                    request.errors.status = HTTPNotAcceptable.code
+                    error = service.error_handler(request)
+                    raise error
+
+            if "content_type" in args:
+                supported_contenttypes.extend(
+                    service.get_contenttypes(method, filter_callables=True)
+                )
+                supported_contenttypes.extend(request.info.get("supported_contenttypes", []))
+                supported_contenttypes = list(set(supported_contenttypes))
+
+                # Now check if that was actually the source of the problem.
+                if not content_type_matches(request, supported_contenttypes):
+                    request.errors.add(
+                        "header",
+                        "Content-Type",
+                        "Content-Type header should be one of {0}".format(
+                            supported_contenttypes
+                        ).encode("ascii"),
+                    )
+                    request.errors.status = HTTPUnsupportedMediaType.code
+                    error = service.error_handler(request)
+                    raise error
+
+        # In the absence of further information about what went wrong,
+        # let upstream deal with the mismatch.
+
+        # After "custom predicates" feature has been added there is no need in
+        # this line. Instead requests will be filtered by  "custom predicates"
+        # feature filter and exception "404 Not found" error will be raised. In
+        # order to avoid unpredictable cases, we left this line in place and
+        # excluded it from coverage.
+        raise PredicateMismatch(service.name)  # pragma: no cover
+
+    return _fallback_view
+
+
+def apply_filters(request, response):
+    if request.matched_route is not None:
+        # do some sanity checking on the response using filters
+        service = current_service(request)
+        if service is not None:
+            kwargs, ob = getattr(request, "cornice_args", ({}, None))
+            for _filter in kwargs.get("filters", []):
+                if is_string(_filter) and ob is not None:
+                    _filter = getattr(ob, _filter)
+                try:
+                    response = _filter(response, request)
+                except TypeError:
+                    response = _filter(response)
+            if service.cors_enabled:
+                apply_cors_post_request(service, request, response)
+
+    return response
+
+
+def handle_exceptions(exc, request):
+    # At this stage, the checks done by the validators had been removed because
+    # a new response started (the exception), so we need to do that again.
+    if not isinstance(exc, HTTPException):
+        raise
+    request.info["cors_checked"] = False
+    return apply_filters(request, exc)
+
+
+def add_nosniff_header(request, response):
+    """IE has some rather unfortunately content-type-sniffing behaviour
+    that can be used to trigger XSS attacks via a JSON API, as described here:
+
+    * http://blog.watchfire.com/wfblog/2011/10/json-based-xss-exploitation.html
+    * https://superevr.com/blog/2012/exploiting-xss-in-ajax-web-applications/
+
+    Make cornice safe-by-default against this attack by including the header.
+    """
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+
+
+def wrap_request(event):
+    """Adds a "validated" dict, a custom "errors" object and an "info" dict to
+    the request object if they don't already exists
+    """
+    request = event.request
+    request.add_response_callback(apply_filters)
+    request.add_response_callback(add_nosniff_header)
+
+    if not hasattr(request, "validated"):
+        setattr(request, "validated", {})
+
+    if not hasattr(request, "errors"):
+        if request.registry.settings.get("available_languages"):
+            setattr(request, "errors", Errors(localizer=request.localizer))
+        else:
+            setattr(request, "errors", Errors())
+
+    if not hasattr(request, "info"):
+        setattr(request, "info", {})
+
+
+def register_service_views(config, service):
+    """Register the routes of the given service into the pyramid router.
+
+    :param config: the pyramid configuration object that will be populated.
+    :param service: the service object containing the definitions
+    """
+    route_name = service.name
+    existing_route = service.pyramid_route
+    prefix = config.route_prefix or ""
+    services = config.registry.cornice_services
+    if existing_route:
+        route_name = existing_route
+        services["__cornice" + existing_route] = service
+    else:
+        services[prefix + service.path] = service
+
+    # before doing anything else, register a view for the OPTIONS method
+    # if we need to
+    if service.cors_enabled and "OPTIONS" not in service.defined_methods:
+        service.add_view(
+            "options", view=get_cors_preflight_view(service), permission=NO_PERMISSION_REQUIRED
+        )
+
+    # register the fallback view, which takes care of returning good error
+    # messages to the user-agent
+    cors_validator = get_cors_validator(service)
+
+    # Cornice-specific arguments that pyramid does not know about
+    cornice_parameters = (
+        "filters",
+        "validators",
+        "schema",
+        "klass",
+        "error_handler",
+        "deserializer",
+    ) + CORS_PARAMETERS
+
+    # 1. register route
+
+    route_args = {}
+
+    if hasattr(service, "factory"):
+        route_args["factory"] = service.factory
+
+    routes = config.get_predlist("route")
+    for predicate in routes.sorter.names:
+        # Do not let the custom predicates handle validation of Header Accept,
+        # which will pass it through to pyramid. It is handled by
+        # _fallback_view(), because it allows callable.
+        if predicate == "accept":
+            continue
+
+        if hasattr(service, predicate):
+            route_args[predicate] = getattr(service, predicate)
+
+    # register route when not using exiting pyramid routes
+    if not existing_route:
+        config.add_route(route_name, service.path, **route_args)
+
+    # 2. register view(s)
+
+    for method, view, args in service.definitions:
+        args = copy.copy(args)  # make a copy of the dict to not modify it
+        # Deepcopy only the params we're possibly passing on to pyramid
+        # (Some of those in cornice_parameters, e.g. ``schema``, may contain
+        # unpickleable values.)
+        for item in args:
+            if item not in cornice_parameters:
+                args[item] = copy.deepcopy(args[item])
+
+        args["request_method"] = method
+
+        if service.cors_enabled:
+            args["validators"].insert(0, cors_validator)
+
+        decorated_view = decorate_view(view, dict(args), method, route_args)
+
+        for item in cornice_parameters:
+            if item in args:
+                del args[item]
+
+        # filter predicates defined on Resource
+        route_predicates = config.get_predlist("route").sorter.names
+        view_predicates = config.get_predlist("view").sorter.names
+        for pred in set(route_predicates).difference(view_predicates):
+            if pred in args:
+                args.pop(pred)
+
+        # pop and compute predicates which get passed through to Pyramid 1:1
+
+        predicate_definitions = _pop_complex_predicates(args)
+
+        if predicate_definitions:
+            empty_contenttype = [({"kind": "content_type", "value": ""},)]
+            for predicate_list in predicate_definitions + empty_contenttype:
+                args = dict(args)  # make a copy of the dict to not modify it
+
+                # prepare view args by evaluating complex predicates
+                _mungle_view_args(args, predicate_list)
+
+                # We register the same view multiple times with different
+                # accept / content_type / custom_predicates arguments
+                config.add_view(view=decorated_view, route_name=route_name, **args)
+
+        else:
+            # it is a simple view, we don't need to loop on the definitions
+            # and just add it one time.
+            config.add_view(view=decorated_view, route_name=route_name, **args)
+
+    if service.definitions:
+        # Add the fallback view last
+        config.add_view(
+            view=get_fallback_view(service),
+            route_name=route_name,
+            permission=NO_PERMISSION_REQUIRED,
+            require_csrf=False,
+        )
+
+
+def _pop_complex_predicates(args):
+    """
+    Compute the cartesian product of "accept" and "content_type"
+    fields to establish all possible predicate combinations.
+
+    .. seealso::
+
+        https://github.com/mozilla-services/cornice/pull/91#discussion_r3441384
+    """
+
+    # pop and prepare individual predicate lists
+    accept_list = _pop_predicate_definition(args, "accept")
+    content_type_list = _pop_predicate_definition(args, "content_type")
+
+    # compute cartesian product of prepared lists, additionally
+    # remove empty elements of input and output lists
+    product_input = filter(None, [accept_list, content_type_list])
+
+    # In Python 3, the filter() function returns an iterator, not a list.
+    # http://getpython3.com/diveintopython3/ \
+    # porting-code-to-python-3-with-2to3.html#filter
+    predicate_product = list(filter(None, itertools.product(*product_input)))
+
+    return predicate_product
+
+
+def _pop_predicate_definition(args, kind):
+    """
+    Build a dictionary enriched by "kind" of predicate definition list.
+    This is required for evaluation in ``_mungle_view_args``.
+    """
+    values = to_list(args.pop(kind, ()))
+    # In much the same way as filter(), the map() function [in Python 3] now
+    # returns an iterator. (In Python 2, it returned a list.)
+    # http://getpython3.com/diveintopython3/ \
+    # porting-code-to-python-3-with-2to3.html#map
+    values = list(map(lambda value: {"kind": kind, "value": value}, values))
+    return values
+
+
+def _mungle_view_args(args, predicate_list):
+    """
+    Prepare view args by evaluating complex predicates
+    which get passed through to Pyramid 1:1.
+    Also resolve predicate definitions passed as callables.
+
+    .. seealso::
+
+        https://github.com/mozilla-services/cornice/pull/91#discussion_r3441384
+    """
+
+    # map kind of argument value to function for resolving callables
+    callable_map = {
+        "accept": match_accept_header,
+        "content_type": match_content_type_header,
+    }
+
+    # iterate and resolve all predicates
+    for predicate_entry in predicate_list:
+        kind = predicate_entry["kind"]
+        value = predicate_entry["value"]
+
+        # we need to build a custom predicate if argument value is a callable
+        predicates = args.get("custom_predicates", [])
+        if callable(value):
+            func = callable_map[kind]
+            predicate_checker = functools.partial(func, value)
+            predicates.append(predicate_checker)
+            args["custom_predicates"] = predicates
+        else:
+            # otherwise argument value is just a scalar
+            args[kind] = value
+
+
+def register_resource_views(config, resource):
+    """Register a resource and it's views.
+
+    :param config:
+        The pyramid configuration object that will be populated.
+    :param resource:
+        The resource class containing the definitions
+    """
+    services = resource._services
+
+    for service in services.values():
+        config.add_cornice_service(service)

--- a/kinto/core/cornice/pyramidhook.py
+++ b/kinto/core/cornice/pyramidhook.py
@@ -5,22 +5,6 @@ import copy
 import functools
 import itertools
 
-from cornice.cors import (
-    CORS_PARAMETERS,
-    apply_cors_post_request,
-    get_cors_preflight_view,
-    get_cors_validator,
-)
-from cornice.errors import Errors
-from cornice.service import decorate_view
-from cornice.util import (
-    content_type_matches,
-    current_service,
-    is_string,
-    match_accept_header,
-    match_content_type_header,
-    to_list,
-)
 from pyramid.exceptions import PredicateMismatch
 from pyramid.httpexceptions import (
     HTTPException,
@@ -29,6 +13,23 @@ from pyramid.httpexceptions import (
     HTTPUnsupportedMediaType,
 )
 from pyramid.security import NO_PERMISSION_REQUIRED
+
+from kinto.core.cornice.cors import (
+    CORS_PARAMETERS,
+    apply_cors_post_request,
+    get_cors_preflight_view,
+    get_cors_validator,
+)
+from kinto.core.cornice.errors import Errors
+from kinto.core.cornice.service import decorate_view
+from kinto.core.cornice.util import (
+    content_type_matches,
+    current_service,
+    is_string,
+    match_accept_header,
+    match_content_type_header,
+    to_list,
+)
 
 
 def get_fallback_view(service):

--- a/kinto/core/cornice/renderer.py
+++ b/kinto/core/cornice/renderer.py
@@ -1,0 +1,89 @@
+from pyramid import httpexceptions as exc
+from pyramid.renderers import JSON
+from pyramid.response import Response
+
+
+def bytes_adapter(obj, request):
+    """Convert bytes objects to strings for json error renderer."""
+    if isinstance(obj, bytes):
+        return obj.decode("utf8")
+    return obj
+
+
+class JSONError(exc.HTTPError):
+    def __init__(self, serializer, serializer_kw, errors, status=400):
+        body = {"status": "error", "errors": errors}
+        Response.__init__(self, serializer(body, **serializer_kw))
+        self.status = status
+        self.content_type = "application/json"
+
+
+class CorniceRenderer(JSON):
+    """We implement JSON serialization by extending Pyramid's default
+    JSON rendering machinery using our own custom Content-Type logic `[1]`_.
+
+    This allows developers to config the JSON renderer using Pyramid's
+    configuration machinery `[2]`_.
+
+      .. _`[1]`: https://github.com/mozilla-services/cornice/pull/116 \
+                 #issuecomment-14355865
+      .. _`[2]`: http://pyramid.readthedocs.io/en/latest/narr/renderers.html \
+                 #serializing-custom-objects
+    """
+
+    acceptable = ("application/json", "text/plain")
+
+    def __init__(self, *args, **kwargs):
+        """Adds a `bytes` adapter by default."""
+        super(CorniceRenderer, self).__init__(*args, **kwargs)
+        self.add_adapter(bytes, bytes_adapter)
+
+    def render_errors(self, request):
+        """Returns an HTTPError with the given status and message.
+
+        The HTTP error content type is "application/json"
+        """
+        default = self._make_default(request)
+        serializer_kw = self.kw.copy()
+        serializer_kw["default"] = default
+        return JSONError(
+            serializer=self.serializer,
+            serializer_kw=serializer_kw,
+            errors=request.errors,
+            status=request.errors.status,
+        )
+
+    def render(self, value, system):
+        """Extends the default `_render` function of the pyramid JSON renderer.
+
+        Compared to the default `pyramid.renderers.JSON` renderer:
+            1. Overrides the response with an empty string and
+               no Content-Type in case of HTTP 204.
+            2. Overrides the default behavior of Content-Type handling,
+               forcing the use of `acceptable_offers`, instead of letting
+               the user specify the Content-Type manually.
+               TODO: maybe explain this a little better
+        """
+        request = system.get("request")
+        if request is not None:
+            response = request.response
+
+            # Do not return content with ``204 No Content``
+            if response.status_code == 204:
+                response.content_type = None
+                return ""
+
+            ctypes = request.accept.acceptable_offers(offers=self.acceptable)
+            if not ctypes:
+                ctypes = [(self.acceptable[0], 1.0)]
+            response.content_type = ctypes[0][0]
+        default = self._make_default(request)
+        return self.serializer(value, default=default, **self.kw)
+
+    def __call__(self, info):
+        """Overrides the default behavior of `pyramid.renderers.JSON`.
+
+        Uses a public `render()` method instead of defining render inside
+        `__call__`, to let the user extend it if necessary.
+        """
+        return self.render

--- a/kinto/core/cornice/resource.py
+++ b/kinto/core/cornice/resource.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import functools
+import warnings
+
+import venusian
+from cornice import Service
+
+
+def resource(depth=2, **kw):
+    """Class decorator to declare resources.
+
+    All the methods of this class named by the name of HTTP resources
+    will be used as such. You can also prefix them by ``"collection_"`` and
+    they will be treated as HTTP methods for the given collection path
+    (collection_path), if any.
+
+    :param depth:
+        Which frame should be looked in default 2.
+
+    :param kw:
+        Keyword arguments configuring the resource.
+
+    Here is an example::
+
+        @resource(collection_path='/users', path='/users/{id}')
+    """
+
+    def wrapper(klass):
+        return add_resource(klass, depth, **kw)
+
+    return wrapper
+
+
+def add_resource(klass, depth=2, **kw):
+    """Function to declare resources of a Class.
+
+    All the methods of this class named by the name of HTTP resources
+    will be used as such. You can also prefix them by ``"collection_"`` and
+    they will be treated as HTTP methods for the given collection path
+    (collection_path), if any.
+
+    :param klass:
+        The class (resource) on which to register the service.
+
+    :param depth:
+        Which frame should be looked in default 2.
+
+    :param kw:
+        Keyword arguments configuring the resource.
+
+
+    Here is an example:
+
+    .. code-block:: python
+
+        class User(object):
+            pass
+
+        add_resource(User, collection_path='/users', path='/users/{id}')
+
+    Alternatively if you want to reuse your existing pyramid routes:
+
+    .. code-block:: python
+
+        class User(object):
+            pass
+
+        add_resource(User, collection_pyramid_route='users',
+            pyramid_route='user')
+
+    """
+
+    services = {}
+
+    if ("collection_pyramid_route" in kw or "pyramid_route" in kw) and (
+        "collection_path" in kw or "path" in kw
+    ):
+        raise ValueError("You use either paths or route names, not both")
+
+    if "collection_path" in kw:
+        if kw["collection_path"] == kw["path"]:
+            msg = "Warning: collection_path and path are not distinct."
+            warnings.warn(msg)
+
+        prefixes = ("", "collection_")
+    else:
+        prefixes = ("",)
+
+    if "collection_pyramid_route" in kw:
+        if kw["collection_pyramid_route"] == kw["pyramid_route"]:
+            msg = "Warning: collection_pyramid_route and pyramid_route are not distinct."
+            warnings.warn(msg)
+
+        prefixes = ("", "collection_")
+
+    for prefix in prefixes:
+        # get clean view arguments
+        service_args = {}
+        for k in list(kw):
+            if k.startswith("collection_"):
+                if prefix == "collection_":
+                    service_args[k[len(prefix) :]] = kw[k]
+            elif k not in service_args:
+                service_args[k] = kw[k]
+
+        # auto-wire klass as its own view factory, unless one
+        # is explicitly declared.
+        if "factory" not in kw:
+            service_args["factory"] = klass
+
+        # create service
+        service_name = service_args.pop("name", None) or klass.__name__.lower()
+        service_name = prefix + service_name
+        service = services[service_name] = Service(name=service_name, depth=depth, **service_args)
+        # ensure the service comes with the same properties as the wrapped
+        # resource
+        functools.update_wrapper(service, klass)
+
+        # initialize views
+        for verb in ("get", "post", "put", "delete", "options", "patch"):
+            view_attr = prefix + verb
+            meth = getattr(klass, view_attr, None)
+
+            if meth is not None:
+                # if the method has a __views__ arguments, then it had
+                # been decorated by a @view decorator. get back the name of
+                # the decorated method so we can register it properly
+                views = getattr(meth, "__views__", [])
+                if views:
+                    for view_args in views:
+                        service.add_view(verb, view_attr, klass=klass, **view_args)
+                else:
+                    service.add_view(verb, view_attr, klass=klass)
+
+    setattr(klass, "_services", services)
+
+    def callback(context, name, ob):
+        # get the callbacks registered by the inner services
+        # and call them from here when the @resource classes are being
+        # scanned by venusian.
+        for service in services.values():
+            config = context.config.with_package(info.module)
+            config.add_cornice_service(service)
+
+    info = venusian.attach(klass, callback, category="pyramid", depth=depth)
+
+    return klass
+
+
+def view(**kw):
+    """Method decorator to store view arguments when defining a resource with
+    the @resource class decorator
+
+    :param kw:
+        Keyword arguments configuring the view.
+    """
+
+    def wrapper(func):
+        return add_view(func, **kw)
+
+    return wrapper
+
+
+def add_view(func, **kw):
+    """Method to store view arguments when defining a resource with
+    the add_resource class method
+
+    :param func:
+        The func to hook to
+
+    :param kw:
+        Keyword arguments configuring the view.
+
+    Example:
+
+    .. code-block:: python
+
+        class User(object):
+
+            def __init__(self, request):
+                self.request = request
+
+            def collection_get(self):
+                return {'users': _USERS.keys()}
+
+            def get(self):
+                return _USERS.get(int(self.request.matchdict['id']))
+
+        add_view(User.get, renderer='json')
+        add_resource(User, collection_path='/users', path='/users/{id}')
+    """
+    # XXX needed in py2 to set on instancemethod
+    if hasattr(func, "__func__"):  # pragma: no cover
+        func = func.__func__
+    # store view argument to use them later in @resource
+    views = getattr(func, "__views__", None)
+    if views is None:
+        views = []
+        setattr(func, "__views__", views)
+    views.append(kw)
+    return func

--- a/kinto/core/cornice/resource.py
+++ b/kinto/core/cornice/resource.py
@@ -6,7 +6,8 @@ import functools
 import warnings
 
 import venusian
-from cornice import Service
+
+from kinto.core.cornice import Service
 
 
 def resource(depth=2, **kw):

--- a/kinto/core/cornice/service.py
+++ b/kinto/core/cornice/service.py
@@ -1,0 +1,640 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import functools
+
+import venusian
+from cornice.util import func_name, is_string, to_list
+from cornice.validators import (
+    DEFAULT_FILTERS,
+    DEFAULT_VALIDATORS,
+)
+from pyramid.exceptions import ConfigurationError
+from pyramid.interfaces import IRendererFactory
+from pyramid.response import Response
+
+
+SERVICES = []
+
+
+def clear_services():
+    SERVICES[:] = []
+
+
+def get_services(names=None, exclude=None):
+    def _keep(service):
+        if exclude is not None and service.name in exclude:
+            # excluded !
+            return False
+
+        # in white list or no white list provided
+        return names is None or service.name in names
+
+    return [service for service in SERVICES if _keep(service)]
+
+
+class Service(object):
+    """Contains a service definition (in the definition attribute).
+
+    A service is composed of a path and many potential methods, associated
+    with context.
+
+    All the class attributes defined in this class or in children are
+    considered default values.
+
+    :param name:
+        The name of the service. Should be unique among all the services.
+
+    :param path:
+        The path the service is available at. Should also be unique.
+
+    :param pyramid_route:
+        Use existing pyramid route instead of creating new one.
+
+    :param renderer:
+        The renderer that should be used by this service. Default value is
+        'cornicejson'.
+
+    :param description:
+        The description of what the webservice does. This is primarily intended
+        for documentation purposes.
+
+    :param validators:
+        A list of callables to pass the request into before passing it to the
+        associated view.
+
+    :param filters:
+        A list of callables to pass the response into before returning it to
+        the client.
+
+    :param accept:
+        A list of ``Accept`` header values accepted for this service
+        (or method if overwritten when defining a method).
+        It can also be a callable, in which case the values will be
+        discovered at runtime. If a callable is passed, it should be able
+        to take the request as a first argument.
+
+    :param content_type:
+        A list of ``Content-Type`` header values accepted for this service
+        (or method if overwritten when defining a method).
+        It can also be a callable, in which case the values will be
+        discovered at runtime. If a callable is passed, it should be able
+        to take the request as a first argument.
+
+    :param factory:
+        A factory returning callables which return boolean values.  The
+        callables take the request as their first argument and return boolean
+        values.
+
+    :param permission:
+        As for ``pyramid.config.Configurator.add_view()``.
+        Note: `permission` can also be applied
+        to instance method decorators such as :meth:`~get` and :meth:`~put`.
+
+    :param klass:
+        The class to use when resolving views (if they are not callables)
+
+    :param error_handler:
+        A callable which is used to render responses following validation
+        failures.  By default it will call the registered renderer
+        `render_errors` method.
+
+    :param traverse:
+        A traversal pattern that will be passed on route declaration and that
+        will be used as the traversal path.
+
+    There are also a number of parameters that are related to the support of
+    CORS (Cross Origin Resource Sharing). You can read the CORS specification
+    at http://www.w3.org/TR/cors/
+
+    :param cors_enabled:
+        To use if you especially want to disable CORS support for a particular
+        service / method.
+
+    :param cors_origins:
+        The list of origins for CORS. You can use wildcards here if needed,
+        e.g. ('list', 'of', '\\*.domain').
+
+    :param cors_headers:
+        The list of headers supported for the services.
+
+    :param cors_credentials:
+        Should the client send credential information (False by default).
+
+    :param cors_max_age:
+         Indicates how long the results of a preflight request can be cached in
+         a preflight result cache.
+
+    :param cors_expose_all_headers:
+        If set to True, all the headers will be exposed and considered valid
+        ones (Default: True). If set to False, all the headers need be
+        explicitly mentioned with the cors_headers parameter.
+
+    :param cors_policy:
+        It may be easier to have an external object containing all the policy
+        information related to CORS, e.g::
+
+            >>> cors_policy = {'origins': ('*',), 'max_age': 42,
+            ...                'credentials': True}
+
+        You can pass a dict here and all the values will be
+        unpacked and considered rather than the parameters starting by `cors_`
+        here.
+
+    See
+    https://pyramid.readthedocs.io/en/1.0-branch/glossary.html#term-acl
+    for more information about ACLs.
+
+    Service cornice instances also have methods :meth:`~get`, :meth:`~post`,
+    :meth:`~put`, :meth:`~options` and :meth:`~delete` are decorators that can
+    be used to decorate views.
+    """
+
+    renderer = "cornicejson"
+    default_validators = DEFAULT_VALIDATORS
+    default_filters = DEFAULT_FILTERS
+
+    mandatory_arguments = ("renderer",)
+    list_arguments = ("validators", "filters", "cors_headers", "cors_origins")
+
+    def __repr__(self):
+        return "<Service %s at %s>" % (self.name, self.pyramid_route or self.path)
+
+    def __init__(
+        self,
+        name,
+        path=None,
+        description=None,
+        cors_policy=None,
+        depth=1,
+        pyramid_route=None,
+        **kw,
+    ):
+        self.name = name
+        self.path = path
+        self.pyramid_route = pyramid_route
+
+        if not self.path and not self.pyramid_route:
+            raise TypeError("You need to pass path or pyramid_route arg")
+
+        self.description = description
+        self.cors_expose_all_headers = True
+        self._cors_enabled = None
+
+        if cors_policy:
+            for key, value in cors_policy.items():
+                kw.setdefault("cors_" + key, value)
+
+        for key in self.list_arguments:
+            # default_{validators,filters} and {filters,validators} don't
+            # have to be mutables, so we need to create a new list from them
+            extra = to_list(kw.get(key, []))
+            kw[key] = []
+            kw[key].extend(getattr(self, "default_%s" % key, []))
+            kw[key].extend(extra)
+
+        self.arguments = self.get_arguments(kw)
+        for key, value in self.arguments.items():
+            # avoid squashing Service.decorator if ``decorator``
+            # argument is used to specify a default pyramid view
+            # decorator
+            if key != "decorator":
+                setattr(self, key, value)
+
+        if hasattr(self, "acl"):
+            raise ConfigurationError("'acl' is not supported")
+
+        # instantiate some variables we use to keep track of what's defined for
+        # this service.
+        self.defined_methods = []
+        self.definitions = []
+
+        # add this service to the list of available services
+        SERVICES.append(self)
+
+        # this callback will be called when config.scan (from pyramid) will
+        # be triggered.
+        def callback(context, name, ob):
+            config = context.config.with_package(info.module)
+            config.add_cornice_service(self)
+
+        info = venusian.attach(self, callback, category="pyramid", depth=depth)
+
+    def default_error_handler(self, request):
+        """Default error_handler.
+
+        Uses the renderer for the service to render `request.errors`.
+        Only works if the registered renderer for the Service exposes the
+        method `render_errors`, which is implemented by default by
+        :class:`cornice.renderer.CorniceRenderer`.
+
+        :param request: the current Request.
+        """
+        renderer = request.registry.queryUtility(IRendererFactory, name=self.renderer)
+        return renderer.render_errors(request)
+
+    def get_arguments(self, conf=None):
+        """Return a dictionary of arguments. Takes arguments from the :param
+        conf: param and merges it with the arguments passed in the constructor.
+
+        :param conf: the dictionary to use.
+        """
+        if conf is None:
+            conf = {}
+
+        arguments = {}
+        for arg in self.mandatory_arguments:
+            # get the value from the passed conf, then from the instance, then
+            # from the default class settings.
+            arguments[arg] = conf.pop(arg, getattr(self, arg, None))
+
+        for arg in self.list_arguments:
+            # rather than overwriting, extend the defined lists if
+            # any. take care of re-creating the lists before appending
+            # items to them, to avoid modifications to the already
+            # existing ones
+            value = list(getattr(self, arg, []))
+            if arg in conf:
+                value.extend(to_list(conf.pop(arg)))
+            arguments[arg] = value
+
+        # Allow custom error handler
+        arguments["error_handler"] = conf.pop(
+            "error_handler", getattr(self, "error_handler", self.default_error_handler)
+        )
+
+        # exclude some validators or filters
+        if "exclude" in conf:
+            for item in to_list(conf.pop("exclude")):
+                for container in arguments["validators"], arguments["filters"]:
+                    if item in container:
+                        container.remove(item)
+
+        # also include the other key,value pair we don't know anything about
+        arguments.update(conf)
+
+        # if some keys have been defined service-wide, then we need to add
+        # them to the returned dict.
+        if hasattr(self, "arguments"):
+            for key, value in self.arguments.items():
+                if key not in arguments:
+                    arguments[key] = value
+
+        return arguments
+
+    def add_view(self, method, view, **kwargs):
+        """Add a view to a method and arguments.
+
+        All the :class:`Service` keyword params except `name` and `path`
+        can be overwritten here. Additionally,
+        :meth:`~cornice.service.Service.api` has following keyword params:
+
+        :param method: The request method. Should be one of 'GET', 'POST',
+                       'PUT', 'DELETE', 'OPTIONS', 'TRACE', or 'CONNECT'.
+        :param view: the view to hook to
+        :param **kwargs: additional configuration for this view,
+                        including `permission`.
+        """
+        method = method.upper()
+
+        if "klass" in kwargs and not callable(view):
+            view = _UnboundView(kwargs["klass"], view)
+
+        args = self.get_arguments(kwargs)
+
+        # remove 'factory' if present,
+        # it's not a valid pyramid view param
+        if "factory" in args:
+            del args["factory"]
+
+        if hasattr(self, "get_view_wrapper"):
+            view = self.get_view_wrapper(kwargs)(view)
+        self.definitions.append((method, view, args))
+
+        # keep track of the defined methods for the service
+        if method not in self.defined_methods:
+            self.defined_methods.append(method)
+
+        # auto-define a HEAD method if we have a definition for GET.
+        if method == "GET":
+            self.definitions.append(("HEAD", view, args))
+            if "HEAD" not in self.defined_methods:
+                self.defined_methods.append("HEAD")
+
+    def decorator(self, method, **kwargs):
+        """Add the ability to define methods using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.decorator("get", accept="application/json")
+            def my_view(request):
+                pass
+        """
+
+        def wrapper(view):
+            self.add_view(method, view, **kwargs)
+            return view
+
+        return wrapper
+
+    def get(self, **kwargs):
+        """Add the ability to define get using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.get(accept="application/json")
+            def my_view(request):
+                pass
+        """
+        return self.decorator("GET", **kwargs)
+
+    def post(self, **kwargs):
+        """Add the ability to define post using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.post(accept="application/json")
+            def my_view(request):
+                pass
+        """
+        return self.decorator("POST", **kwargs)
+
+    def put(self, **kwargs):
+        """Add the ability to define put using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.put(accept="application/json")
+            def my_view(request):
+                pass
+        """
+        return self.decorator("PUT", **kwargs)
+
+    def delete(self, **kwargs):
+        """Add the ability to define delete using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.delete(accept="application/json")
+            def my_view(request):
+                pass
+        """
+        return self.decorator("DELETE", **kwargs)
+
+    def options(self, **kwargs):
+        """Add the ability to define options using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.options(accept="application/json")
+            def my_view(request):
+                pass
+        """
+        return self.decorator("OPTIONS", **kwargs)
+
+    def patch(self, **kwargs):
+        """Add the ability to define patch using python's decorators
+        syntax.
+
+        For instance, it is possible to do this with this method::
+
+            service = Service("blah", "/blah")
+            @service.patch(accept="application/json")
+            def my_view(request):
+                pass
+        """
+        return self.decorator("PATCH", **kwargs)
+
+    def filter_argumentlist(self, method, argname, filter_callables=False):
+        """
+        Helper method to ``get_acceptable`` and ``get_contenttypes``. DRY.
+        """
+        result = []
+        for meth, view, args in self.definitions:
+            if meth.upper() == method.upper():
+                result_tmp = to_list(args.get(argname))
+                if filter_callables:
+                    result_tmp = [a for a in result_tmp if not callable(a)]
+                result.extend(result_tmp)
+        return result
+
+    def get_acceptable(self, method, filter_callables=False):
+        """return a list of acceptable egress content-type headers that were
+        defined for this service.
+
+        :param method: the method to get the acceptable egress content-types
+                       for.
+        :param filter_callables: it is possible to give acceptable
+                                 content-types dynamically, with callables.
+                                 This toggles filtering the callables (default:
+                                 False)
+        """
+        return self.filter_argumentlist(method, "accept", filter_callables)
+
+    def get_contenttypes(self, method, filter_callables=False):
+        """return a list of supported ingress content-type headers that were
+        defined for this service.
+
+        :param method: the method to get the supported ingress content-types
+                       for.
+        :param filter_callables: it is possible to give supported
+                                 content-types dynamically, with callables.
+                                 This toggles filtering the callables (default:
+                                 False)
+        """
+        return self.filter_argumentlist(method, "content_type", filter_callables)
+
+    def get_validators(self, method):
+        """return a list of validators for the given method.
+
+        :param method: the method to get the validators for.
+        """
+        validators = []
+        for meth, view, args in self.definitions:
+            if meth.upper() == method.upper() and "validators" in args:
+                for validator in args["validators"]:
+                    if validator not in validators:
+                        validators.append(validator)
+        return validators
+
+    @property
+    def cors_enabled(self):
+        if self._cors_enabled is False:
+            return False
+
+        return bool(self.cors_origins or self._cors_enabled)
+
+    @cors_enabled.setter
+    def cors_enabled(self, value):
+        self._cors_enabled = value
+
+    def cors_supported_headers_for(self, method=None):
+        """Return an iterable of supported headers for this service.
+
+        The supported headers are defined by the :param headers: argument
+        that is passed to services or methods, at definition time.
+        """
+        headers = set()
+        for meth, _, args in self.definitions:
+            if args.get("cors_enabled", True):
+                exposed_headers = args.get("cors_headers", ())
+                if method is not None:
+                    if meth.upper() == method.upper():
+                        return set(exposed_headers)
+                else:
+                    headers |= set(exposed_headers)
+        return headers
+
+    @property
+    def cors_supported_methods(self):
+        """Return an iterable of methods supported by CORS"""
+        methods = []
+        for meth, _, args in self.definitions:
+            if args.get("cors_enabled", True) and meth not in methods:
+                methods.append(meth)
+        return methods
+
+    @property
+    def cors_supported_origins(self):
+        origins = set(getattr(self, "cors_origins", ()))
+        for _, _, args in self.definitions:
+            origins |= set(args.get("cors_origins", ()))
+        return origins
+
+    def cors_origins_for(self, method):
+        """Return the list of origins supported for a given HTTP method"""
+        origins = set()
+        for meth, view, args in self.definitions:
+            if meth.upper() == method.upper():
+                origins |= set(args.get("cors_origins", ()))
+
+        if not origins:
+            origins = self.cors_origins
+        return origins
+
+    def cors_support_credentials_for(self, method=None):
+        """Returns if the given method support credentials.
+
+        :param method:
+            The method to check the credentials support for
+        """
+        for meth, view, args in self.definitions:
+            if method and meth.upper() == method.upper():
+                return args.get("cors_credentials", False)
+
+        if getattr(self, "cors_credentials", False):
+            return self.cors_credentials
+        return False
+
+    def cors_max_age_for(self, method=None):
+        max_age = None
+        for meth, view, args in self.definitions:
+            if method and meth.upper() == method.upper():
+                max_age = args.get("cors_max_age", None)
+                break
+
+        if max_age is None:
+            max_age = getattr(self, "cors_max_age", None)
+        return max_age
+
+
+def decorate_view(view, args, method, route_args={}):
+    """Decorate a given view with cornice niceties.
+
+    This function returns a function with the same signature than the one
+    you give as :param view:
+
+    :param view: the view to decorate
+    :param args: the args to use for the decoration
+    :param method: the HTTP method
+    :param route_args: the args used for the associated route
+    """
+
+    def wrapper(request):
+        # if the args contain a klass argument then use it to resolve the view
+        # location (if the view argument isn't a callable)
+        ob = None
+        view_ = view
+        if "klass" in args and not callable(view):
+            # XXX: given that request.context exists and root-factory
+            # only expects request param, having params seems unnecessary
+            # ob = args['klass'](request)
+            params = dict(request=request)
+            if "factory" in route_args:
+                params["context"] = request.context
+            ob = args["klass"](**params)
+            if is_string(view):
+                view_ = getattr(ob, view.lower())
+            elif isinstance(view, _UnboundView):
+                view_ = view.make_bound_view(ob)
+
+        # the validators can either be a list of callables or contain some
+        # non-callable values. In which case we want to resolve them using the
+        # object if any
+        validators = args.get("validators", ())
+        for validator in validators:
+            if is_string(validator) and ob is not None:
+                validator = getattr(ob, validator)
+            validator(request, **args)
+
+        # only call the view if we don't have validation errors
+        if len(request.errors) == 0:
+            try:
+                # If we have an object, it already has the request.
+                if ob:
+                    response = view_()
+                else:
+                    response = view_(request)
+            except Exception:
+                # cors headers need to be set if an exception was raised
+                request.info["cors_checked"] = False
+                raise
+
+        # check for errors and return them if any
+        if len(request.errors) > 0:
+            # We already checked for CORS, but since the response is created
+            # again, we want to do that again before returning the response.
+            request.info["cors_checked"] = False
+            return args["error_handler"](request)
+
+        # if the view returns its own response, cors headers need to be set
+        if isinstance(response, Response):
+            request.info["cors_checked"] = False
+
+        # We can't apply filters at this level, since "response" may not have
+        # been rendered into a proper Response object yet.  Instead, give the
+        # request a reference to its api_kwargs so that a tween can apply them.
+        # We also pass the object we created (if any) so we can use it to find
+        # the filters that are in fact methods.
+        request.cornice_args = (args, ob)
+        return response
+
+    # return the wrapper, not the function, keep the same signature
+    if not is_string(view):
+        functools.update_wrapper(wrapper, view)
+
+    # Set the wrapper name to something useful
+    wrapper.__name__ = "{0}__{1}".format(func_name(view), method)
+    return wrapper
+
+
+class _UnboundView(object):
+    def __init__(self, klass, view):
+        self.unbound_view = getattr(klass, view.lower())
+        functools.update_wrapper(self, self.unbound_view)
+        self.__name__ = func_name(self.unbound_view)
+
+    def make_bound_view(self, ob):
+        return functools.partial(self.unbound_view, ob)

--- a/kinto/core/cornice/service.py
+++ b/kinto/core/cornice/service.py
@@ -4,14 +4,15 @@
 import functools
 
 import venusian
-from cornice.util import func_name, is_string, to_list
-from cornice.validators import (
-    DEFAULT_FILTERS,
-    DEFAULT_VALIDATORS,
-)
 from pyramid.exceptions import ConfigurationError
 from pyramid.interfaces import IRendererFactory
 from pyramid.response import Response
+
+from kinto.core.cornice.util import func_name, is_string, to_list
+from kinto.core.cornice.validators import (
+    DEFAULT_FILTERS,
+    DEFAULT_VALIDATORS,
+)
 
 
 SERVICES = []

--- a/kinto/core/cornice/util.py
+++ b/kinto/core/cornice/util.py
@@ -1,0 +1,138 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import warnings
+
+
+__all__ = [
+    "is_string",
+    "to_list",
+    "match_accept_header",
+    "ContentTypePredicate",
+    "current_service",
+    "func_name",
+]
+
+
+def is_string(s):
+    return isinstance(s, str)
+
+
+def to_list(obj):
+    """Convert an object to a list if it is not already one"""
+    if not isinstance(obj, (list, tuple)):
+        obj = [
+            obj,
+        ]
+    return obj
+
+
+def match_accept_header(func, context, request):
+    """
+    Return True if the request ``Accept`` header match
+    the list returned by the callable specified in :param:func.
+
+    Also attach the total list of possible accepted
+    egress media types to the request.
+
+    Utility function for performing content negotiation.
+
+    :param func:
+        The callable returning the list of acceptable
+        internet media types for content negotiation.
+        It obtains the request object as single argument.
+    """
+    acceptable = to_list(func(request))
+    request.info["acceptable"] = acceptable
+    return len(request.accept.acceptable_offers(acceptable)) > 0
+
+
+def match_content_type_header(func, context, request):
+    """
+    Return True if the request ``Content-Type`` header match
+    the list returned by the callable specified in :param:func.
+
+    Also attach the total list of possible accepted
+    ingress media types to the request.
+
+    Utility function for performing request body
+    media type checks.
+
+    :param func:
+        The callable returning the list of acceptable
+        internet media types for request body
+        media type checks.
+        It obtains the request object as single argument.
+    """
+    supported_contenttypes = to_list(func(request))
+    request.info["supported_contenttypes"] = supported_contenttypes
+    return content_type_matches(request, supported_contenttypes)
+
+
+def extract_json_data(request):
+    warnings.warn("Use ``cornice.validators.extract_cstruct()`` instead", DeprecationWarning)
+    from cornice.validators import extract_cstruct
+
+    return extract_cstruct(request)["body"]
+
+
+def extract_form_urlencoded_data(request):
+    warnings.warn("Use ``cornice.validators.extract_cstruct()`` instead", DeprecationWarning)
+    return request.POST
+
+
+def content_type_matches(request, content_types):
+    """
+    Check whether ``request.content_type``
+    matches given list of content types.
+    """
+    return request.content_type in content_types
+
+
+class ContentTypePredicate(object):
+    """
+    Pyramid predicate for matching against ``Content-Type`` request header.
+    Should live in ``pyramid.config.predicates``.
+
+    .. seealso::
+      http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html
+      #view-and-route-predicates
+    """
+
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return "content_type = %s" % (self.val,)
+
+    phash = text
+
+    def __call__(self, context, request):
+        return request.content_type == self.val
+
+
+def func_name(f):
+    """Return the name of a function or class method."""
+    if isinstance(f, str):
+        return f
+    elif hasattr(f, "__qualname__"):  # pragma: no cover
+        return f.__qualname__  # Python 3
+    elif hasattr(f, "im_class"):  # pragma: no cover
+        return "{0}.{1}".format(f.im_class.__name__, f.__name__)  # Python 2
+    else:  # pragma: no cover
+        return f.__name__  # Python 2
+
+
+def current_service(request):
+    """Return the Cornice service matching the specified request.
+
+    :returns: the service or None if unmatched.
+    :rtype: cornice.Service
+    """
+    if request.matched_route:
+        services = request.registry.cornice_services
+        pattern = request.matched_route.pattern
+        name = request.matched_route.name
+        # try pattern first, then route name else return None
+        service = services.get(pattern, services.get("__cornice" + name))
+        return service

--- a/kinto/core/cornice/util.py
+++ b/kinto/core/cornice/util.py
@@ -71,7 +71,7 @@ def match_content_type_header(func, context, request):
 
 def extract_json_data(request):
     warnings.warn("Use ``cornice.validators.extract_cstruct()`` instead", DeprecationWarning)
-    from cornice.validators import extract_cstruct
+    from kinto.core.cornice.validators import extract_cstruct
 
     return extract_cstruct(request)["body"]
 
@@ -127,7 +127,7 @@ def current_service(request):
     """Return the Cornice service matching the specified request.
 
     :returns: the service or None if unmatched.
-    :rtype: cornice.Service
+    :rtype: kinto.core.cornice.Service
     """
     if request.matched_route:
         services = request.registry.cornice_services

--- a/kinto/core/cornice/validators/__init__.py
+++ b/kinto/core/cornice/validators/__init__.py
@@ -3,19 +3,24 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import re
 
-from cornice.validators._colander import body_validator as colander_body_validator
-from cornice.validators._colander import headers_validator as colander_headers_validator
-from cornice.validators._colander import path_validator as colander_path_validator
-from cornice.validators._colander import querystring_validator as colander_querystring_validator
-from cornice.validators._colander import validator as colander_validator
-from cornice.validators._marshmallow import body_validator as marshmallow_body_validator
-from cornice.validators._marshmallow import headers_validator as marshmallow_headers_validator
-from cornice.validators._marshmallow import path_validator as marshmallow_path_validator
-from cornice.validators._marshmallow import (
+from webob.multidict import MultiDict
+
+from kinto.core.cornice.validators._colander import body_validator as colander_body_validator
+from kinto.core.cornice.validators._colander import headers_validator as colander_headers_validator
+from kinto.core.cornice.validators._colander import path_validator as colander_path_validator
+from kinto.core.cornice.validators._colander import (
+    querystring_validator as colander_querystring_validator,
+)
+from kinto.core.cornice.validators._colander import validator as colander_validator
+from kinto.core.cornice.validators._marshmallow import body_validator as marshmallow_body_validator
+from kinto.core.cornice.validators._marshmallow import (
+    headers_validator as marshmallow_headers_validator,
+)
+from kinto.core.cornice.validators._marshmallow import path_validator as marshmallow_path_validator
+from kinto.core.cornice.validators._marshmallow import (
     querystring_validator as marshmallow_querystring_validator,
 )
-from cornice.validators._marshmallow import validator as marshmallow_validator
-from webob.multidict import MultiDict
+from kinto.core.cornice.validators._marshmallow import validator as marshmallow_validator
 
 
 __all__ = [

--- a/kinto/core/cornice/validators/__init__.py
+++ b/kinto/core/cornice/validators/__init__.py
@@ -1,0 +1,89 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import re
+
+from cornice.validators._colander import body_validator as colander_body_validator
+from cornice.validators._colander import headers_validator as colander_headers_validator
+from cornice.validators._colander import path_validator as colander_path_validator
+from cornice.validators._colander import querystring_validator as colander_querystring_validator
+from cornice.validators._colander import validator as colander_validator
+from cornice.validators._marshmallow import body_validator as marshmallow_body_validator
+from cornice.validators._marshmallow import headers_validator as marshmallow_headers_validator
+from cornice.validators._marshmallow import path_validator as marshmallow_path_validator
+from cornice.validators._marshmallow import (
+    querystring_validator as marshmallow_querystring_validator,
+)
+from cornice.validators._marshmallow import validator as marshmallow_validator
+from webob.multidict import MultiDict
+
+
+__all__ = [
+    "colander_validator",
+    "colander_body_validator",
+    "colander_headers_validator",
+    "colander_path_validator",
+    "colander_querystring_validator",
+    "marshmallow_validator",
+    "marshmallow_body_validator",
+    "marshmallow_headers_validator",
+    "marshmallow_path_validator",
+    "marshmallow_querystring_validator",
+    "extract_cstruct",
+    "DEFAULT_VALIDATORS",
+    "DEFAULT_FILTERS",
+]
+
+
+DEFAULT_VALIDATORS = []
+DEFAULT_FILTERS = []
+
+
+def extract_cstruct(request):
+    """
+    Extract attributes from the specified `request` such as body, url, path,
+    method, querystring, headers, cookies, and returns them in a single dict
+    object.
+
+    :param request: Current request
+    :type request: :class:`~pyramid:pyramid.request.Request`
+
+    :returns: A mapping containing most request attributes.
+    :rtype: dict
+    """
+    is_json = re.match("^application/(.*?)json$", str(request.content_type))
+
+    if request.content_type in ("application/x-www-form-urlencoded", "multipart/form-data"):
+        body = request.POST.mixed()
+    elif request.content_type and not is_json:
+        body = request.body
+    else:
+        if request.body:
+            try:
+                body = request.json_body
+            except ValueError as e:
+                request.errors.add("body", "", "Invalid JSON: %s" % e)
+                return {}
+            else:
+                if not hasattr(body, "items") and not isinstance(body, list):
+                    request.errors.add("body", "", "Should be a JSON object or an array")
+                    return {}
+        else:
+            body = {}
+
+    cstruct = {
+        "method": request.method,
+        "url": request.url,
+        "path": request.matchdict,
+        "body": body,
+    }
+
+    for sub, attr in (("querystring", "GET"), ("header", "headers"), ("cookies", "cookies")):
+        data = getattr(request, attr)
+        if isinstance(data, MultiDict):
+            data = data.mixed()
+        else:
+            data = dict(data)
+        cstruct[sub] = data
+
+    return cstruct

--- a/kinto/core/cornice/validators/_colander.py
+++ b/kinto/core/cornice/validators/_colander.py
@@ -1,0 +1,141 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import inspect
+import warnings
+
+
+def _generate_colander_validator(location):
+    """
+    Generate a colander validator for data from the given location.
+
+    :param location: The location in the request to find the data to be
+        validated, such as "body" or "querystring".
+    :type location: str
+    :return: Returns a callable that will validate the request at the given
+        location.
+    :rtype: callable
+    """
+
+    def _validator(request, schema=None, deserializer=None, **kwargs):
+        """
+        Validate the location against the schema defined on the service.
+
+        The content of the location is deserialized, validated and stored in
+        the ``request.validated`` attribute.
+
+        .. note::
+
+            If no schema is defined, this validator does nothing.
+            Schema should be of type :class:`~colander:colander.MappingSchema`.
+
+        :param request: Current request
+        :type request: :class:`~pyramid:pyramid.request.Request`
+
+        :param schema: The Colander schema
+        :param deserializer: Optional deserializer, defaults to
+            :func:`cornice.validators.extract_cstruct`
+        """
+        import colander
+
+        if schema is None:
+            return
+
+        schema_instance = _ensure_instantiated(schema)
+
+        if not isinstance(schema_instance, colander.MappingSchema):
+            raise TypeError("Schema should inherit from colander.MappingSchema.")
+
+        class RequestSchemaMeta(colander._SchemaMeta):
+            """
+            A metaclass that will inject a location class attribute into
+            RequestSchema.
+            """
+
+            def __new__(cls, name, bases, class_attrs):
+                """
+                Instantiate the RequestSchema class.
+
+                :param name: The name of the class we are instantiating. Will
+                    be "RequestSchema".
+                :type name: str
+                :param bases: The class's superclasses.
+                :type bases: tuple
+                :param dct: The class's class attributes.
+                :type dct: dict
+                """
+                class_attrs[location] = schema_instance
+                return type(name, bases, class_attrs)
+
+        class RequestSchema(colander.MappingSchema, metaclass=RequestSchemaMeta):  # noqa
+            """A schema to validate the request's location attributes."""
+
+            pass
+
+        validator(request, RequestSchema(), deserializer, **kwargs)
+        validated_location = request.validated.get(location, {})
+        request.validated.update(validated_location)
+        if location not in validated_location:
+            request.validated.pop(location, None)
+
+    return _validator
+
+
+body_validator = _generate_colander_validator("body")
+headers_validator = _generate_colander_validator("headers")
+path_validator = _generate_colander_validator("path")
+querystring_validator = _generate_colander_validator("querystring")
+
+
+def validator(request, schema=None, deserializer=None, **kwargs):
+    """
+    Validate the full request against the schema defined on the service.
+
+    Each attribute of the request is deserialized, validated and stored in the
+    ``request.validated`` attribute
+    (eg. body in ``request.validated['body']``).
+
+    .. note::
+
+        If no schema is defined, this validator does nothing.
+
+    :param request: Current request
+    :type request: :class:`~pyramid:pyramid.request.Request`
+
+    :param schema: The Colander schema
+    :param deserializer: Optional deserializer, defaults to
+        :func:`cornice.validators.extract_cstruct`
+    """
+    import colander
+    from cornice.validators import extract_cstruct
+
+    if deserializer is None:
+        deserializer = extract_cstruct
+
+    if schema is None:
+        return
+
+    schema = _ensure_instantiated(schema)
+    cstruct = deserializer(request)
+    try:
+        deserialized = schema.deserialize(cstruct)
+    except colander.Invalid as e:
+        translate = request.localizer.translate
+        error_dict = e.asdict(translate=translate)
+        for name, msg in error_dict.items():
+            location, _, field = name.partition(".")
+            request.errors.add(location, field, msg)
+    else:
+        request.validated.update(deserialized)
+
+
+def _ensure_instantiated(schema):
+    if inspect.isclass(schema):
+        warnings.warn(
+            "Setting schema to a class is deprecated. Set schema to an instance instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        schema = schema()
+    return schema

--- a/kinto/core/cornice/validators/_colander.py
+++ b/kinto/core/cornice/validators/_colander.py
@@ -108,7 +108,8 @@ def validator(request, schema=None, deserializer=None, **kwargs):
         :func:`cornice.validators.extract_cstruct`
     """
     import colander
-    from cornice.validators import extract_cstruct
+
+    from kinto.core.cornice.validators import extract_cstruct
 
     if deserializer is None:
         deserializer = extract_cstruct

--- a/kinto/core/cornice/validators/_marshmallow.py
+++ b/kinto/core/cornice/validators/_marshmallow.py
@@ -1,0 +1,181 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import inspect
+
+
+def _generate_marshmallow_validator(location):
+    """
+    Generate a marshmallow validator for data from the given location.
+
+    :param location: The location in the request to find the data to be
+        validated, such as "body" or "querystring".
+    :type location: str
+    :return: Returns a callable that will validate the request at the given
+        location.
+    :rtype: callable
+    """
+
+    def _validator(request, schema=None, deserializer=None, **kwargs):
+        """
+        Validate the location against the schema defined on the service.
+
+        The content of the location is deserialized, validated and stored in
+        the ``request.validated`` attribute.
+
+        Keyword arguments to be included when initialising the marshmallow
+        schema can be passed as a dict in ``kwargs['schema_kwargs']`` variable.
+
+        .. note::
+
+            If no schema is defined, this validator does nothing.
+
+        :param request: Current request
+        :type request: :class:`~pyramid:pyramid.request.Request`
+
+        :param schema: The marshmallow schema
+        :param deserializer: Optional deserializer, defaults to
+            :func:`cornice.validators.extract_cstruct`
+        """
+        import marshmallow
+        import marshmallow.schema
+        from marshmallow.utils import EXCLUDE
+
+        if schema is None:
+            return
+
+        # see if the user wants to set any keyword arguments for their schema
+        schema_kwargs = kwargs.get("schema_kwargs", {})
+        schema = _instantiate_schema(schema, **schema_kwargs)
+
+        class ValidatedField(marshmallow.fields.Field):
+            def _deserialize(self, value, attr, data, **kwargs):
+                schema.context.setdefault("request", request)
+                deserialized = schema.load(value)
+                return deserialized
+
+        class Meta(object):
+            strict = True
+            ordered = True
+            unknown = EXCLUDE
+
+        class RequestSchemaMeta(marshmallow.schema.SchemaMeta):
+            """
+            A metaclass that will inject a location class attribute into
+            RequestSchema.
+            """
+
+            def __new__(cls, name, bases, class_attrs):
+                """
+                Instantiate the RequestSchema class.
+
+                :param name: The name of the class we are instantiating. Will
+                    be "RequestSchema".
+                :type name: str
+                :param bases: The class's superclasses.
+                :type bases: tuple
+                :param dct: The class's class attributes.
+                :type dct: dict
+                """
+
+                class_attrs[location] = ValidatedField(
+                    required=True, metadata={"load_from": location}
+                )
+                class_attrs["Meta"] = Meta
+                return type(name, bases, class_attrs)
+
+        class RequestSchema(marshmallow.Schema, metaclass=RequestSchemaMeta):  # noqa
+            """A schema to validate the request's location attributes."""
+
+            pass
+
+        validator(request, RequestSchema, deserializer, **kwargs)
+        request.validated = request.validated.get(location, {})
+
+    return _validator
+
+
+body_validator = _generate_marshmallow_validator("body")
+headers_validator = _generate_marshmallow_validator("header")
+path_validator = _generate_marshmallow_validator("path")
+querystring_validator = _generate_marshmallow_validator("querystring")
+
+
+def _message_normalizer(exc, no_field_name="_schema"):
+    """
+    Normally `normalize_messages` will exist on `ValidationError` but pre 2.10
+    versions don't have it
+    :param exc:
+    :param no_field_name:
+    :return:
+    """
+    if isinstance(exc.messages, dict):
+        return exc.messages
+    field_names = exc.kwargs.get("field_names", [])
+    if len(field_names) == 0:
+        return {no_field_name: exc.messages}
+    return dict((name, exc.messages) for name in field_names)
+
+
+def validator(request, schema=None, deserializer=None, **kwargs):
+    """
+    Validate the full request against the schema defined on the service.
+
+    Each attribute of the request is deserialized, validated and stored in the
+    ``request.validated`` attribute
+    (eg. body in ``request.validated['body']``).
+
+    .. note::
+
+        If no schema is defined, this validator does nothing.
+
+    :param request: Current request
+    :type request: :class:`~pyramid:pyramid.request.Request`
+
+    :param schema: The marshmallow schema
+    :param deserializer: Optional deserializer, defaults to
+        :func:`cornice.validators.extract_cstruct`
+    """
+    import marshmallow
+    from cornice.validators import extract_cstruct
+
+    if deserializer is None:
+        deserializer = extract_cstruct
+
+    if schema is None:
+        return
+
+    schema = _instantiate_schema(schema)
+    schema.context.setdefault("request", request)
+
+    cstruct = deserializer(request)
+    try:
+        deserialized = schema.load(cstruct)
+    except marshmallow.ValidationError as err:
+        # translate = request.localizer.translate
+        normalized_errors = _message_normalizer(err)
+        for location, details in normalized_errors.items():
+            location = location if location != "_schema" else ""
+            if hasattr(details, "items"):
+                for subfield, msg in details.items():
+                    request.errors.add(location, subfield, msg)
+            else:
+                request.errors.add(location, location, details)
+    else:
+        request.validated.update(deserialized)
+
+
+def _instantiate_schema(schema, **kwargs):
+    """
+    Returns an object of the given marshmallow schema.
+
+    :param schema: The marshmallow schema class with which the request should
+        be validated
+    :param kwargs: The keyword arguments that will be provided to the
+        marshmallow schema's constructor
+    :return: The object of the marshmallow schema
+    """
+    if not inspect.isclass(schema):
+        raise ValueError("You need to pass Marshmallow class instead of schema instance")
+    return schema(**kwargs)

--- a/kinto/core/cornice/validators/_marshmallow.py
+++ b/kinto/core/cornice/validators/_marshmallow.py
@@ -138,7 +138,8 @@ def validator(request, schema=None, deserializer=None, **kwargs):
         :func:`cornice.validators.extract_cstruct`
     """
     import marshmallow
-    from cornice.validators import extract_cstruct
+
+    from kinto.core.cornice.validators import extract_cstruct
 
     if deserializer is None:
         deserializer = extract_cstruct

--- a/kinto/core/cornice_swagger/__init__.py
+++ b/kinto/core/cornice_swagger/__init__.py
@@ -1,6 +1,6 @@
 from pyramid.security import NO_PERMISSION_REQUIRED
 
-from cornice_swagger.swagger import CorniceSwagger
+from kinto.core.cornice_swagger.swagger import CorniceSwagger
 
 
 __author__ = """Josip Delic"""

--- a/kinto/core/cornice_swagger/__init__.py
+++ b/kinto/core/cornice_swagger/__init__.py
@@ -1,0 +1,92 @@
+from pyramid.security import NO_PERMISSION_REQUIRED
+
+from cornice_swagger.swagger import CorniceSwagger
+
+
+__author__ = """Josip Delic"""
+__email__ = "delicj@delijati.net"
+__version__ = "0.3.0"
+
+
+__all__ = ["CorniceSwagger"]
+
+
+class CorniceSwaggerPredicate(object):
+    """Predicate to add simple information to Cornice Swagger."""
+
+    def __init__(self, schema, config):
+        self.schema = schema
+
+    def phash(self):
+        return str(self.schema)
+
+    def __call__(self, context, request):
+        return self.schema
+
+
+def includeme(config):
+    # Custom view parameters
+    config.add_view_predicate("response_schemas", CorniceSwaggerPredicate)
+    config.add_view_predicate("tags", CorniceSwaggerPredicate)
+    config.add_view_predicate("operation_id", CorniceSwaggerPredicate)
+    config.add_view_predicate("api_security", CorniceSwaggerPredicate)
+    config.add_directive("cornice_enable_openapi_view", cornice_enable_openapi_view)
+    config.add_directive("cornice_enable_openapi_explorer", cornice_enable_openapi_explorer)
+
+
+def cornice_enable_openapi_view(
+    config,
+    api_path="/api-explorer/swagger.json",
+    permission=NO_PERMISSION_REQUIRED,
+    route_factory=None,
+    **kwargs,
+):
+    """
+    :param config:
+        Pyramid configurator object
+    :param api_path:
+        where to expose swagger JSON definition view
+    :param permission:
+        pyramid permission for those views
+    :param route_factory:
+        factory for context object for those routes
+    :param kwargs:
+        kwargs that will be passed to CorniceSwagger's `generate()`
+
+    This registers and configures the view that serves api definitions
+    """
+    config.registry.settings["cornice_swagger.spec_kwargs"] = kwargs
+    config.add_route("cornice_swagger.open_api_path", api_path, factory=route_factory)
+    config.add_view(
+        "cornice_swagger.views.open_api_json_view",
+        renderer="json",
+        permission=permission,
+        route_name="cornice_swagger.open_api_path",
+    )
+
+
+def cornice_enable_openapi_explorer(
+    config,
+    api_explorer_path="/api-explorer",
+    permission=NO_PERMISSION_REQUIRED,
+    route_factory=None,
+    **kwargs,
+):
+    """
+    :param config:
+        Pyramid configurator object
+    :param api_explorer_path:
+        where to expose Swagger UI interface view
+    :param permission:
+        pyramid permission for those views
+    :param route_factory:
+        factory for context object for those routes
+
+    This registers and configures the view that serves api explorer
+    """
+    config.add_route("cornice_swagger.api_explorer_path", api_explorer_path, factory=route_factory)
+    config.add_view(
+        "cornice_swagger.views.swagger_ui_template_view",
+        permission=permission,
+        route_name="cornice_swagger.api_explorer_path",
+    )

--- a/kinto/core/cornice_swagger/converters/__init__.py
+++ b/kinto/core/cornice_swagger/converters/__init__.py
@@ -3,8 +3,8 @@ This module handles the conversion between colander object schemas and swagger
 object schemas.
 """
 
-from cornice_swagger.converters.parameters import ParameterConversionDispatcher
-from cornice_swagger.converters.schema import TypeConversionDispatcher
+from kinto.core.cornice_swagger.converters.parameters import ParameterConversionDispatcher
+from kinto.core.cornice_swagger.converters.schema import TypeConversionDispatcher
 
 
 def convert_schema(schema_node):

--- a/kinto/core/cornice_swagger/converters/__init__.py
+++ b/kinto/core/cornice_swagger/converters/__init__.py
@@ -1,0 +1,21 @@
+"""
+This module handles the conversion between colander object schemas and swagger
+object schemas.
+"""
+
+from cornice_swagger.converters.parameters import ParameterConversionDispatcher
+from cornice_swagger.converters.schema import TypeConversionDispatcher
+
+
+def convert_schema(schema_node):
+    dispatcher = TypeConversionDispatcher()
+    converted = dispatcher(schema_node)
+
+    return converted
+
+
+def convert_parameter(location, schema_node, definition_handler=convert_schema):
+    dispatcher = ParameterConversionDispatcher(definition_handler)
+    converted = dispatcher(location, schema_node)
+
+    return converted

--- a/kinto/core/cornice_swagger/converters/exceptions.py
+++ b/kinto/core/cornice_swagger/converters/exceptions.py
@@ -1,0 +1,6 @@
+class ConversionError(Exception):
+    pass
+
+
+class NoSuchConverter(ConversionError):
+    pass

--- a/kinto/core/cornice_swagger/converters/parameters.py
+++ b/kinto/core/cornice_swagger/converters/parameters.py
@@ -1,6 +1,6 @@
 """Converts from colander request chema to Swagger parameters."""
 
-from cornice_swagger.converters.exceptions import NoSuchConverter
+from kinto.core.cornice_swagger.converters.exceptions import NoSuchConverter
 
 
 class ParameterConverter(object):

--- a/kinto/core/cornice_swagger/converters/parameters.py
+++ b/kinto/core/cornice_swagger/converters/parameters.py
@@ -1,0 +1,90 @@
+"""Converts from colander request chema to Swagger parameters."""
+
+from cornice_swagger.converters.exceptions import NoSuchConverter
+
+
+class ParameterConverter(object):
+    _in = None
+
+    def convert(self, schema_node, definition_handler):
+        """
+        Convert node schema into a parameter object.
+        """
+
+        converted = {"name": schema_node.name, "in": self._in, "required": schema_node.required}
+        if schema_node.description:
+            converted["description"] = schema_node.description
+
+        if schema_node.default:
+            converted["default"] = schema_node.default
+
+        schema = definition_handler(schema_node)
+        # Parameters shouldn't have a title
+        schema.pop("title", None)
+        converted.update(schema)
+
+        if schema.get("type") == "array":
+            converted["items"] = {"type": schema["items"]["type"]}
+
+        return converted
+
+
+class PathParameterConverter(ParameterConverter):
+    _in = "path"
+
+    def convert(self, schema_node, definition_handler):
+        converted = super(PathParameterConverter, self).convert(schema_node, definition_handler)
+        # Extract regex pattern from name
+        template = converted["name"].split(":", 1)
+        if len(template) == 2:
+            converted["name"] = template[0]
+            converted["pattern"] = template[1]
+
+        return converted
+
+
+class QueryParameterConverter(ParameterConverter):
+    _in = "query"
+
+
+class HeaderParameterConverter(ParameterConverter):
+    _in = "header"
+
+
+class BodyParameterConverter(ParameterConverter):
+    _in = "body"
+
+    def convert(self, schema_node, definition_handler):
+        converted = {"name": schema_node.name, "in": self._in, "required": schema_node.required}
+        if schema_node.description:
+            converted["description"] = schema_node.description
+
+        schema_node.title = schema_node.__class__.__name__
+        schema = definition_handler(schema_node)
+        converted["schema"] = schema
+
+        return converted
+
+
+class ParameterConversionDispatcher(object):
+    converters = {
+        "body": BodyParameterConverter,
+        "path": PathParameterConverter,
+        "querystring": QueryParameterConverter,
+        "GET": QueryParameterConverter,
+        "header": HeaderParameterConverter,
+        "headers": HeaderParameterConverter,
+    }
+
+    def __init__(self, definition_handler):
+        self.definition_handler = definition_handler
+
+    def __call__(self, location, schema_node):
+        converter_class = self.converters.get(location)
+        if converter_class is None:
+            raise NoSuchConverter()
+
+        converter = converter_class()
+        converted = converter.convert(schema_node, self.definition_handler)
+
+        return converted

--- a/kinto/core/cornice_swagger/converters/schema.py
+++ b/kinto/core/cornice_swagger/converters/schema.py
@@ -5,7 +5,7 @@ object schemas by converting types and node validators.
 
 import colander
 
-from cornice_swagger.converters.exceptions import NoSuchConverter
+from kinto.core.cornice_swagger.converters.exceptions import NoSuchConverter
 
 
 def convert_length_validator_factory(max_key, min_key):

--- a/kinto/core/cornice_swagger/converters/schema.py
+++ b/kinto/core/cornice_swagger/converters/schema.py
@@ -1,0 +1,249 @@
+"""
+This module handles the conversion between colander object schemas and swagger
+object schemas by converting types and node validators.
+"""
+
+import colander
+
+from cornice_swagger.converters.exceptions import NoSuchConverter
+
+
+def convert_length_validator_factory(max_key, min_key):
+    def validator_converter(validator):
+        converted = None
+
+        if isinstance(validator, colander.Length):
+            converted = {}
+            if validator.max is not None:
+                converted[max_key] = validator.max
+            if validator.min is not None:
+                converted[min_key] = validator.min
+
+        return converted
+
+    return validator_converter
+
+
+def convert_oneof_validator_factory():
+    def validator_converter(validator):
+        converted = None
+
+        if isinstance(validator, colander.OneOf):
+            converted = {"enum": list(validator.choices)}
+        return converted
+
+    return validator_converter
+
+
+def convert_range_validator(validator):
+    converted = None
+
+    if isinstance(validator, colander.Range):
+        converted = {}
+
+        if validator.max is not None:
+            converted["maximum"] = validator.max
+        if validator.min is not None:
+            converted["minimum"] = validator.min
+
+    return converted
+
+
+def convert_regex_validator(validator):
+    converted = None
+
+    if isinstance(validator, colander.Regex):
+        converted = {}
+
+        if hasattr(colander, "url") and validator is colander.url:
+            converted["format"] = "url"
+        elif isinstance(validator, colander.Email):
+            converted["format"] = "email"
+        else:
+            converted["pattern"] = validator.match_object.pattern
+
+    return converted
+
+
+class ValidatorConversionDispatcher(object):
+    def __init__(self, *converters):
+        self.converters = converters
+
+    def __call__(self, schema_node, validator=None):
+        if validator is None:
+            validator = schema_node.validator
+
+        converted = {}
+        if validator is not None:
+            for converter in (self.convert_all_validator,) + self.converters:
+                ret = converter(validator)
+                if ret is not None:
+                    converted = ret
+                    break
+
+        return converted
+
+    def convert_all_validator(self, validator):
+        if isinstance(validator, colander.All):
+            converted = {}
+            for v in validator.validators:
+                ret = self(None, v)
+                converted.update(ret)
+            return converted
+        else:
+            return None
+
+
+class TypeConverter(object):
+    type = ""
+
+    def __init__(self, dispatcher):
+        self.dispatcher = dispatcher
+
+    def convert_validator(self, schema_node):
+        return {}
+
+    def convert_type(self, schema_node):
+        converted = {"type": self.type}
+
+        if schema_node.title:
+            converted["title"] = schema_node.title
+        if schema_node.description:
+            converted["description"] = schema_node.description
+        if schema_node.missing not in (colander.required, colander.drop, colander.null):
+            converted["default"] = schema_node.missing
+        if "example" in schema_node.__dict__:
+            converted["example"] = schema_node.example
+
+        return converted
+
+    def __call__(self, schema_node):
+        converted = self.convert_type(schema_node)
+        converted.update(self.convert_validator(schema_node))
+
+        return converted
+
+
+class BaseStringTypeConverter(TypeConverter):
+    type = "string"
+    format = None
+
+    def convert_type(self, schema_node):
+        converted = super(BaseStringTypeConverter, self).convert_type(schema_node)
+
+        if self.format is not None:
+            converted["format"] = self.format
+
+        return converted
+
+
+class BooleanTypeConverter(TypeConverter):
+    type = "boolean"
+
+
+class DateTypeConverter(BaseStringTypeConverter):
+    format = "date"
+
+
+class DateTimeTypeConverter(BaseStringTypeConverter):
+    format = "date-time"
+
+
+class NumberTypeConverter(TypeConverter):
+    type = "number"
+
+    convert_validator = ValidatorConversionDispatcher(
+        convert_range_validator,
+        convert_oneof_validator_factory(),
+    )
+
+
+class IntegerTypeConverter(NumberTypeConverter):
+    type = "integer"
+
+
+class StringTypeConverter(BaseStringTypeConverter):
+    convert_validator = ValidatorConversionDispatcher(
+        convert_length_validator_factory("maxLength", "minLength"),
+        convert_regex_validator,
+        convert_oneof_validator_factory(),
+    )
+
+
+class TimeTypeConverter(BaseStringTypeConverter):
+    format = "time"
+
+
+class ObjectTypeConverter(TypeConverter):
+    type = "object"
+
+    def convert_type(self, schema_node):
+        converted = super(ObjectTypeConverter, self).convert_type(schema_node)
+
+        properties = {}
+        required = []
+
+        for sub_node in schema_node.children:
+            properties[sub_node.name] = self.dispatcher(sub_node)
+            if sub_node.required:
+                required.append(sub_node.name)
+
+        if len(properties) > 0:
+            converted["properties"] = properties
+
+        if len(required) > 0:
+            converted["required"] = required
+
+        if schema_node.typ.unknown == "preserve":
+            converted["additionalProperties"] = {}
+
+        return converted
+
+
+class ArrayTypeConverter(TypeConverter):
+    type = "array"
+
+    convert_validator = ValidatorConversionDispatcher(
+        convert_length_validator_factory("maxItems", "minItems"),
+    )
+
+    def convert_type(self, schema_node):
+        converted = super(ArrayTypeConverter, self).convert_type(schema_node)
+
+        converted["items"] = self.dispatcher(schema_node.children[0])
+
+        return converted
+
+
+class TypeConversionDispatcher(object):
+    def __init__(self, custom_converters={}, default_converter=None):
+        self.converters = {
+            colander.Boolean: BooleanTypeConverter,
+            colander.Date: DateTypeConverter,
+            colander.DateTime: DateTimeTypeConverter,
+            colander.Float: NumberTypeConverter,
+            colander.Integer: IntegerTypeConverter,
+            colander.Mapping: ObjectTypeConverter,
+            colander.Sequence: ArrayTypeConverter,
+            colander.String: StringTypeConverter,
+            colander.Time: TimeTypeConverter,
+        }
+
+        self.converters.update(custom_converters)
+        self.default_converter = default_converter
+
+    def __call__(self, schema_node):
+        schema_type = schema_node.typ
+        schema_type = type(schema_type)
+
+        converter_class = self.converters.get(schema_type)
+        if converter_class is None:
+            if self.default_converter:
+                converter_class = self.default_converter
+            else:
+                raise NoSuchConverter
+
+        converter = converter_class(self)
+        converted = converter(schema_node)
+
+        return converted

--- a/kinto/core/cornice_swagger/swagger.py
+++ b/kinto/core/cornice_swagger/swagger.py
@@ -5,13 +5,15 @@ import warnings
 from collections import OrderedDict
 
 import colander
-from cornice import Service
-from cornice.util import to_list
 from pyramid.threadlocal import get_current_registry
 
-from cornice_swagger.converters import ParameterConversionDispatcher as ParameterConverter
-from cornice_swagger.converters import TypeConversionDispatcher as TypeConverter
-from cornice_swagger.util import body_schema_transformer, merge_dicts, trim
+from kinto.core.cornice import Service
+from kinto.core.cornice.util import to_list
+from kinto.core.cornice_swagger.converters import (
+    ParameterConversionDispatcher as ParameterConverter,
+)
+from kinto.core.cornice_swagger.converters import TypeConversionDispatcher as TypeConverter
+from kinto.core.cornice_swagger.util import body_schema_transformer, merge_dicts, trim
 
 
 class CorniceSwaggerException(Exception):
@@ -287,15 +289,15 @@ class CorniceSwagger(object):
 
     definitions = DefinitionHandler
     """Default :class:`cornice_swagger.swagger.DefinitionHandler` class to use when
-    handling OpenAPI schema definitions from cornice payload schemas."""
+    handling OpenAPI schema definitions from kinto.core.cornice payload schemas."""
 
     parameters = ParameterHandler
     """Default :class:`cornice_swagger.swagger.ParameterHandler` class to use when
-    handling OpenAPI operation parameters from cornice request schemas."""
+    handling OpenAPI operation parameters from kinto.core.cornice request schemas."""
 
     responses = ResponseHandler
     """Default :class:`cornice_swagger.swagger.ResponseHandler` class to use when
-    handling OpenAPI responses from cornice_swagger defined responses."""
+    handling OpenAPI responses from kinto.core.cornice_swagger defined responses."""
 
     schema_transformers = [body_schema_transformer]
     """List of request schema transformers that should be applied to a request
@@ -494,7 +496,7 @@ class CorniceSwagger(object):
 
     def _build_paths(self):
         """
-        Build the Swagger "paths" and "tags" attributes from cornice service
+        Build the Swagger "paths" and "tags" attributes from kinto.core.cornice service
         definitions.
         """
         paths = {}
@@ -593,7 +595,7 @@ class CorniceSwagger(object):
             if route_intr:
                 path = route_intr["pattern"]
             else:
-                msg = "Route `{}` is not found by " "pyramid introspector".format(route_name)
+                msg = "Route `{}` is not found by pyramid introspector".format(route_name)
                 raise ValueError(msg)
 
         # handle traverse and subpath as regular parameters

--- a/kinto/core/cornice_swagger/swagger.py
+++ b/kinto/core/cornice_swagger/swagger.py
@@ -1,0 +1,723 @@
+"""Cornice Swagger 2.0 documentor"""
+
+import inspect
+import warnings
+from collections import OrderedDict
+
+import colander
+from cornice import Service
+from cornice.util import to_list
+from pyramid.threadlocal import get_current_registry
+
+from cornice_swagger.converters import ParameterConversionDispatcher as ParameterConverter
+from cornice_swagger.converters import TypeConversionDispatcher as TypeConverter
+from cornice_swagger.util import body_schema_transformer, merge_dicts, trim
+
+
+class CorniceSwaggerException(Exception):
+    """Raised when cornice services have structural problems to be converted."""
+
+
+class DefinitionHandler(object):
+    """Handles Swagger object definitions provided by cornice as colander schemas."""
+
+    json_pointer = "#/definitions/"
+
+    def __init__(self, ref=0, type_converter=TypeConverter()):
+        """
+        :param ref:
+            The depth that should be used by self.ref when calling self.from_schema.
+        """
+
+        self.definition_registry = {}
+        self.ref = ref
+        self.type_converter = type_converter
+
+    def from_schema(self, schema_node, base_name=None):
+        """
+        Creates a Swagger definition from a colander schema.
+
+        :param schema_node:
+            Colander schema to be transformed into a Swagger definition.
+        :param base_name:
+            Schema alternative title.
+
+        :rtype: dict
+        :returns: Swagger schema.
+        """
+        return self._ref_recursive(self.type_converter(schema_node), self.ref, base_name)
+
+    def _ref_recursive(self, schema, depth, base_name=None):
+        """
+        Dismantle nested swagger schemas into several definitions using JSON pointers.
+        Note: This can be dangerous since definition titles must be unique.
+
+        :param schema:
+            Base swagger schema.
+        :param depth:
+            How many levels of the swagger object schemas should be split into
+            swaggger definitions with JSON pointers. Default (0) is no split.
+            You may use negative values to split everything.
+        :param base_name:
+            If schema doesn't have a name, the caller may provide it to be
+            used as reference.
+
+        :rtype: dict
+        :returns:
+            JSON pointer to the root definition schema,
+            or the original definition if depth is zero.
+        """
+
+        if depth == 0:
+            return schema
+
+        if schema["type"] != "object":
+            return schema
+
+        name = base_name or schema["title"]
+
+        pointer = self.json_pointer + name
+        for child_name, child in schema.get("properties", {}).items():
+            schema["properties"][child_name] = self._ref_recursive(child, depth - 1)
+
+        self.definition_registry[name] = schema
+
+        return {"$ref": pointer}
+
+
+class ParameterHandler(object):
+    """Handles swagger parameter definitions."""
+
+    json_pointer = "#/parameters/"
+
+    def __init__(
+        self,
+        definition_handler=DefinitionHandler(),
+        ref=False,
+        type_converter=TypeConverter(),
+        parameter_converter=ParameterConverter(TypeConverter()),
+    ):
+        """
+        :param definition_handler:
+            Callable that handles swagger definition schemas.
+        :param ref:
+            Specifies the ref value when calling from_xxx methods.
+        """
+
+        self.parameter_registry = {}
+
+        self.type_converter = type_converter
+        self.parameter_converter = parameter_converter
+        self.definitions = definition_handler
+        self.ref = ref
+
+    def from_schema(self, schema_node):
+        """
+        Creates a list of Swagger params from a colander request schema.
+
+        :param schema_node:
+            Request schema to be transformed into Swagger.
+        :param validators:
+            Validators used in colander with the schema.
+
+        :rtype: list
+        :returns: List of Swagger parameters.
+        """
+
+        params = []
+
+        for param_schema in schema_node.children:
+            location = param_schema.name
+            if location == "body":
+                name = param_schema.__class__.__name__
+                if name == "body":
+                    name = schema_node.__class__.__name__ + "Body"
+                param = self.parameter_converter(location, param_schema)
+                param["name"] = name
+                if self.ref:
+                    param = self._ref(param)
+                params.append(param)
+
+            elif location in (("path", "header", "headers", "querystring", "GET")):
+                for node_schema in param_schema.children:
+                    param = self.parameter_converter(location, node_schema)
+                    if self.ref:
+                        param = self._ref(param)
+                    params.append(param)
+
+        return params
+
+    def from_path(self, path):
+        """
+        Create a list of Swagger path params from a cornice service path.
+
+        :type path: string
+        :rtype: list
+        """
+        path_components = path.split("/")
+        param_names = [
+            comp[1:-1] for comp in path_components if comp.startswith("{") and comp.endswith("}")
+        ]
+
+        params = []
+        for name in param_names:
+            param_schema = colander.SchemaNode(colander.String(), name=name)
+            param = self.parameter_converter("path", param_schema)
+            if self.ref:
+                param = self._ref(param)
+            params.append(param)
+
+        return params
+
+    def _ref(self, param, base_name=None):
+        """
+        Store a parameter schema and return a reference to it.
+
+        :param schema:
+            Swagger parameter definition.
+        :param base_name:
+            Name that should be used for the reference.
+
+        :rtype: dict
+        :returns: JSON pointer to the original parameter definition.
+        """
+
+        name = base_name or param.get("title", "") or param.get("name", "")
+
+        pointer = self.json_pointer + name
+        self.parameter_registry[name] = param
+
+        return {"$ref": pointer}
+
+
+class ResponseHandler(object):
+    """Handles swagger response definitions."""
+
+    json_pointer = "#/responses/"
+
+    def __init__(
+        self, definition_handler=DefinitionHandler(), type_converter=TypeConverter(), ref=False
+    ):
+        """
+        :param definition_handler:
+            Callable that handles swagger definition schemas.
+        :param ref:
+            Specifies the ref value when calling from_xxx methods.
+        """
+
+        self.response_registry = {}
+
+        self.type_converter = type_converter
+        self.definitions = definition_handler
+        self.ref = ref
+
+    def from_schema_mapping(self, schema_mapping):
+        """
+        Creates a Swagger response object from a dict of response schemas.
+
+        :param schema_mapping:
+            Dict with entries matching ``{status_code: response_schema}``.
+        :rtype: dict
+        :returns: Response schema.
+        """
+
+        responses = {}
+
+        for status, response_schema in schema_mapping.items():
+            response = {}
+            if response_schema.description:
+                response["description"] = response_schema.description
+            else:
+                raise CorniceSwaggerException("Responses must have a description.")
+
+            for field_schema in response_schema.children:
+                location = field_schema.name
+
+                if location == "body":
+                    title = field_schema.__class__.__name__
+                    if title == "body":
+                        title = response_schema.__class__.__name__ + "Body"
+                    field_schema.title = title
+                    response["schema"] = self.definitions.from_schema(field_schema)
+
+                elif location in ("header", "headers"):
+                    header_schema = self.type_converter(field_schema)
+                    headers = header_schema.get("properties")
+                    if headers:
+                        # Response headers doesn't accept titles
+                        for header in headers.values():
+                            header.pop("title")
+
+                        response["headers"] = headers
+
+            pointer = response_schema.__class__.__name__
+            if self.ref:
+                response = self._ref(response, pointer)
+            responses[status] = response
+
+        return responses
+
+    def _ref(self, resp, base_name=None):
+        """
+        Store a response schema and return a reference to it.
+
+        :param schema:
+            Swagger response definition.
+        :param base_name:
+            Name that should be used for the reference.
+
+        :rtype: dict
+        :returns: JSON pointer to the original response definition.
+        """
+
+        name = base_name or resp.get("title", "") or resp.get("name", "")
+
+        pointer = self.json_pointer + name
+        self.response_registry[name] = resp
+
+        return {"$ref": pointer}
+
+
+class CorniceSwagger(object):
+    """Handles the creation of a swagger document from a cornice application."""
+
+    services = []
+    """List of cornice services to document. You may use
+    `cornice.service.get_services()` to get it."""
+
+    definitions = DefinitionHandler
+    """Default :class:`cornice_swagger.swagger.DefinitionHandler` class to use when
+    handling OpenAPI schema definitions from cornice payload schemas."""
+
+    parameters = ParameterHandler
+    """Default :class:`cornice_swagger.swagger.ParameterHandler` class to use when
+    handling OpenAPI operation parameters from cornice request schemas."""
+
+    responses = ResponseHandler
+    """Default :class:`cornice_swagger.swagger.ResponseHandler` class to use when
+    handling OpenAPI responses from cornice_swagger defined responses."""
+
+    schema_transformers = [body_schema_transformer]
+    """List of request schema transformers that should be applied to a request
+    schema to make it comply with a cornice default request schema."""
+
+    type_converter = TypeConverter
+    """Default :class:`cornice_swagger.converters.schema.TypeConversionDispatcher`
+    class used for converting colander schema Types to Swagger Types."""
+
+    parameter_converter = ParameterConverter
+    """Default :class:`cornice_swagger.converters.parameters.ParameterConversionDispatcher`
+    class used for converting colander/cornice request schemas to Swagger Parameters."""
+
+    custom_type_converters = {}
+    """Mapping for supporting custom types conversion on the default TypeConverter.
+    Should map `colander.TypeSchema` to `cornice_swagger.converters.schema.TypeConverter`
+    callables."""
+
+    default_type_converter = None
+    """Supplies a default type converter matching the interface of
+    `cornice_swagger.converters.schema.TypeConverter` to be used with unknown types."""
+
+    default_tags = None
+    """Provide a default list of tags or a callable that takes a cornice
+    service and the method name (e.g GET) and returns a list of Swagger
+    tags to be used if not provided by the view."""
+
+    default_op_ids = None
+    """Provide a callable that takes a cornice service and the method name
+    (e.g. GET) and returns an operation Id that is used if an operation Id is
+    not provided. Each operation Id should be unique."""
+
+    default_security = None
+    """Provide a default list or a callable that takes a cornice service and
+    the method name (e.g. GET) and returns a list of OpenAPI security policies."""
+
+    summary_docstrings = False
+    """Enable extracting operation summaries from view docstrings."""
+
+    ignore_methods = ["HEAD", "OPTIONS"]
+    """List of service methods that should NOT be presented on the
+    documentation. You may use this to remove methods that are not
+    essential on the API documentation. Default ignores HEAD and OPTIONS."""
+
+    ignore_ctypes = []
+    """List of service content-types that should NOT be presented on the
+    documentation. You may use this when a Cornice service definition has
+    multiple view definitions for a same method, which is not supported on
+    OpenAPI 2.0."""
+
+    api_title = ""
+    """Title of the OpenAPI document."""
+
+    api_version = ""
+    """Version of the OpenAPI document."""
+
+    base_path = "/"
+    """Base path of the documented API. Default is "/"."""
+
+    swagger = {"info": {}}
+    """Base OpenAPI document that should be merged with the extracted info
+    from the generate call."""
+
+    def __init__(
+        self,
+        services=None,
+        def_ref_depth=0,
+        param_ref=False,
+        resp_ref=False,
+        pyramid_registry=None,
+    ):
+        """
+        :param services:
+            List of cornice services to document. You may use
+            cornice.service.get_services() to get it.
+        :param def_ref_depth:
+            How depth swagger object schemas should be split into
+            swaggger definitions with JSON pointers. Default (0) is no split.
+            You may use negative values to split everything.
+        :param param_ref:
+            Defines if swagger parameters should be put inline on the operation
+            or on the parameters section and referenced by JSON pointers.
+            Default is inline.
+        :param resp_ref:
+            Defines if swagger responses should be put inline on the operation
+            or on the responses section and referenced by JSON pointers.
+            Default is inline.
+        :param pyramid_registry:
+            Pyramid registry, should be passed if you use pyramid routes
+            instead of service level paths.
+        """
+        super(CorniceSwagger, self).__init__()
+
+        type_converter = self.type_converter(
+            self.custom_type_converters, self.default_type_converter
+        )
+        parameter_converter = self.parameter_converter(type_converter)
+        self.pyramid_registry = pyramid_registry
+        if services is not None:
+            self.services = services
+
+        # Instantiate handlers
+        self.definitions = self.definitions(ref=def_ref_depth, type_converter=type_converter)
+        self.parameters = self.parameters(
+            self.definitions,
+            ref=param_ref,
+            type_converter=type_converter,
+            parameter_converter=parameter_converter,
+        )
+        self.responses = self.responses(
+            self.definitions, ref=resp_ref, type_converter=type_converter
+        )
+
+    def generate(
+        self, title=None, version=None, base_path=None, info=None, swagger=None, **kwargs
+    ):
+        """Generate a Swagger 2.0 documentation. Keyword arguments may be used
+        to provide additional information to build methods as such ignores.
+
+        :param title:
+            The name presented on the swagger document.
+        :param version:
+            The version of the API presented on the swagger document.
+        :param base_path:
+            The path that all requests to the API must refer to.
+        :param info:
+            Swagger info field.
+        :param swagger:
+            Extra fields that should be provided on the swagger documentation.
+
+        :rtype: dict
+        :returns: Full OpenAPI/Swagger compliant specification for the application.
+        """
+        title = title or self.api_title
+        version = version or self.api_version
+        info = info or self.swagger.get("info", {})
+        swagger = swagger or self.swagger
+        base_path = base_path or self.base_path
+
+        swagger = swagger.copy()
+        info.update(title=title, version=version)
+        swagger.update(swagger="2.0", info=info, basePath=base_path)
+
+        paths, tags = self._build_paths()
+
+        # Update the provided tags with the extracted ones preserving order
+        if tags:
+            swagger.setdefault("tags", [])
+            tag_names = {t["name"] for t in swagger["tags"]}
+            for tag in tags:
+                if tag["name"] not in tag_names:
+                    swagger["tags"].append(tag)
+
+        # Create/Update swagger sections with extracted values where not provided
+        if paths:
+            swagger.setdefault("paths", {})
+            merge_dicts(swagger["paths"], paths)
+
+        definitions = self.definitions.definition_registry
+        if definitions:
+            swagger.setdefault("definitions", {})
+            merge_dicts(swagger["definitions"], definitions)
+
+        parameters = self.parameters.parameter_registry
+        if parameters:
+            swagger.setdefault("parameters", {})
+            merge_dicts(swagger["parameters"], parameters)
+
+        responses = self.responses.response_registry
+        if responses:
+            swagger.setdefault("responses", {})
+            merge_dicts(swagger["responses"], responses)
+
+        return swagger
+
+    def __call__(self, *args, **kwargs):
+        """Deprecated alias of `generate`."""
+        self.__dict__.update(**kwargs)
+
+        message = "Calling `CorniceSwagger is deprecated, call `generate` instead"
+        warnings.warn(message, DeprecationWarning)
+        return self.generate(*args, **kwargs)
+
+    def _check_tags(self, tags):
+        """Check if tags was correctly defined as a list"""
+        if not isinstance(tags, list):
+            raise CorniceSwaggerException("tags should be a list or callable")
+
+    def _get_tags(self, current_tags, new_tags):
+        tags = list(current_tags)
+        for tag in new_tags:
+            root_tag = {"name": tag}
+            if root_tag not in tags:
+                tags.append(root_tag)
+        return tags
+
+    def _build_paths(self):
+        """
+        Build the Swagger "paths" and "tags" attributes from cornice service
+        definitions.
+        """
+        paths = {}
+        tags = []
+
+        for service in self.services:
+            path, path_obj = self._extract_path_from_service(service)
+
+            service_tags = getattr(service, "tags", [])
+            self._check_tags(service_tags)
+            tags = self._get_tags(tags, service_tags)
+
+            for method, view, args in service.definitions:
+                if method.lower() in map(str.lower, self.ignore_methods):
+                    continue
+
+                op = self._extract_operation_from_view(view, args)
+
+                if any(ctype in op.get("consumes", []) for ctype in self.ignore_ctypes):
+                    continue
+
+                # XXX: Swagger doesn't support different schemas for for a same method
+                # with different ctypes as cornice. If this happens, you may ignore one
+                # content-type from the documentation otherwise we raise an Exception
+                # Related to https://github.com/OAI/OpenAPI-Specification/issues/146
+                previous_definition = path_obj.get(method.lower())
+                if previous_definition:
+                    raise CorniceSwaggerException(
+                        (
+                            "Swagger doesn't support multiple "
+                            "views for a same method. You may "
+                            "ignore one."
+                        )
+                    )
+
+                # If tag not defined and a default tag is provided
+                if "tags" not in op and self.default_tags:
+                    if callable(self.default_tags):
+                        op["tags"] = self.default_tags(service, method)
+                    else:
+                        op["tags"] = self.default_tags
+
+                op_tags = op.get("tags", [])
+                self._check_tags(op_tags)
+
+                # Add service tags
+                if service_tags:
+                    new_tags = service_tags + op_tags
+                    op["tags"] = list(OrderedDict.fromkeys(new_tags))
+
+                # Add method tags to root tags
+                tags = self._get_tags(tags, op_tags)
+
+                # If operation id is not defined and a default generator is provided
+                if "operationId" not in op and self.default_op_ids:
+                    if not callable(self.default_op_ids):
+                        raise CorniceSwaggerException("default_op_id should be a callable.")
+                    op["operationId"] = self.default_op_ids(service, method)
+
+                # If security options not defined and default is provided
+                if "security" not in op and self.default_security:
+                    if callable(self.default_security):
+                        op["security"] = self.default_security(service, method)
+                    else:
+                        op["security"] = self.default_security
+
+                if not isinstance(op.get("security", []), list):
+                    raise CorniceSwaggerException("security should be a list or callable")
+
+                path_obj[method.lower()] = op
+            paths[path] = path_obj
+
+        return paths, tags
+
+    def _extract_path_from_service(self, service):
+        """
+        Extract path object and its parameters from service definitions.
+
+        :param service:
+            Cornice service to extract information from.
+
+        :rtype: dict
+        :returns: Path definition.
+        """
+
+        path_obj = {}
+        path = service.path
+        route_name = getattr(service, "pyramid_route", None)
+        # handle services that don't create fresh routes,
+        # we still need the paths so we need to grab pyramid introspector to
+        # extract that information
+        if route_name:
+            # avoid failure if someone forgets to pass registry
+            registry = self.pyramid_registry or get_current_registry()
+            route_intr = registry.introspector.get("routes", route_name)
+            if route_intr:
+                path = route_intr["pattern"]
+            else:
+                msg = "Route `{}` is not found by " "pyramid introspector".format(route_name)
+                raise ValueError(msg)
+
+        # handle traverse and subpath as regular parameters
+        # docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html
+        for subpath_marker in ("*subpath", "*traverse"):
+            path = path.replace(subpath_marker, "{subpath}")
+
+        # Extract path parameters
+        parameters = self.parameters.from_path(path)
+        if parameters:
+            path_obj["parameters"] = parameters
+
+        return path, path_obj
+
+    def _extract_operation_from_view(self, view, args):
+        """
+        Extract swagger operation details from colander view definitions.
+
+        :param view:
+            View to extract information from.
+        :param args:
+            Arguments from the view decorator.
+
+        :rtype: dict
+        :returns: Operation definition.
+        """
+
+        op = {
+            "responses": {"default": {"description": "UNDOCUMENTED RESPONSE"}},
+        }
+
+        # If 'produces' are not defined in the view, try get from renderers
+        renderer = args.get("renderer", "")
+
+        is_json_renderer = (
+            "json" in renderer  # allows for "json" or "simplejson"
+            or renderer == Service.renderer  # default renderer is json.
+        )
+
+        if is_json_renderer:
+            produces = ["application/json"]
+        elif renderer == "xml":
+            produces = ["text/xml"]
+        else:
+            produces = None
+
+        if produces:
+            op.setdefault("produces", produces)
+
+        # Get explicit accepted content-types
+        consumes = args.get("content_type")
+
+        if consumes is not None:
+            # convert to a list, if it's not yet one
+            consumes = to_list(consumes)
+
+            # It is possible to add callables for content_type, so we have to
+            # to filter those out, since we cannot evaluate those here.
+            consumes = [x for x in consumes if not callable(x)]
+            op["consumes"] = consumes
+
+        # Get parameters from view schema
+        is_colander = self._is_colander_schema(args)
+        if is_colander:
+            schema = self._extract_transform_colander_schema(args)
+            parameters = self.parameters.from_schema(schema)
+        else:
+            # Bail out for now
+            parameters = None
+        if parameters:
+            op["parameters"] = parameters
+
+        # Get summary from docstring
+        if isinstance(view, str):
+            if "klass" in args:
+                ob = args["klass"]
+                view_ = getattr(ob, view.lower())
+                docstring = trim(view_.__doc__)
+        else:
+            docstring = str(trim(view.__doc__))
+
+        if docstring and self.summary_docstrings:
+            op["summary"] = docstring
+
+        # Get response definitions
+        if "response_schemas" in args:
+            op["responses"] = self.responses.from_schema_mapping(args["response_schemas"])
+
+        # Get response tags
+        if "tags" in args:
+            op["tags"] = args["tags"]
+
+        # Get response operationId
+        if "operation_id" in args:
+            op["operationId"] = args["operation_id"]
+
+        # Get security policies
+        if "api_security" in args:
+            op["security"] = args["api_security"]
+
+        return op
+
+    def _is_colander_schema(self, args):
+        schema = args.get("schema")
+        return isinstance(schema, colander.Schema) or (
+            inspect.isclass(schema) and issubclass(schema, colander.MappingSchema)
+        )
+
+    def _extract_transform_colander_schema(self, args):
+        """
+        Extract schema from view args and transform it using
+        the pipeline of schema transformers
+
+        :param args:
+            Arguments from the view decorator.
+
+        :rtype: colander.MappingSchema()
+        :returns: View schema cloned and transformed
+        """
+
+        schema = args.get("schema", colander.MappingSchema())
+        if not isinstance(schema, colander.Schema):
+            schema = schema()
+        schema = schema.clone()
+        for transformer in self.schema_transformers:
+            schema = transformer(schema, args)
+        return schema

--- a/kinto/core/cornice_swagger/templates/index.html
+++ b/kinto/core/cornice_swagger/templates/index.html
@@ -1,0 +1,73 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="${ui_css_url}" >
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+
+<body>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+  <defs>
+    <symbol viewBox="0 0 20 20" id="unlocked">
+          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="locked">
+      <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="close">
+      <path d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="large-arrow">
+      <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 20 20" id="large-arrow-down">
+      <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>
+    </symbol>
+
+
+    <symbol viewBox="0 0 24 24" id="jump-to">
+      <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>
+    </symbol>
+
+    <symbol viewBox="0 0 24 24" id="expand">
+      <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+    </symbol>
+
+  </defs>
+</svg>
+
+<div id="swagger-ui"></div>
+
+<script src="${ui_js_bundle_url}"> </script>
+<script src="${ui_js_standalone_url}"> </script>
+${swagger_ui_script}
+</body>
+
+</html>

--- a/kinto/core/cornice_swagger/templates/index_script_template.html
+++ b/kinto/core/cornice_swagger/templates/index_script_template.html
@@ -1,0 +1,21 @@
+<script>
+    window.onload = function() {
+
+        // Build a system
+        const ui = SwaggerUIBundle({
+            url: "${swagger_spec_url}",
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            layout: "StandaloneLayout"
+        })
+
+        window.ui = ui
+    }
+</script>

--- a/kinto/core/cornice_swagger/util.py
+++ b/kinto/core/cornice_swagger/util.py
@@ -1,0 +1,41 @@
+import colander
+from cornice.validators import colander_body_validator
+
+
+def trim(docstring):
+    """
+    Remove the tabs to spaces, and remove the extra spaces / tabs that are in
+    front of the text in docstrings.
+
+    Implementation taken from http://www.python.org/dev/peps/pep-0257/
+    """
+    if not docstring:
+        return ""
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    lines = [line.strip() for line in lines]
+    res = "\n".join(lines)
+    return res
+
+
+def body_schema_transformer(schema, args):
+    validators = args.get("validators", [])
+    if colander_body_validator in validators:
+        body_schema = schema
+        schema = colander.MappingSchema()
+        schema["body"] = body_schema
+    return schema
+
+
+def merge_dicts(base, changes):
+    """Merge b into a recursively, without overwriting values.
+
+    :param base: the dict that will be altered.
+    :param changes: changes to update base.
+    """
+    for k, v in changes.items():
+        if isinstance(v, dict):
+            merge_dicts(base.setdefault(k, {}), v)
+        else:
+            base.setdefault(k, v)

--- a/kinto/core/cornice_swagger/util.py
+++ b/kinto/core/cornice_swagger/util.py
@@ -1,5 +1,6 @@
 import colander
-from cornice.validators import colander_body_validator
+
+from kinto.core.cornice.validators import colander_body_validator
 
 
 def trim(docstring):

--- a/kinto/core/cornice_swagger/views.py
+++ b/kinto/core/cornice_swagger/views.py
@@ -1,0 +1,81 @@
+import importlib
+from string import Template
+
+import cornice
+import pkg_resources
+from pyramid.response import Response
+
+import cornice_swagger
+
+
+# hardcode for now since that will work for vast majority of users
+# maybe later add minified resources for behind firewall support?
+ui_css_url = "https://cdnjs.cloudflare.com/ajax/libs/" "swagger-ui/3.23.11/swagger-ui.css"
+ui_js_bundle_url = (
+    "https://cdnjs.cloudflare.com/ajax/libs/" "swagger-ui/3.23.11/swagger-ui-bundle.js"
+)
+ui_js_standalone_url = (
+    "https://cdnjs.cloudflare.com/ajax/libs/" "swagger-ui/3.23.11/swagger-ui-standalone-preset.js"
+)
+
+
+def swagger_ui_template_view(request):
+    """
+    Serves Swagger UI page, default Swagger UI config is used but you can
+    override the callable that generates the `<script>` tag by setting
+    `cornice_swagger.swagger_ui_script_generator` in pyramid config, it defaults
+    to 'cornice_swagger.views:swagger_ui_script_template'
+
+    :param request:
+    :return:
+    """
+    script_generator = request.registry.settings.get(
+        "cornice_swagger.swagger_ui_script_generator",
+        "cornice_swagger.views:swagger_ui_script_template",
+    )
+    package, callable = script_generator.split(":")
+    imported_package = importlib.import_module(package)
+    script_callable = getattr(imported_package, callable)
+    template = pkg_resources.resource_string("cornice_swagger", "templates/index.html").decode(
+        "utf8"
+    )
+
+    html = Template(template).safe_substitute(
+        ui_css_url=ui_css_url,
+        ui_js_bundle_url=ui_js_bundle_url,
+        ui_js_standalone_url=ui_js_standalone_url,
+        swagger_ui_script=script_callable(request),
+    )
+    return Response(html)
+
+
+def open_api_json_view(request):
+    """
+    :param request:
+    :return:
+
+    Generates JSON representation of Swagger spec
+    """
+    doc = cornice_swagger.CorniceSwagger(
+        cornice.service.get_services(), pyramid_registry=request.registry
+    )
+    kwargs = request.registry.settings["cornice_swagger.spec_kwargs"]
+    my_spec = doc.generate(**kwargs)
+    return my_spec
+
+
+def swagger_ui_script_template(request, **kwargs):
+    """
+    :param request:
+    :return:
+
+    Generates the <script> code that bootstraps Swagger UI, it will be injected
+    into index template
+    """
+    swagger_spec_url = request.route_url("cornice_swagger.open_api_path")
+    template = pkg_resources.resource_string(
+        "cornice_swagger", "templates/index_script_template.html"
+    ).decode("utf8")
+    return Template(template).safe_substitute(
+        swagger_spec_url=swagger_spec_url,
+    )

--- a/kinto/core/cornice_swagger/views.py
+++ b/kinto/core/cornice_swagger/views.py
@@ -2,20 +2,17 @@ import importlib
 from string import Template
 
 import cornice
+import cornice_swagger
 import pkg_resources
 from pyramid.response import Response
-
-import cornice_swagger
 
 
 # hardcode for now since that will work for vast majority of users
 # maybe later add minified resources for behind firewall support?
-ui_css_url = "https://cdnjs.cloudflare.com/ajax/libs/" "swagger-ui/3.23.11/swagger-ui.css"
-ui_js_bundle_url = (
-    "https://cdnjs.cloudflare.com/ajax/libs/" "swagger-ui/3.23.11/swagger-ui-bundle.js"
-)
+ui_css_url = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.11/swagger-ui.css"
+ui_js_bundle_url = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.11/swagger-ui-bundle.js"
 ui_js_standalone_url = (
-    "https://cdnjs.cloudflare.com/ajax/libs/" "swagger-ui/3.23.11/swagger-ui-standalone-preset.js"
+    "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.11/swagger-ui-standalone-preset.js"
 )
 
 

--- a/kinto/core/openapi.py
+++ b/kinto/core/openapi.py
@@ -1,6 +1,5 @@
 from kinto.core.cornice_swagger import CorniceSwagger
 from kinto.core.cornice_swagger.converters.schema import TypeConverter
-
 from kinto.core.schema import Any
 
 

--- a/kinto/core/openapi.py
+++ b/kinto/core/openapi.py
@@ -1,5 +1,5 @@
-from cornice_swagger import CorniceSwagger
-from cornice_swagger.converters.schema import TypeConverter
+from kinto.core.cornice_swagger import CorniceSwagger
+from kinto.core.cornice_swagger.converters.schema import TypeConverter
 
 from kinto.core.schema import Any
 

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -2,10 +2,10 @@ import functools
 import warnings
 
 import colander
-from cornice.validators import colander_validator
 from pyramid.settings import asbool
 
 from kinto.core import authorization
+from kinto.core.cornice.validators import colander_validator
 
 from .schema import (
     ObjectGetQuerySchema,

--- a/kinto/core/testing.py
+++ b/kinto/core/testing.py
@@ -5,10 +5,10 @@ from collections import defaultdict
 from unittest import mock
 
 import webtest
-from cornice import errors as cornice_errors
 from pyramid.url import parse_url_overrides
 
 from kinto.core import DEFAULT_SETTINGS
+from kinto.core.cornice import errors as cornice_errors
 from kinto.core.storage import generators
 from kinto.core.utils import encode64, follow_subrequest, memcache, sqlalchemy
 from kinto.plugins import prometheus, statsd

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -13,13 +13,14 @@ from urllib.parse import unquote
 import jsonpatch
 import rapidjson
 from colander import null
-from cornice import cors
 from pyramid import httpexceptions
 from pyramid.authorization import Authenticated
 from pyramid.interfaces import IRoutesMapper
 from pyramid.request import Request, apply_request_extensions
 from pyramid.settings import aslist
 from pyramid.view import render_view_to_response
+
+from kinto.core.cornice import cors
 
 
 try:

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -290,7 +290,7 @@ def current_service(request):
     """Return the Cornice service matching the specified request.
 
     :returns: the service or None if unmatched.
-    :rtype: cornice.Service
+    :rtype: kinto.core.cornice.Service
     """
     if request.matched_route:
         services = request.registry.cornice_services

--- a/kinto/core/views/batch.py
+++ b/kinto/core/views/batch.py
@@ -1,11 +1,11 @@
 import logging
 
 import colander
-from cornice.validators import colander_validator
 from pyramid import httpexceptions
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from kinto.core import Service, errors
+from kinto.core.cornice.validators import colander_validator
 from kinto.core.errors import ErrorSchema
 from kinto.core.resource.viewset import CONTENT_TYPES
 from kinto.core.utils import build_request, build_response, merge_dicts

--- a/kinto/core/views/openapi.py
+++ b/kinto/core/views/openapi.py
@@ -1,8 +1,8 @@
 import colander
-from cornice.service import get_services
 from pyramid.security import NO_PERMISSION_REQUIRED
 
 from kinto.core import Service
+from kinto.core.cornice.service import get_services
 from kinto.core.openapi import OpenAPI
 
 

--- a/kinto/plugins/flush.py
+++ b/kinto/plugins/flush.py
@@ -1,6 +1,6 @@
-from cornice import Service
 from pyramid.security import NO_PERMISSION_REQUIRED
 
+from kinto.core import Service
 from kinto.events import ServerFlushed
 
 

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -3,10 +3,10 @@ import urllib.parse
 
 import colander
 import requests
-from cornice.validators import colander_validator
 from pyramid import httpexceptions
 
 from kinto.core import Service
+from kinto.core.cornice.validators import colander_validator
 from kinto.core.errors import ERRORS, raise_invalid
 from kinto.core.resource.schema import ErrorResponseSchema
 from kinto.core.schema import URL

--- a/kinto/views/contribute.py
+++ b/kinto/views/contribute.py
@@ -1,6 +1,7 @@
 import colander
-from cornice import Service
 from pyramid.security import NO_PERMISSION_REQUIRED
+
+from kinto.core import Service
 
 
 contribute = Service(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ authors = [
 dependencies = [
     "bcrypt",
     "colander",
-    "cornice",
     "cornice_swagger",
     "dockerflow",
     "jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ strip-extras = true
 
 [tool.coverage.run]
 branch = true
+omit = [
+    "kinto/core/cornice/*",
+    "kinto/core/cornice_swagger/*",
+]
 
 [tool.ruff]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ authors = [
 dependencies = [
     "bcrypt",
     "colander",
-    "cornice_swagger",
     "dockerflow",
     "jsonschema",
     "jsonpatch",

--- a/tests/core/resource/test_viewset.py
+++ b/tests/core/resource/test_viewset.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
 
 import colander
-from cornice.validators import colander_validator
 from pyramid import exceptions, testing
 
 from kinto.core import DEFAULT_SETTINGS, authorization
+from kinto.core.cornice.validators import colander_validator
 from kinto.core.resource import ViewSet, register_resource
 from kinto.core.resource.viewset import PartialSchema, ShareableViewSet, StrictSchema
 from kinto.core.testing import unittest

--- a/tests/core/test_openapi.py
+++ b/tests/core/test_openapi.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest import mock
 
-from cornice.service import get_services
-
+from kinto.core.cornice.service import get_services
 from kinto.core.openapi import OpenAPI
 
 from .support import BaseWebTest


### PR DESCRIPTION
In order to remove the number of repositories that we maintain to support https://github.com/mozilla/remote-settings we could vendor and `cornice` and `cornice.ext.swagger`.

In the past years, I have laboriously maintained a myriad of repositories by myself. It was not always fun. Many [open issues](https://github.com/Cornices/cornice/issues) require to dive deeply in code to support specific use-case and corner-cases. It is very time consuming, for very little value for our project. I don't want to do this anymore. 

Since https://github.com/Pylons/trypyramid.com/pull/388 we don't recommend using Cornice in your new Pyramid projects.
Cornice is an abstraction layer on top of Pyramid, and with this PR, it becomes an internal module of Kinto.

I am very open to suggestions on how to execute this major move. 

* [x] Vendor libs
* [x] Remove dead code (total coverage 97%)
* [ ] Import unit tests to fix branching coverage
* [x] Add message/banner on the Cornice and Cornice.ext.swagger repos to official look for maintainers
