### PR TITLE
Fix request duration duration unit

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -517,7 +517,7 @@ def setup_metrics(config):
 
         try:
             current = utils.msec_time()
-            duration = current - request._received_at
+            duration = (current - request._received_at) / 1000
             metrics_service.timer(
                 "request_duration_seconds",
                 value=duration,


### PR DESCRIPTION
Graph is showing only 6 seconds as 50th percentile. Cannot be true.

<img width="629" alt="Screenshot 2025-05-15 at 09 47 42" src="https://github.com/user-attachments/assets/a17198d6-d20b-4610-be53-d7d33819df5b" />

6 is our last bucket before `+Inf`. Meaning all measurements go to `+Inf`.
Confirmed with:
```
$ curl https://remote-settings.mozilla.org/v1/__metrics__ | grep remotesettings_request_duration_seconds_bucket | grep -v '} 0.0' | wc -l
     697
$ curl https://remote-settings.mozilla.org/v1/__metrics__ | grep remotesettings_request_duration_seconds_bucket | grep -v '} 0.0' | grep -v '+Inf' | wc -l
      48
```

Looking at code again. We missed this one in #3539 

