### PR TITLE
Add ability to log request ID to all output messages

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -456,6 +456,19 @@ Example output:
     {"Pid": 19240, "Type": "root", "Timestamp": 1489067817834153984, "Severity": 4, "Hostname": "pluo", "Logger": "%", "EnvVersion": "2.0", "Fields": {"perm": "read", "userid": "ldap:john@corp.com", "message": "Permission not granted.", "uri": "/buckets/123"}}
 
 
+Request IDs
+:::::::::::
+
+In order to add requests IDs to log messages, set the provided handler:
+
+.. code-block:: ini
+
+    [handler_console]
+    class = kinto.core.StreamHandlerWithRequestID
+
+It will read the value from the ``X-Request-Id`` request header if present, or generate a random string when the request is received otherwise.
+
+
 .. _handling-exceptions-with-sentry:
 
 Handling exceptions with Sentry

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -245,7 +245,7 @@ keys = root, kinto
 keys = console
 
 [formatters]
-keys = color
+keys = color, json
 
 [logger_root]
 level = INFO
@@ -265,3 +265,6 @@ formatter = color
 
 [formatter_color]
 class = logging_color_formatter.ColorFormatter
+
+[formatter_json]
+class = kinto.core.JsonLogFormatter

--- a/kinto/config/kinto.tpl
+++ b/kinto/config/kinto.tpl
@@ -258,7 +258,7 @@ qualname = kinto
 propagate = 0
 
 [handler_console]
-class = StreamHandler
+class = kinto.core.StreamHandlerWithRequestID
 args = (sys.stderr,)
 level = NOTSET
 formatter = color

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -151,6 +151,19 @@ class JsonLogFormatter(dockerflow_logging.JsonLogFormatter):
         self.logger_name = logger_name
 
 
+class StreamHandlerWithRequestID(logging.StreamHandler):
+    """
+    A custom StreamHandler that adds the Dockerflow's `RequestIdLogFilter`.
+
+    Defining a custom handler seems to be the only way to bypass the fact that
+    ``logging.config.fileConfig()`` does not load filters from ``.ini`` files.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        filter_ = dockerflow_logging.RequestIdLogFilter()
+        self.addFilter(filter_)
+
+
 def get_user_info(request):
     # Default user info (shown in hello view for example).
     user_info = {"id": request.prefixed_userid, "principals": request.prefixed_principals}

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -158,6 +158,7 @@ class StreamHandlerWithRequestID(logging.StreamHandler):
     Defining a custom handler seems to be the only way to bypass the fact that
     ``logging.config.fileConfig()`` does not load filters from ``.ini`` files.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         filter_ = dockerflow_logging.RequestIdLogFilter()

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -4,9 +4,9 @@ import re
 import urllib.parse
 import warnings
 from datetime import datetime
-from secrets import token_hex
 
 from dateutil import parser as dateparser
+from dockerflow.logging import get_or_generate_request_id, request_id_context
 from pyramid.events import ApplicationCreated, NewRequest, NewResponse
 from pyramid.exceptions import ConfigurationError
 from pyramid.httpexceptions import (
@@ -350,7 +350,6 @@ def install_middlewares(app, settings):
 
     return app
 
-from dockerflow.logging import get_or_generate_request_id, request_id_context
 
 def setup_logging(config):
     """Setup structured logging, and emit `request.summary` event on each

--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -350,6 +350,7 @@ def install_middlewares(app, settings):
 
     return app
 
+from dockerflow.logging import get_or_generate_request_id, request_id_context
 
 def setup_logging(config):
     """Setup structured logging, and emit `request.summary` event on each
@@ -374,12 +375,15 @@ def setup_logging(config):
                 message="Invalid URL path.",
             )
 
+        rid = get_or_generate_request_id(headers=request.headers)
+        request_id_context.set(rid)
+
         request.log_context(
             agent=request.headers.get("User-Agent"),
             path=request_path,
             method=request.method,
             lang=request.headers.get("Accept-Language"),
-            rid=request.headers.get("X-Request-Id", token_hex(16)),
+            rid=rid,
             errno=0,
         )
         qs = dict(errors.request_GET(request))

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -245,7 +245,7 @@ keys = root, kinto
 keys = console
 
 [formatters]
-keys = color
+keys = color, json
 
 [logger_root]
 level = INFO
@@ -265,3 +265,6 @@ formatter = color
 
 [formatter_color]
 class = logging_color_formatter.ColorFormatter
+
+[formatter_json]
+class = kinto.core.JsonLogFormatter

--- a/tests/test_configuration/test.ini
+++ b/tests/test_configuration/test.ini
@@ -258,7 +258,7 @@ qualname = kinto
 propagate = 0
 
 [handler_console]
-class = StreamHandler
+class = kinto.core.StreamHandlerWithRequestID
 args = (sys.stderr,)
 level = NOTSET
 formatter = color


### PR DESCRIPTION
Unlike `dictConfig()`,  Python `fileConfig()` [does not load filters from ini files](https://github.com/python/cpython/blob/aeb23273867b27818a3dabd5fca086a1a2e8d229/Lib/logging/config.py#L140-L176)

Therefore we cannot do the following from our config file:
```diff
+[filters]
+keys = request_id
+
+[filter_request_id]
+class = dockerflow.logging.RequestIdLogFilter

 [handler_consoler]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
 formatter = json
+filters = (request_id,)
```

We have to do it via code. This PR provides a default stream handler that will add the filter for us.

The config will have to be changed like this though:
```diff
 [handler_consoler]
-class = StreamHandler
+class = kinto.core.StreamHandlerWithRequestID
```


Ref https://github.com/mozilla/remote-settings/issues/777
> [!NOTE]  
> We could have done it in https://github.com/mozilla/remote-settings/pull/778 but makes more sense in `kinto.core` since we already have `kinto.core.JSONFormatter`