### PR TITLE
Add option to disable history for certain users

### DIFF
--- a/docs/api/1.x/history.rst
+++ b/docs/api/1.x/history.rst
@@ -202,13 +202,13 @@ Or certain users:
 
     kinto.history.exclude_user_ids = account:quicksuggest
 
-In order to limit the size of the history length of each object:
+In order to limit the size of the history length of each resource:
 
 .. code-block:: ini
 
     kinto.history.auto_trim_max_count = 100
 
-In order to limit the size of the history length of each object only for certain users:
+In order to limit the size of the history length of each resource only for certain users:
 
 .. code-block:: ini
 

--- a/docs/api/1.x/history.rst
+++ b/docs/api/1.x/history.rst
@@ -201,3 +201,15 @@ Or certain users:
 .. code-block:: ini
 
     kinto.history.exclude_user_ids = account:quicksuggest
+
+In order to limit the size of the history length of each object:
+
+.. code-block:: ini
+
+    kinto.history.auto_trim_max_count = 100
+
+In order to limit the size of the history length of each object only for certain users:
+
+.. code-block:: ini
+
+    kinto.history.auto_trim_user_ids = account:quicksuggest

--- a/docs/api/1.x/history.rst
+++ b/docs/api/1.x/history.rst
@@ -195,3 +195,9 @@ It is possible to exclude certain resources from being tracked by history using 
 
     kinto.history.exclude_resources = /buckets/preview
                                       /buckets/signed/collections/certificates
+
+Or certain users:
+
+.. code-block:: ini
+
+    kinto.history.exclude_user_ids = account:quicksuggest

--- a/kinto/plugins/history/listener.py
+++ b/kinto/plugins/history/listener.py
@@ -130,10 +130,17 @@ def on_resource_changed(event):
         # Note: this will be rolledback if the transaction is rolledback.
         entry = storage.create(parent_id=bucket_uri, resource_name="history", obj=attrs)
 
-        # We trim history by resource.
+        # If enabled, we trim history by resource.
+        # This means that we will only keep the last `auto_trim_max_count` history entries
+        # for this same type of object (eg. `collection`, `record`).
+        #
+        # If trim by user is enabled, we only trim if the user matches the config
+        # and we only delete the history entries of this user.
+        # This means that if a user touches X different types of objects, we will keep
+        # ``(X * auto_trim_max_count)`` entries.
         if is_trim_enabled and (not is_trim_by_user_enabled or user_id in trim_user_ids):
             filters = [
-                Filter("uri", uri, COMPARISON.EQ),
+                Filter("resource_name", resource_name, COMPARISON.EQ),
             ]
             if is_trim_by_user_enabled:
                 filters.append(Filter("user_id", user_id, COMPARISON.EQ))


### PR DESCRIPTION
If certain users like machine-to-machine jobs generate a lot of history that users never look at, then we can choose to just exclude them with this (cheap to implement) option.


I chose to trim the history by resource_name (ie. type of objects) instead of by URI.
This way, if a user deletes the whole collection content and recreates a lot of new records, the history will be trimmed. Whereas by URI, we would keep 2 entries for each record URI, and never trim anything.