### PR TITLE
Optimize `all_resource_timestamps()`

### DIFF
--- a/kinto/core/storage/postgresql/migrations/migration_024_025.sql
+++ b/kinto/core/storage/postgresql/migrations/migration_024_025.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS idx_objects_parent_id_record_last_modified
+    ON objects (parent_id, last_modified DESC)
+    WHERE resource_name = 'record';
+
+-- Bump storage schema version.
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '25');

--- a/kinto/core/storage/postgresql/schema.sql
+++ b/kinto/core/storage/postgresql/schema.sql
@@ -49,10 +49,14 @@ CREATE INDEX IF NOT EXISTS idx_objects_last_modified_epoch
     ON objects(as_epoch(last_modified));
 CREATE INDEX IF NOT EXISTS idx_objects_resource_name_parent_id_deleted
     ON objects(resource_name, parent_id, deleted);
+-- Index for collections timestamps
+CREATE INDEX IF NOT EXISTS idx_objects_parent_id_record_last_modified
+    ON objects (parent_id, last_modified DESC)
+    WHERE resource_name = 'record';
 -- Index for history plugin trimming.
 CREATE INDEX IF NOT EXISTS idx_objects_history_userid_and_resourcename
-  ON objects ((data->'user_id'), (data->'resource_name'))
-  WHERE resource_name = 'history';
+    ON objects ((data->'user_id'), (data->'resource_name'))
+    WHERE resource_name = 'history';
 
 CREATE TABLE IF NOT EXISTS timestamps (
   parent_id TEXT NOT NULL COLLATE "C",
@@ -136,4 +140,4 @@ INSERT INTO metadata (name, value) VALUES ('created_at', NOW()::TEXT);
 
 -- Set storage schema version.
 -- Should match ``kinto.core.storage.postgresql.PostgreSQL.schema_version``
-INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '24');
+INSERT INTO metadata (name, value) VALUES ('storage_schema_version', '25');


### PR DESCRIPTION
<img width="1676" height="308" alt="Image" src="https://github.com/user-attachments/assets/80123a25-bc95-4722-9836-8f5f917db53e" />

Cost divided by 3, by adding a partial index on `resource_name = 'record'`.
The rest of changes bring some improvements but not crucial.

Before

<img width="722" height="759" alt="Screenshot 2025-11-04 at 17 40 25" src="https://github.com/user-attachments/assets/cbff5757-b63f-4328-969f-93b726c5e735" />

https://explain.dalibo.com/plan/2542259f3947cc83#plan/node/6

After 
<img width="666" height="587" alt="Screenshot 2025-11-04 at 17 40 41" src="https://github.com/user-attachments/assets/e8286a3f-8aba-4b18-9348-4893a9c24c0b" />

https://explain.dalibo.com/plan/hd7f0f51e0db8646#plan/node/5