### PR TITLE
Use explicit seconds suffix for duration metrics

### DIFF
--- a/kinto/core/metrics.py
+++ b/kinto/core/metrics.py
@@ -13,7 +13,7 @@ class IMetricsService(Interface):
 
     def timer(key):
         """
-        Watch execution time.
+        Watch execution time in seconds.
         """
 
     def observe(self, key, value, labels=[]):
@@ -68,9 +68,9 @@ def watch_execution_time(metrics_service, obj, prefix="", classname=None):
         method = getattr(obj, name)
         is_method = isinstance(method, types.MethodType)
         if not name.startswith("_") and is_method:
-            statsd_key = f"{prefix}.{classname}"
+            metric_name = f"{prefix}.{classname}.seconds"
             labels = [("method", name)]
-            decorated_method = metrics_service.timer(statsd_key, labels=labels)(method)
+            decorated_method = metrics_service.timer(metric_name, labels=labels)(method)
             setattr(obj, name, decorated_method)
 
 
@@ -88,7 +88,7 @@ def listener_with_timer(config, key, func):
             # not listed in the `initialization_sequence` setting.
             return func(*args, **kwargs)
         # If metrics are enabled, monitor execution time of listeners.
-        with metrics_service.timer(key):
+        with metrics_service.timer(key + ".seconds" if not key.endswith(".seconds") else key):
             return func(*args, **kwargs)
 
     return wrapped

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -53,7 +53,7 @@ class Timer:
     """
     A decorator to time the execution of a function. It will use the
     `prometheus_client.Histogram` to record the time taken by the function
-    in milliseconds. The histogram is passed as an argument to the
+    in seconds. The histogram is passed as an argument to the
     constructor.
 
     Main limitation: it does not support `labels` on the decorator.
@@ -78,8 +78,8 @@ class Timer:
             try:
                 return f(*args, **kwargs)
             finally:
-                dt_ms = 1000.0 * (time_now() - start_time)
-                self.histogram.observe(dt_ms)
+                dt_sec = time_now() - start_time
+                self.histogram.observe(dt_sec)
 
         return _wrapped
 
@@ -96,8 +96,8 @@ class Timer:
     def stop(self):
         if self._start_time is None:  # pragma: nocover
             raise RuntimeError("Timer has not started.")
-        dt_ms = 1000.0 * (time_now() - self._start_time)
-        self.histogram.observe(dt_ms)
+        dt_sec = time_now() - self._start_time
+        self.histogram.observe(dt_sec)
         return self
 
 

--- a/tests/core/resource/test_events.py
+++ b/tests/core/resource/test_events.py
@@ -511,7 +511,7 @@ class StatsDTest(BaseWebTest, unittest.TestCase):
         with mock.patch.object(metrics_client, "timing") as mocked:
             self.app.post_json(self.plural_url, {"data": {"name": "pouet"}}, headers=self.headers)
             timers = set(c[0][0] for c in mocked.call_args_list)
-            self.assertIn("listeners.test", timers)
+            self.assertIn("listeners.test.seconds", timers)
 
 
 @skip_if_no_prometheus
@@ -529,4 +529,4 @@ class PrometheusTest(BaseWebTest, unittest.TestCase):
         self.app.post_json(self.plural_url, {"data": {"name": "pouet"}}, headers=self.headers)
 
         resp = self.app.get("/__metrics__")
-        self.assertIn("listeners_test_count 1.0", resp.text)
+        self.assertIn("listeners_test_seconds_count 1.0", resp.text)

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -25,7 +25,7 @@ class WatchExecutionTimeTest(unittest.TestCase):
     def test_public_methods_generates_statsd_calls(self):
         self.test_object.test_method()
         self.mocked.timer.assert_called_with(
-            "test.testedclass", labels=[("method", "test_method")]
+            "test.testedclass.seconds", labels=[("method", "test_method")]
         )
 
     def test_private_methods_does_not_generates_statsd_calls(self):
@@ -48,4 +48,4 @@ class ListenerWithTimerTest(unittest.TestCase):
         wrapped = metrics.listener_with_timer(self.config, "key", self.func)
 
         self.assertEqual(wrapped(42), 42)
-        self.config.registry.metrics.timer.assert_called_with("key")
+        self.config.registry.metrics.timer.assert_called_with("key.seconds")

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -38,7 +38,7 @@ class MetricsTest(HistoryWebTest):
     def test_a_statsd_timer_is_used_for_history_if_configured(self):
         with mock.patch("kinto.plugins.statsd.StatsDService.timer") as mocked:
             self.app.put("/buckets/test", headers=self.headers)
-            mocked.assert_any_call("plugins.history")
+            mocked.assert_any_call("plugins.history.seconds")
 
 
 class HistoryViewTest(HistoryWebTest):


### PR DESCRIPTION
The default buckets of the prometheus client are seconds.

We were sending milliseconds. Quantiles were wrong:

We had 0 calls to `cache.delete()` that would take less than 1sec.
```
remotesettings_backend_cache_bucket{le="0.005",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.01",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.025",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.05",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.075",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.1",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.25",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.5",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="0.75",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="1.0",method="delete"} 0.0
remotesettings_backend_cache_bucket{le="2.5",method="delete"} 3.0
remotesettings_backend_cache_bucket{le="5.0",method="delete"} 57.0
remotesettings_backend_cache_bucket{le="7.5",method="delete"} 119.0
remotesettings_backend_cache_bucket{le="10.0",method="delete"} 120.0
remotesettings_backend_cache_bucket{le="+Inf",method="delete"} 121.0
remotesettings_backend_cache_count{method="delete"} 121.0
```

This PR is a breaking change since it adds a `_seconds` suffix to avoid confusion.