### PR TITLE
Ref mozilla/remote-settings#884: Fix duplicated metrics issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,6 +190,8 @@ jobs:
           context: .
 
       - name: Run container
+        env:
+          PROMETHEUS_MULTIPROC_DIR: /tmp/metrics
         run: |
           docker run --net=host --detach --rm \
             -p 8888:8888 \

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ need-kinto-running:
 
 runkinto: install-dev
 	$(VENV)/bin/kinto migrate --ini tests/functional.ini
-	$(VENV)/bin/kinto start --ini tests/functional.ini
+	PROMETHEUS_MULTIPROC_DIR=/tmp/metrics KINTO_INI=tests/functional.ini $(VENV)/bin/uwsgi --http :8888 --ini tests/functional.ini
 
 functional: install-dev need-kinto-running
 	$(VENV)/bin/py.test tests/functional.py

--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -245,6 +245,8 @@ def includeme(config):
     if not asbool(settings.get("prometheus_created_metrics_enabled", True)):
         prometheus_module.disable_created_metrics()
 
+    get_registry()  # Initialize the registry.
+
     config.add_api_capability(
         "prometheus",
         description="Prometheus metrics.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dev = [
     "build",
     "ruff",
     "twine",
+    "uwsgi",
 ]
 
 [tool.pip-tools]

--- a/tests/functional.ini
+++ b/tests/functional.ini
@@ -69,3 +69,10 @@ formatter = color
 
 [formatter_color]
 class = logging_color_formatter.ColorFormatter
+
+[uwsgi]
+wsgi-file = app.wsgi
+master = true
+module = kinto
+static-map = /attachments=/tmp/attachments
+processes = 4

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -65,6 +65,17 @@ class FunctionalTest(unittest.TestCase):
         resp.raise_for_status()
         self.assertEqual(resp.json()["http_api_version"], HTTP_API_VERSION)
 
+    def test_prometheus_metrics_are_unique(self):
+        self.session.post(self.server_url, "{collection_url}")
+
+        resp = self.session.get(
+            urljoin(self.server_url, "/__metrics__"), headers={"Accept": "text/plain"}
+        )
+        resp.raise_for_status()
+
+        metrics = resp.text.splitlines()
+        self.assertEqual(len(metrics), len(set(metrics)))
+
     def test_user_default_bucket_tutorial(self):
         collection_id = "tasks-%s" % uuid.uuid4()
         collection_url = urljoin(

--- a/tests/plugins/test_prometheus.py
+++ b/tests/plugins/test_prometheus.py
@@ -27,6 +27,10 @@ class PrometheusMissing(unittest.TestCase):
 
 
 class PrometheusWebTest(support.BaseWebTest, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        prometheus.reset_registry()
+
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)


### PR DESCRIPTION
* [x] Do not reproduce the issue with single process
* [x] Reproduce the issue with multiprocess
* [x] Try without `rmtree` in the metrics folder
* [x] Try without resetting the registry on startup
* [x] Find the root cause