### PR TITLE
Import cornice tests

### DIFF
--- a/kinto/core/views/openapi.py
+++ b/kinto/core/views/openapi.py
@@ -31,5 +31,14 @@ def openapi_view(request):
     try:
         return openapi_view.__json__
     except AttributeError:
-        openapi_view.__json__ = OpenAPI(get_services(), request).generate()
+        # ``get_services()`` returns the process-global list of registered
+        # services. Restrict it to the ones actually routed by this app, so
+        # that services registered elsewhere (e.g. by tests) are not exposed.
+        introspector = request.registry.introspector
+        services = [
+            service
+            for service in get_services()
+            if introspector.get("routes", getattr(service, "pyramid_route", None) or service.name)
+        ]
+        openapi_view.__json__ = OpenAPI(services, request).generate()
         return openapi_view.__json__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ monitoring = [
 ]
 test = [
     "bravado",
+    "flex",
     "pytest",
     "pytest-cache",
     "pytest-cov",

--- a/tests/core/cornice/__init__.py
+++ b/tests/core/cornice/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/core/cornice/support.py
+++ b/tests/core/cornice/support.py
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import logging
+import logging.handlers
+import weakref
+
+from pyramid import testing
+from pyramid.httpexceptions import HTTPException
+from webob import exc
+from webob.dec import wsgify
+
+from kinto.core.cornice.errors import Errors
+
+
+logger = logging.getLogger("kinto.core.cornice")
+
+
+class DummyContext(object):
+    def __repr__(self):
+        return "context!"
+
+
+class DummyRequest(testing.DummyRequest):
+    def __init__(self, *args, **kwargs):
+        super(DummyRequest, self).__init__(*args, **kwargs)
+        self.context = DummyContext()
+        self.errors = Errors()
+        self.content_type = None
+
+
+def dummy_factory(request):
+    return DummyContext()
+
+
+# stolen from the packaging stdlib testsuite tools
+
+
+class _TestHandler(logging.handlers.BufferingHandler):
+    # stolen and adapted from test.support
+
+    def __init__(self):
+        logging.handlers.BufferingHandler.__init__(self, 0)
+        self.setLevel(logging.DEBUG)
+
+    def shouldFlush(self):
+        return False
+
+    def emit(self, record):
+        self.buffer.append(record)
+
+
+class LoggingCatcher(object):
+    """TestCase-compatible mixin to receive logging calls.
+
+    Upon setUp, instances of this classes get a BufferingHandler that's
+    configured to record all messages logged to the 'cornice' logger
+    """
+
+    def setUp(self):
+        super(LoggingCatcher, self).setUp()
+        self.loghandler = handler = _TestHandler()
+        self._old_level = logger.level
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)  # we want all messages
+
+    def tearDown(self):
+        handler = self.loghandler
+        # All this is necessary to properly shut down the logging system and
+        # avoid a regrtest complaint.  Thanks to Vinay Sajip for the help.
+        handler.close()
+        logger.removeHandler(handler)
+        for ref in weakref.getweakrefs(handler):
+            logging._removeHandlerRef(ref)
+        del self.loghandler
+        logger.setLevel(self._old_level)
+        super(LoggingCatcher, self).tearDown()
+
+    def get_logs(self, level=logging.WARNING, flush=True):
+        """Return all log messages with given level.
+
+        *level* defaults to logging.WARNING.
+
+        For log calls with arguments (i.e.  logger.info('bla bla %r', arg)),
+        the messages will be formatted before being returned (e.g. "bla bla
+        'thing'").
+
+        Returns a list.  Automatically flushes the loghandler after being
+        called, unless *flush* is False (this is useful to get e.g. all
+        warnings then all info messages).
+        """
+        messages = [log.getMessage() for log in self.loghandler.buffer if log.levelno == level]
+        if flush:
+            self.loghandler.flush()
+        return messages
+
+
+class CatchErrors(object):
+    def __init__(self, app):
+        self.app = app
+        if hasattr(app, "registry"):
+            self.registry = app.registry
+
+    @wsgify
+    def __call__(self, request):
+        try:
+            return request.get_response(self.app)
+        except (exc.HTTPException, HTTPException) as e:
+            return e

--- a/tests/core/cornice/support.py
+++ b/tests/core/cornice/support.py
@@ -43,7 +43,7 @@ class _TestHandler(logging.handlers.BufferingHandler):
         logging.handlers.BufferingHandler.__init__(self, 0)
         self.setLevel(logging.DEBUG)
 
-    def shouldFlush(self):
+    def shouldFlush(self):  # ty: ignore[invalid-method-override]
         return False
 
     def emit(self, record):
@@ -58,7 +58,7 @@ class LoggingCatcher(object):
     """
 
     def setUp(self):
-        super(LoggingCatcher, self).setUp()
+        super(LoggingCatcher, self).setUp()  # ty: ignore[unresolved-attribute]
         self.loghandler = handler = _TestHandler()
         self._old_level = logger.level
         logger.addHandler(handler)
@@ -71,10 +71,10 @@ class LoggingCatcher(object):
         handler.close()
         logger.removeHandler(handler)
         for ref in weakref.getweakrefs(handler):
-            logging._removeHandlerRef(ref)
+            logging._removeHandlerRef(ref)  # ty: ignore[unresolved-attribute]
         del self.loghandler
         logger.setLevel(self._old_level)
-        super(LoggingCatcher, self).tearDown()
+        super(LoggingCatcher, self).tearDown()  # ty: ignore[unresolved-attribute]
 
     def get_logs(self, level=logging.WARNING, flush=True):
         """Return all log messages with given level.

--- a/tests/core/cornice/test_cors.py
+++ b/tests/core/cornice/test_cors.py
@@ -1,0 +1,383 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+from unittest import TestCase
+
+from pyramid import testing
+from pyramid.authentication import BasicAuthAuthenticationPolicy
+from pyramid.exceptions import HTTPBadRequest, NotFound
+from pyramid.interfaces import IAuthorizationPolicy
+from pyramid.response import Response
+from pyramid.view import view_config
+from webtest import TestApp
+from zope.interface import implementer
+
+from kinto.core.cornice.service import Service
+
+from .support import CatchErrors
+
+
+squirel = Service(path="/squirel", name="squirel", cors_origins=("foobar",))
+spam = Service(path="/spam", name="spam", cors_origins=("*",))
+eggs = Service(path="/eggs", name="egg", cors_origins=("*",), cors_expose_all_headers=False)
+bacon = Service(path="/bacon/{type}", name="bacon", cors_origins=("*",))
+
+
+class Klass(object):
+    """
+    Class implementation of a service
+    """
+
+    def __init__(self, request):
+        self.request = request
+
+    def post(self):
+        return "moar squirels (take care)"
+
+
+cors_policy = {"origins": ("*",), "credentials": True}
+
+cors_klass = Service(name="cors_klass", path="/cors_klass", klass=Klass, cors_policy=cors_policy)
+cors_klass.add_view("post", "post")
+
+
+@squirel.get(cors_origins=("notmyidea.org",), cors_headers=("X-My-Header",))
+def get_squirel(request):
+    return "squirels"
+
+
+@squirel.post(cors_headers=("X-Another-Header"))
+def post_squirel(request):
+    return "moar squirels (take care)"
+
+
+@squirel.put()
+def put_squirel(request):
+    return "squirels!"
+
+
+@spam.get(cors_credentials=True, cors_headers=("X-My-Header"), cors_max_age=42)
+def gimme_some_spam_please(request):
+    return "spam"
+
+
+@spam.post(permission="read-only")
+def moar_spam(request):
+    return "moar spam"
+
+
+@eggs.get(
+    cors_origins=("notmyidea.org",),
+    cors_headers=("X-My-Header", "X-Another-Header", "X-Another-Header2"),
+)
+def get_eggs(request):
+    return "eggs"
+
+
+def is_bacon_good(request, **kwargs):
+    if not request.matchdict["type"].endswith("good"):
+        request.errors.add("querystring", "type", "should be better!")
+
+
+@bacon.get(validators=is_bacon_good)
+def get_some_bacon(request):
+    # Okay, you there. Bear in mind, the only kind of bacon existing is 'good'.
+    if request.matchdict["type"] != "good":
+        raise NotFound(detail="Not. Found.")
+    return "yay"
+
+
+@bacon.post()
+def post_some_bacon(request):
+    return Response()
+
+
+@bacon.put()
+def put_some_bacon(request):
+    raise HTTPBadRequest()
+
+
+@view_config(route_name="noservice")
+def noservice(request):
+    return Response("No Service here.")
+
+
+class TestCORS(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.add_route("noservice", "/noservice")
+        self.config.scan("tests.core.cornice.test_cors")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_preflight_cors_klass_post(self):
+        resp = self.app.options(
+            "/cors_klass",
+            status=200,
+            headers={"Origin": "lolnet.org", "Access-Control-Request-Method": "POST"},
+        )
+        self.assertEqual("POST,OPTIONS", dict(resp.headers)["Access-Control-Allow-Methods"])
+
+    def test_preflight_cors_klass_put(self):
+        self.app.options(
+            "/cors_klass",
+            status=400,
+            headers={"Origin": "lolnet.org", "Access-Control-Request-Method": "PUT"},
+        )
+
+    def test_preflight_missing_headers(self):
+        # we should have an OPTION method defined.
+        # If we just try to reach it, without using correct headers:
+        # "Access-Control-Request-Method"or without the "Origin" header,
+        # we should get a 400.
+        resp = self.app.options("/squirel", status=400)
+        self.assertEqual(len(resp.json["errors"]), 2)
+
+    def test_preflight_missing_origin(self):
+        resp = self.app.options(
+            "/squirel", headers={"Access-Control-Request-Method": "GET"}, status=400
+        )
+        self.assertEqual(len(resp.json["errors"]), 1)
+
+    def test_preflight_does_not_expose_headers(self):
+        resp = self.app.options(
+            "/squirel",
+            headers={"Access-Control-Request-Method": "GET", "Origin": "notmyidea.org"},
+            status=200,
+        )
+        self.assertNotIn("Access-Control-Expose-Headers", resp.headers)
+
+    def test_preflight_missing_request_method(self):
+        resp = self.app.options("/squirel", headers={"Origin": "foobar.org"}, status=400)
+
+        self.assertEqual(len(resp.json["errors"]), 1)
+
+    def test_preflight_incorrect_origin(self):
+        # we put "lolnet.org" where only "notmyidea.org" is authorized
+        resp = self.app.options(
+            "/squirel",
+            headers={"Origin": "lolnet.org", "Access-Control-Request-Method": "GET"},
+            status=400,
+        )
+        self.assertEqual(len(resp.json["errors"]), 1)
+
+    def test_preflight_correct_origin(self):
+        resp = self.app.options(
+            "/squirel", headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "GET"}
+        )
+        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "notmyidea.org")
+
+        allowed_methods = resp.headers["Access-Control-Allow-Methods"].split(",")
+
+        # self.assertNotIn("POST", allowed_methods)
+        self.assertIn("GET", allowed_methods)
+        self.assertIn("PUT", allowed_methods)
+        self.assertIn("HEAD", allowed_methods)
+
+        allowed_headers = resp.headers["Access-Control-Allow-Headers"].split(",")
+
+        self.assertIn("X-My-Header", allowed_headers)
+        # self.assertNotIn("X-Another-Header", allowed_headers)
+
+    def test_preflight_deactivated_method(self):
+        self.app.options(
+            "/squirel",
+            headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "POST"},
+            status=400,
+        )
+
+    def test_preflight_origin_not_allowed_for_method(self):
+        self.app.options(
+            "/squirel",
+            headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "PUT"},
+            status=400,
+        )
+
+    def test_preflight_credentials_are_supported(self):
+        resp = self.app.options(
+            "/spam", headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "GET"}
+        )
+        self.assertIn("Access-Control-Allow-Credentials", resp.headers)
+        self.assertEqual(resp.headers["Access-Control-Allow-Credentials"], "true")
+
+    def test_preflight_credentials_header_not_included_when_not_needed(self):
+        resp = self.app.options(
+            "/spam", headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "POST"}
+        )
+
+        self.assertNotIn("Access-Control-Allow-Credentials", resp.headers)
+
+    def test_preflight_contains_max_age(self):
+        resp = self.app.options(
+            "/spam", headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "GET"}
+        )
+
+        self.assertIn("Access-Control-Max-Age", resp.headers)
+        self.assertEqual(resp.headers["Access-Control-Max-Age"], "42")
+
+    def test_resp_dont_include_allow_origin(self):
+        resp = self.app.get("/squirel")  # omit the Origin header
+        self.assertNotIn("Access-Control-Allow-Origin", resp.headers)
+        self.assertEqual(resp.json, "squirels")
+
+    def test_origin_is_not_wildcard_if_allow_credentials(self):
+        resp = self.app.options(
+            "/cors_klass",
+            status=200,
+            headers={
+                "Origin": "lolnet.org",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "lolnet.org")
+        self.assertEqual(resp.headers["Access-Control-Allow-Credentials"], "true")
+
+    def test_responses_include_an_allow_origin_header(self):
+        resp = self.app.get("/squirel", headers={"Origin": "notmyidea.org"})
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
+        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "notmyidea.org")
+
+    def test_credentials_are_included(self):
+        resp = self.app.get("/spam", headers={"Origin": "notmyidea.org"})
+        self.assertIn("Access-Control-Allow-Credentials", resp.headers)
+        self.assertEqual(resp.headers["Access-Control-Allow-Credentials"], "true")
+
+    def test_headers_are_exposed(self):
+        resp = self.app.get("/squirel", headers={"Origin": "notmyidea.org"})
+        self.assertIn("Access-Control-Expose-Headers", resp.headers)
+
+        headers = resp.headers["Access-Control-Expose-Headers"].split(",")
+        self.assertIn("X-My-Header", headers)
+
+    def test_preflight_request_headers_are_included(self):
+        resp = self.app.options(
+            "/squirel",
+            headers={
+                "Origin": "notmyidea.org",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "foo,    bar,baz  ",
+            },
+        )
+        # The specification says we can have any number of LWS (Linear white
+        # spaces) in the values and that it should be removed.
+
+        # per default, they should be authorized, and returned in the list of
+        # authorized headers
+        headers = resp.headers["Access-Control-Allow-Headers"].split(",")
+        self.assertIn("foo", headers)
+        self.assertIn("bar", headers)
+        self.assertIn("baz", headers)
+
+    def test_preflight_request_headers_isnt_too_permissive(self):
+        # The specification says we can have any number of LWS (Linear white
+        # spaces) in the values.
+        self.app.options(
+            "/eggs",
+            headers={
+                "Origin": "notmyidea.org",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": (
+                    "  X-My-Header  ,X-Another-Header,   X-Another-Header2 "
+                ),
+            },
+            status=200,
+        )
+
+        self.app.options(
+            "/eggs",
+            headers={
+                "Origin": "notmyidea.org",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": ("X-My-Header   ,baz ,  X-Another-Header  "),
+            },
+            status=400,
+        )
+
+    def test_preflight_headers_arent_case_sensitive(self):
+        self.app.options(
+            "/spam",
+            headers={
+                "Origin": "notmyidea.org",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-my-header",
+            },
+        )
+
+    def test_400_returns_CORS_headers(self):
+        resp = self.app.get("/bacon/not", status=400, headers={"Origin": "notmyidea.org"})
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
+
+    def test_response_returns_CORS_headers(self):
+        resp = self.app.post("/bacon/response", status=200, headers={"Origin": "notmyidea.org"})
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
+
+    def test_existing_non_service_route(self):
+        resp = self.app.get("/noservice", status=200, headers={"Origin": "notmyidea.org"})
+        self.assertEqual(resp.body, b"No Service here.")
+
+
+class TestAuthenticatedCORS(TestCase):
+    def setUp(self):
+        def check_cred(username, *args, **kwargs):
+            return [username]
+
+        @implementer(IAuthorizationPolicy)
+        class AuthorizationPolicy(object):
+            def permits(self, context, principals, permission):
+                return permission in principals
+
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.add_route("noservice", "/noservice")
+        self.config.set_authorization_policy(AuthorizationPolicy())
+        self.config.set_authentication_policy(BasicAuthAuthenticationPolicy(check_cred))
+        self.config.set_default_permission("readwrite")
+        self.config.scan("tests.core.cornice.test_cors")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_post_on_spam_should_be_forbidden(self):
+        self.app.post("/spam", status=403)
+
+    def test_preflight_does_not_need_authentication(self):
+        self.app.options(
+            "/spam",
+            status=200,
+            headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "POST"},
+        )
+
+
+class TestAlwaysCORS(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.add_route("noservice", "/noservice")
+        self.config.scan("tests.core.cornice.test_cors")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_response_returns_CORS_headers_without_origin(self):
+        resp = self.app.post("/bacon/response", status=200)
+        self.assertIn("Access-Control-Allow-Origin", resp.headers)
+
+    def test_response_does_not_return_CORS_headers_if_no_origin(self):
+        resp = self.app.put("/squirel")
+        self.assertNotIn("Access-Control-Allow-Origin", resp.headers)
+
+    def test_preflight_checks_origin_when_not_star(self):
+        self.app.options(
+            "/squirel",
+            headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "PUT"},
+            status=400,
+        )
+        self.app.put("/squirel", headers={"Origin": "notmyidea.org"}, status=400)
+
+    def test_checks_origin_when_not_star(self):
+        self.app.put("/squirel", headers={"Origin": "not foobar"}, status=400)

--- a/tests/core/cornice/test_cors.py
+++ b/tests/core/cornice/test_cors.py
@@ -17,7 +17,7 @@ from kinto.core.cornice.service import Service
 from .support import CatchErrors
 
 
-squirel = Service(path="/squirel", name="squirel", cors_origins=("foobar",))
+squirrel = Service(path="/squirrel", name="squirrel", cors_origins=("foobar",))
 spam = Service(path="/spam", name="spam", cors_origins=("*",))
 eggs = Service(path="/eggs", name="egg", cors_origins=("*",), cors_expose_all_headers=False)
 bacon = Service(path="/bacon/{type}", name="bacon", cors_origins=("*",))
