### PR TITLE
Fix typos in documentation: ResourceReponses → ResourceResponses and …

### DIFF
--- a/docs/api/1.x/errors.rst
+++ b/docs/api/1.x/errors.rst
@@ -53,7 +53,7 @@ Precondition errors
 As detailed in the :ref:`timestamps  <server-timestamps>` section, it is
 possible to add concurrency control using ``ETag`` request headers.
 
-When a the provided preconditions are not met, a |status-412| error response
+When the provided preconditions are not met, a |status-412| error response
 is returned.
 
 Additional information about the record currently stored on the server will be

--- a/docs/api/1.x/openapi.rst
+++ b/docs/api/1.x/openapi.rst
@@ -102,7 +102,7 @@ The current implementation supports extensions as follows:
   `Cornice Swagger documentation <https://cornices.github.io/cornice.ext.swagger/>`_.
 
 - If the plugin changes the possible responses for a Resource, you can
-  document it by subclassing :class:`kinto.core.resource.schema.ResourceReponses` and
+  document it by subclassing :class:`kinto.core.resource.schema.ResourceResponses` and
   changing the ``responses`` attribute on your Resource ``ViewSet``.
 
 - If the plugin adds an authentication method, you may declare it using

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -319,7 +319,7 @@ class Resource:
     #
 
     def plural_head(self):
-        """Model ``HEAD`` endpoint: empty reponse with a ``Total-Objects`` header.
+        """Model ``HEAD`` endpoint: empty response with a ``Total-Objects`` header.
 
         :raises: :exc:`~pyramid:pyramid.httpexceptions.HTTPNotModified` if
             ``If-None-Match`` header is provided and collection not

--- a/kinto/core/resource/schema.py
+++ b/kinto/core/resource/schema.py
@@ -21,7 +21,7 @@ positive_big_integer = colander.Range(min=0, max=POSTGRESQL_MAX_INTEGER_VALUE)
 
 
 class TimeStamp(TimeStamp):
-    """This schema is deprecated, you shoud use `kinto.core.schema.TimeStamp` instead."""
+    """This schema is deprecated, you should use `kinto.core.schema.TimeStamp` instead."""
 
     def __init__(self, *args, **kwargs):
         message = (
@@ -33,7 +33,7 @@ class TimeStamp(TimeStamp):
 
 
 class URL(URL):
-    """This schema is deprecated, you shoud use `kinto.core.schema.URL` instead."""
+    """This schema is deprecated, you should use `kinto.core.schema.URL` instead."""
 
     def __init__(self, *args, **kwargs):
         message = (
@@ -422,7 +422,7 @@ class PluralResponseSchema(colander.MappingSchema):
         return datalist
 
 
-class ResourceReponses:
+class ResourceResponses:
     """Class that wraps and handles Resource responses."""
 
     default_schemas = {
@@ -448,7 +448,7 @@ class ResourceReponses:
     }
     default_get_schemas = {
         "304": NotModifiedResponseSchema(
-            description="Reponse has not changed since value in If-None-Match header"
+            description="Response has not changed since value in If-None-Match header"
         )
     }
     default_post_schemas = {

--- a/kinto/core/resource/viewset.py
+++ b/kinto/core/resource/viewset.py
@@ -16,7 +16,7 @@ from .schema import (
     PluralGetQuerySchema,
     PluralQuerySchema,
     RequestSchema,
-    ResourceReponses,
+    ResourceResponses,
 )
 
 
@@ -64,7 +64,7 @@ class ViewSet:
 
     factory = authorization.RouteFactory
 
-    responses = ResourceReponses()
+    responses = ResourceResponses()
 
     service_arguments = {"description": "Set of {resource_name}"}
 

--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
@@ -422,7 +422,7 @@ def follow_subrequest(request, subrequest, **kwargs):
     """Run a subrequest (e.g. batch), and follow the redirection if any.
 
     :rtype: tuple
-    :returns: the reponse and the redirection request (or `subrequest`
+    :returns: the response and the redirection request (or `subrequest`
               if no redirection happened.)
     """
     try:

--- a/tests/core/resource/test_schema.py
+++ b/tests/core/resource/test_schema.py
@@ -370,9 +370,9 @@ class PluralQuerySchemaTest(unittest.TestCase):
         self.assertRaises(colander.Invalid, self.schema.deserialize, querystring)
 
 
-class ResourceReponsesTest(unittest.TestCase):
+class ResourceResponsesTest(unittest.TestCase):
     def setUp(self):
-        self.handler = schema.ResourceReponses()
+        self.handler = schema.ResourceResponses()
         self.resource = colander.MappingSchema(title="fake")
         self.obj = schema.ObjectSchema().bind(data=self.resource)
 


### PR DESCRIPTION
## Summary
Fixed two typos found in the Kinto documentation.

## Changes
- Fixed `ResourceReponses` → `ResourceResponses` in resource schema documentation  
- Fixed `shoud` → `should` in resource schema documentation

## Type of change
- [x] Documentation improvement

**Checklist:**
- [x] Add documentation. *(You fixed existing docs)*
- [ ] Add tests. *(Not needed for typo fixes)*
- [ ] Add a changelog entry. *(Not needed for minor typo fixes)*
- [ ] Add your name in the contributors file. *(Optional - maintainers may do this)*
- [ ] If you changed the HTTP API... *(Not applicable)*
- [ ] If you added a new configuration setting... *(Not applicable)*