### PR TITLE
Use Prometheus histograms for timers (instead of summary)

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -515,9 +515,9 @@ def setup_metrics(config):
         try:
             current = utils.msec_time()
             duration = current - request._received_at
-            metrics_service.observe(
+            metrics_service.timer(
                 "request_duration",
-                duration,
+                value=duration,
                 labels=[("endpoint", endpoint), ("method", request.method.lower())]
                 + metrics_matchdict_labels,
             )

--- a/kinto/core/metrics.py
+++ b/kinto/core/metrics.py
@@ -47,7 +47,7 @@ class NoOpTimer:
 
 @implementer(IMetricsService)
 class NoOpMetricsService:
-    def timer(self, key):
+    def timer(self, key, value=None, labels=[]):
         return NoOpTimer()
 
     def observe(self, key, value, labels=[]):

--- a/kinto/core/metrics.py
+++ b/kinto/core/metrics.py
@@ -65,11 +65,12 @@ def watch_execution_time(metrics_service, obj, prefix="", classname=None):
     classname = classname or utils.classname(obj)
     members = dir(obj)
     for name in members:
-        value = getattr(obj, name)
-        is_method = isinstance(value, types.MethodType)
+        method = getattr(obj, name)
+        is_method = isinstance(method, types.MethodType)
         if not name.startswith("_") and is_method:
-            statsd_key = f"{prefix}.{classname}.{name}"
-            decorated_method = metrics_service.timer(statsd_key)(value)
+            statsd_key = f"{prefix}.{classname}"
+            labels = [("method", name)]
+            decorated_method = metrics_service.timer(statsd_key, labels=labels)(method)
             setattr(obj, name, decorated_method)
 
 

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -49,9 +49,26 @@ def _fix_metric_name(s):
 
 
 class Timer:
+    """
+    A decorator to time the execution of a function. It will use the
+    `prometheus_client.Histogram` to record the time taken by the function
+    in milliseconds. The histogram is passed as an argument to the
+    constructor.
+
+    Main limitation: it does not support `labels` on the decorator.
+    """
+
     def __init__(self, histogram):
         self.histogram = histogram
         self._start_time = None
+
+    def set_labels(self, labels):
+        if not labels:
+            return
+        self.histogram = self.histogram.labels(*(label_value for _, label_value in labels))
+
+    def observe(self, value):
+        return self.histogram.observe(value)
 
     def __call__(self, f):
         @safe_wraps(f)
@@ -95,13 +112,16 @@ class PrometheusService:
             prefix_clean = _fix_metric_name(prefix).replace("_", "") + "_"
         self.prefix = prefix_clean.lower()
 
-    def timer(self, key):
+    def timer(self, key, value=None, labels=[]):
         global _METRICS
         key = self.prefix + key
 
         if key not in _METRICS:
             _METRICS[key] = prometheus_module.Histogram(
-                _fix_metric_name(key), f"Histogram of {key}", registry=get_registry()
+                _fix_metric_name(key),
+                f"Histogram of {key}",
+                registry=get_registry(),
+                labelnames=[label_name for label_name, _ in labels],
             )
 
         if not isinstance(_METRICS[key], prometheus_module.Histogram):
@@ -109,7 +129,17 @@ class PrometheusService:
                 f"Metric {key} already exists with different type ({_METRICS[key]})"
             )
 
-        return Timer(_METRICS[key])
+        timer = Timer(_METRICS[key])
+        timer.set_labels(labels)
+
+        if value is not None:
+            # We are timing something.
+            return timer.observe(value)
+
+        # We are not timing anything, just returning the timer object
+        # (eg. to be used as decorator or context manager).
+        # Note that in this case, the labels values will be the same for all calls.
+        return timer
 
     def observe(self, key, value, labels=[]):
         global _METRICS

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -49,8 +49,8 @@ def _fix_metric_name(s):
 
 
 class Timer:
-    def __init__(self, summary):
-        self.summary = summary
+    def __init__(self, histogram):
+        self.histogram = histogram
         self._start_time = None
 
     def __call__(self, f):
@@ -61,7 +61,7 @@ class Timer:
                 return f(*args, **kwargs)
             finally:
                 dt_ms = 1000.0 * (time_now() - start_time)
-                self.summary.observe(dt_ms)
+                self.histogram.observe(dt_ms)
 
         return _wrapped
 
@@ -79,7 +79,7 @@ class Timer:
         if self._start_time is None:  # pragma: nocover
             raise RuntimeError("Timer has not started.")
         dt_ms = 1000.0 * (time_now() - self._start_time)
-        self.summary.observe(dt_ms)
+        self.histogram.observe(dt_ms)
         return self
 
 
@@ -100,11 +100,11 @@ class PrometheusService:
         key = self.prefix + key
 
         if key not in _METRICS:
