### PR TITLE
Fix purge-delete committing

### DIFF
--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -635,6 +635,7 @@ class Storage(StorageBase, MigratorMixin):
                     {resource_name_filter}
                     AND rn > :max_retained
             )
+            RETURNING 1
             """
 
         id_field = id_field or self.id_field
@@ -660,7 +661,7 @@ class Storage(StorageBase, MigratorMixin):
             safeholders["conditions_filter"] = "AND as_epoch(last_modified) < :before"
             placeholders["before"] = before
 
-        with self.client.connect() as conn:
+        with self.client.connect(force_commit=True) as conn:
             result = conn.execute(sa.text(delete_tombstones.format_map(safeholders)), placeholders)
             deleted = result.rowcount
 


### PR DESCRIPTION
I noticed that when running the `purge-deleted` command several times, it would always the same number:
```
$ kinto purge-deleted --ini=config/rsprod.ini record history 10000
INFO   Running kinto 23.3.1.dev7+g74063b96a.d20251229.
INFO   Keep only 10000 tombstones per parent and resource.
INFO   3255 tombstone(s) deleted.
$
$ kinto purge-deleted --ini=config/rsprod.ini record history 10000
INFO   Running kinto 23.3.1.dev7+g74063b96a.d20251229.
INFO   Keep only 10000 tombstones per parent and resource.
INFO   3255 tombstone(s) deleted.
```

And found out that the transaction was rollback in the postgresql logs:
```
2025-12-29 17:49:36.004 CET [10696] LOG:  unexpected EOF on client connection with an open transaction
```

I realized that all our CLI commands have `force_commit=True`, and that `purge-deleted` was missing it.

See https://github.com/Kinto/kinto/blob/98c269b3181bfcfbe521534623dd8fd479407085/kinto/core/storage/postgresql/__init__.py#L191
or https://github.com/Kinto/kinto/blob/1c2355979d610c9e92bbeb898978add9052505ea/kinto/core/storage/postgresql/migrator.py#L97