@@ -32,7 +32,7 @@ class Klass(object):
         self.request = request
 
     def post(self):
-        return "moar squirels (take care)"
+        return "moar squirrels (take care)"
 
 
 cors_policy = {"origins": ("*",), "credentials": True}
@@ -41,19 +41,19 @@ cors_klass = Service(name="cors_klass", path="/cors_klass", klass=Klass, cors_po
 cors_klass.add_view("post", "post")
 
 
-@squirel.get(cors_origins=("notmyidea.org",), cors_headers=("X-My-Header",))
-def get_squirel(request):
-    return "squirels"
+@squirrel.get(cors_origins=("notmyidea.org",), cors_headers=("X-My-Header",))
+def get_squirrel(request):
+    return "squirrels"
 
 
-@squirel.post(cors_headers=("X-Another-Header"))
-def post_squirel(request):
-    return "moar squirels (take care)"
+@squirrel.post(cors_headers=("X-Another-Header"))
+def post_squirrel(request):
+    return "moar squirrels (take care)"
 
 
-@squirel.put()
-def put_squirel(request):
-    return "squirels!"
+@squirrel.put()
+def put_squirrel(request):
+    return "squirrels!"
 
 
 @spam.get(cors_credentials=True, cors_headers=("X-My-Header"), cors_max_age=42)
@@ -133,32 +133,32 @@ class TestCORS(TestCase):
         # If we just try to reach it, without using correct headers:
         # "Access-Control-Request-Method"or without the "Origin" header,
         # we should get a 400.
-        resp = self.app.options("/squirel", status=400)
+        resp = self.app.options("/squirrel", status=400)
         self.assertEqual(len(resp.json["errors"]), 2)
 
     def test_preflight_missing_origin(self):
         resp = self.app.options(
-            "/squirel", headers={"Access-Control-Request-Method": "GET"}, status=400
+            "/squirrel", headers={"Access-Control-Request-Method": "GET"}, status=400
         )
         self.assertEqual(len(resp.json["errors"]), 1)
 
     def test_preflight_does_not_expose_headers(self):
         resp = self.app.options(
-            "/squirel",
+            "/squirrel",
             headers={"Access-Control-Request-Method": "GET", "Origin": "notmyidea.org"},
             status=200,
         )
         self.assertNotIn("Access-Control-Expose-Headers", resp.headers)
 
     def test_preflight_missing_request_method(self):
-        resp = self.app.options("/squirel", headers={"Origin": "foobar.org"}, status=400)
+        resp = self.app.options("/squirrel", headers={"Origin": "foobar.org"}, status=400)
 
         self.assertEqual(len(resp.json["errors"]), 1)
 
     def test_preflight_incorrect_origin(self):
         # we put "lolnet.org" where only "notmyidea.org" is authorized
         resp = self.app.options(
-            "/squirel",
+            "/squirrel",
             headers={"Origin": "lolnet.org", "Access-Control-Request-Method": "GET"},
             status=400,
         )
@@ -166,7 +166,8 @@ class TestCORS(TestCase):
 
     def test_preflight_correct_origin(self):
         resp = self.app.options(
-            "/squirel", headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "GET"}
+            "/squirrel",
+            headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "GET"},
         )
         self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "notmyidea.org")
 
@@ -184,14 +185,14 @@ class TestCORS(TestCase):
 
     def test_preflight_deactivated_method(self):
         self.app.options(
-            "/squirel",
+            "/squirrel",
             headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "POST"},
             status=400,
         )
 
     def test_preflight_origin_not_allowed_for_method(self):
         self.app.options(
-            "/squirel",
+            "/squirrel",
             headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "PUT"},
             status=400,
         )
@@ -219,9 +220,9 @@ class TestCORS(TestCase):
         self.assertEqual(resp.headers["Access-Control-Max-Age"], "42")
 
     def test_resp_dont_include_allow_origin(self):
-        resp = self.app.get("/squirel")  # omit the Origin header
+        resp = self.app.get("/squirrel")  # omit the Origin header
         self.assertNotIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertEqual(resp.json, "squirels")
+        self.assertEqual(resp.json, "squirrels")
 
     def test_origin_is_not_wildcard_if_allow_credentials(self):
         resp = self.app.options(
@@ -236,7 +237,7 @@ class TestCORS(TestCase):
         self.assertEqual(resp.headers["Access-Control-Allow-Credentials"], "true")
 
     def test_responses_include_an_allow_origin_header(self):
-        resp = self.app.get("/squirel", headers={"Origin": "notmyidea.org"})
+        resp = self.app.get("/squirrel", headers={"Origin": "notmyidea.org"})
         self.assertIn("Access-Control-Allow-Origin", resp.headers)
         self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "notmyidea.org")
 
@@ -246,7 +247,7 @@ class TestCORS(TestCase):
         self.assertEqual(resp.headers["Access-Control-Allow-Credentials"], "true")
 
     def test_headers_are_exposed(self):
-        resp = self.app.get("/squirel", headers={"Origin": "notmyidea.org"})
+        resp = self.app.get("/squirrel", headers={"Origin": "notmyidea.org"})
         self.assertIn("Access-Control-Expose-Headers", resp.headers)
 
         headers = resp.headers["Access-Control-Expose-Headers"].split(",")
