### PR TITLE
Partitioning objects table and adding a new index

### DIFF
--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -79,7 +79,7 @@ class Storage(StorageBase, MigratorMixin):
 
     # MigratorMixin attributes.
     name = "storage"
-    schema_version = 22
+    schema_version = 23
     schema_file = os.path.join(HERE, "schema.sql")
     migrations_directory = os.path.join(HERE, "migrations")
 

--- a/kinto/core/storage/postgresql/migrations/migration_022_023.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_022_023.sql
@@ -9,8 +9,7 @@ CREATE TABLE IF NOT EXISTS objects_partitioned
     CONSTRAINT objects_pkey PRIMARY KEY (id, parent_id, resource_name)
 ) PARTITION BY LIST(resource_name);
 
-CREATE TABLE objects_default PARTITION OF objects_partitioned 
-    FOR VALUES IN ('', 'account', 'bucket', 'collection', 'group');
+CREATE TABLE objects_default PARTITION OF objects_partitioned DEFAULT;
 CREATE TABLE objects_record PARTITION OF objects_partitioned 
     FOR VALUES IN ('record');
 CREATE TABLE objects_history PARTITION OF objects_partitioned

--- a/kinto/core/storage/postgresql/migrations/migration_022_023.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_022_023.sql
@@ -10,10 +10,6 @@ CREATE TABLE IF NOT EXISTS objects_partitioned
 ) PARTITION BY LIST(resource_name);
 
 CREATE TABLE objects_default PARTITION OF objects_partitioned DEFAULT;
-CREATE TABLE objects_record PARTITION OF objects_partitioned 
-    FOR VALUES IN ('record');
-CREATE TABLE objects_history PARTITION OF objects_partitioned
-    FOR VALUES IN ('history');
 
 INSERT INTO objects_partitioned(id, parent_id, resource_name, last_modified, data, deleted)
 SELECT id, parent_id, resource_name, last_modified, data, deleted

