### PR TITLE
Do not trim history on each insertion

### DIFF
--- a/docs/api/1.x/history.rst
+++ b/docs/api/1.x/history.rst
@@ -263,3 +263,9 @@ In order to limit the size of the history length of each resource only for certa
 .. code-block:: ini
 
     kinto.history.auto_trim_user_ids = account:quicksuggest
+
+Entries will be trimmed by groups of 100 by default. Adjust using this setting:
+
+.. code-block:: ini
+
+    kinto.history.auto_trim_threshold = 0

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -721,6 +721,7 @@ class TrimHistoryTest(HistoryWebTest):
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
         settings["history.auto_trim_max_count"] = "5"
+        settings["history.auto_trim_threshold"] = "0"
         return settings
 
     def test_history_length_is_limited_by_resource(self):
@@ -755,6 +756,7 @@ class TrimUserIdTest(HistoryWebTest):
         settings = super().get_app_settings(extras)
         settings["history.auto_trim_user_ids"] = cls.joan_principal
         settings["history.auto_trim_max_count"] = "5"
+        settings["history.auto_trim_threshold"] = "0"
         return settings
 
     def setUp(self):


### PR DESCRIPTION
I noticed that applying the permissions file was very slow. And that the history was trimmed on each insertion...

```
Trimmed 1 old history entries. rid=055acd04-0e2d-4c47-9af0-f6db5ef3cd12
Trimmed 1 old history entries. rid=055acd04-0e2d-4c47-9af0-f6db5ef3cd12
Trimmed 1 old history entries. rid=055acd04-0e2d-4c47-9af0-f6db5ef3cd12
Trimmed 1 old history entries. rid=055acd04-0e2d-4c47-9af0-f6db5ef3cd12
Trimmed 1 old history entries. rid=055acd04-0e2d-4c47-9af0-f6db5ef3cd12
...
...
```

We could add another index dedicated to this, but in the mean time, this PR seems like a low hanging fruit.

Counting is 4x faster than deleting

```
2025-12-29 15:56:17.857 CET [16359] LOG:  duration: 768.727 ms  statement:
	            WITH to_delete AS (
	                SELECT id
	                FROM objects
	                WHERE parent_id = '/buckets/main-workspace'
	                  AND resource_name = 'history'
	                  AND (data->'resource_name' IS NOT NULL AND data->'resource_name' = '"group"') AND (data->'user_id' IS NOT NULL AND data->'user_id' = '"account:admin"')
	                ORDER BY last_modified DESC
	                OFFSET 1000
	            )
	            DELETE FROM objects o
	            USING to_delete d
	            WHERE o.id = d.id
	            RETURNING 1;
```

```
2025-12-29 15:56:19.025 CET [16359] LOG:  duration: 286.766 ms  statement:
	            SELECT COUNT(*) AS total_count
	            FROM objects
	            WHERE parent_id = '/buckets/main-workspace'
	            AND resource_name = 'history'
	            AND NOT deleted
	            AND (data->'resource_name' IS NOT NULL AND data->'resource_name' = '"group"') AND (data->'user_id' IS NOT NULL AND data->'user_id' = '"account:admin"')
```

So wait for 100 insertions before trimming