-            _METRICS[key] = prometheus_module.Summary(
-                _fix_metric_name(key), f"Summary of {key}", registry=get_registry()
+            _METRICS[key] = prometheus_module.Histogram(
+                _fix_metric_name(key), f"Histogram of {key}", registry=get_registry()
             )
 
-        if not isinstance(_METRICS[key], prometheus_module.Summary):
+        if not isinstance(_METRICS[key], prometheus_module.Histogram):
             raise RuntimeError(
                 f"Metric {key} already exists with different type ({_METRICS[key]})"
             )

--- a/kinto/plugins/statsd.py
+++ b/kinto/plugins/statsd.py
@@ -32,8 +32,7 @@ class StatsDService:
             # [("method", "get")] -> "method.get"
             key = f"{key}." + ".".join(f"{label[0]}.{sanitize(label[1])}" for label in labels)
         if value:
-            if not isinstance(value, timedelta):
-                value = timedelta(seconds=value)
+            value = timedelta(seconds=value)
             return self._client.timing(key, value)
         return self._client.timer(key)
 

--- a/kinto/plugins/statsd.py
+++ b/kinto/plugins/statsd.py
@@ -1,4 +1,5 @@
 import warnings
+from datetime import timedelta
 from urllib.parse import urlparse
 
 from pyramid.exceptions import ConfigurationError
@@ -26,7 +27,14 @@ class StatsDService:
     def __init__(self, host, port, prefix):
         self._client = statsd_module.StatsClient(host, port, prefix=prefix)
 
-    def timer(self, key):
+    def timer(self, key, value=None, labels=[]):
+        if labels:
+            # [("method", "get")] -> "method.get"
+            key = f"{key}." + ".".join(f"{label[0]}.{sanitize(label[1])}" for label in labels)
+        if value:
+            if not isinstance(value, timedelta):
+                value = timedelta(seconds=value)
+            return self._client.timing(key, value)
         return self._client.timer(key)
 
     def observe(self, key, value, labels=[]):

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -440,9 +440,9 @@ class MetricsConfigurationTest(unittest.TestCase):
         kinto.core.initialize(self.config, "0.0.1", "settings_prefix")
         app = webtest.TestApp(self.config.make_wsgi_app())
         app.get("/v0/__heartbeat__")
-        self.mocked().observe.assert_any_call(
+        self.mocked().timer.assert_any_call(
             "request_duration",
-            mock.ANY,
+            value=mock.ANY,
             labels=[("endpoint", "heartbeat"), ("method", "get")],
         )
 

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -24,7 +24,9 @@ class WatchExecutionTimeTest(unittest.TestCase):
 
     def test_public_methods_generates_statsd_calls(self):
         self.test_object.test_method()
-        self.mocked.timer.assert_called_with("test.testedclass.test_method")
+        self.mocked.timer.assert_called_with(
+            "test.testedclass", labels=[("method", "test_method")]
+        )
 
     def test_private_methods_does_not_generates_statsd_calls(self):
         self.test_object._private_method()

--- a/tests/plugins/test_prometheus.py
+++ b/tests/plugins/test_prometheus.py
@@ -60,7 +60,7 @@ class ServiceTest(PrometheusWebTest):
             self.assertEqual(my_func(1, 1), 2)
 
         resp = self.app.get("/__metrics__")
-        self.assertIn("TYPE kintoprod_func_latency_context summary", resp.text)
+        self.assertIn("TYPE kintoprod_func_latency_context histogram", resp.text)
 
     def test_timer_can_be_used_as_decorator(self):
         decorated = self.app.app.registry.metrics.timer("func.latency.decorator")(my_func)
@@ -68,7 +68,7 @@ class ServiceTest(PrometheusWebTest):
         self.assertEqual(decorated(1, 1), 2)
 
         resp = self.app.get("/__metrics__")
-        self.assertIn("TYPE kintoprod_func_latency_decorator summary", resp.text)
+        self.assertIn("TYPE kintoprod_func_latency_decorator histogram", resp.text)
 
     def test_timer_can_be_used_as_decorator_on_partial_function(self):
         partial = functools.partial(my_func, 3)
@@ -77,7 +77,7 @@ class ServiceTest(PrometheusWebTest):
         self.assertEqual(decorated(3), 6)
 
         resp = self.app.get("/__metrics__")
-        self.assertIn("TYPE kintoprod_func_latency_partial summary", resp.text)
+        self.assertIn("TYPE kintoprod_func_latency_partial histogram", resp.text)
 
     def test_observe_a_single_value(self):
         self.app.app.registry.metrics.observe("price", 111)


### PR DESCRIPTION
Fix https://github.com/mozilla/remote-settings/issues/853

**Breaking changes**

- The metrics for backends like `storage`, `permission`, etc. will use the method as label instead of metric name (eg. `storage_create`)
- The timers Prometheus metrics will now be of type Histogram instead of Summary