@@ -254,7 +255,7 @@ class TestCORS(TestCase):
 
     def test_preflight_request_headers_are_included(self):
         resp = self.app.options(
-            "/squirel",
+            "/squirrel",
             headers={
                 "Origin": "notmyidea.org",
                 "Access-Control-Request-Method": "GET",
@@ -368,16 +369,16 @@ class TestAlwaysCORS(TestCase):
         self.assertIn("Access-Control-Allow-Origin", resp.headers)
 
     def test_response_does_not_return_CORS_headers_if_no_origin(self):
-        resp = self.app.put("/squirel")
+        resp = self.app.put("/squirrel")
         self.assertNotIn("Access-Control-Allow-Origin", resp.headers)
 
     def test_preflight_checks_origin_when_not_star(self):
         self.app.options(
-            "/squirel",
+            "/squirrel",
             headers={"Origin": "notmyidea.org", "Access-Control-Request-Method": "PUT"},
             status=400,
         )
-        self.app.put("/squirel", headers={"Origin": "notmyidea.org"}, status=400)
+        self.app.put("/squirrel", headers={"Origin": "notmyidea.org"}, status=400)
 
     def test_checks_origin_when_not_star(self):
-        self.app.put("/squirel", headers={"Origin": "not foobar"}, status=400)
+        self.app.put("/squirrel", headers={"Origin": "not foobar"}, status=400)

--- a/tests/core/cornice/test_cors.py
+++ b/tests/core/cornice/test_cors.py
@@ -354,7 +354,7 @@ class TestAuthenticatedCORS(TestCase):
 
 class TestAlwaysCORS(TestCase):
     def setUp(self):
-        self.config = testing.setUp()
+        self.config = testing.setUp(settings={"cornice.always_cors": "true"})
         self.config.include("kinto.core.cornice")
         self.config.add_route("noservice", "/noservice")
         self.config.scan("tests.core.cornice.test_cors")

--- a/tests/core/cornice/test_errors.py
+++ b/tests/core/cornice/test_errors.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+
+from pyramid.i18n import TranslationString
+
+from kinto.core.cornice.errors import Errors
+from kinto.core.cornice.service import Service
+
+
+class TestErrorsHelper(TestCase):
+    def setUp(self):
+        self.errors = Errors()
+
+    def test_add_to_supported_location(self):
+        self.errors.add("")
+        self.errors.add("body", description="!")
+        self.errors.add("querystring", name="field")
+        self.errors.add("url")
+        self.errors.add("header")
+        self.errors.add("path")
+        self.errors.add("cookies")
+        self.errors.add("method")
+        self.assertEqual(len(self.errors), 8)
+
+    def test_raises_an_exception_when_location_is_unsupported(self):
+        with self.assertRaises(ValueError):
+            self.errors.add("something")
+
+
+service1 = Service(name="service1", path="/error-service1")
+
+
+@service1.get()
+def get1(request):
+    return request.errors.add("body", "field", "Description")
+
+
+service2 = Service(name="service2", path="/error-service2")
+
+
+@service2.get()
+def get2(request):
+    return request.errors.add("body", "field", TranslationString("Description"))

--- a/tests/core/cornice/test_pyramidhook.py
+++ b/tests/core/cornice/test_pyramidhook.py
@@ -1,0 +1,378 @@
+# flake8: noqa
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import logging
+import re
+from unittest import mock, TestCase
+from pyramid.interfaces import IDebugLogger
+
+from pyramid import testing
+from pyramid.exceptions import PredicateMismatch
+from pyramid.httpexceptions import HTTPOk, HTTPForbidden, HTTPNotFound, HTTPMethodNotAllowed
+from pyramid.csrf import CookieCSRFStoragePolicy
+from pyramid.response import Response
+from pyramid.security import Allow, Deny, NO_PERMISSION_REQUIRED
+from pyramid.authentication import AuthTktAuthenticationPolicy
+from pyramid.authorization import ACLAuthorizationPolicy
+
+from pyramid.exceptions import ConfigurationError
+from webtest import TestApp
+
+from kinto.core.cornice import Service
+from kinto.core.cornice.pyramidhook import register_service_views
+from kinto.core.cornice.util import func_name, ContentTypePredicate, current_service
+
+from .support import CatchErrors, dummy_factory
+
+
+def my_acl(request):
+    return [
+        (Allow, "alice", "read"),
+        (Allow, "bob", "write"),
+        (Deny, "carol", "write"),
+        (Allow, "dan", ("write", "update")),
+    ]
+
+
+class MyFactory(object):
+    def __init__(self, request):
+        self.request = request
+
+    def __acl__(self):
+        return my_acl(self.request)
+
+
+service = Service(name="service", path="/service", factory=MyFactory)
+
+
+@service.get()
+def return_404(request):
+    raise HTTPNotFound()
+
+
+@service.put(permission="update")
+def update_view(request):
+    return "updated_view"
+
+
+@service.patch(permission="write")
+def return_yay(request):
+    return "yay"
+
+
+@service.delete()
+def delete_view(request):
+    request.response.status = 204
+
+
+class TemperatureCooler(object):
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def get_fresh_air(self):
+        resp = Response()
+        resp.text = "air with " + repr(self.context)
+        return resp
+
+    def check_temperature(self, request, **kw):
+        if not "X-Temperature" in request.headers:
+            request.errors.add("header", "X-Temperature")
+
+
+tc = Service(
+    name="TemperatureCooler", path="/fresh-air", klass=TemperatureCooler, factory=dummy_factory
+)
+tc.add_view("GET", "get_fresh_air", validators=("check_temperature",))
+
+
+class TestService(TestCase):
+    def setUp(self):
+        self.config = testing.setUp(settings={"pyramid.debug_authorization": True})
+
+        # Set up debug_authorization logging to console
+        logging.basicConfig(level=logging.DEBUG)
+        debug_logger = logging.getLogger()
+        self.config.registry.registerUtility(debug_logger, IDebugLogger)
+
+        self.config.include("kinto.core.cornice")
+
+        self.authz_policy = ACLAuthorizationPolicy()
+        self.config.set_authorization_policy(self.authz_policy)
+
+        self.authn_policy = AuthTktAuthenticationPolicy("$3kr1t")
+        self.config.set_authentication_policy(self.authn_policy)
+
+        self.config.scan("tests.core.cornice.test_service")
+        self.config.scan("tests.core.cornice.test_pyramidhook")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+        register_service_views(self.config, service)
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_404(self):
+        # a get on a resource that explicitly return a 404 should return 404
+        self.app.get("/service", status=HTTPNotFound.code)
+
+    def test_405(self):
+        # calling a unknown verb on an existing resource should return a 405
+        self.app.post("/service", status=HTTPMethodNotAllowed.code)
+
+    def test_204(self):
+        resp = self.app.delete("/service", status=204)
+        self.assertNotIn("Content-Type", resp.headers)
+
+    def test_acl_support_unauthenticated_service_patch(self):
+        # calling a view with permissions without an auth'd user => 403
+        self.app.patch("/service", status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_allowed_service_patch(self):
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="bob"):
+            result = self.app.patch("/service", status=HTTPOk.code)
+            self.assertEqual("yay", result.json)
+        # The other user with 'write' permission
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="dan"):
+            result = self.app.patch("/service", status=HTTPOk.code)
+            self.assertEqual("yay", result.json)
+
+    def test_acl_support_authenticated_valid_user_wrong_permission_service_patch(self):
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="alice"):
+            self.app.patch("/service", status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_valid_user_permission_denied_service_patch(self):
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="carol"):
+            self.app.patch("/service", status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_invalid_user_service_patch(self):
+        with mock.patch.object(
+            self.authn_policy, "unauthenticated_userid", return_value="mallory"
+        ):
+            self.app.patch("/service", status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_allowed_service_put(self):
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="dan"):
+            result = self.app.put("/service", status=HTTPOk.code)
+            self.assertEqual("updated_view", result.json)
+
+    def test_acl_support_authenticated_valid_user_wrong_permission_service_put(self):
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="bob"):
+            self.app.put("/service", status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_valid_user_permission_denied_service_put(self):
+        with mock.patch.object(self.authn_policy, "unauthenticated_userid", return_value="carol"):
+            self.app.put("/service", status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_invalid_user_service_put(self):
+        with mock.patch.object(
+            self.authn_policy, "unauthenticated_userid", return_value="mallory"
+        ):
+            self.app.put("/service", status=HTTPForbidden.code)
+
+
+class WrapperService(Service):
+    def get_view_wrapper(self, kw):
+        def upper_wrapper(func):
+            def upperizer(*args, **kwargs):
+                result = func(*args, **kwargs)
+                return result.upper()
+
+            return upperizer
+
+        return upper_wrapper
+
+
+wrapper_service = WrapperService(name="wrapperservice", path="/wrapperservice")
+
+
+@wrapper_service.get()
+def return_foo(request):
+    return "foo"
+
+
+class TestServiceWithWrapper(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.scan("tests.core.cornice.test_pyramidhook")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_wrapped(self):
+        result = self.app.get("/wrapperservice")
+        self.assertEqual(result.json, "FOO")
+
+    def test_func_name_undecorated_function(self):
+        self.assertEqual("my_acl", func_name(my_acl))
+
+    def test_func_name_decorated_function(self):
+        self.assertEqual("return_foo", func_name(return_foo))
+
+    def test_func_name_string(self):
+        self.assertEqual("some_string", func_name("some_string"))
+
+    def test_func_name_class_method(self):
+        self.assertEqual(
+            "TestServiceWithWrapper.test_wrapped", func_name(TestServiceWithWrapper.test_wrapped)
+        )
+
+
+class TestNosniffHeader(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.scan("tests.core.cornice.test_pyramidhook")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def test_no_sniff_is_added_to_responses(self):
+        response = self.app.get("/wrapperservice")
+        self.assertEqual(response.headers["X-Content-Type-Options"], "nosniff")
+
+
+test_service = Service(name="jardinet", path="/jardinet")
+test_service.add_view("GET", lambda request: request.current_service.name)
+
+
+class TestCurrentService(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.scan("tests.core.cornice.test_pyramidhook")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def test_current_service_on_request(self):
+        resp = self.app.get("/jardinet")
+        self.assertEqual(resp.json, "jardinet")
+
+
+class TestRouteWithTraverse(TestCase):
+    def test_route_construction(self):
+        config = mock.MagicMock()
+        config.add_route = mock.MagicMock()
+
+        register_service_views(config, test_service)
+        config.add_route.assert_called_with("jardinet", "/jardinet")
+
+    def test_route_with_prefix(self):
+        config = testing.setUp(settings={})
+        config.add_route = mock.MagicMock()
+        config.route_prefix = "/prefix"
+        config.registry.cornice_services = {}
+        config.add_directive("add_cornice_service", register_service_views)
+        config.scan("tests.core.cornice.test_pyramidhook")
+
+        services = config.registry.cornice_services
+        self.assertTrue("/prefix/wrapperservice" in services)
+
+
+class TestRouteFromPyramid(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.add_route("proute", "/from_pyramid")
+        self.config.scan("tests.core.cornice.test_pyramidhook")
+
+        def handle_response(request):
+            return {"service": request.current_service.name, "route": request.matched_route.name}
+
+        rserv = Service(name="ServiceWPyramidRoute", pyramid_route="proute")
+        rserv.add_view("GET", handle_response)
+
+        register_service_views(self.config, rserv)
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def test_service_routing(self):
+        result = self.app.get("/from_pyramid", status=200)
+        self.assertEqual("proute", result.json["route"])
+        self.assertEqual("ServiceWPyramidRoute", result.json["service"])
+
+    def test_no_route_or_path(self):
+        with self.assertRaises(TypeError):
+            Service(
+                name="broken service",
+            )
+
+
+class TestPrefixRouteFromPyramid(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.route_prefix = "/prefix"
+        self.config.include("kinto.core.cornice")
+        self.config.add_route("proute", "/from_pyramid")
+        self.config.scan("tests.core.cornice.test_pyramidhook")
+
+        def handle_response(request):
+            return {"service": request.current_service.name, "route": request.matched_route.name}
+
+        rserv = Service(name="ServiceWPyramidRoute", pyramid_route="proute")
+        rserv.add_view("GET", handle_response)
+
+        register_service_views(self.config, rserv)
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def test_service_routing(self):
+        result = self.app.get("/prefix/from_pyramid", status=200)
+        self.assertEqual("proute", result.json["route"])
+        self.assertEqual("ServiceWPyramidRoute", result.json["service"])
+
+    def test_no_route_or_path(self):
+        with self.assertRaises(TypeError):
+            Service(
+                name="broken service",
+            )
+
+    def test_current_service(self):
+        pyramid_app = self.app.app.app
+        request = mock.MagicMock()
+        request.matched_route = pyramid_app.routes_mapper.get_route("proute")
+        request.registry = pyramid_app.registry
+        assert current_service(request)
+
+
+class TestServiceWithNonpickleableSchema(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.registry.cornice_services = {}
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test(self):
+        # Compiled regexs are, apparently, non-pickleable
+        service = Service(name="test", path="/", schema={"a": re.compile("")})
+        service.add_view("GET", lambda _: _)
+        register_service_views(self.config, service)
+
+
+class TestFallbackRegistration(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.add_view_predicate("content_type", ContentTypePredicate)
+        self.config.set_csrf_storage_policy(CookieCSRFStoragePolicy(domain="localhost"))
+        self.config.set_default_csrf_options(require_csrf=True)
+        self.config.registry.cornice_services = {}
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_fallback_permission(self):
+        """
+        Fallback view should be registered with NO_PERMISSION_REQUIRED
+        Fixes: https://github.com/mozilla-services/cornice/issues/245
+        """
+        service = Service(name="fallback-test", path="/")
+        service.add_view("GET", lambda _: _)
+        register_service_views(self.config, service)
+
+        # This is a bit baroque
+        introspector = self.config.introspector
+        views = introspector.get_category("views")
+        fallback_views = [i for i in views if i["introspectable"]["route_name"] == "fallback-test"]
+
+        for v in fallback_views:
+            if v["introspectable"].title == "function cornice.pyramidhook._fallback_view":
+                permissions = [p["value"] for p in v["related"] if p.type_name == "permission"]
+                self.assertIn(NO_PERMISSION_REQUIRED, permissions)

--- a/tests/core/cornice/test_renderer.py
+++ b/tests/core/cornice/test_renderer.py
@@ -1,0 +1,32 @@
+from unittest import TestCase, mock
+
+from pyramid.renderers import JSON
+
+from kinto.core.cornice import CorniceRenderer
+from kinto.core.cornice.renderer import JSONError
+
+
+class TestRenderer(TestCase):
+    def test_renderer_is_pyramid_renderer_subclass(self):
+        self.assertIsInstance(CorniceRenderer(), JSON)
+
+    def test_renderer_calls_render_method(self):
+        renderer = CorniceRenderer()
+        self.assertEqual(renderer(info=None), renderer.render)
+
+    def test_renderer_render_errors(self):
+        renderer = CorniceRenderer()
+        request = mock.MagicMock()
+
+        class FakeErrors(object):
+            status = 418
+
+            def __json__(self, request):
+                return ["error_1", "error_2"]
+
+        request.errors = FakeErrors()
+
+        result = renderer.render_errors(request)
+        self.assertIsInstance(result, JSONError)
+        self.assertEqual(result.status_int, 418)
+        self.assertEqual(result.json_body, {"status": "error", "errors": ["error_1", "error_2"]})

--- a/tests/core/cornice/test_service.py
+++ b/tests/core/cornice/test_service.py
@@ -1,0 +1,504 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+from unittest import TestCase, mock
+
+from pyramid.exceptions import ConfigurationError
+from pyramid.interfaces import IRendererFactory
+
+from kinto.core.cornice.service import (
+    Service,
+    _UnboundView,
+    clear_services,
+    decorate_view,
+    get_services,
+)
+from kinto.core.cornice.util import func_name
+
+
+def _validator(req):
+    return True
+
+
+def _validator2(req):
+    return True
+
+
+def _stub(req):
+    return None
+
+
+class TestService(TestCase):
+    def tearDown(self):
+        clear_services()
+
+    def test_service_instantiation(self):
+        service = Service("coconuts", "/migrate")
+        self.assertEqual(service.name, "coconuts")
+        self.assertEqual(service.path, "/migrate")
+        self.assertEqual(service.renderer, Service.renderer)
+
+        service = Service("coconuts", "/migrate", renderer="html")
+        self.assertEqual(service.renderer, "html")
+
+        # test that lists are also set
+        validators = [
+            lambda x: True,
+        ]
+        service = Service("coconuts", "/migrate", validators=validators)
+        self.assertEqual(service.validators, validators)
+
+    def test_representation(self):
+        service = Service("coconuts", "/migrate")
+        self.assertEqual(repr(service), "<Service coconuts at /migrate>")
+
+    def test_representation_path(self):
+        service = Service("coconuts", pyramid_route="some_route")
+        self.assertEqual(repr(service), "<Service coconuts at some_route>")
+
+    def test_get_arguments(self):
+        service = Service("coconuts", "/migrate")
+        # not specifying anything, we should get the default values
+        args = service.get_arguments({})
+        for arg in Service.mandatory_arguments:
+            self.assertEqual(args[arg], getattr(Service, arg, None))
+
+        # calling this method on a configured service should use the values
+        # passed at instantiation time as default values
+        service = Service("coconuts", "/migrate", renderer="html")
+        args = service.get_arguments({})
+        self.assertEqual(args["renderer"], "html")
+
+        # if we specify another renderer for this service, despite the fact
+        # that one is already set in the instance, this one should be used
+        args = service.get_arguments({"renderer": "foobar"})
+        self.assertEqual(args["renderer"], "foobar")
+
+        # test that list elements are not overwritten
+        # define a validator for the needs of the test
+
+        service = Service("vaches", "/fetchez", validators=(_validator,))
+        self.assertEqual(len(service.validators), 1)
+        args = service.get_arguments({"validators": (_validator2,)})
+
+        # the list of validators didn't changed
+        self.assertEqual(len(service.validators), 1)
+
+        # but the one returned contains 2 validators
+        self.assertEqual(len(args["validators"]), 2)
+
+        # test that exclude effectively removes the items from the list of
+        # validators / filters it returns, without removing it from the ones
+        # registered for the service.
+        service = Service("open bar", "/bar", validators=(_validator, _validator2))
+        self.assertEqual(service.validators, [_validator, _validator2])
+
+        args = service.get_arguments({"exclude": _validator2})
+        self.assertEqual(args["validators"], [_validator])
+
+        # defining some non-mandatory arguments in a service should make
+        # them available on further calls to get_arguments.
+
+        service = Service("vaches", "/fetchez", foobar="baz")
+        self.assertIn("foobar", service.arguments)
+        self.assertIn("foobar", service.get_arguments())
+
+    def test_view_registration(self):
+        # registering a new view should make it available in the list.
+        # The methods list is populated
+        service = Service("color", "/favorite-color")
+
+        def view(request):
+            pass
+
+        service.add_view("post", view, validators=(_validator,))
+        self.assertEqual(len(service.definitions), 1)
+        method, _view, _ = service.definitions[0]
+
+        # the view had been registered. we also test here that the method had
+        # been inserted capitalized (POST instead of post)
+        self.assertEqual(("POST", view), (method, _view))
+
+    def test_error_handler(self):
+        error_handler = object()
+        service = Service("color", "/favorite-color", error_handler=error_handler)
+
+        @service.get()
+        def get_favorite_color(request):
+            return "blue, hmm, red, hmm, aaaaaaaah"
+
+        method, view, args = service.definitions[0]
+        self.assertIs(args["error_handler"], error_handler)
+
+    def test_default_error_handler(self):
+        # If not configured otherwise, Service.default_error_handler should
+        # be used to handle and render errors.
+        service = Service("error service", "/error_service")
+
+        @service.get()
+        def get_error(request):
+            return "error"
+
+        method, view, args = service.definitions[0]
+        self.assertEqual(args["error_handler"], service.default_error_handler)
+
+    def test_default_error_handler_calls_default_renderer(self):
+        # Default error handler should call `render_errors` on the
+        # registered renderer.
+        service = Service("error service", "/error_service")
+
+        renderer = mock.MagicMock()
+        renderer.render_errors.return_value = "rendered_errors"
+
+        request = mock.MagicMock()
+        request.registry.queryUtility.return_value = renderer
+
+        self.assertEqual(service.default_error_handler(request), "rendered_errors")
+        request.registry.queryUtility.assert_called_with(IRendererFactory, name=service.renderer)
+        renderer.render_errors.assert_called_with(request)
+
+    def test_decorators(self):
+        service = Service("color", "/favorite-color")
+
+        @service.get()
+        def get_favorite_color(request):
+            return "blue, hmm, red, hmm, aaaaaaaah"
+
+        self.assertEqual(2, len(service.definitions))
+        method, view, _ = service.definitions[0]
+        self.assertEqual(("GET", get_favorite_color), (method, view))
+        method, view, _ = service.definitions[1]
+        self.assertEqual(("HEAD", get_favorite_color), (method, view))
+
+        @service.post(accept="text/plain", renderer="plain")
+        @service.post(accept="application/json")
+        def post_favorite_color(request):
+            pass
+
+        # using multiple decorators on a resource should register them all in
+        # as many different definitions in the service
+        self.assertEqual(4, len(service.definitions))
+
+        @service.patch()
+        def patch_favorite_color(request):
+            return ""
+
+        method, view, _ = service.definitions[4]
+        self.assertEqual("PATCH", method)
+
+        @service.put()
+        def put_favorite_color(request):
+            return ""
+
+        method, view, _ = service.definitions[5]
+        self.assertEqual("PUT", method)
+
+        @service.delete()
+        def delete_favorite_color(request):
+            return ""
+
+        method, view, _ = service.definitions[6]
+        self.assertEqual("DELETE", method)
+
+        @service.options()
+        def favorite_color_options(request):
+            return ""
+
+        method, view, _ = service.definitions[7]
+        self.assertEqual("OPTIONS", method)
+
+    def test_get_acceptable(self):
+        # defining a service with different "accept" headers, we should be able
+        # to retrieve this information easily
+        service = Service("color", "/favorite-color")
+        service.add_view("GET", lambda x: "blue", accept="text/plain")
+        self.assertEqual(service.get_acceptable("GET"), ["text/plain"])
+
+        service.add_view("GET", lambda x: "blue", accept="application/json")
+        self.assertEqual(service.get_acceptable("GET"), ["text/plain", "application/json"])
+
+        # adding a view for the POST method should not break everything :-)
+        service.add_view("POST", lambda x: "ok", accept=("foo/bar"))
+        self.assertEqual(service.get_acceptable("GET"), ["text/plain", "application/json"])
+        # and of course the list of accepted egress content-types should be
+        # available for the "POST" as well.
+        self.assertEqual(service.get_acceptable("POST"), ["foo/bar"])
+
+        # it is possible to give acceptable egress content-types dynamically at
+        # run-time. You don't always want to have the callables when retrieving
+        # all the acceptable content-types
+        service.add_view("POST", lambda x: "ok", accept=lambda r: "application/json")
+        self.assertEqual(len(service.get_acceptable("POST")), 2)
+        self.assertEqual(len(service.get_acceptable("POST", True)), 1)
+
+    def test_get_contenttypes(self):
+        # defining a service with different "content_type" headers, we should
+        # be able to retrieve this information easily
+        service = Service("color", "/favorite-color")
+        service.add_view("GET", lambda x: "blue", content_type="text/plain")
+        self.assertEqual(service.get_contenttypes("GET"), ["text/plain"])
+
+        service.add_view("GET", lambda x: "blue", content_type="application/json")
+        self.assertEqual(service.get_contenttypes("GET"), ["text/plain", "application/json"])
+
+        # adding a view for the POST method should not break everything :-)
+        service.add_view("POST", lambda x: "ok", content_type=("foo/bar"))
+        self.assertEqual(service.get_contenttypes("GET"), ["text/plain", "application/json"])
+        # and of course the list of supported ingress content-types should be
+        # available for the "POST" as well.
+        self.assertEqual(service.get_contenttypes("POST"), ["foo/bar"])
+
+        # it is possible to give supported ingress content-types dynamically at
+        # run-time. You don't always want to have the callables when retrieving
+        # all the supported content-types
+        service.add_view("POST", lambda x: "ok", content_type=lambda r: "application/json")
+        self.assertEqual(len(service.get_contenttypes("POST")), 2)
+        self.assertEqual(len(service.get_contenttypes("POST", True)), 1)
+
+    def test_class_parameters(self):
+        # when passing a "klass" argument, it gets registered. It also tests
+        # that the view argument can be a string and not a callable.
+        class TemperatureCooler(object):
+            def get_fresh_air(self):
+                pass
+
+        service = Service("TemperatureCooler", "/freshair", klass=TemperatureCooler)
+        service.add_view("get", "get_fresh_air")
+
+        self.assertEqual(len(service.definitions), 2)
+
+        method, view, args = service.definitions[0]
+        self.assertEqual(view, "get_fresh_air")
+        self.assertEqual(args["klass"], TemperatureCooler)
+
+    def test_get_services(self):
+        self.assertEqual([], get_services())
+        foobar = Service("Foobar", "/foobar")
+        self.assertIn(foobar, get_services())
+
+        barbaz = Service("Barbaz", "/barbaz")
+        self.assertIn(barbaz, get_services())
+
+        self.assertEqual(
+            [
+                barbaz,
+            ],
+            get_services(
+                exclude=[
+                    "Foobar",
+                ]
+            ),
+        )
+        self.assertEqual(
+            [
+                foobar,
+            ],
+            get_services(
+                names=[
+                    "Foobar",
+                ]
+            ),
+        )
+        self.assertEqual([foobar, barbaz], get_services(names=["Foobar", "Barbaz"]))
+
+    def test_default_validators(self):
+        old_validators = Service.default_validators
+        try:
+
+            def custom_validator(request):
+                pass
+
+            def custom_filter(request):
+                pass
+
+            def freshair(request):
+                pass
+
+            # the default validators should be used when registering a service
+            Service.default_validators = [
+                custom_validator,
+            ]
+            service = Service("TemperatureCooler", "/freshair")
+            service.add_view("GET", freshair)
+            method, view, args = service.definitions[0]
+
+            self.assertIn(custom_validator, args["validators"])
+
+            # defining a service with additional filters / validators should
+            # work as well
+            def another_validator(request):
+                pass
+
+            def groove_em_all(request):
+                pass
+
+            service2 = Service(
+                "FunkyGroovy",
+                "/funky-groovy",
+                validators=[another_validator],
+            )
+
+            service2.add_view("GET", groove_em_all)
+            method, view, args = service2.definitions[0]
+
+            self.assertIn(custom_validator, args["validators"])
+            self.assertIn(another_validator, args["validators"])
+        finally:
+            Service.default_validators = old_validators
+
+    def test_cors_headers_for_service_instantiation(self):
+        # When defining services, it's possible to add headers. This tests
+        # it is possible to list all the headers supported by a service.
+        service = Service("coconuts", "/migrate", cors_headers=("X-Header-Coconut"))
+        self.assertNotIn("X-Header-Coconut", service.cors_supported_headers_for())
+
+        service.add_view("POST", _stub)
+        self.assertIn("X-Header-Coconut", service.cors_supported_headers_for())
+
+    def test_cors_headers_for_view_definition(self):
+        # defining headers in the view should work.
+        service = Service("coconuts", "/migrate")
+        service.add_view("POST", _stub, cors_headers=("X-Header-Foobar"))
+        self.assertIn("X-Header-Foobar", service.cors_supported_headers_for())
+
+    def test_cors_headers_for_method(self):
+        # defining headers in the view should work.
+        service = Service("coconuts", "/migrate")
+        service.add_view("GET", _stub, cors_headers=("X-Header-Foobar"))
+        service.add_view("POST", _stub, cors_headers=("X-Header-Barbaz"))
+        get_headers = service.cors_supported_headers_for(method="GET")
+        self.assertNotIn("X-Header-Barbaz", get_headers)
+
+    def test_cors_headers_for_method_are_deduplicated(self):
+        # defining headers in the view should work.
+        service = Service("coconuts", "/migrate")
+        service.cors_headers = ("X-Header-Foobar",)
+        service.add_view("GET", _stub, cors_headers=("X-Header-Foobar", "X-Header-Barbaz"))
+        get_headers = service.cors_supported_headers_for(method="GET")
+        expected = set(["X-Header-Foobar", "X-Header-Barbaz"])
+        self.assertEqual(expected, get_headers)
+
+    def test_cors_supported_methods(self):
+        foo = Service(name="foo", path="/foo")
+        foo.add_view("GET", _stub)
+        self.assertIn("GET", foo.cors_supported_methods)
+
+        foo.add_view("POST", _stub)
+        self.assertIn("POST", foo.cors_supported_methods)
+
+    def test_cors_supported_origins(self):
+        foo = Service(name="foo", path="/foo", cors_origins=("mozilla.org",))
+
+        foo.add_view("GET", _stub, cors_origins=("notmyidea.org", "lolnet.org"))
+
+        self.assertIn("mozilla.org", foo.cors_supported_origins)
+        self.assertIn("notmyidea.org", foo.cors_supported_origins)
+        self.assertIn("lolnet.org", foo.cors_supported_origins)
+
+    def test_per_method_supported_origins(self):
+        foo = Service(name="foo", path="/foo", cors_origins=("mozilla.org",))
+        foo.add_view("GET", _stub, cors_origins=("lolnet.org",))
+
+        self.assertTrue("mozilla.org" in foo.cors_origins_for("GET"))
+        self.assertTrue("lolnet.org" in foo.cors_origins_for("GET"))
+
+        foo.add_view("POST", _stub)
+        self.assertFalse("lolnet.org" in foo.cors_origins_for("POST"))
+
+    def test_credential_support_can_be_enabled(self):
+        foo = Service(name="foo", path="/foo", cors_credentials=True)
+        foo.add_view("POST", _stub)
+        self.assertTrue(foo.cors_support_credentials_for())
+
+    def test_credential_support_is_disabled_by_default(self):
+        foo = Service(name="foo", path="/foo")
+        foo.add_view("POST", _stub)
+        self.assertFalse(foo.cors_support_credentials_for())
+
+    def test_per_method_credential_support(self):
+        foo = Service(name="foo", path="/foo")
+        foo.add_view("GET", _stub, cors_credentials=True)
+        foo.add_view("POST", _stub)
+        self.assertTrue(foo.cors_support_credentials_for("GET"))
+        self.assertFalse(foo.cors_support_credentials_for("POST"))
+
+    def test_method_takes_precendence_for_credential_support(self):
+        foo = Service(name="foo", path="/foo", cors_credentials=True)
+        foo.add_view("GET", _stub, cors_credentials=False)
+        self.assertFalse(foo.cors_support_credentials_for("GET"))
+
+    def test_max_age_is_none_if_undefined(self):
+        foo = Service(name="foo", path="/foo")
+        foo.add_view("POST", _stub)
+        self.assertIsNone(foo.cors_max_age_for("POST"))
+
+    def test_max_age_can_be_defined(self):
+        foo = Service(name="foo", path="/foo", cors_max_age=42)
+        foo.add_view("POST", _stub)
+        self.assertEqual(foo.cors_max_age_for(), 42)
+
+    def test_max_age_can_be_different_dependeing_methods(self):
+        foo = Service(name="foo", path="/foo", cors_max_age=42)
+        foo.add_view("GET", _stub)
+        foo.add_view("POST", _stub, cors_max_age=32)
+        foo.add_view("PUT", _stub, cors_max_age=7)
+
+        self.assertEqual(foo.cors_max_age_for("GET"), 42)
+        self.assertEqual(foo.cors_max_age_for("POST"), 32)
+        self.assertEqual(foo.cors_max_age_for("PUT"), 7)
+
+    def test_cors_policy(self):
+        policy = {"origins": ("foo", "bar", "baz")}
+        foo = Service(name="foo", path="/foo", cors_policy=policy)
+        self.assertTrue("foo" in foo.cors_supported_origins)
+        self.assertTrue("bar" in foo.cors_supported_origins)
+        self.assertTrue("baz" in foo.cors_supported_origins)
+
+    def test_cors_policy_can_be_overwritten(self):
+        policy = {"origins": ("foo", "bar", "baz")}
+        foo = Service(name="foo", path="/foo", cors_origins=(), cors_policy=policy)
+        self.assertEqual(len(foo.cors_supported_origins), 0)
+
+    def test_can_specify_a_view_decorator(self):
+        def dummy_decorator(view):
+            return view
+
+        service = Service("coconuts", "/migrate", decorator=dummy_decorator)
+        args = service.get_arguments({})
+        self.assertEqual(args["decorator"], dummy_decorator)
+
+        # make sure Service.decorator() still works
+        @service.decorator("put")
+        def dummy_view(request):
+            return "data"
+
+        self.assertTrue(any(view is dummy_view for method, view, args in service.definitions))
+
+    def test_cannot_specify_both_factory_and_acl(self):
+        with self.assertRaises(ConfigurationError):
+            Service(
+                "coconuts",
+                "/migrate",
+                acl="dummy_permission",
+                factory="TheFactoryMethodCalledByPyramid",
+            )
+
+    def test_decorate_view(self):
+        def myfunction():
+            pass
+
+        meth = "POST"
+        decorated = decorate_view(myfunction, {}, meth)
+        self.assertEqual(decorated.__name__, "{0}__{1}".format(func_name(myfunction), meth))
+
+    def test_decorate_resource_view(self):
+        class MyResource(object):
+            def __init__(self, **kwargs):
+                pass
+
+            def myview(self):
+                pass
+
+        meth = "POST"
+        decorated = decorate_view(_UnboundView(MyResource, "myview"), {}, meth)
+        self.assertEqual(decorated.__name__, "{0}__{1}".format(func_name(MyResource.myview), meth))

--- a/tests/core/cornice/test_service.py
+++ b/tests/core/cornice/test_service.py
@@ -50,7 +50,7 @@ class TestService(TestCase):
             lambda x: True,
         ]
         service = Service("coconuts", "/migrate", validators=validators)
-        self.assertEqual(service.validators, validators)
+        self.assertEqual(service.validators, validators)  # ty: ignore[unresolved-attribute]
 
     def test_representation(self):
         service = Service("coconuts", "/migrate")
@@ -82,11 +82,11 @@ class TestService(TestCase):
         # define a validator for the needs of the test
 
         service = Service("vaches", "/fetchez", validators=(_validator,))
-        self.assertEqual(len(service.validators), 1)
+        self.assertEqual(len(service.validators), 1)  # ty: ignore[unresolved-attribute]
         args = service.get_arguments({"validators": (_validator2,)})
 
         # the list of validators didn't changed
-        self.assertEqual(len(service.validators), 1)
+        self.assertEqual(len(service.validators), 1)  # ty: ignore[unresolved-attribute]
 
         # but the one returned contains 2 validators
         self.assertEqual(len(args["validators"]), 2)
@@ -95,7 +95,7 @@ class TestService(TestCase):
         # validators / filters it returns, without removing it from the ones
         # registered for the service.
         service = Service("open bar", "/bar", validators=(_validator, _validator2))
-        self.assertEqual(service.validators, [_validator, _validator2])
+        self.assertEqual(service.validators, [_validator, _validator2])  # ty: ignore[unresolved-attribute]
 
         args = service.get_arguments({"exclude": _validator2})
         self.assertEqual(args["validators"], [_validator])
@@ -376,7 +376,7 @@ class TestService(TestCase):
     def test_cors_headers_for_method_are_deduplicated(self):
         # defining headers in the view should work.
         service = Service("coconuts", "/migrate")
-        service.cors_headers = ("X-Header-Foobar",)
+        service.cors_headers = ("X-Header-Foobar",)  # ty: ignore[unresolved-attribute]
         service.add_view("GET", _stub, cors_headers=("X-Header-Foobar", "X-Header-Barbaz"))
         get_headers = service.cors_supported_headers_for(method="GET")
         expected = set(["X-Header-Foobar", "X-Header-Barbaz"])

--- a/tests/core/cornice/test_service.py
+++ b/tests/core/cornice/test_service.py
@@ -426,7 +426,7 @@ class TestService(TestCase):
         self.assertTrue(foo.cors_support_credentials_for("GET"))
         self.assertFalse(foo.cors_support_credentials_for("POST"))
 
-    def test_method_takes_precendence_for_credential_support(self):
+    def test_method_takes_precedence_for_credential_support(self):
         foo = Service(name="foo", path="/foo", cors_credentials=True)
         foo.add_view("GET", _stub, cors_credentials=False)
         self.assertFalse(foo.cors_support_credentials_for("GET"))
@@ -441,7 +441,7 @@ class TestService(TestCase):
         foo.add_view("POST", _stub)
         self.assertEqual(foo.cors_max_age_for(), 42)
 
-    def test_max_age_can_be_different_dependeing_methods(self):
+    def test_max_age_can_be_different_depending_methods(self):
         foo = Service(name="foo", path="/foo", cors_max_age=42)
         foo.add_view("GET", _stub)
         foo.add_view("POST", _stub, cors_max_age=32)

--- a/tests/core/cornice/test_service.py
+++ b/tests/core/cornice/test_service.py
@@ -7,9 +7,9 @@ from pyramid.exceptions import ConfigurationError
 from pyramid.interfaces import IRendererFactory
 
 from kinto.core.cornice.service import (
+    SERVICES,
     Service,
     _UnboundView,
-    clear_services,
     decorate_view,
     get_services,
 )
@@ -29,8 +29,12 @@ def _stub(req):
 
 
 class TestService(TestCase):
+    def setUp(self):
+        self._saved_services = list(SERVICES)
+        SERVICES[:] = []
+
     def tearDown(self):
-        clear_services()
+        SERVICES[:] = self._saved_services
 
     def test_service_instantiation(self):
         service = Service("coconuts", "/migrate")
@@ -399,11 +403,11 @@ class TestService(TestCase):
         foo = Service(name="foo", path="/foo", cors_origins=("mozilla.org",))
         foo.add_view("GET", _stub, cors_origins=("lolnet.org",))
 
-        self.assertTrue("mozilla.org" in foo.cors_origins_for("GET"))
-        self.assertTrue("lolnet.org" in foo.cors_origins_for("GET"))
+        self.assertIn("mozilla.org", foo.cors_origins_for("GET"))
+        self.assertIn("lolnet.org", foo.cors_origins_for("GET"))
 
         foo.add_view("POST", _stub)
-        self.assertFalse("lolnet.org" in foo.cors_origins_for("POST"))
+        self.assertNotIn("lolnet.org", foo.cors_origins_for("POST"))
 
     def test_credential_support_can_be_enabled(self):
         foo = Service(name="foo", path="/foo", cors_credentials=True)

--- a/tests/core/cornice/test_service_definition.py
+++ b/tests/core/cornice/test_service_definition.py
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+from unittest import TestCase
+
+from pyramid import testing
+from webtest import TestApp
+
+from kinto.core.cornice import Service
+
+from .support import CatchErrors
+
+
+service1 = Service(name="service1", path="/service1")
+service2 = Service(name="service2", path="/service2")
+
+
+@service1.get()
+def get1(request):
+    return {"test": "succeeded"}
+
+
+@service1.post()
+def post1(request):
+    return {"body": request.body}
+
+
+@service2.get(accept="text/html")
+@service2.post(accept="audio/ogg")
+def get2_or_post2(request):
+    return {"test": "succeeded"}
+
+
+class TestServiceDefinition(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("kinto.core.cornice")
+        self.config.scan("tests.core.cornice.test_service_definition")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_basic_service_operation(self):
+        self.app.get("/unknown", status=404)
+        self.assertEqual(self.app.get("/service1").json, {"test": "succeeded"})
+
+        self.assertEqual(self.app.post("/service1", params="BODY").json, {"body": "BODY"})
+
+    def test_loading_into_multiple_configurators(self):
+        # When initializing a second configurator, it shouldn't interfere
+        # with the one already in place.
+        config2 = testing.setUp()
+        config2.include("kinto.core.cornice")
+        config2.scan("tests.core.cornice.test_service_definition")
+
+        # Calling the new configurator works as expected.
+        app = TestApp(CatchErrors(config2.make_wsgi_app()))
+        self.assertEqual(app.get("/service1").json, {"test": "succeeded"})
+
+        # Calling the old configurator works as expected.
+        self.assertEqual(self.app.get("/service1").json, {"test": "succeeded"})
+
+    def test_stacking_api_decorators(self):
+        # Stacking multiple @api calls on a single function should
+        # register it multiple times, just like @view_config does.
+        resp = self.app.get("/service2", headers={"Accept": "text/html"})
+        self.assertEqual(resp.json, {"test": "succeeded"})
+
+        resp = self.app.post("/service2", headers={"Accept": "audio/ogg"})
+        self.assertEqual(resp.json, {"test": "succeeded"})

--- a/tests/core/cornice/test_util.py
+++ b/tests/core/cornice/test_util.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+import unittest
+from unittest import mock
+
+from kinto.core.cornice import util
+
+
+class CurrentServiceTest(unittest.TestCase):
+    def test_current_service_returns_the_service_for_existing_patterns(self):
+        request = mock.MagicMock()
+        request.matched_route.pattern = "/buckets"
+        request.registry.cornice_services = {"/buckets": mock.sentinel.service}
+
+        self.assertEqual(util.current_service(request), mock.sentinel.service)
+
+    def test_current_service_returns_none_for_unexisting_patterns(self):
+        request = mock.MagicMock()
+        request.matched_route.pattern = "/unexisting"
+        request.registry.cornice_services = {}
+
+        self.assertEqual(util.current_service(request), None)

--- a/tests/core/cornice/test_validation.py
+++ b/tests/core/cornice/test_validation.py
@@ -1,0 +1,410 @@
+# -*- encoding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
+import unittest
+from unittest import TestCase, mock
+
+from pyramid.request import Request
+from webtest import TestApp
+
+from kinto.core.cornice.errors import Errors
+from kinto.core.cornice.validators import (
+    colander_validator,
+    extract_cstruct,
+)
+
+from .support import DummyRequest, LoggingCatcher
+from .validationapp import main
+
+
+class TestServiceDefinition(LoggingCatcher, TestCase):
+    def test_validation(self):
+        app = TestApp(main({}))
+        app.get("/service", status=400)
+
+        response = app.post("/service", params="buh", status=400)
+        self.assertTrue(b"Not a json body" in response.body)
+
+        response = app.post("/service", params=json.dumps("buh"))
+
+        expected = json.dumps({"body": '"buh"'}).encode("ascii")
+        self.assertEqual(response.body, expected)
+
+        app.get("/service?paid=yup")
+
+        # valid = foo is one
+        response = app.get("/service?foo=1&paid=yup")
+        self.assertEqual(response.json["foo"], 1)
+
+        # invalid value for foo
+        response = app.get("/service?foo=buh&paid=yup", status=400)
+
+        # check that json is returned
+        errors = Errors()
+        for err in json.loads(response.body).get("errors", []):
+            errors.add("body", err)
+        self.assertEqual(len(errors), 1)
+
+    def test_validation_hooked_error_response(self):
+        app = TestApp(main({}))
+
+        response = app.post("/service4", status=400)
+        self.assertTrue(b"<errors>" in response.body)
+
+    def test_accept(self):
+        # tests that the accept headers are handled the proper way
+        app = TestApp(main({}))
+
+        # requesting the wrong accept header should return a 406 ...
+        response = app.get("/service2", headers={"Accept": "audio/*"}, status=406)
+
+        # ... with the list of accepted content-types
+        error_location = response.json["errors"][0]["location"]
+        error_name = response.json["errors"][0]["name"]
+        error_description = response.json["errors"][0]["description"]
+        self.assertEqual("header", error_location)
+        self.assertEqual("Accept", error_name)
+        self.assertIn("application/json", error_description)
+        self.assertIn("text/plain", error_description)
+
+        # requesting a supported type should give an appropriate response type
+        response = app.get("/service2", headers={"Accept": "application/*"})
+        self.assertEqual(response.content_type, "application/json")
+
+        response = app.get("/service2", headers={"Accept": "text/plain"})
+        self.assertEqual(response.content_type, "text/plain")
+
+        # it should also work with multiple Accept headers
+        response = app.get("/service2", headers={"Accept": "audio/*, application/*"})
+        self.assertEqual(response.content_type, "application/json")
+
+        # and requested preference order should be respected
+        headers = {"Accept": "application/json; q=1.0, text/plain; q=0.9"}
+        response = app.get("/service2", headers=headers)
+        self.assertEqual(response.content_type, "application/json")
+
+        headers = {"Accept": "application/json; q=0.9, text/plain; q=1.0"}
+        response = app.get("/service2", headers=headers)
+        self.assertEqual(response.content_type, "text/plain")
+
+        # test that using a callable to define what's accepted works as well
+        response = app.get("/service3", headers={"Accept": "audio/*"}, status=406)
+        error_description = response.json["errors"][0]["description"]
+        self.assertIn("application/json", error_description)
+
+        response = app.get("/service3", headers={"Accept": "text/*"})
+        self.assertEqual(response.content_type, "text/plain")
+
+        # Test that using a callable to define what's accepted works as well.
+        # Now, the callable returns a scalar instead of a list.
+        response = app.put("/service3", headers={"Accept": "audio/*"}, status=406)
+        error_description = response.json["errors"][0]["description"]
+        self.assertIn("application/json", error_description)
+
+        response = app.put("/service3", headers={"Accept": "text/*"})
+        self.assertEqual(response.content_type, "text/plain")
+
+        # If we are not asking for a particular content-type,
+        # we should get one of the two types that the service supports.
+        response = app.get("/service2")
+        self.assertIn(response.content_type, ("application/json", "text/plain"))
+
+    def test_accept_issue_113_text_star(self):
+        app = TestApp(main({}))
+
+        response = app.get("/service3", headers={"Accept": "text/*"})
+        self.assertEqual(response.content_type, "text/plain")
+
+    def test_accept_issue_113_text_application_star(self):
+        app = TestApp(main({}))
+
+        response = app.get("/service3", headers={"Accept": "application/*"})
+        self.assertEqual(response.content_type, "application/json")
+
+    def test_accept_issue_113_text_application_json(self):
+        app = TestApp(main({}))
+
+        response = app.get("/service3", headers={"Accept": "application/json"})
+        self.assertEqual(response.content_type, "application/json")
+
+    def test_accept_issue_113_text_html_not_acceptable(self):
+        app = TestApp(main({}))
+
+        # Requesting an unsupported content type should
+        # return HTTP response "406 Not Acceptable".
+        app.get("/service3", headers={"Accept": "text/html"}, status=406)
+
+    def test_accept_issue_113_audio_or_text(self):
+        app = TestApp(main({}))
+
+        response = app.get("/service2", headers={"Accept": "audio/mp4; q=0.9, text/plain; q=0.5"})
+        self.assertEqual(response.content_type, "text/plain")
+
+        # If we are not asking for a particular content-type,
+        # we should get one of the two types that the service supports.
+        response = app.get("/service2")
+        self.assertIn(response.content_type, ("application/json", "text/plain"))
+
+    def test_override_default_accept_issue_252(self):
+        # Override default acceptable content_types for interoperate with
+        # legacy applications i.e. ExtJS 3.
+        from kinto.core.cornice.renderer import CorniceRenderer
+
+        CorniceRenderer.acceptable += ("text/html",)
+
+        app = TestApp(main({}))
+
+        response = app.get("/service5", headers={"Accept": "text/html"})
+        self.assertEqual(response.content_type, "text/html")
+        # revert the override
+        CorniceRenderer.acceptable = CorniceRenderer.acceptable[:-1]
+
+    def test_multiple_querystrings(self):
+        app = TestApp(main({}))
+
+        # it is possible to have more than one value with the same name in the
+        # querystring
+        self.assertEqual(b'{"field": ["5"]}', app.get("/foobaz?field=5").body)
+        self.assertEqual(b'{"field": ["5", "2"]}', app.get("/foobaz?field=5&field=2").body)
+
+    def test_content_type_missing(self):
+        # test that a Content-Type request headers is present
+        app = TestApp(main({}))
+
+        # Requesting without a Content-Type header should
+        # return "415 Unsupported Media Type" ...
+        request = app.RequestClass.blank("/service5", method="POST", POST="some data")
+        response = app.do_request(request, 415, True)
+        self.assertEqual(response.status_code, 415)
+
+        # ... with an appropriate json error structure.
+        error_location = response.json["errors"][0]["location"]
+        error_name = response.json["errors"][0]["name"]
+        error_description = response.json["errors"][0]["description"]
+        self.assertEqual("header", error_location)
+        self.assertEqual("Content-Type", error_name)
+        self.assertIn("application/json", error_description)
+
+    def test_validated_body_content_from_schema(self):
+        app = TestApp(main({}))
+        content = {"email": "alexis@notmyidea.org"}
+        response = app.post_json("/newsletter", params=content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["body"], content)
+
+    def test_validated_querystring_content_from_schema(self):
+        app = TestApp(main({}))
+        response = app.post_json("/newsletter?ref=3")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["querystring"], {"ref": 3})
+
+    def test_validated_querystring_and_schema_from_same_schema(self):
+        app = TestApp(main({}))
+        content = {"email": "alexis@notmyidea.org"}
+        response = app.post_json("/newsletter?ref=20", params=content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["body"], content)
+        self.assertEqual(response.json["querystring"], {"ref": 20})
+
+        response = app.post_json("/newsletter?ref=2", params=content, status=400)
+        self.assertEqual(response.status_code, 400)
+        error = {"location": "body", "name": "email", "description": "Invalid email length"}
+        self.assertEqual(response.json["errors"][0], error)
+
+    def test_validated_path_content_from_schema(self):
+        # Test validation request.matchdict.  (See #411)
+        app = TestApp(main({}))
+        response = app.get("/item/42", status=200)
+        self.assertEqual(response.json, {"item_id": 42})
+
+    def test_content_type_with_no_body_should_pass(self):
+        app = TestApp(main({}))
+
+        request = app.RequestClass.blank(
+            "/newsletter", method="POST", headers={"Content-Type": "application/json"}
+        )
+        response = app.do_request(request, 200, True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["body"], {})
+
+    def test_content_type_missing_with_no_body_should_pass(self):
+        app = TestApp(main({}))
+
+        # requesting without a Content-Type header nor a body should
+        # return a 200.
+        request = app.RequestClass.blank("/newsletter", method="POST")
+        response = app.do_request(request, 200, True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["body"], {})
+
+    def test_content_type_wrong_single(self):
+        # Tests that the Content-Type request header satisfies the requirement.
+        app = TestApp(main({}))
+
+        # Requesting the wrong Content-Type header should
+        # return "415 Unsupported Media Type" ...
+        response = app.post("/service5", headers={"Content-Type": "text/plain"}, status=415)
+
+        # ... with an appropriate json error structure.
+        error_description = response.json["errors"][0]["description"]
+        self.assertIn("application/json", error_description)
+
+    def test_content_type_wrong_multiple(self):
+        # Tests that the Content-Type request header satisfies the requirement.
+        app = TestApp(main({}))
+
+        # Requesting without a Content-Type header should
+        # return "415 Unsupported Media Type" ...
+        response = app.put("/service5", headers={"Content-Type": "text/xml"}, status=415)
+
+        # ... with an appropriate json error structure.
+        error_description = response.json["errors"][0]["description"]
+        self.assertIn("text/plain", error_description)
+        self.assertIn("application/json", error_description)
+
+    def test_content_type_correct(self):
+        # Tests that the Content-Type request header satisfies the requirement.
+        app = TestApp(main({}))
+
+        # Requesting with one of the allowed Content-Type headers should work,
+        # even when having a charset parameter as suffix.
+        response = app.put("/service5", headers={"Content-Type": "text/plain; charset=utf-8"})
+        self.assertEqual(response.json, "some response")
+
+    def test_content_type_on_get(self):
+        # Test that a Content-Type request header is not
+        # checked on GET requests, they don't usually have a body.
+        app = TestApp(main({}))
+        response = app.get("/service5")
+        self.assertEqual(response.json, "some response")
+
+    def test_content_type_with_callable(self):
+        # Test that using a callable for content_type works as well.
+        app = TestApp(main({}))
+        response = app.post("/service6", headers={"Content-Type": "audio/*"}, status=415)
+        error_description = response.json["errors"][0]["description"]
+        self.assertIn("text/xml", error_description)
+        self.assertIn("application/json", error_description)
+
+    def test_content_type_with_callable_returning_scalar(self):
+        # Test that using a callable for content_type works as well.
+        # Now, the callable returns a scalar instead of a list.
+        app = TestApp(main({}))
+        response = app.put("/service6", headers={"Content-Type": "audio/*"}, status=415)
+        error_description = response.json["errors"][0]["description"]
+        self.assertIn("text/xml", error_description)
+
+    def test_accept_and_content_type(self):
+        # Tests that using both the "Accept" and "Content-Type"
+        # request headers satisfy the requirement.
+        app = TestApp(main({}))
+
+        # POST endpoint just has one accept and content_type definition
+        response = app.post(
+            "/service7",
+            headers={
+                "Accept": "text/xml, application/json",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+        )
+        self.assertEqual(response.json, "some response")
+
+        response = app.post(
+            "/service7",
+            headers={
+                "Accept": "text/plain, application/json",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            status=406,
+        )
+
+        response = app.post(
+            "/service7",
+            headers={
+                "Accept": "text/xml, application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            status=415,
+        )
+
+        # PUT endpoint has a list of accept and content_type definitions
+        response = app.put(
+            "/service7",
+            headers={
+                "Accept": "text/xml, application/json",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+        )
+        self.assertEqual(response.json, "some response")
+
+        response = app.put(
+            "/service7",
+            headers={"Accept": "audio/*", "Content-Type": "application/json; charset=utf-8"},
+            status=406,
+        )
+
+        response = app.put(
+            "/service7",
+            headers={
+                "Accept": "text/xml, application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            status=415,
+        )
+
+
+class TestErrorMessageTranslationColander(TestCase):
+    def post(self, settings={}, headers={}):
+        app = TestApp(main({}, **settings))
+        return app.post_json(
+            "/foobar?yeah=test",
+            {
+                "foo": "hello",
+                "bar": "open",
+                "yeah": "man",
+                "ipsum": 10,
+            },
+            status=400,
+            headers=headers,
+        )
+
+    def assertErrorDescription(self, response, message):
+        error_description = response.json["errors"][0]["description"]
+        self.assertEqual(error_description, message)
+
+    def test_no_language_settings(self):
+        response = self.post()
+        self.assertErrorDescription(response, "10 is greater than maximum value 3")
+
+
+class TestValidatorEdgeCases(TestCase):
+    def test_no_schema(self):
+        request = DummyRequest()
+        request.validated = mock.sentinel.validated
+        colander_validator(request)
+        self.assertEqual(request.validated, mock.sentinel.validated)
+        self.assertEqual(len(request.errors), 0)
+
+    def _no_body_schema(self):
+        request = DummyRequest()
+        request.validated = mock.sentinel.validated
+        colander_validator(request)
+        self.assertEqual(request.validated, mock.sentinel.validated)
+        self.assertEqual(len(request.errors), 0)
+
+
+class TestExtractedJSONValueTypes(unittest.TestCase):
+    """Make sure that all JSON string values extracted from the request
+    are unicode when running using PY2.
+    """
+
+    def test_extracted_json_values(self):
+        """Extracted JSON values are unicode in PY2."""
+        body = b'{"foo": "bar", "currency": "\xe2\x82\xac"}'
+        request = Request.blank("/", body=body)
+        data = extract_cstruct(request)
+        self.assertEqual(type(data["body"]["foo"]), str)
+        self.assertEqual(type(data["body"]["currency"]), str)
+        self.assertEqual(data["body"]["currency"], "€")

--- a/tests/core/cornice/test_validation.py
+++ b/tests/core/cornice/test_validation.py
@@ -10,6 +10,7 @@ from pyramid.request import Request
 from webtest import TestApp
 
 from kinto.core.cornice.errors import Errors
+from kinto.core.cornice.service import clear_services
 from kinto.core.cornice.validators import (
     colander_validator,
     extract_cstruct,
@@ -20,6 +21,10 @@ from .validationapp import main
 
 
 class TestServiceDefinition(LoggingCatcher, TestCase):
+    def tearDown(self):
+        clear_services()
+        return super().tearDown()
+
     def test_validation(self):
         app = TestApp(main({}))
         app.get("/service", status=400)
@@ -356,6 +361,10 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
 
 
 class TestErrorMessageTranslationColander(TestCase):
+    def tearDown(self):
+        clear_services()
+        return super().tearDown()
+
     def post(self, settings={}, headers={}):
         app = TestApp(main({}, **settings))
         return app.post_json(

--- a/tests/core/cornice/test_validation.py
+++ b/tests/core/cornice/test_validation.py
@@ -10,7 +10,7 @@ from pyramid.request import Request
 from webtest import TestApp
 
 from kinto.core.cornice.errors import Errors
-from kinto.core.cornice.service import clear_services
+from kinto.core.cornice.service import SERVICES
 from kinto.core.cornice.validators import (
     colander_validator,
     extract_cstruct,
@@ -21,8 +21,12 @@ from .validationapp import main
 
 
 class TestServiceDefinition(LoggingCatcher, TestCase):
+    def setUp(self):
+        super().setUp()
+        self._saved_services = list(SERVICES)
+
     def tearDown(self):
-        clear_services()
+        SERVICES[:] = self._saved_services
         return super().tearDown()
 
     def test_validation(self):
@@ -361,8 +365,11 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
 
 
 class TestErrorMessageTranslationColander(TestCase):
+    def setUp(self):
+        self._saved_services = list(SERVICES)
+
     def tearDown(self):
-        clear_services()
+        SERVICES[:] = self._saved_services
         return super().tearDown()
 
     def post(self, settings={}, headers={}):

--- a/tests/core/cornice/test_validation.py
+++ b/tests/core/cornice/test_validation.py
@@ -398,16 +398,16 @@ class TestErrorMessageTranslationColander(TestCase):
 class TestValidatorEdgeCases(TestCase):
     def test_no_schema(self):
         request = DummyRequest()
-        request.validated = mock.sentinel.validated
+        request.validated = mock.sentinel.validated  # ty: ignore[unresolved-attribute]
         colander_validator(request)
-        self.assertEqual(request.validated, mock.sentinel.validated)
+        self.assertEqual(request.validated, mock.sentinel.validated)  # ty: ignore[unresolved-attribute]
         self.assertEqual(len(request.errors), 0)
 
     def _no_body_schema(self):
         request = DummyRequest()
-        request.validated = mock.sentinel.validated
+        request.validated = mock.sentinel.validated  # ty: ignore[unresolved-attribute]
         colander_validator(request)
-        self.assertEqual(request.validated, mock.sentinel.validated)
+        self.assertEqual(request.validated, mock.sentinel.validated)  # ty: ignore[unresolved-attribute]
         self.assertEqual(len(request.errors), 0)
 
 

--- a/tests/core/cornice/validationapp.py
+++ b/tests/core/cornice/validationapp.py
@@ -1,0 +1,346 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
+
+from colander import (
+    Email,
+    Integer,
+    Invalid,
+    MappingSchema,
+    Range,
+    SchemaNode,
+    SequenceSchema,
+    String,
+    deferred,
+    drop,
+    null,
+)
+from pyramid.config import Configurator
+from pyramid.httpexceptions import HTTPBadRequest
+
+from kinto.core.cornice import Service
+from kinto.core.cornice.validators import colander_validator
+
+from .support import CatchErrors
+
+
+# Service for testing callback-based validators.
+service = Service(name="service", path="/service")
+
+
+def has_payed(request, **kw):
+    if "paid" not in request.GET:
+        request.errors.add("body", "paid", "You must pay!")
+
+
+def foo_int(request, **kw):
+    if "foo" not in request.GET:
+        return
+    try:
+        request.validated["foo"] = int(request.GET["foo"])
+    except ValueError:
+        request.errors.add("url", "foo", "Not an int")
+
+
+@service.get(validators=(has_payed, foo_int))
+def get1(request):
+    res = {"test": "succeeded"}
+    try:
+        res["foo"] = request.validated["foo"]
+    except KeyError:
+        pass
+
+    return res
+
+
+def _json(request, **kw):
+    """The request body should be a JSON object."""
+    try:
+        request.validated["json"] = json.loads(request.body.decode("utf-8"))
+    except ValueError:
+        request.errors.add("body", "json", "Not a json body")
+
+
+@service.post(validators=_json)
+def post1(request):
+    return {"body": request.body}
+
+
+# Service for testing the "accept" parameter (scalar and list).
+service2 = Service(name="service2", path="/service2")
+
+
+@service2.get(accept=("application/json"))
+@service2.get(accept=("text/plain"), renderer="string")
+def get2(request):
+    return {"body": "yay!"}
+
+
+# Service for testing the "accept" parameter (callable).
+service3 = Service(name="service3", path="/service3")
+
+
+@service3.get(accept=lambda request: ("application/json", "text/plain"))
+@service3.put(accept=lambda request: ("application/json", "text/plain"))
+def get3(request):
+    return {"body": "yay!"}
+
+
+service4 = Service(name="service4", path="/service4")
+
+
+def fail(request, **kw):
+    request.errors.add("body", "xml", "Not XML")
+
+
+def xml_error(request):
+    errors = request.errors
+    lines = ["<errors>"]
+    for error in errors:
+        lines.append(
+            "<error>"
+            "<location>%(location)s</location>"
+            "<type>%(name)s</type>"
+            "<message>%(description)s</message>"
+            "</error>" % error
+        )
+    lines.append("</errors>")
+    return HTTPBadRequest(body="".join(lines))
+
+
+@service4.post(validators=fail, error_handler=xml_error)
+def post4(request):
+    raise ValueError("Shouldn't get here")
+
+
+# Service for testing the "content_type" parameter (scalar and list).
+service5 = Service(name="service5", path="/service5")
+
+
+@service5.get()
+@service5.post(content_type="application/json")
+@service5.put(content_type=("text/plain", "application/json"))
+def post5(request):
+    return "some response"
+
+
+# Service for testing the "content_type" parameter (callable).
+service6 = Service(name="service6", path="/service6")
+
+
+@service6.post(content_type=lambda request: ("text/xml", "application/json"))
+@service6.put(content_type=lambda request: "text/xml")
+def post6(request):
+    return {"body": "yay!"}
+
+
+# Service for testing a mix of "accept" and "content_type" parameters.
+service7 = Service(name="service7", path="/service7")
+
+
+@service7.post(accept="text/xml", content_type="application/json")
+@service7.put(accept=("text/xml", "text/plain"), content_type=("application/json", "text/xml"))
+def post7(request):
+    return "some response"
+
+
+# services for colander validation
+signup = Service(name="signup", path="/signup")
+bound = Service(name="bound", path="/bound")
+group_signup = Service(name="group signup", path="/group_signup")
+body_group_signup = Service(name="body_group signup", path="/body_group_signup")
+body_signup = Service(name="body signup", path="/body_signup")
+foobar = Service(name="foobar", path="/foobar")
+foobaz = Service(name="foobaz", path="/foobaz")
+email_service = Service(name="newsletter", path="/newsletter")
+item_service = Service(name="item", path="/item/{item_id}")
+form_service = Service(name="form", path="/form")
+
+
+class SignupSchema(MappingSchema):
+    username = SchemaNode(String())
+
+
+@deferred
+def deferred_missing(node, kw):
+    import random
+
+    return kw.get("missing_foo") or random.random()
+
+
+class NeedsBindingSchema(MappingSchema):
+    somefield = SchemaNode(String(), missing=deferred_missing)
+
+
+def rebinding_validator(request, **kwargs):
+    kwargs["schema"] = NeedsBindingSchema().bind()
+    return colander_validator(request, **kwargs)
+
+
+@bound.post(schema=NeedsBindingSchema().bind(), validators=(rebinding_validator,))
+def bound_post(request):
+    return request.validated
+
+
+@bound.post(
+    schema=NeedsBindingSchema().bind(missing_foo=-10),
+    validators=(colander_validator,),
+    header="X-foo",
+)
+def bound_post_with_override(request):
+    return request.validated
+
+
+@signup.post(schema=SignupSchema(), validators=(colander_validator,))
+def signup_post(request):
+    return request.validated
+
+
+class GroupSignupSchema(SequenceSchema):
+    user = SignupSchema()
+
+
+@group_signup.post(schema=GroupSignupSchema(), validators=(colander_validator,))
+def group_signup_post(request):
+    return {"data": request.validated}
+
+
+class BodyGroupSignupSchema(MappingSchema):
+    body = GroupSignupSchema()
+
+
+@body_group_signup.post(schema=BodyGroupSignupSchema(), validators=(colander_validator,))
+def body_group_signup_post(request):
+    return {"data": request.validated["body"]}
+
+
+class BodySignupSchema(MappingSchema):
+    body = SignupSchema()
+
+
+@body_signup.post(schema=BodySignupSchema(), validators=(colander_validator,))
+def body_signup_post(request):
+    return {"data": request.validated}
+
+
+def validate_bar(node, value, **kwargs):
+    if value != "open":
+        raise Invalid(node, "The bar is not open.")
+
+
+class Integers(SequenceSchema):
+    integer = SchemaNode(Integer(), type="int")
+
+
+class BodySchema(MappingSchema):
+    # foo and bar are required, baz is optional
+    foo = SchemaNode(String())
+    bar = SchemaNode(String(), validator=validate_bar)
+    baz = SchemaNode(String(), missing=None)
+    ipsum = SchemaNode(Integer(), missing=1, validator=Range(0, 3))
+    integers = Integers(missing=())
+
+
+class Query(MappingSchema):
+    yeah = SchemaNode(String(), type="str")
+
+
+class RequestSchema(MappingSchema):
+    body = BodySchema()
+    querystring = Query()
+
+    def deserialize(self, cstruct):
+        if "body" in cstruct and cstruct["body"] == b"hello,open,yeah":
+            values = cstruct["body"].decode().split(",")
+            cstruct["body"] = dict(zip(["foo", "bar", "yeah"], values))
+
+        return MappingSchema.deserialize(self, cstruct)
+
+
+@foobar.post(schema=RequestSchema(), validators=(colander_validator,))
+def foobar_post(request):
+    return {"test": "succeeded"}
+
+
+class StringSequence(SequenceSchema):
+    _ = SchemaNode(String())
+
+
+class ListQuerystringSequence(MappingSchema):
+    field = StringSequence()
+
+    def deserialize(self, cstruct):
+        if "field" in cstruct and not isinstance(cstruct["field"], list):
+            cstruct["field"] = [cstruct["field"]]
+        return MappingSchema.deserialize(self, cstruct)
+
+
+class QSSchema(MappingSchema):
+    querystring = ListQuerystringSequence()
+
+
+@foobaz.get(schema=QSSchema(), validators=(colander_validator,))
+def foobaz_get(request):
+    return {"field": request.validated["querystring"]["field"]}
+
+
+class NewsletterSchema(MappingSchema):
+    email = SchemaNode(String(), validator=Email(), missing=drop)
+
+
+class RefererSchema(MappingSchema):
+    ref = SchemaNode(Integer(), missing=drop)
+
+
+class NewsletterPayload(MappingSchema):
+    body = NewsletterSchema()
+    querystring = RefererSchema()
+
+    def deserialize(self, cstruct=null):
+        appstruct = super(NewsletterPayload, self).deserialize(cstruct)
+        email = appstruct["body"].get("email")
+        ref = appstruct["querystring"].get("ref")
+        if email and ref and len(email) != ref:
+            body_node, _ = self.children
+            exc = Invalid(body_node)
+            exc["email"] = "Invalid email length"
+            raise exc
+        return appstruct
+
+
+@email_service.post(schema=NewsletterPayload(), validators=(colander_validator,))
+def newsletter(request):
+    return request.validated
+
+
+class ItemPathSchema(MappingSchema):
+    item_id = SchemaNode(Integer())
+
+
+class ItemSchema(MappingSchema):
+    path = ItemPathSchema()
+
+
+@item_service.get(schema=ItemSchema(), validators=(colander_validator,))
+def item(request):
+    return request.validated["path"]
+
+
+class FormSchema(MappingSchema):
+    field1 = SchemaNode(String())
+    field2 = SchemaNode(String())
+
+
+@form_service.post(schema=FormSchema(), validators=(colander_validator,))
+def form(request):
+    return request.validated
+
+
+def main(global_config, **settings):
+    config = Configurator(settings=settings)
+    config.include("kinto.core.cornice")
+    config.scan("tests.core.cornice.validationapp")
+    # used for simulating pyramid session object access in validators
+    config.add_request_method(lambda x: "secret", "get_csrf")
+    return CatchErrors(config.make_wsgi_app())

--- a/tests/core/cornice/validationapp.py
+++ b/tests/core/cornice/validationapp.py
@@ -29,7 +29,7 @@ from .support import CatchErrors
 service = Service(name="service", path="/service")
 
 
-def has_payed(request, **kw):
+def has_paid(request, **kw):
     if "paid" not in request.GET:
         request.errors.add("body", "paid", "You must pay!")
 
@@ -43,7 +43,7 @@ def foo_int(request, **kw):
         request.errors.add("url", "foo", "Not an int")
 
 
-@service.get(validators=(has_payed, foo_int))
+@service.get(validators=(has_paid, foo_int))
 def get1(request):
     res = {"test": "succeeded"}
     try:

--- a/tests/core/cornice_swagger/converters/test_parameters.py
+++ b/tests/core/cornice_swagger/converters/test_parameters.py
@@ -1,0 +1,115 @@
+import unittest
+
+import colander
+
+from kinto.core.cornice_swagger.converters import convert_parameter, convert_schema
+from kinto.core.cornice_swagger.converters.exceptions import NoSuchConverter
+
+
+class ParameterConversionTest(unittest.TestCase):
+    def test_path(self):
+        node = colander.SchemaNode(colander.String(), name="foo")
+        ret = convert_parameter("path", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "path",
+                "name": "foo",
+                "type": "string",
+                "required": True,
+            },
+        )
+
+    def test_query(self):
+        node = colander.SchemaNode(colander.String(), name="bar")
+        ret = convert_parameter("querystring", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "query",
+                "name": "bar",
+                "type": "string",
+                "required": True,
+            },
+        )
+
+    def test_query_array(self):
+        class MyArray(colander.SequenceSchema):
+            values = colander.SchemaNode(colander.String())
+
+        node = MyArray(name="bar")
+        ret = convert_parameter("querystring", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "query",
+                "name": "bar",
+                "type": "array",
+                "items": {"type": "string"},
+                "required": True,
+            },
+        )
+
+    def test_header(self):
+        node = colander.SchemaNode(colander.String(), name="meh")
+        ret = convert_parameter("headers", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "header",
+                "name": "meh",
+                "type": "string",
+                "required": True,
+            },
+        )
+
+    def test_body_array(self):
+        class MyArray(colander.SequenceSchema):
+            values = colander.SchemaNode(colander.String())
+
+        node = MyArray(name="bla")
+        ret = convert_parameter("body", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "body",
+                "name": "bla",
+                "required": True,
+                "schema": convert_schema(MyArray(title="MyArray")),
+            },
+        )
+
+    def test_body(self):
+        class MyBody(colander.MappingSchema):
+            foo = colander.SchemaNode(colander.String())
+            bar = colander.SchemaNode(colander.String())
+
+        node = MyBody(name="bla")
+        ret = convert_parameter("body", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "body",
+                "name": "bla",
+                "required": True,
+                "schema": convert_schema(MyBody(title="MyBody")),
+            },
+        )
+
+    def test_supports_description(self):
+        node = colander.SchemaNode(colander.String(), name="bar", description="tyred")
+        ret = convert_parameter("querystring", node)
+        self.assertDictEqual(
+            ret,
+            {
+                "in": "query",
+                "name": "bar",
+                "type": "string",
+                "required": True,
+                "description": "tyred",
+            },
+        )
+
+    def test_raise_no_such_converter_on_invalid_location(self):
+        node = colander.SchemaNode(colander.String(), name="foo")
+        self.assertRaises(NoSuchConverter, convert_parameter, "aaa", node)

--- a/tests/core/cornice_swagger/converters/test_schema.py
+++ b/tests/core/cornice_swagger/converters/test_schema.py
@@ -1,0 +1,337 @@
+import unittest
+
+import colander
+
+from kinto.core.cornice_swagger.converters import TypeConversionDispatcher
+from kinto.core.cornice_swagger.converters import convert_schema as convert
+from kinto.core.cornice_swagger.converters.exceptions import NoSuchConverter
+
+from ..support import AnyType, AnyTypeConverter
+
+
+class ConversionTest(unittest.TestCase):
+    def test_validate_all(self):
+        node = colander.SchemaNode(
+            colander.String(),
+            validator=colander.All(colander.Length(12, 42), colander.Regex(r"foo*bar")),
+        )
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "pattern": "foo*bar",
+                "maxLength": 42,
+                "minLength": 12,
+            },
+        )
+
+    def test_support_custom_converters(self):
+        node = colander.SchemaNode(AnyType())
+        custom_converters = {AnyType: AnyTypeConverter}
+        converter = TypeConversionDispatcher(custom_converters)
+        ret = converter(node)
+        self.assertEqual(ret, {})
+
+    def test_support_default_converter(self):
+        node = colander.SchemaNode(AnyType())
+        converter = TypeConversionDispatcher(default_converter=AnyTypeConverter)
+        ret = converter(node)
+        self.assertEqual(ret, {})
+
+    def test_raise_no_such_converter_on_invalid_type(self):
+        node = colander.SchemaNode(dict)
+        self.assertRaises(NoSuchConverter, convert, node)
+
+
+class StringConversionTest(unittest.TestCase):
+    def test_sanity(self):
+        node = colander.SchemaNode(colander.String())
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+            },
+        )
+
+    def test_validate_default(self):
+        node = colander.SchemaNode(colander.String(), missing="foo")
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "default": "foo",
+            },
+        )
+
+    def test_validate_length(self):
+        node = colander.SchemaNode(colander.String(), validator=colander.Length(12, 42))
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "maxLength": 42,
+                "minLength": 12,
+            },
+        )
+
+    def test_validate_regex(self):
+        node = colander.SchemaNode(colander.String(), validator=colander.Regex(r"foo*bar"))
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "pattern": "foo*bar",
+            },
+        )
+
+    def test_validate_regex_email(self):
+        node = colander.SchemaNode(colander.String(), validator=colander.Email())
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "format": "email",
+            },
+        )
+
+    def test_validate_regex_url(self):
+        node = colander.SchemaNode(colander.String(), validator=colander.url)
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "format": "url",
+            },
+        )
+
+    def test_validate_oneof(self):
+        node = colander.SchemaNode(colander.String(), validator=colander.OneOf(["one", "two"]))
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "enum": ["one", "two"],
+            },
+        )
+
+    def test_title(self):
+        node = colander.SchemaNode(colander.String(), title="foo")
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "title": "foo",
+            },
+        )
+
+    def test_description(self):
+        node = colander.SchemaNode(colander.String(), description="bar")
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "description": "bar",
+            },
+        )
+
+
+class IntegerConversionTest(unittest.TestCase):
+    def test_sanity(self):
+        node = colander.SchemaNode(colander.Integer())
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "integer",
+            },
+        )
+
+    def test_default(self):
+        node = colander.SchemaNode(colander.Integer(), missing=1)
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "integer",
+                "default": 1,
+            },
+        )
+
+    def test_enum(self):
+        node = colander.SchemaNode(colander.Integer(), validator=colander.OneOf([1, 2, 3, 4]))
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "integer",
+                "enum": [1, 2, 3, 4],
+            },
+        )
+
+    def test_range(self):
+        node = colander.SchemaNode(colander.Integer(), validator=colander.Range(111, 555))
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "integer",
+                "minimum": 111,
+                "maximum": 555,
+            },
+        )
+
+
+class DateTimeConversionTest(unittest.TestCase):
+    def test_sanity(self):
+        node = colander.SchemaNode(colander.DateTime())
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "string",
+                "format": "date-time",
+            },
+        )
+
+
+class MappingConversionTest(unittest.TestCase):
+    def test_sanity(self):
+        node = colander.MappingSchema()
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "object",
+            },
+        )
+
+    def test_required(self):
+        class Mapping(colander.MappingSchema):
+            foo = colander.SchemaNode(colander.String())
+
+        node = Mapping()
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "object",
+                "properties": {"foo": {"title": "Foo", "type": "string"}},
+                "required": ["foo"],
+            },
+        )
+
+    def test_not_required(self):
+        class Mapping(colander.MappingSchema):
+            foo = colander.SchemaNode(colander.String(), missing=colander.drop)
+
+        node = Mapping()
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "object",
+                "properties": {"foo": {"title": "Foo", "type": "string"}},
+            },
+        )
+
+    def test_nested_schema(self):
+        class BaseMapping(colander.MappingSchema):
+            foo = colander.SchemaNode(colander.String(), missing=colander.drop)
+
+        class TopMapping(colander.MappingSchema):
+            bar = BaseMapping(missing=colander.drop)
+
+        node = TopMapping()
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "object",
+                "properties": {
+                    "bar": {
+                        "title": "Bar",
+                        "type": "object",
+                        "properties": {"foo": {"title": "Foo", "type": "string"}},
+                    }
+                },
+            },
+        )
+
+    def test_open_schema(self):
+        class Mapping(colander.MappingSchema):
+            foo = colander.SchemaNode(colander.String(), missing=colander.drop)
+
+            @staticmethod
+            def schema_type():
+                return colander.Mapping(unknown="preserve")
+
+        node = Mapping()
+        ret = convert(node)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "object",
+                "properties": {"foo": {"title": "Foo", "type": "string"}},
+                "additionalProperties": {},
+            },
+        )
+
+
+class SequenceConversionTest(unittest.TestCase):
+    def primitive_sequence_test(self):
+        class Integers(colander.SequenceSchema):
+            num = colander.SchemaNode(colander.Integer())
+
+        ret = convert(Integers)
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "array",
+                "items": {
+                    "type": "integer",
+                },
+            },
+        )
+
+    def mapping_sequence_test(self):
+        class BaseMapping(colander.MappingSchema):
+            name = colander.SchemaNode(colander.String())
+            number = colander.SchemaNode(colander.Integer())
+
+        class BaseMappings(colander.SequenceSchema):
+            base_mapping = BaseMapping()
+
+        schema = BaseMappings()
+        ret = convert(schema)
+
+        self.assertDictEqual(
+            ret,
+            {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Name",
+                        },
+                        "number": {
+                            "type": "integer",
+                            "title": "Number",
+                        },
+                    },
+                    "required": ["name", "number"],
+                    "title": "Base Mapping",
+                },
+            },
+        )

