### PR TITLE
Fixing duplicated prometheus metrics. Resolves remote-settings #872

### DIFF
--- a/kinto/plugins/prometheus.py
+++ b/kinto/plugins/prometheus.py
@@ -121,7 +121,6 @@ class PrometheusService:
             _METRICS[key] = prometheus_module.Histogram(
                 _fix_metric_name(key),
                 f"Histogram of {key}",
-                registry=get_registry(),
                 labelnames=[label_name for label_name, _ in labels],
             )
 
@@ -151,7 +150,6 @@ class PrometheusService:
                 _fix_metric_name(key),
                 f"Summary of {key}",
                 labelnames=[label_name for label_name, _ in labels],
-                registry=get_registry(),
             )
 
         if not isinstance(_METRICS[key], prometheus_module.Summary):
@@ -194,7 +192,6 @@ class PrometheusService:
                 _fix_metric_name(key),
                 f"Counter of {key}",
                 labelnames=[label_name for label_name, _ in labels],
-                registry=get_registry(),
             )
 
         if not isinstance(_METRICS[key], prometheus_module.Counter):


### PR DESCRIPTION
Fixes Remote-Settings [#872](https://github.com/mozilla/remote-settings/issues/872).

According to the prometheus python multi-process [documentation](https://prometheus.github.io/client_python/multiprocess/), we shouldn't register our metrics with the multi-proc metrics collector.

> The application must initialize a new CollectorRegistry, and store the multi-process collector inside. It is a best practice to create this registry inside the context of a request to avoid metrics registering themselves to a collector used by a MultiProcessCollector. **If a registry with metrics registered is used by a MultiProcessCollector duplicate metrics may be exported, one for multiprocess, and one for the process serving the request.**

:question: I'm not sure what a good test to add for this is. It's in an optional plugin and this seems like a prometheus client config issue to me.