### PR TITLE
Add new settings to control Prometheus metrics

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -512,6 +512,7 @@ Prometheus metrics can be enabled with (disabled by default):
     kinto.includes = kinto.plugins.prometheus
 
     # kinto.prometheus_prefix = kinto-prod
+    # kinto.prometheus_created_metrics_enabled = true
 
 Metrics can then be crawled from the ``/__metrics__`` endpoint.
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -512,7 +512,12 @@ Prometheus metrics can be enabled with (disabled by default):
     kinto.includes = kinto.plugins.prometheus
 
     # kinto.prometheus_prefix = kinto-prod
-    # kinto.prometheus_created_metrics_enabled = true
+
+    # Expose metrics created time (default: true)
+    # kinto.prometheus_created_metrics_enabled = false
+
+    # Exclude certain labels to reduce cardinality (default: none)
+    # kinto.prometheus_exclude_labels = record_id group_id
 
 Metrics can then be crawled from the ``/__metrics__`` endpoint.
 

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -6,7 +6,7 @@ from time import perf_counter as time_now
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.response import Response
-from pyramid.settings import asbool
+from pyramid.settings import asbool, aslist
 from zope.interface import implementer
 
 from kinto.core import metrics
@@ -103,7 +103,7 @@ class Timer:
 
 @implementer(metrics.IMetricsService)
 class PrometheusService:
-    def __init__(self, prefix=""):
+    def __init__(self, prefix="", exclude_labels=None):
         prefix_clean = ""
         if prefix:
             # In GCP Console, the metrics are grouped by the first
@@ -112,10 +112,19 @@ class PrometheusService:
             # (eg. `remote-settings` -> `remotesettings_`, `kinto_` -> `kinto_`)
             prefix_clean = _fix_metric_name(prefix).replace("_", "") + "_"
         self.prefix = prefix_clean.lower()
+        self.exclude_labels = exclude_labels or []
+
+    def _exclude_labels(self, labels):
+        return [
+            (label_name, label_value)
+            for label_name, label_value in labels
+            if label_name not in self.exclude_labels
+        ]
 
     def timer(self, key, value=None, labels=[]):
         global _METRICS
         key = self.prefix + key
+        labels = self._exclude_labels(labels)
 
         if key not in _METRICS:
             _METRICS[key] = prometheus_module.Histogram(
@@ -145,6 +154,7 @@ class PrometheusService:
     def observe(self, key, value, labels=[]):
         global _METRICS
         key = self.prefix + key
+        labels = self._exclude_labels(labels)
 
         if key not in _METRICS:
             _METRICS[key] = prometheus_module.Summary(
@@ -185,6 +195,7 @@ class PrometheusService:
                 label_name, label_value = unique.rsplit(".", 1)
                 unique = [(label_name, label_value)]
 
+            unique = self._exclude_labels(unique)
             labels = [
                 (_fix_metric_name(label_name), label_value) for label_name, label_value in unique
             ]
@@ -258,4 +269,11 @@ def includeme(config):
 
     prefix = settings.get("prometheus_prefix", settings["project_name"])
 
-    config.registry.registerUtility(PrometheusService(prefix=prefix), metrics.IMetricsService)
+    # If we want to reduce the metrics cardinality, we can exclude certain
+    # labels (eg. records_id). This way all metrics will be grouped by the
+    # remaining labels.
+    exclude_labels = aslist(settings.get("prometheus_exclude_labels", ""))
+
+    config.registry.registerUtility(
+        PrometheusService(prefix=prefix, exclude_labels=exclude_labels), metrics.IMetricsService
+    )

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -6,6 +6,7 @@ from time import perf_counter as time_now
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.response import Response
+from pyramid.settings import asbool
 from zope.interface import implementer
 
 from kinto.core import metrics
@@ -229,6 +230,11 @@ def includeme(config):
         )
         raise ConfigurationError(error_msg)
 
+    settings = config.get_settings()
+
+    if not asbool(settings.get("prometheus_created_metrics_enabled", True)):
+        prometheus_module.disable_created_metrics()
+
     config.add_api_capability(
         "prometheus",
         description="Prometheus metrics.",
@@ -250,7 +256,6 @@ def includeme(config):
             pass
     _METRICS.clear()
 
-    settings = config.get_settings()
     prefix = settings.get("prometheus_prefix", settings["project_name"])
 
     config.registry.registerUtility(PrometheusService(prefix=prefix), metrics.IMetricsService)

--- a/tests/plugins/test_prometheus.py
+++ b/tests/plugins/test_prometheus.py
@@ -174,3 +174,32 @@ class PrometheusNoCreatedTest(PrometheusWebTest):
 
         self.assertIn("TYPE kintoprod_price summary", resp.text)
         self.assertNotIn("TYPE kintoprod_price_created summary", resp.text)
+
+
+@skip_if_no_prometheus
+class PrometheusExcludedLabelsTest(PrometheusWebTest):
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings["prometheus_exclude_labels"] = "record_id group_id"
+        return settings
+
+    def test_metrics_excluded_labels(self):
+        headers = get_user_headers("aaa")
+        self.app.put("/buckets/bid", headers=headers)
+        self.app.put("/buckets/bid/collections/cid", headers=headers)
+        self.app.put("/buckets/bid/groups/gid", headers=headers)
+        self.app.put("/buckets/bid/collections/cid/records/rid", headers=headers)
+
+        resp = self.app.get("/__metrics__")
+
+        self.assertNotIn("group_id=", resp.text)
+        self.assertNotIn("record_id=", resp.text)
+        self.assertIn(
+            'kintoprod_request_size_count{bucket_id="bid",collection_id="",endpoint="group-object"}',
+            resp.text,
+        )
+        self.assertIn(
+            'kintoprod_request_size_count{bucket_id="bid",collection_id="cid",endpoint="record-object"}',
+            resp.text,
+        )

--- a/tests/plugins/test_prometheus.py
+++ b/tests/plugins/test_prometheus.py
@@ -157,3 +157,20 @@ class PrometheusNoPrefixTest(PrometheusWebTest):
 
         resp = self.app.get("/__metrics__")
         self.assertIn("TYPE price summary", resp.text)
+
+
+@skip_if_no_prometheus
+class PrometheusNoCreatedTest(PrometheusWebTest):
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        settings["prometheus_created_metrics_enabled"] = "false"
+        return settings
+
+    def test_metrics_created_not_in_response(self):
+        self.app.app.registry.metrics.observe("price", 111)
+
+        resp = self.app.get("/__metrics__")
+
+        self.assertIn("TYPE kintoprod_price summary", resp.text)
+        self.assertNotIn("TYPE kintoprod_price_created summary", resp.text)


### PR DESCRIPTION
- Add setting to disable `_created` metrics (see https://prometheus.github.io/client_python/instrumenting/#disabling-_created-metrics)
- Add setting to exclude certain labels (eg. `record_id`). By using this, the metrics will only be grouped by the other labels (eg. `endpoint=record-object`, `bucket_id=bid`, `collection_id=cid`) and cardinality will be reduced (see https://github.com/mozilla/remote-settings/issues/864) 
