### PR TITLE
Fixes #3630 - performance regression in `all_resource_timestamps()` for Postgres

### DIFF
--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -252,10 +252,10 @@ class Storage(StorageBase, MigratorMixin):
         WITH existing_timestamps AS (
           -- Timestamp of latest object by parent_id.
           (
-            SELECT DISTINCT ON (parent_id) parent_id, last_modified
+            SELECT parent_id, MAX(last_modified) AS last_modified
             FROM objects
             WHERE resource_name = :resource_name
-            ORDER BY parent_id, last_modified DESC
+            GROUP BY parent_id
           )
           -- Timestamp of resources without sub-objects.
           UNION ALL


### PR DESCRIPTION
Fixes #3630

Before: Sort  (cost=120634.50..120635.00 rows=200 width=49) (actual time=482.285..482.344 rows=318 loops=1)

After: Sort  (cost=105049.60..105050.10 rows=200 width=40) (actual time=218.164..218.180 rows=318 loops=1)