--- a/tests/core/cornice_swagger/converters/test_schema.py
+++ b/tests/core/cornice_swagger/converters/test_schema.py
@@ -272,7 +272,7 @@ class MappingConversionTest(unittest.TestCase):
             foo = colander.SchemaNode(colander.String(), missing=colander.drop)
 
             @staticmethod
-            def schema_type():
+            def schema_type():  # ty: ignore[invalid-method-override]
                 return colander.Mapping(unknown="preserve")
 
         node = Mapping()

--- a/tests/core/cornice_swagger/support.py
+++ b/tests/core/cornice_swagger/support.py
@@ -1,0 +1,73 @@
+import colander
+
+from kinto.core.cornice_swagger.converters.schema import TypeConverter
+
+
+class MyNestedSchema(colander.MappingSchema):
+    my_precious = colander.SchemaNode(colander.Boolean())
+
+
+class BodySchema(colander.MappingSchema):
+    id = colander.SchemaNode(colander.String())
+    timestamp = colander.SchemaNode(colander.Int())
+    obj = MyNestedSchema()
+    ex = colander.SchemaNode(colander.String(), missing=colander.drop, example="example string")
+
+
+class QuerySchema(colander.MappingSchema):
+    foo = colander.SchemaNode(
+        colander.String(), validator=colander.Length(3), missing=colander.drop
+    )
+
+
+class HeaderSchema(colander.MappingSchema):
+    bar = colander.SchemaNode(colander.String(), missing=colander.drop)
+
+
+class PathSchema(colander.MappingSchema):
+    meh = colander.SchemaNode(colander.String(), default="default")
+
+
+class GetRequestSchema(colander.MappingSchema):
+    querystring = QuerySchema()
+
+
+class PutRequestSchema(colander.MappingSchema):
+    body = BodySchema()
+    querystring = QuerySchema()
+    header = HeaderSchema()
+
+
+class ResponseSchema(colander.MappingSchema):
+    body = BodySchema()
+    header = HeaderSchema()
+
+
+response_schemas = {
+    "200": ResponseSchema(description="Return ice cream"),
+    "404": ResponseSchema(description="Return sadness"),
+}
+
+
+class DeclarativeSchema(colander.MappingSchema):
+    @colander.instantiate(description="my body")
+    class body(colander.MappingSchema):
+        id = colander.SchemaNode(colander.String())
+
+
+class AnotherDeclarativeSchema(colander.MappingSchema):
+    @colander.instantiate(description="my another body")
+    class body(colander.MappingSchema):
+        timestamp = colander.SchemaNode(colander.Int())
+
+
+class AnyType(colander.SchemaType):
+    """A simple custom colander type."""
+
+    def deserialize(self, cstruct=colander.null):
+        return cstruct
+
+
+class AnyTypeConverter(TypeConverter):
+    def __call__(self, schema_node):
+        return {}

