### PR TITLE
Prevent random values to become metrics labels values

### DIFF
--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -433,7 +433,7 @@ class MetricsConfigurationTest(unittest.TestCase):
         self.mocked().observe.assert_any_call(
             "request_size",
             len("{}"),
-            labels=[("endpoint", "heartbeat")],
+            labels=[("method", "get"), ("endpoint", "heartbeat"), ("status", "200")],
         )
 
     def test_statsd_observe_request_duration(self):
@@ -443,7 +443,7 @@ class MetricsConfigurationTest(unittest.TestCase):
         self.mocked().timer.assert_any_call(
             "request_duration",
             value=mock.ANY,
-            labels=[("endpoint", "heartbeat"), ("method", "get")],
+            labels=[("method", "get"), ("endpoint", "heartbeat"), ("status", "200")],
         )
 
     def test_statsd_counts_unknown_urls(self):

--- a/tests/plugins/test_prometheus.py
+++ b/tests/plugins/test_prometheus.py
@@ -196,10 +196,10 @@ class PrometheusExcludedLabelsTest(PrometheusWebTest):
         self.assertNotIn("group_id=", resp.text)
         self.assertNotIn("record_id=", resp.text)
         self.assertIn(
-            'kintoprod_request_size_count{bucket_id="bid",collection_id="",endpoint="group-object"}',
+            'kintoprod_request_size_count{bucket_id="bid",collection_id="",endpoint="group-object",method="put",status="201"}',
             resp.text,
         )
         self.assertIn(
-            'kintoprod_request_size_count{bucket_id="bid",collection_id="cid",endpoint="record-object"}',
+            'kintoprod_request_size_count{bucket_id="bid",collection_id="cid",endpoint="record-object",method="put",status="201"}',
             resp.text,
         )

--- a/tests/test_views_metrics.py
+++ b/tests/test_views_metrics.py
@@ -31,7 +31,7 @@ class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
         self.app.get("/buckets/beers/collections/barley/records", headers=self.headers)
 
         resp = self.app.get("/__metrics__")
-        print(resp.text)
+
         self.assertIn(
             'request_size_sum{bucket_id="beers",collection_id="",endpoint="bucket-object",group_id="",record_id=""}',
             resp.text,
@@ -59,5 +59,15 @@ class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
         )
         self.assertIn(
             'request_summary_total{bucket_id="beers",collection_id="barley",endpoint="record-plural",group_id="",method="get",record_id="",status="200"}',
+            resp.text,
+        )
+
+    def test_4xx_do_not_have_matchdict_labels_values(self):
+        self.app.get("/buckets/water", headers=self.headers, status=403)
+
+        resp = self.app.get("/__metrics__")
+
+        self.assertIn(
+            'request_summary_total{bucket_id="",collection_id="",endpoint="bucket-object",group_id="",method="get",record_id="",status="403"}',
             resp.text,
         )

--- a/tests/test_views_metrics.py
+++ b/tests/test_views_metrics.py
@@ -33,11 +33,11 @@ class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get("/__metrics__")
 
         self.assertIn(
-            'request_size_sum{bucket_id="beers",collection_id="",endpoint="bucket-object",group_id="",record_id=""}',
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="bucket-object",group_id="",method="put",record_id="",status="201"}',
             resp.text,
         )
         self.assertIn(
-            'request_size_sum{bucket_id="beers",collection_id="",endpoint="group-object",group_id="amateurs",record_id=""}',
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="group-object",group_id="amateurs",method="put",record_id="",status="201"}',
             resp.text,
         )
         self.assertIn(
@@ -45,7 +45,7 @@ class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
             resp.text,
         )
         self.assertIn(
-            'request_duration_sum{bucket_id="beers",collection_id="barley",endpoint="record-object",group_id="",method="put",record_id="abc"}',
+            'request_duration_sum{bucket_id="beers",collection_id="barley",endpoint="record-object",group_id="",method="put",record_id="abc",status="201"}',
             resp.text,
         )
 


### PR DESCRIPTION
The internet is wild... and bloat our metrics labels values:

https://github.com/user-attachments/assets/47c0aaa3-16a8-421c-a2f1-7e12cf31b80d


