### PR TITLE
Remove `status` from request_size and request_duration_seconds labels

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -510,17 +510,16 @@ def setup_metrics(config):
         request_labels = [
             ("method", request.method.lower()),
             ("endpoint", endpoint),
-            ("status", str(status)),
         ] + metrics_matchdict_labels
 
         # Count served requests.
-        metrics_service.count("request_summary", unique=request_labels)
+        metrics_service.count("request_summary", unique=request_labels + [("status", str(status))])
 
         try:
             current = utils.msec_time()
             duration = current - request._received_at
             metrics_service.timer(
-                "request_duration",
+                "request_duration_seconds",
                 value=duration,
                 labels=request_labels,
             )

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -433,7 +433,7 @@ class MetricsConfigurationTest(unittest.TestCase):
         self.mocked().observe.assert_any_call(
             "request_size",
             len("{}"),
-            labels=[("method", "get"), ("endpoint", "heartbeat"), ("status", "200")],
+            labels=[("method", "get"), ("endpoint", "heartbeat")],
         )
 
     def test_statsd_observe_request_duration(self):
@@ -441,9 +441,9 @@ class MetricsConfigurationTest(unittest.TestCase):
         app = webtest.TestApp(self.config.make_wsgi_app())
         app.get("/v0/__heartbeat__")
         self.mocked().timer.assert_any_call(
-            "request_duration",
+            "request_duration_seconds",
             value=mock.ANY,
-            labels=[("method", "get"), ("endpoint", "heartbeat"), ("status", "200")],
+            labels=[("method", "get"), ("endpoint", "heartbeat")],
         )
 
     def test_statsd_counts_unknown_urls(self):

--- a/tests/test_views_metrics.py
+++ b/tests/test_views_metrics.py
@@ -33,22 +33,21 @@ class ViewsMetricsTest(BaseWebTest, unittest.TestCase):
         resp = self.app.get("/__metrics__")
 
         self.assertIn(
-            'request_size_sum{bucket_id="beers",collection_id="",endpoint="bucket-object",group_id="",method="put",record_id="",status="201"}',
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="bucket-object",group_id="",method="put",record_id=""}',
             resp.text,
         )
         self.assertIn(
-            'request_size_sum{bucket_id="beers",collection_id="",endpoint="group-object",group_id="amateurs",method="put",record_id="",status="201"}',
+            'request_size_sum{bucket_id="beers",collection_id="",endpoint="group-object",group_id="amateurs",method="put",record_id=""}',
+            resp.text,
+        )
+        self.assertIn(
+            'request_duration_seconds_sum{bucket_id="beers",collection_id="barley",endpoint="record-object",group_id="",method="put",record_id="abc"}',
             resp.text,
         )
         self.assertIn(
             'request_summary_total{bucket_id="beers",collection_id="barley",endpoint="collection-object",group_id="",method="put",record_id="",status="201"}',
             resp.text,
         )
-        self.assertIn(
-            'request_duration_sum{bucket_id="beers",collection_id="barley",endpoint="record-object",group_id="",method="put",record_id="abc",status="201"}',
-            resp.text,
-        )
-
         self.assertIn(
             'request_summary_total{bucket_id="",collection_id="",endpoint="bucket-plural",group_id="",method="get",record_id="",status="200"}',
             resp.text,


### PR DESCRIPTION
This does not seem to be reasonable:

```
$ curl -s https://remote-settings.allizom.org/v1/__metrics__ | wc -l
   26661
$ curl -s https://remote-settings.allizom.org/v1/__metrics__ | grep remotesettings_request_duration | wc -l
   20761
```

This PR adds the `_seconds` suffix to the request duration metric, and removes the status label from size and duration metrics. This will divide the cardinality by a factor of at least 2 (200, 201) 