--- a/kinto/core/storage/postgresql/migrations/migration_022_023.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_022_023.sql
@@ -19,11 +19,6 @@ INSERT INTO objects_partitioned(id, parent_id, resource_name, last_modified, dat
 SELECT id, parent_id, resource_name, last_modified, data, deleted
 FROM objects;
 
-ALTER TABLE objects_partitioned OWNER to kinto;
-REVOKE ALL ON TABLE objects_partitioned FROM kinto_ro;
-GRANT ALL ON TABLE objects_partitioned TO kinto;
-GRANT SELECT ON TABLE objects_partitioned TO kinto_ro;
-
 ALTER TABLE objects RENAME TO objects_old;
 ALTER TABLE objects_partitioned RENAME TO objects;
 

--- a/kinto/core/storage/postgresql/migrations/migration_022_023.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_022_023.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS objects_partitioned
+(
+    id text NOT NULL,
+    parent_id text NOT NULL,
+    resource_name text NOT NULL,
+    last_modified timestamp without time zone NOT NULL,
+    data jsonb NOT NULL DEFAULT '{}'::jsonb,
+    deleted boolean NOT NULL DEFAULT false,
+    CONSTRAINT objects_pkey PRIMARY KEY (id, parent_id, resource_name)
+) PARTITION BY LIST(resource_name);
+
+CREATE TABLE objects_default PARTITION OF objects_partitioned 
+    FOR VALUES IN ('', 'account', 'bucket', 'collection', 'group');
+CREATE TABLE objects_record PARTITION OF objects_partitioned 
+    FOR VALUES IN ('record');
+CREATE TABLE objects_history PARTITION OF objects_partitioned
+    FOR VALUES IN ('history');
+
+INSERT INTO objects_partitioned(id, parent_id, resource_name, last_modified, data, deleted)
+SELECT id, parent_id, resource_name, last_modified, data, deleted
+FROM objects;
+
+ALTER TABLE objects_partitioned OWNER to kinto;
+REVOKE ALL ON TABLE objects_partitioned FROM kinto_ro;
+GRANT ALL ON TABLE objects_partitioned TO kinto;
+GRANT SELECT ON TABLE objects_partitioned TO kinto_ro;
+
+ALTER TABLE objects RENAME TO objects_old;
+ALTER TABLE objects_partitioned RENAME TO objects;
+
+CREATE INDEX IF NOT EXISTS idx_objects_last_modified_epoch_partitioned
+    ON objects USING btree
+    (as_epoch(last_modified) ASC NULLS LAST);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_objects_parent_id_resource_name_last_modified_partitioned
+    ON objects USING btree
+    (parent_id ASC NULLS LAST, resource_name ASC NULLS LAST, last_modified DESC NULLS FIRST);
+
+CREATE OR REPLACE TRIGGER tgr_objects_last_modified
+    BEFORE INSERT OR UPDATE OF data
+    ON objects
+    FOR EACH ROW
+    EXECUTE FUNCTION bump_timestamp();
+
+ALTER INDEX idx_objects_last_modified_epoch RENAME TO idx_objects_last_modified_epoch_old;
+ALTER INDEX idx_objects_parent_id_resource_name_last_modified RENAME TO idx_objects_parent_id_resource_name_last_modified_old;
+ALTER INDEX idx_objects_last_modified_epoch_partitioned RENAME TO idx_objects_last_modified_epoch;
+ALTER INDEX idx_objects_parent_id_resource_name_last_modified_partitioned RENAME TO idx_objects_parent_id_resource_name_last_modified;
+
+CREATE INDEX IF NOT EXISTS idx_objects_resource_name_parent_id_deleted
+    ON objects(resource_name, parent_id, deleted);
+
+DROP TABLE objects_old;
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '23');

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -33,8 +33,7 @@ CREATE TABLE IF NOT EXISTS objects
     CONSTRAINT objects_pkey PRIMARY KEY (id, parent_id, resource_name)
 ) PARTITION BY LIST(resource_name);
 
-CREATE TABLE objects_default PARTITION OF objects
-    FOR VALUES IN ('', 'account', 'bucket', 'collection', 'group');
+CREATE TABLE objects_default PARTITION OF objects DEFAULT;
 CREATE TABLE objects_record PARTITION OF objects
     FOR VALUES IN ('record');
 CREATE TABLE objects_history PARTITION OF objects

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -34,10 +34,6 @@ CREATE TABLE IF NOT EXISTS objects
 ) PARTITION BY LIST(resource_name);
 
 CREATE TABLE objects_default PARTITION OF objects DEFAULT;
-CREATE TABLE objects_record PARTITION OF objects
-    FOR VALUES IN ('record');
-CREATE TABLE objects_history PARTITION OF objects
-    FOR VALUES IN ('history');
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_objects_parent_id_resource_name_last_modified
     ON objects(parent_id, resource_name, last_modified DESC);

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -47,7 +47,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_objects_parent_id_resource_name_last_modif
     ON objects(parent_id, resource_name, last_modified DESC);
 CREATE INDEX IF NOT EXISTS idx_objects_last_modified_epoch
     ON objects(as_epoch(last_modified));
-
+CREATE INDEX IF NOT EXISTS idx_objects_resource_name_parent_id_deleted
+    ON objects(resource_name, parent_id, deleted);
 
 CREATE TABLE IF NOT EXISTS timestamps (
   parent_id TEXT NOT NULL COLLATE "C",


### PR DESCRIPTION
This PR aims to improve performance on the postgres backend by:
1. Partitioning the objects table. But only declaring the default partition, allowing implementers to make their own partitions.
2. Creating a new index to improve checks against deleted records (or looking specifically for non-deleted records)

A migration script is included to transfer existing data from `objects` over to the new partitioned table before dropping the old table.

With the current data for remote-settings, this cuts the execution cost of our common queries in half.