### PR TITLE
Enable Prometheus multiprocess collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,5 @@ RUN kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=
 WORKDIR /app
 USER app
 
-RUN mkdir -p $PROMETHEUS_MULTIPROC_DIR
-
 # Run database migrations and start the kinto server
 CMD ["sh", "-c", "kinto migrate --ini $KINTO_INI && kinto start --ini $KINTO_INI --port $PORT"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY --from=python-builder /opt/venv /opt/venv
 
 ENV KINTO_INI=/etc/kinto/kinto.ini \
     PORT=8888 \
-    PATH="/opt/venv/bin:$PATH"
+    PATH="/opt/venv/bin:$PATH" \
+    PROMETHEUS_MULTIPROC_DIR="/tmp/metrics"
 
 RUN kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=memory
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,7 @@ RUN kinto init --ini $KINTO_INI --host 0.0.0.0 --backend=memory --cache-backend=
 WORKDIR /app
 USER app
 
+RUN mkdir -p $PROMETHEUS_MULTIPROC_DIR
+
 # Run database migrations and start the kinto server
 CMD ["sh", "-c", "kinto migrate --ini $KINTO_INI && kinto start --ini $KINTO_INI --port $PORT"]

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -187,8 +187,8 @@ def metrics_view(request):
     return resp
 
 
-def _reset_multiproc_folder_content():
-    if os.path.exists(PROMETHEUS_MULTIPROC_DIR):  # pragma: no cover
+def _reset_multiproc_folder_content():  # pragma: no cover
+    if os.path.exists(PROMETHEUS_MULTIPROC_DIR):
         shutil.rmtree(PROMETHEUS_MULTIPROC_DIR)
     os.mkdir(PROMETHEUS_MULTIPROC_DIR)
 

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -184,7 +184,7 @@ def metrics_view(request):
     return resp
 
 
-def _reset_multiproc_folder_content(path):
+def _reset_multiproc_folder_content(path):  # pragma: no cover
     if os.path.exists(path):
         shutil.rmtree(path)
     os.mkdir(path)

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -188,7 +188,7 @@ def metrics_view(request):
 
 
 def _reset_multiproc_folder_content(path, _evt):
-    if os.path.exists(path):
+    if os.path.exists(path):  # pragma: no cover
         shutil.rmtree(path)
     os.mkdir(path)
 


### PR DESCRIPTION
While talking to Sven about metrics this morning, he pointed out the fact that we should use a multiprocess collector, because we run `uwsgi` with `workers = X` and `master = true`  ([config](https://github.com/mozilla-it/webservices-infra/blob/429ecad27508f3d0ccd05a31c0eec1adbfe2263b/remote-settings/k8s/remote-settings/templates/configmap.yaml#L406C1-L434C1))

If I'm not mistaken, this should be enough 