--- a/tests/core/cornice_swagger/test_app.py
+++ b/tests/core/cornice_swagger/test_app.py
@@ -1,0 +1,93 @@
+import unittest
+
+import webtest
+from flex.core import validate
+from pyramid import testing
+
+from kinto.core.cornice import Service
+from kinto.core.cornice.service import clear_services
+from kinto.core.cornice.validators import colander_validator
+from kinto.core.cornice_swagger import CorniceSwagger
+
+from .support import GetRequestSchema, PutRequestSchema, response_schemas
+
+
+class AppTest(unittest.TestCase):
+    def tearDown(self):
+        clear_services()
+        testing.tearDown()
+
+    def setUp(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get(
+            validators=(colander_validator,),
+            schema=GetRequestSchema(),
+            response_schemas=response_schemas,
+        )
+        def view_get(request):
+            """Serve icecream"""
+            return request.validated
+
+        @service.put(validators=(colander_validator,), schema=PutRequestSchema())
+        def view_put(request):
+            """Add flavour"""
+            return request.validated
+
+        api_service = Service("OpenAPI", "/api")
+
+        @api_service.get()
+        def api_get(request):
+            swagger = CorniceSwagger([service, api_service])
+            return swagger.generate("IceCreamAPI", "4.2")
+
+        self.config = testing.setUp()
+        self.config.add_route("ice_test", "/ice_test/{flavour}")
+        self.config.include("kinto.core.cornice")
+        self.config.include("kinto.core.cornice_swagger")
+        self.config.add_cornice_service(service)
+        self.config.add_cornice_service(api_service)
+        self.app = webtest.TestApp(self.config.make_wsgi_app())
+
+    def test_app_get(self):
+        self.app.get("/icecream/strawberry")
+
+    def test_app_put(self):
+        body = {"id": "chocolate", "timestamp": 123, "obj": {"my_precious": True}}
+        headers = {"bar": "foo"}
+        self.app.put_json("/icecream/chocolate", body, headers=headers)
+
+    def test_validate_spec(self):
+        spec = self.app.get("/api").json
+        validate(spec)
+
+
+class AppGoodRoutesTest(unittest.TestCase):
+    def tearDown(self):
+        clear_services()
+        testing.tearDown()
+
+    def setUp(self):
+        service = Service("Ice Route", pyramid_route="ice_test")
+
+        @service.get()
+        def view_get(request):
+            """Serve icecream"""
+            return request.validated
+
+        self.config = testing.setUp()
+        self.config.add_route("ice_test", "/ice_test/{flavour}")
+        self.config.include("kinto.core.cornice")
+        self.config.include("kinto.core.cornice_swagger")
+        self.config.add_cornice_service(service)
+        self.app = webtest.TestApp(self.config.make_wsgi_app())
+
+    def test_route_explicit_registry(self):
+        swagger = CorniceSwagger(get_services(), pyramid_registry=self.config.registry)
+        spec = swagger.generate("IceCreamAPI", "4.2")
+        self.assertIn("/ice_test/{flavour}", spec["paths"])
+
+    def test_route_fallback_registry(self):
+        swagger = CorniceSwagger(get_services())
+        spec = swagger.generate("IceCreamAPI", "4.2")
+        self.assertIn("/ice_test/{flavour}", spec["paths"])

--- a/tests/core/cornice_swagger/test_app.py
+++ b/tests/core/cornice_swagger/test_app.py
@@ -5,7 +5,7 @@ from flex.core import validate
 from pyramid import testing
 
 from kinto.core.cornice import Service
-from kinto.core.cornice.service import clear_services
+from kinto.core.cornice.service import clear_services, get_services
 from kinto.core.cornice.validators import colander_validator
 from kinto.core.cornice_swagger import CorniceSwagger
 

--- a/tests/core/cornice_swagger/test_app.py
+++ b/tests/core/cornice_swagger/test_app.py
@@ -5,7 +5,7 @@ from flex.core import validate
 from pyramid import testing
 
 from kinto.core.cornice import Service
-from kinto.core.cornice.service import clear_services, get_services
+from kinto.core.cornice.service import SERVICES, get_services
 from kinto.core.cornice.validators import colander_validator
 from kinto.core.cornice_swagger import CorniceSwagger
 
@@ -14,10 +14,12 @@ from .support import GetRequestSchema, PutRequestSchema, response_schemas
 
 class AppTest(unittest.TestCase):
     def tearDown(self):
-        clear_services()
+        SERVICES[:] = self._saved_services
         testing.tearDown()
 
     def setUp(self):
+        self._saved_services = list(SERVICES)
+        SERVICES[:] = []
         service = Service("IceCream", "/icecream/{flavour}")
 
         @service.get(
@@ -64,10 +66,12 @@ class AppTest(unittest.TestCase):
 
 class AppGoodRoutesTest(unittest.TestCase):
     def tearDown(self):
-        clear_services()
+        SERVICES[:] = self._saved_services
         testing.tearDown()
 
     def setUp(self):
+        self._saved_services = list(SERVICES)
+        SERVICES[:] = []
         service = Service("Ice Route", pyramid_route="ice_test")
 
         @service.get()

--- a/tests/core/cornice_swagger/test_definition_handler.py
+++ b/tests/core/cornice_swagger/test_definition_handler.py
@@ -1,0 +1,45 @@
+import unittest
+
+import colander
+
+from kinto.core.cornice_swagger.converters import convert_schema as convert
+from kinto.core.cornice_swagger.swagger import DefinitionHandler
+
+
+class MyListSchema(colander.SequenceSchema):
+    entry = colander.SchemaNode(colander.String())
+
+
+class BoredoomSchema(colander.MappingSchema):
+    motivators = MyListSchema()
+    status = colander.SchemaNode(
+        colander.String(), validator=colander.OneOf(["increasing", "decrasing"])
+    )
+
+
+class AnxietySchema(colander.MappingSchema):
+    level = colander.SchemaNode(colander.Integer(), validator=colander.Range(42, 9000))
+
+
+class FeelingsSchema(colander.MappingSchema):
+    bleh = BoredoomSchema()
+    aaaa = AnxietySchema()
+
+
+class DefinitionTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = DefinitionHandler()
+
+    def test_from_schema(self):
+        self.assertDictEqual(self.handler.from_schema(FeelingsSchema()), convert(FeelingsSchema()))
+
+
+class RefDefinitionTest(unittest.TestCase):
+    def test_single_level(self):
+        handler = DefinitionHandler(ref=1)
+        ref = handler.from_schema(FeelingsSchema(title="Feelings"))
+
+        self.assertEqual(ref, {"$ref": "#/definitions/Feelings"})
+        self.assertDictEqual(
+            handler.definition_registry["Feelings"], convert(FeelingsSchema(title="Feelings"))
+        )

--- a/tests/core/cornice_swagger/test_definition_handler.py
+++ b/tests/core/cornice_swagger/test_definition_handler.py
@@ -10,10 +10,10 @@ class MyListSchema(colander.SequenceSchema):
     entry = colander.SchemaNode(colander.String())
 
 
-class BoredoomSchema(colander.MappingSchema):
+class BoredomSchema(colander.MappingSchema):
     motivators = MyListSchema()
     status = colander.SchemaNode(
-        colander.String(), validator=colander.OneOf(["increasing", "decrasing"])
+        colander.String(), validator=colander.OneOf(["increasing", "decreasing"])
     )
 
 
@@ -22,7 +22,7 @@ class AnxietySchema(colander.MappingSchema):
 
 
 class FeelingsSchema(colander.MappingSchema):
-    bleh = BoredoomSchema()
+    bleh = BoredomSchema()
     aaaa = AnxietySchema()
 
 

--- a/tests/core/cornice_swagger/test_parameter_handler.py
+++ b/tests/core/cornice_swagger/test_parameter_handler.py
@@ -1,0 +1,203 @@
+import unittest
+
+import colander
+
+from kinto.core.cornice_swagger.converters import convert_schema
+from kinto.core.cornice_swagger.swagger import DefinitionHandler, ParameterHandler
+
+from .support import (
+    AnotherDeclarativeSchema,
+    BodySchema,
+    DeclarativeSchema,
+    HeaderSchema,
+    PathSchema,
+    QuerySchema,
+)
+
+
+class SchemaParamConversionTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = ParameterHandler()
+
+    def test_sanity(self):
+        node = colander.MappingSchema()
+        params = self.handler.from_schema(node)
+        self.assertEqual(params, [])
+
+    def test_covert_body_with_request_validator_schema(self):
+        class RequestSchema(colander.MappingSchema):
+            body = BodySchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+        self.assertEqual(len(params), 1)
+
+        expected = {
+            "name": "BodySchema",
+            "in": "body",
+            "required": True,
+            "schema": convert_schema(BodySchema(title="BodySchema")),
+        }
+
+        self.assertDictEqual(params[0], expected)
+
+    def test_covert_query_with_request_validator_schema(self):
+        class RequestSchema(colander.MappingSchema):
+            querystring = QuerySchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+        self.assertEqual(len(params), 1)
+
+        expected = {
+            "name": "foo",
+            "in": "query",
+            "type": "string",
+            "required": False,
+            "minLength": 3,
+        }
+        self.assertDictEqual(params[0], expected)
+
+    def test_covert_headers_with_request_validator_schema(self):
+        class RequestSchema(colander.MappingSchema):
+            headers = HeaderSchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+        self.assertEqual(len(params), 1)
+
+        expected = {
+            "name": "bar",
+            "in": "header",
+            "type": "string",
+            "required": False,
+        }
+        self.assertDictEqual(params[0], expected)
+
+    def test_covert_path_with_request_validator_schema(self):
+        class RequestSchema(colander.MappingSchema):
+            path = PathSchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+        self.assertEqual(len(params), 1)
+
+        expected = {
+            "name": "meh",
+            "in": "path",
+            "type": "string",
+            "required": True,
+            "default": "default",
+        }
+        self.assertDictEqual(params[0], expected)
+
+    def test_convert_multiple_with_request_validator_schema(self):
+        class RequestSchema(colander.MappingSchema):
+            body = BodySchema()
+            path = PathSchema()
+            querystring = QuerySchema()
+            headers = HeaderSchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+
+        names = [param["name"] for param in params]
+        expected = ["BodySchema", "foo", "bar", "meh"]
+        self.assertEqual(sorted(names), sorted(expected))
+
+    def test_convert_descriptions(self):
+        class RequestSchema(colander.MappingSchema):
+            body = BodySchema(description="my body")
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+
+        expected = {
+            "name": "BodySchema",
+            "in": "body",
+            "required": True,
+            "description": "my body",
+            "schema": convert_schema(BodySchema(title="BodySchema", description="my body")),
+        }
+
+        self.assertDictEqual(params[0], expected)
+
+    def test_declarative_schema_handling(self):
+        handler = ParameterHandler(DefinitionHandler(ref=-1))
+        params = handler.from_schema(DeclarativeSchema())
+        another_params = handler.from_schema(AnotherDeclarativeSchema())
+
+        self.assertNotEqual(params[0]["schema"], another_params[0]["schema"])
+
+    def test_cornice_location_synonyms(self):
+        class RequestSchema(colander.MappingSchema):
+            header = HeaderSchema()
+            GET = QuerySchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+
+        names = [param["name"] for param in params]
+        expected = ["foo", "bar"]
+        self.assertEqual(sorted(names), sorted(expected))
+
+
+class PathParamConversionTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = ParameterHandler()
+
+    def test_from_path(self):
+        params = self.handler.from_path("/my/{param}/path/{id}")
+        names = [param["name"] for param in params]
+        expected = ["param", "id"]
+        self.assertEqual(sorted(names), sorted(expected))
+        for param in params:
+            self.assertEqual(param["in"], "path")
+
+    def test_handles_path_regex(self):
+        params = self.handler.from_path("/my/{param:\\d+}/path/{id:[a-z]{8,42}}")
+        named_params = {param["name"]: param for param in params}
+        expected = ["param", "id"]
+        self.assertEqual(sorted(named_params), sorted(expected))
+        self.assertEqual(named_params["param"]["pattern"], "\\d+")
+        self.assertEqual(named_params["id"]["pattern"], "[a-z]{8,42}")
+
+
+class RefParamTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = ParameterHandler(ref=1)
+        self.handler.parameters = {}
+
+    def test_ref_from_path(self):
+        params = self.handler.from_path("/path/{id}")
+        expected = {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "required": True,
+        }
+
+        self.assertEqual(params, [{"$ref": "#/parameters/id"}])
+        self.assertDictEqual(self.handler.parameter_registry, dict(id=expected))
+
+    def test_ref_from_declarative_validator_schema(self):
+        params = self.handler.from_schema(DeclarativeSchema())
+        self.assertEqual([{"$ref": "#/parameters/DeclarativeSchemaBody"}], params)
+
+    def test_ref_from_request_validator_schema(self):
+        class RequestSchema(colander.MappingSchema):
+            querystring = QuerySchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+
+        expected = {
+            "name": "foo",
+            "in": "query",
+            "type": "string",
+            "required": False,
+            "minLength": 3,
+        }
+
+        self.assertEqual(params, [{"$ref": "#/parameters/foo"}])
+        self.assertDictEqual(self.handler.parameter_registry, dict(foo=expected))

--- a/tests/core/cornice_swagger/test_parameter_handler.py
+++ b/tests/core/cornice_swagger/test_parameter_handler.py
@@ -166,7 +166,7 @@ class PathParamConversionTest(unittest.TestCase):
 class RefParamTest(unittest.TestCase):
     def setUp(self):
         self.handler = ParameterHandler(ref=1)
-        self.handler.parameters = {}
+        self.handler.parameters = {}  # ty: ignore[unresolved-attribute]
 
     def test_ref_from_path(self):
         params = self.handler.from_path("/path/{id}")

--- a/tests/core/cornice_swagger/test_response_handler.py
+++ b/tests/core/cornice_swagger/test_response_handler.py
@@ -1,0 +1,94 @@
+import unittest
+
+import colander
+
+from kinto.core.cornice_swagger.converters import convert_schema
+from kinto.core.cornice_swagger.swagger import CorniceSwaggerException, ResponseHandler
+
+from .support import (
+    AnotherDeclarativeSchema,
+    BodySchema,
+    DeclarativeSchema,
+    HeaderSchema,
+    ResponseSchema,
+    response_schemas,
+)
+
+
+class SchemaResponseConversionTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = ResponseHandler()
+
+    def test_sanity(self):
+        self.handler.from_schema_mapping(response_schemas)
+
+    def test_status_codes(self):
+        responses = self.handler.from_schema_mapping(response_schemas)
+        self.assertIn("200", responses)
+        self.assertIn("404", responses)
+        self.assertEqual(responses["200"]["description"], "Return ice cream")
+        self.assertEqual(responses["404"]["description"], "Return sadness")
+
+    def test_response_schema(self):
+        responses = self.handler.from_schema_mapping(response_schemas)
+        self.assertDictEqual(
+            responses["200"]["schema"], convert_schema(BodySchema(title="BodySchema"))
+        )
+        self.assertDictEqual(responses["200"]["headers"], {"bar": {"type": "string"}})
+
+    def test_response_schema_with_example(self):
+        class ResponseSchema(colander.MappingSchema):
+            body = BodySchema()
+
+        response_schemas = {"200": ResponseSchema(description="Return gelatto")}
+        responses = self.handler.from_schema_mapping(response_schemas)
+        self.assertTrue("ex" in responses["200"]["schema"]["properties"])
+        self.assertTrue("example" in responses["200"]["schema"]["properties"]["ex"])
+        self.assertEqual(
+            responses["200"]["schema"]["properties"]["ex"]["example"], "example string"
+        )
+
+    def test_cornice_location_synonyms(self):
+        class ResponseSchema(colander.MappingSchema):
+            header = HeaderSchema()
+
+        response_schemas = {"200": ResponseSchema(description="Return gelatto")}
+        responses = self.handler.from_schema_mapping(response_schemas)
+
+        self.assertDictEqual(responses["200"]["headers"], {"bar": {"type": "string"}})
+
+    def test_raise_exception_without_description(self):
+        response_schemas = {"200": ResponseSchema()}
+
+        self.assertRaises(
+            CorniceSwaggerException, self.handler.from_schema_mapping, response_schemas
+        )
+
+
+class RefResponseTest(unittest.TestCase):
+    def setUp(self):
+        self.handler = ResponseHandler(ref=1)
+        self.handler.responses = {}
+
+    def test_from_schema_mapping(self):
+        responses = self.handler.from_schema_mapping(response_schemas)
+        expected = {
+            "200": {"$ref": "#/responses/ResponseSchema"},
+            "404": {"$ref": "#/responses/ResponseSchema"},
+        }
+        self.assertEqual(expected, responses)
+        ref = self.handler.response_registry["ResponseSchema"]
+        self.assertDictEqual(ref["schema"], convert_schema(BodySchema(title="BodySchema")))
+        self.assertDictEqual(ref["headers"], {"bar": {"type": "string"}})
+
+    def test_declarative_response_schemas(self):
+        self.handler.from_schema_mapping({"200": DeclarativeSchema(description="response schema")})
+
+        self.handler.from_schema_mapping(
+            {"200": AnotherDeclarativeSchema(description="response schema")}
+        )
+
+        ref = self.handler.response_registry["DeclarativeSchema"]
+        another_ref = self.handler.response_registry["AnotherDeclarativeSchema"]
+
+        self.assertNotEqual(ref["schema"]["title"], another_ref["schema"]["title"])

--- a/tests/core/cornice_swagger/test_response_handler.py
+++ b/tests/core/cornice_swagger/test_response_handler.py
@@ -68,7 +68,7 @@ class SchemaResponseConversionTest(unittest.TestCase):
 class RefResponseTest(unittest.TestCase):
     def setUp(self):
         self.handler = ResponseHandler(ref=1)
-        self.handler.responses = {}
+        self.handler.responses = {}  # ty: ignore[unresolved-attribute]
 
     def test_from_schema_mapping(self):
         responses = self.handler.from_schema_mapping(response_schemas)

--- a/tests/core/cornice_swagger/test_swagger.py
+++ b/tests/core/cornice_swagger/test_swagger.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import mock
 
 from flex.core import validate
 
@@ -7,7 +6,7 @@ from kinto.core.cornice.service import Service
 from kinto.core.cornice.validators import colander_validator
 from kinto.core.cornice_swagger.swagger import CorniceSwagger, CorniceSwaggerException
 
-from .support import BodySchema, GetRequestSchema, HeaderSchema, PutRequestSchema, response_schemas
+from .support import GetRequestSchema, PutRequestSchema, response_schemas
 
 
 class CorniceSwaggerGeneratorTest(unittest.TestCase):

--- a/tests/core/cornice_swagger/test_swagger.py
+++ b/tests/core/cornice_swagger/test_swagger.py
@@ -1,0 +1,542 @@
+import unittest
+from unittest import mock
+
+from flex.core import validate
+
+from kinto.core.cornice.service import Service
+from kinto.core.cornice.validators import colander_validator
+from kinto.core.cornice_swagger.swagger import CorniceSwagger, CorniceSwaggerException
+
+from .support import BodySchema, GetRequestSchema, HeaderSchema, PutRequestSchema, response_schemas
+
+
+class CorniceSwaggerGeneratorTest(unittest.TestCase):
+    def setUp(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(
+                validators=(colander_validator,),
+                schema=GetRequestSchema(),
+                response_schemas=response_schemas,
+            )
+            def view_get(self, request):
+                """Serve ice cream"""
+                return self.request.validated
+
+            @service.put(validators=(colander_validator,), schema=PutRequestSchema())
+            def view_put(self, request):
+                """Add flavour"""
+                return self.request.validated
+
+        self.service = service
+        CorniceSwagger.services = [self.service]
+        CorniceSwagger.api_title = "IceCreamAPI"
+        CorniceSwagger.api_version = "4.2"
+        self.swagger = CorniceSwagger()
+        self.spec = self.swagger.generate()
+        validate(self.spec)
+
+    def test_path(self):
+        self.assertIn("/icecream/{flavour}", self.spec["paths"])
+
+    def test_path_methods(self):
+        path = self.spec["paths"]["/icecream/{flavour}"]
+        self.assertIn("get", path)
+        self.assertIn("put", path)
+
+    def test_path_parameters(self):
+        parameters = self.spec["paths"]["/icecream/{flavour}"]["parameters"]
+        self.assertEqual(len(parameters), 1)
+        self.assertEqual(parameters[0]["name"], "flavour")
+
+    def test_summary_docstrings(self):
+        self.swagger.summary_docstrings = True
+        self.spec = self.swagger.generate()
+        validate(self.spec)
+        summary = self.spec["paths"]["/icecream/{flavour}"]["get"]["summary"]
+        self.assertEqual(summary, "Serve ice cream")
+
+    def test_summary_docstrings_with_klass(self):
+        class TemperatureCooler(object):
+            def put_view(self):
+                """Put it."""
+                pass
+
+        service = Service("TemperatureCooler", "/freshair", klass=TemperatureCooler)
+        service.add_view("put", "put_view")
+        CorniceSwagger.services = [service]
+        self.swagger = CorniceSwagger()
+        self.spec = self.swagger.generate()
+        validate(self.spec)
+
+    def test_with_schema_ref(self):
+        swagger = CorniceSwagger([self.service], def_ref_depth=1)
+        spec = swagger.generate()
+        validate(spec)
+        self.assertIn("definitions", spec)
+
+    def test_with_param_ref(self):
+        swagger = CorniceSwagger([self.service], param_ref=True)
+        spec = swagger.generate()
+        validate(spec)
+        self.assertIn("parameters", spec)
+
+    def test_with_resp_ref(self):
+        swagger = CorniceSwagger([self.service], resp_ref=True)
+        spec = swagger.generate()
+        validate(spec)
+        self.assertIn("responses", spec)
+
+    def test_swagger_field_updates_extracted_paths(self):
+        self.swagger.swagger = {"definitions": {"OtherDef": {"additionalProperties": {}}}}
+        spec = self.swagger.generate()
+        validate(spec)
+        self.assertEqual(spec["definitions"], self.swagger.swagger["definitions"])
+
+
+class ExtractContentTypesTest(unittest.TestCase):
+    def test_default_renderer(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(
+            spec["paths"]["/icecream/{flavour}"]["get"]["produces"], ["application/json"]
+        )
+
+    def test_json_renderer(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(renderer="json")
+            def view_get(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(
+            spec["paths"]["/icecream/{flavour}"]["get"]["produces"], ["application/json"]
+        )
+
+    def test_xml_renderer(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(renderer="xml")
+            def view_get(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(spec["paths"]["/icecream/{flavour}"]["get"]["produces"], ["text/xml"])
+
+    def test_unkown_renderer(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(renderer="")
+            def view_get(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertNotIn("produces", spec["paths"]["/icecream/{flavour}"]["get"])
+
+    def test_single_ctype(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.put(content_type="application/json")
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(
+            spec["paths"]["/icecream/{flavour}"]["put"]["consumes"], ["application/json"]
+        )
+
+    def test_no_ctype_no_list_with_none(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.put()
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertNotIn("consumes", spec["paths"]["/icecream/{flavour}"]["put"])
+
+    def test_multiple_ctypes(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.put(content_type=("application/json", "text/xml"))
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(
+            spec["paths"]["/icecream/{flavour}"]["put"]["consumes"],
+            ["application/json", "text/xml"],
+        )
+
+    def test_single_ctype_callable(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        def my_ctype_callable(request):
+            return "application/octet-stream"
+
+        class IceCream(object):
+            @service.put(content_type=my_ctype_callable)
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(spec["paths"]["/icecream/{flavour}"]["put"]["consumes"], [])
+
+    def test_mixed_ctype_string_and_callable(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        def my_ctype_callable(request):
+            return "application/octet-stream"
+
+        def my_ctype_callable_2(request):
+            return "image/png"
+
+        class IceCream(object):
+            @service.put(
+                content_type=(
+                    my_ctype_callable,
+                    "application/json",
+                    my_ctype_callable_2,
+                    "image/jpeg",
+                )
+            )
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEqual(
+            spec["paths"]["/icecream/{flavour}"]["put"]["consumes"],
+            ["application/json", "image/jpeg"],
+        )
+
+    def test_ignore_multiple_views_by_ctype(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            def view_put(self, request):
+                return "red"
+
+        service.add_view(
+            "put",
+            IceCream.view_put,
+            validators=(colander_validator,),
+            schema=PutRequestSchema(),
+            content_type="application/json",
+        )
+        service.add_view(
+            "put",
+            IceCream.view_put,
+            validators=(colander_validator,),
+            schema=PutRequestSchema(),
+            content_type="text/xml",
+        )
+
+        swagger = CorniceSwagger([service])
+        swagger.ignore_ctypes = ["text/xml"]
+        spec = swagger.generate()
+        self.assertEqual(
+            spec["paths"]["/icecream/{flavour}"]["put"]["consumes"], ["application/json"]
+        )
+
+    def test_multiple_views_with_different_ctypes_raises_exception(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            def view_put(self, request):
+                return "red"
+
+        service.add_view(
+            "put",
+            IceCream.view_put,
+            validators=(colander_validator,),
+            schema=PutRequestSchema(),
+            content_type="application/json",
+        )
+        service.add_view(
+            "put",
+            IceCream.view_put,
+            validators=(colander_validator,),
+            schema=PutRequestSchema(),
+            content_type="text/xml",
+        )
+
+        swagger = CorniceSwagger([service])
+        self.assertRaises(CorniceSwaggerException, swagger.generate)
+
+
+class ExtractPathTest(unittest.TestCase):
+    def test_handles_subpaths_as_parameters(self):
+        service = Service("IceCream", "/icecream/*subpath")
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return self.request
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        expected = {"name": "subpath", "required": True, "type": "string", "in": "path"}
+        self.assertDictEqual(spec["paths"]["/icecream/{subpath}"]["parameters"][0], expected)
+
+
+class ExtractTagsTest(unittest.TestCase):
+    def test_service_defined_tags(self):
+        service = Service("IceCream", "/icecream/{flavour}", tags=["yum"])
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        validate(spec)
+        tags = spec["paths"]["/icecream/{flavour}"]["get"]["tags"]
+        self.assertEqual(tags, ["yum"])
+
+    def test_view_defined_tags(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(tags=["cold", "foo"])
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        validate(spec)
+        tags = spec["paths"]["/icecream/{flavour}"]["get"]["tags"]
+        self.assertEqual(tags, ["cold", "foo"])
+
+    def test_both_defined_tags(self):
+        service = Service("IceCream", "/icecream/{flavour}", tags=["yum"])
+
+        class IceCream(object):
+            @service.get(tags=["cold", "foo"])
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        validate(spec)
+        tags = spec["paths"]["/icecream/{flavour}"]["get"]["tags"]
+        self.assertEqual(tags, ["yum", "cold", "foo"])
+
+    def test_listed_default_tags(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        swagger.default_tags = ["cold"]
+        spec = swagger.generate()
+        validate(spec)
+        tags = spec["paths"]["/icecream/{flavour}"]["get"]["tags"]
+        self.assertEqual(tags, ["cold"])
+
+    def test_callable_default_tags(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return service
+
+        def default_tag_callable(service, method):
+            return ["cold"]
+
+        swagger = CorniceSwagger([service])
+        swagger.default_tags = default_tag_callable
+        spec = swagger.generate()
+        validate(spec)
+        tags = spec["paths"]["/icecream/{flavour}"]["get"]["tags"]
+        self.assertEqual(tags, ["cold"])
+
+    def test_provided_tags_override_sorting(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(tags=["cold", "foo"])
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        tags = [{"name": "foo", "description": "bar"}]
+        swagger.swagger = {"tags": tags}
+        spec = swagger.generate()
+        validate(spec)
+        self.assertListEqual(
+            [{"name": "foo", "description": "bar"}, {"name": "cold"}], spec["tags"]
+        )
+
+    def test_invalid_view_tag_raises_exception(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(tags="cold")
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        self.assertRaises(CorniceSwaggerException, swagger.generate)
+
+    def test_invalid_service_tag_raises_exception(self):
+        service = Service("IceCream", "/icecream/{flavour}", tags="cold")
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        self.assertRaises(CorniceSwaggerException, swagger.generate)
+
+
+class ExtractOperationIdTest(unittest.TestCase):
+    def test_view_defined_operation_id(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get(operation_id="serve_icecream")
+        def view_get(self, request):
+            return service
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        validate(spec)
+        op_id = spec["paths"]["/icecream/{flavour}"]["get"]["operationId"]
+        self.assertEqual(op_id, "serve_icecream")
+
+    def test_default_operation_ids(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get()
+        def view_get(self, request):
+            return service
+
+        @service.put()
+        def view_put(self, request):
+            return service
+
+        def op_id_generator(service, method):
+            return "%s_%s" % (method.lower(), service.path.split("/")[-2])
+
+        swagger = CorniceSwagger([service])
+        swagger.default_op_ids = op_id_generator
+        spec = swagger.generate()
+        validate(spec)
+        op_id = spec["paths"]["/icecream/{flavour}"]["get"]["operationId"]
+        self.assertEqual(op_id, "get_icecream")
+        op_id = spec["paths"]["/icecream/{flavour}"]["put"]["operationId"]
+        self.assertEqual(op_id, "put_icecream")
+
+    def test_invalid_default_opid_raises_exception(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get()
+        def view_get(self, request):
+            return service
+
+        swagger = CorniceSwagger([service])
+        swagger.default_op_ids = "foo"
+        self.assertRaises(CorniceSwaggerException, swagger.generate)
+
+
+class ExtractSecurityTest(unittest.TestCase):
+    def test_view_defined_security(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get(api_security=[{"basicAuth": []}])
+        def view_get(self, request):
+            return service
+
+        swagger = CorniceSwagger([service])
+        swagger.swagger = {"securityDefinitions": {"basicAuth": {"type": "basic"}}}
+        spec = swagger.generate()
+        validate(spec)
+        security = spec["paths"]["/icecream/{flavour}"]["get"]["security"]
+        self.assertEqual(security, [{"basicAuth": []}])
+
+    def test_listed_default_security(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get()
+        def view_get(self, request):
+            return service
+
+        swagger = CorniceSwagger([service])
+        swagger.swagger = {"securityDefinitions": {"basicAuth": {"type": "basic"}}}
+        swagger.default_security = [{"basicAuth": []}]
+        spec = swagger.generate()
+        validate(spec)
+        security = spec["paths"]["/icecream/{flavour}"]["get"]["security"]
+        self.assertEqual(security, [{"basicAuth": []}])
+
+    def test_callable_default_security(self):
+        def get_security(service, method):
+            definitions = service.definitions
+            for definition in definitions:
+                met, view, args = definition
+                if met == method:
+                    break
+
+            if "security" in args:
+                return [{"basicAuth": []}]
+            else:
+                return []
+
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        @service.get()
+        def view_get(self, request):
+            return service
+
+        @service.post(security="foo")
+        def view_post(self, request):
+            return service
+
+        swagger = CorniceSwagger([service])
+        swagger.swagger = {"securityDefinitions": {"basicAuth": {"type": "basic"}}}
+        swagger.default_security = get_security
+        spec = swagger.generate()
+        validate(spec)
+        security = spec["paths"]["/icecream/{flavour}"]["post"]["security"]
+        self.assertEqual(security, [{"basicAuth": []}])
+        security = spec["paths"]["/icecream/{flavour}"]["get"]["security"]
+        self.assertEqual(security, [])
+
+    def test_invalid_security_raises_exception(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(api_security="basicAuth")
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        self.assertRaises(CorniceSwaggerException, swagger.generate)

--- a/tests/core/cornice_swagger/test_swagger.py
+++ b/tests/core/cornice_swagger/test_swagger.py
@@ -21,12 +21,12 @@ class CorniceSwaggerGeneratorTest(unittest.TestCase):
             )
             def view_get(self, request):
                 """Serve ice cream"""
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
             @service.put(validators=(colander_validator,), schema=PutRequestSchema())
             def view_put(self, request):
                 """Add flavour"""
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         self.service = service
         CorniceSwagger.services = [self.service]
@@ -101,7 +101,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.get()
             def view_get(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -115,7 +115,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.get(renderer="json")
             def view_get(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -129,7 +129,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.get(renderer="xml")
             def view_get(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -141,7 +141,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.get(renderer="")
             def view_get(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -153,7 +153,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.put(content_type="application/json")
             def view_put(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -167,7 +167,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.put()
             def view_put(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -179,7 +179,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.put(content_type=("application/json", "text/xml"))
             def view_put(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -197,7 +197,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         class IceCream(object):
             @service.put(content_type=my_ctype_callable)
             def view_put(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -222,7 +222,7 @@ class ExtractContentTypesTest(unittest.TestCase):
                 )
             )
             def view_put(self, request):
-                return self.request.validated
+                return self.request.validated  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -293,7 +293,7 @@ class ExtractPathTest(unittest.TestCase):
         class IceCream(object):
             @service.get()
             def view_get(self, request):
-                return self.request
+                return self.request  # ty: ignore[unresolved-attribute]
 
         swagger = CorniceSwagger([service])
         spec = swagger.generate()
@@ -387,7 +387,7 @@ class ExtractTagsTest(unittest.TestCase):
 
         swagger = CorniceSwagger([service])
         tags = [{"name": "foo", "description": "bar"}]
-        swagger.swagger = {"tags": tags}
+        swagger.swagger = {"tags": tags}  # ty: ignore[invalid-assignment]
         spec = swagger.generate()
         validate(spec)
         self.assertListEqual(

--- a/tests/core/cornice_swagger/test_swagger.py
+++ b/tests/core/cornice_swagger/test_swagger.py
@@ -135,7 +135,7 @@ class ExtractContentTypesTest(unittest.TestCase):
         spec = swagger.generate()
         self.assertEqual(spec["paths"]["/icecream/{flavour}"]["get"]["produces"], ["text/xml"])
 
-    def test_unkown_renderer(self):
+    def test_unknown_renderer(self):
         service = Service("IceCream", "/icecream/{flavour}")
 
         class IceCream(object):

--- a/tests/core/test_openapi.py
+++ b/tests/core/test_openapi.py
@@ -1,13 +1,18 @@
 import unittest
 from unittest import mock
 
-from kinto.core.cornice.service import get_services
+from kinto.core.cornice.service import clear_services, get_services
 from kinto.core.openapi import OpenAPI
 
 from .support import BaseWebTest
 
 
 class OpenAPITest(BaseWebTest, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        clear_services()
+        super().setUpClass()
+
     def setUp(self):
         super(OpenAPITest, self).setUp()
         self.request = mock.MagicMock()

--- a/tests/core/test_openapi.py
+++ b/tests/core/test_openapi.py
@@ -1,23 +1,24 @@
 import unittest
 from unittest import mock
 
-from kinto.core.cornice.service import clear_services, get_services
+from kinto.core.cornice.service import get_services
 from kinto.core.openapi import OpenAPI
 
 from .support import BaseWebTest
 
 
 class OpenAPITest(BaseWebTest, unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        clear_services()
-        super().setUpClass()
-
     def setUp(self):
         super(OpenAPITest, self).setUp()
         self.request = mock.MagicMock()
         self.request.registry.settings = self.get_app_settings()
-        self.generator = OpenAPI(get_services(), self.request)
+        # Other test modules (e.g. cornice's own tests) register services into
+        # the process-global registry. Keep only the services routed by the app
+        # being tested, so the generated OpenAPI spec is not polluted.
+        routes = self.app.app.registry.introspector.get_category("routes") or []
+        app_routes = {intr["introspectable"]["name"] for intr in routes}
+        services = [s for s in get_services() if s.name in app_routes]
+        self.generator = OpenAPI(services, self.request)
         self.api_doc = self.generator.generate()
 
     def test_assign_base_path(self):

--- a/tests/openapi/support.py
+++ b/tests/openapi/support.py
@@ -7,6 +7,7 @@ from bravado_core.response import OutgoingResponse, validate_response
 from bravado_core.spec import Spec
 
 from kinto.core.utils import json
+from kinto.core.views.openapi import openapi_view
 
 from ..support import (
     MINIMALIST_BUCKET,
@@ -21,6 +22,11 @@ class OpenAPITest(BaseWebTest, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # The OpenAPI spec is memoized on the view across requests; drop any
+        # spec cached by a previously built app so it is regenerated for the
+        # app being tested here.
+        if hasattr(openapi_view, "__json__"):
+            del openapi_view.__json__
         cls.spec_dict = cls.app.get("/__api__").json
         bravado_config = {
             # Use models (Python classes) instead of dicts for #/definitions/{models}

--- a/uv.lock
+++ b/uv.lock
@@ -646,6 +646,22 @@ wheels = [
 ]
 
 [[package]]
+name = "flex"
+version = "6.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "jsonpointer" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rfc3987" },
+    { name = "six" },
+    { name = "strict-rfc3339" },
+    { name = "validate-email" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/51/f3bf1779a12e92c3bf9f2d0ee242298775ef625adb596951090bdd24854f/flex-6.14.1.tar.gz", hash = "sha256:292ed6a37f1ac0a10ad8669f5ceb82e8ba3106c16c54090820927bac8b0b29eb", size = 40864, upload-time = "2019-09-14T20:20:22.288Z" }
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1211,6 +1227,7 @@ redis = [
 ]
 test = [
     { name = "bravado" },
+    { name = "flex" },
     { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-cache" },
@@ -1232,6 +1249,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'" },
     { name = "colander" },
     { name = "dockerflow" },
+    { name = "flex", marker = "extra == 'test'" },
     { name = "granian", marker = "extra == 'dev'" },
     { name = "httpie", marker = "extra == 'container'" },
     { name = "jsonpatch" },
@@ -2407,6 +2425,15 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3987"
+version = "1.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/bb/f1395c4b62f251a1cb503ff884500ebd248eed593f41b469f89caa3547bd/rfc3987-1.3.8.tar.gz", hash = "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733", size = 20700, upload-time = "2018-07-29T17:23:47.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/d4/f7407c3d15d5ac779c3dd34fbbc6ea2090f77bd7dd12f207ccf881551208/rfc3987-1.3.8-py2.py3-none-any.whl", hash = "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53", size = 13377, upload-time = "2018-07-29T17:23:45.313Z" },
+]
+
+[[package]]
 name = "rfc3987-syntax"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2783,6 +2810,12 @@ wheels = [
 ]
 
 [[package]]
+name = "strict-rfc3339"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/e4/879ef1dbd6ddea1c77c0078cd59b503368b0456bcca7d063a870ca2119d3/strict-rfc3339-0.7.tar.gz", hash = "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277", size = 17552, upload-time = "2016-04-24T04:24:04.403Z" }
+
+[[package]]
 name = "swagger-spec-validator"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2992,6 +3025,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
+
+[[package]]
+name = "validate-email"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/a0/cb53fb64b52123513d04f9b913b905f3eb6fda7264e639b4573cc715c29f/validate_email-1.3.tar.gz", hash = "sha256:784719dc5f780be319cdd185dc85dd93afebdb6ebb943811bc4c7c5f9c72aeaf", size = 4694, upload-time = "2015-03-23T04:22:45.115Z" }
 
 [[package]]
 name = "venusian"


### PR DESCRIPTION
In #3497 we hadn't imported the tests. This is the follow-up PR.

The main trick consisted in running `clear_services` on test suites that have side effects to fix tests ran in parallel 