### PR TITLE
feat: Add offset-based pagination support

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/kinto.iml
+++ b/.idea/kinto.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.13 virtualenv at C:\Users\deept\Downloads\kinto-fresh\venv" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Chameleon" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/kinto/core/cornice_swagger/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 virtualenv at C:\Users\deept\Downloads\kinto-fresh\venv" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 virtualenv at C:\Users\deept\Downloads\kinto-fresh\venv" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/kinto.iml" filepath="$PROJECT_DIR$/.idea/kinto.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
# Add Offset-Based Pagination Support

## Problem
Currently, Kinto only supports token-based pagination which requires sequential access to records. Users cannot jump directly to specific record positions (e.g., records 100-120) without paging through all previous records.

## Solution
This PR adds support for `_offset` parameter alongside the existing token-based pagination, allowing direct access to any record position.

## Changes
- **New `_offset` parameter**: Allows specifying starting position for records
- **Backward compatible**: Existing token-based pagination continues to work unchanged
- **Enhanced response format**: Includes pagination metadata for offset requests
- **Manual offset handling**: Implements offset slicing for memory backend

## Key Features
1. **Direct Access**: `GET /records?_limit=20&_offset=100` returns records 100-119 directly
2. **Pagination Metadata**: Response includes `pagination` object with limit, offset, total, has_more
3. **Next Page URLs**: Automatically generated with correct offset values
4. **Priority System**: Offset takes precedence over token when both are provided

## API Examples
```bash
# Offset pagination
GET /records?_limit=20&_offset=100

# Response
{
  "data": [...],
  "pagination": {
    "limit": 20,
    "offset": 100,
    "total": null,
    "has_more": true
  },
  "next": "/records?_limit=20&_offset=120"
}

# Backward compatibility maintained
GET /records?_limit=20&_token=abc123  # Still works
