### PR TITLE
Add command to purge tombstones

### DIFF
--- a/kinto/__main__.py
+++ b/kinto/__main__.py
@@ -33,6 +33,7 @@ def main(args=None):
         "flush-cache",
         "version",
         "create-user",
+        "purge-deleted",
     )
     subparsers = parser.add_subparsers(
         title="subcommands",
@@ -128,6 +129,17 @@ def main(args=None):
             subparser.add_argument(
                 "-p", "--password", help="Superuser password", required=False, default=None
             )
+        elif command == "purge-deleted":
+            subparser.add_argument(
+                "--timestamp", help="The maximum timestamp (exclusive).", type=int, default=None
+            )
+            subparser.add_argument(
+                "--max-count",
+                help="The maximum number of tombstones to keep per collection",
+                type=int,
+                dest="max_count",
+                default=None,
+            )
 
     # Parse command-line arguments
     parsed_args = vars(parser.parse_args(args))
@@ -207,6 +219,10 @@ def main(args=None):
         password = parsed_args["password"]
         env = bootstrap(config_file, options={"command": "create-user"})
         return accounts_scripts.create_user(env, username=username, password=password)
+
+    elif which_command == "purge-deleted":
+        env = bootstrap(config_file)
+        return core_scripts.purge_deleted(env, parsed_args["timestamp"], parsed_args["max_count"])
 
     elif which_command == "start":
         pserve_argv = ["pserve"]

--- a/kinto/core/scripts.py
+++ b/kinto/core/scripts.py
@@ -28,6 +28,26 @@ def migrate(env, dry_run=False):
                 getattr(registry, backend).initialize_schema(dry_run=dry_run)
 
 
+def purge_deleted(env, min_timestamp, max_count):
+    if min_timestamp is None and max_count is None:
+        logger.warning("Purge all tombstones.")
+        # TODO: ask confirmation?
+    elif min_timestamp:
+        logger.info("Purge tombstones before %r." % min_timestamp)
+    elif max_count:
+        logger.info("Keep only %r tombstones per collection." % min_timestamp)
+
+    registry = env["registry"]
+
+    count = registry.storage.purge_deleted(
+        parent_id="*", collection_id=None, before=min_timestamp, max_count=max_count
+    )
+
+    logger.info("%s tombstone(s) deleted." % count)
+
+    return 0
+
+
 def flush_cache(env):
     registry = env["registry"]
     registry.cache.flush()

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -45,3 +45,20 @@ class InitSchemaTest(unittest.TestCase):
         scripts.flush_cache({"registry": self.registry})
         reg = self.registry
         reg.cache.flush.assert_called_with()
+
+
+class PurgeDeletedTest(unittest.TestCase):
+    def setUp(self):
+        self.registry = mock.MagicMock()
+
+    def test_purge_deleted_with_no_timestamp(self):
+        code = scripts.purge_deleted({"registry": self.registry}, None)
+        assert code == 0
+        self.registry.storage.purge_deleted.assert_called_with(
+            parent_id="*", collection_id=None, before=None
+        )
+
+    def test_purge_deleted_with_timestamp(self):
+        code = scripts.purge_deleted({"registry": self.registry}, 4)
+        assert code == 0
+        self.registry.storage.purge_deleted.assert_called_with(parent_id="*", before=4)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,3 +312,17 @@ class TestMain(unittest.TestCase):
             res = main(["flush-cache", "--ini", TEMP_KINTO_INI])
             assert res == 0
             assert mocked_cache_script.call_count == 1
+
+    def test_cli_purge_deleted_runs_purge_deleted_script(self):
+        with mock.patch("kinto.__main__.scripts.purge_deleted") as purge_deleted:
+            purge_deleted.return_value = mock.sentinel.purge_deleted
+            main(["--ini", TEMP_KINTO_INI, "init", "--backend", "memory"])
+            res = main(["--ini", TEMP_KINTO_INI, "purge-deleted"])
+            assert res == mock.sentinel.purge_deleted
+            assert purge_deleted.call_count == 1
+
+    def test_cli_purge_deleted_fails_if_wrong_timestamp(self):
+        with mock.patch("kinto.__main__.scripts.purge_deleted"):
+            main(["--ini", TEMP_KINTO_INI, "init", "--backend", "memory"])
+            with self.assertRaises(SystemExit):
+                main(["--ini", TEMP_KINTO_INI, "purge-deleted", "--timestamp", "abc"])


### PR DESCRIPTION
Since our server is configured with `paginate_by=None` and `storage.max_fetch_limit=10000`, it does not make sense to keep more than 10K tombstones for each collection.

Some of our collection in production (after 10 years of sync!) have more than 22K tombstones 🤣 

See https://github.com/Kinto/kinto/pull/990 for a jump in the past 😅 

* [ ] Basic rebase
* [ ] Import code to add more parameters (collection, buckets)
* [ ] Add docs, etc.