### PR TITLE
Ref mozilla/remote-settings#966: expose excluded resources

### DIFF
--- a/kinto/plugins/history/__init__.py
+++ b/kinto/plugins/history/__init__.py
@@ -7,6 +7,28 @@ from kinto.core.events import ResourceChanged
 from .listener import on_resource_changed
 
 
+def uri_to_dict(uri):
+    """
+    Convert a resource URI to a dictionary with its components.
+    We don't use `kinto.core.view_lookup_registry()` here because it requires
+    a request context or an initialized registry, which is not available at
+    this point.
+    """
+    parts = uri.split("/")
+    if len(parts) == 3:
+        _, _buckets, bid = parts
+        return {"bucket": bid}
+    if len(parts) == 5:
+        _, _buckets, bid, resource, rid = parts
+        if resource == "collections":
+            return {"bucket": bid, "collection": rid}
+        return {"bucket": bid, "group": rid}
+    if len(parts) == 7:
+        _, _buckets, bid, _collections, cid, _records, rid = parts
+        return {"bucket": bid, "collection": cid, "record": rid}
+    raise ValueError(f"Invalid URI: {uri}")
+
+
 def includeme(config):
     settings = config.get_settings()
     exposed_settings = {}
@@ -14,6 +36,8 @@ def includeme(config):
         exposed_settings["auto_trim_max_count"] = trim_history_max
     if trim_user_ids := aslist(settings.get("history.auto_trim_user_ids", "")):
         exposed_settings["auto_trim_user_ids"] = trim_user_ids
+    if excluded_resources := aslist(settings.get("history.exclude_resources", "")):
+        exposed_settings["excluded_resources"] = [uri_to_dict(uri) for uri in excluded_resources]
 
     config.add_api_capability(
         "history",


### PR DESCRIPTION
Ref mozilla/remote-settings#966

I know that this URL split is very ugly. We also do it in https://github.com/mozilla/remote-settings/blob/2d60231034c901331aeee5ee1bc6fb4610c8cacf/kinto-remote-settings/src/kinto_remote_settings/signer/utils.py#L43