### PR TITLE
Improve Prometheus metrics design

### DIFF
--- a/tests/test_views_metrics.py
+++ b/tests/test_views_metrics.py
@@ -26,20 +26,38 @@ class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
         self.app.put("/buckets/beers/collections/barley", headers=self.headers)
         self.app.put("/buckets/beers/collections/barley/records/abc", headers=self.headers)
 
+        self.app.get("/buckets", headers=self.headers)
+        self.app.get("/buckets/beers/collections", headers=self.headers)
+        self.app.get("/buckets/beers/collections/barley/records", headers=self.headers)
+
         resp = self.app.get("/__metrics__")
+        print(resp.text)
         self.assertIn(
-            'request_size_sum{bucket_id="beers",collection_id="",endpoint="/buckets/beers",group_id="",record_id=""}',
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="bucket-object",group_id="",record_id=""}',
             resp.text,
         )
         self.assertIn(
-            'request_size_sum{bucket_id="beers",collection_id="",endpoint="/buckets/beers/groups/amateurs",group_id="amateurs",record_id=""}',
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="group-object",group_id="amateurs",record_id=""}',
             resp.text,
         )
         self.assertIn(
-            'request_summary_total{bucket_id="beers",collection_id="barley",endpoint="/buckets/beers/collections/barley",group_id="",method="put",record_id="",status="201"}',
+            'request_summary_total{bucket_id="beers",collection_id="barley",endpoint="collection-object",group_id="",method="put",record_id="",status="201"}',
             resp.text,
         )
         self.assertIn(
-            'request_duration_sum{bucket_id="beers",collection_id="barley",endpoint="/buckets/beers/collections/barley/records/abc",group_id="",record_id="abc"}',
+            'request_duration_sum{bucket_id="beers",collection_id="barley",endpoint="record-object",group_id="",method="put",record_id="abc"}',
+            resp.text,
+        )
+
+        self.assertIn(
+            'request_summary_total{bucket_id="",collection_id="",endpoint="bucket-plural",group_id="",method="get",record_id="",status="200"}',
+            resp.text,
+        )
+        self.assertIn(
+            'request_summary_total{bucket_id="beers",collection_id="",endpoint="collection-plural",group_id="",method="get",record_id="",status="200"}',
+            resp.text,
+        )
+        self.assertIn(
+            'request_summary_total{bucket_id="beers",collection_id="barley",endpoint="record-plural",group_id="",method="get",record_id="",status="200"}',
             resp.text,
         )


### PR DESCRIPTION
- [x] Remove variables from metrics names https://github.com/mozilla/remote-settings/issues/852
- [x] Use route name / service name instead of URL https://github.com/mozilla/remote-settings/issues/855

This is a breaking change, since we renamed metrics, and dropped the view count
