### PR TITLE
Fix breaking change with dropped support for userids with colons

### DIFF
--- a/kinto/core/initialization.py
+++ b/kinto/core/initialization.py
@@ -475,8 +475,9 @@ def setup_metrics(config):
         # Count unique users.
         user_id = request.prefixed_userid
         if user_id:
-            # Get rid of colons in metric packet (see #1282).
-            auth, user_id = user_id.split(":")
+            auth, user_id = user_id.split(":", 1)
+            # Get rid of colons in metric packet (see #1282 and  #3571).
+            user_id = user_id.replace(":", ".")
             metrics_service.count("users", unique=[("auth", auth), ("userid", user_id)])
 
         status = event.response.status_code


### PR DESCRIPTION
Fixes #3571

- [ ] Add documentation.
- [ ] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it.
