### PR TITLE
Fix crash when object ID contains regex special chars (Fixes #2676)

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -36,6 +36,7 @@ Contributors
 * Fil <fil@rezo.net>
 * FooBarQuaxx
 * Francisco J. Piedrahita <@fpiedrah>
+* Franco Morales <francomorales0001@gmail.com>
 * Frank Bertsch <frank@mozilla.com>
 * Greeshma <greeshmabalabadra@gmail.com>
 * Gabriela Surita <gabsurita@gmail.com>

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import re
 
 from pyramid.authorization import Authenticated
 from pyramid.interfaces import IAuthorizationPolicy
@@ -228,7 +229,13 @@ class RouteFactory:
             bound_perms = get_bound_permissions(self._object_id_match, perm)
         else:
             bound_perms = [(self._object_id_match, perm)]
-        by_obj_id = self._get_accessible_objects(principals, bound_perms, with_children=False)
+        
+        safe_bound_perms = [
+            (re.escape(obj_id).replace(r'\*', '*') if obj_id else obj_id, p)
+            for obj_id, p in bound_perms
+        ]
+
+        by_obj_id = self._get_accessible_objects(principals, safe_bound_perms, with_children=False)
         ids = by_obj_id.keys()
         # Store for later use in ``Resource``.
         self.shared_ids = [self._extract_object_id(id_) for id_ in ids]

--- a/kinto/core/authorization.py
+++ b/kinto/core/authorization.py
@@ -229,9 +229,9 @@ class RouteFactory:
             bound_perms = get_bound_permissions(self._object_id_match, perm)
         else:
             bound_perms = [(self._object_id_match, perm)]
-        
+
         safe_bound_perms = [
-            (re.escape(obj_id).replace(r'\*', '*') if obj_id else obj_id, p)
+            (re.escape(obj_id).replace(r"\*", "*") if obj_id else obj_id, p)
             for obj_id, p in bound_perms
         ]
 

--- a/tests/core/test_authorization.py
+++ b/tests/core/test_authorization.py
@@ -165,7 +165,7 @@ class RouteFactoryTest(unittest.TestCase):
         context.required_permission = "book:create"
         context._settings = {"book_create_principals": "fxa:user"}
         self.assertTrue(context.check_permission(["fxa:user"], None))
-    
+
     def test_fetch_shared_objects_with_regex_special_chars_in_object_id(self):
         """Bucket IDs with unbalanced parentheses should not raise re.error."""
         # Reproduce issue #2676

--- a/tests/core/test_authorization.py
+++ b/tests/core/test_authorization.py
@@ -165,6 +165,19 @@ class RouteFactoryTest(unittest.TestCase):
         context.required_permission = "book:create"
         context._settings = {"book_create_principals": "fxa:user"}
         self.assertTrue(context.check_permission(["fxa:user"], None))
+    
+    def test_fetch_shared_objects_with_regex_special_chars_in_object_id(self):
+        """Bucket IDs with unbalanced parentheses should not raise re.error."""
+        # Reproduce issue #2676
+        request = DummyRequest()
+        request.route_path.return_value = "/v1/buckets/%29EFg9%3D%29"
+        service = mock.MagicMock()
+        service.type = "object"
+        with mock.patch("kinto.core.authorization.utils.current_service") as m:
+            m.return_value = service
+            context = RouteFactory(request)
+        # Should not raise re.error
+        context.fetch_shared_objects("read", ["userid"], None)
 
 
 class AuthorizationPolicyTest(unittest.TestCase):


### PR DESCRIPTION
## Problem
When a bucket ID contains unbalanced parentheses or other regex special
characters (e.g. `)EFg9=)^(M~ 37`), Kinto crashes with HTTP 500:

    re.error: unbalanced parenthesis at position 10

## Solution
Escape special regex characters in object IDs before passing them to
get_accessible_objects. The `*` wildcard used by plural endpoints
is preserved after escaping.

## Testing
- All existing tests in `tests/core/test_authorization.py` pass (32/32)
- Added regression test for this specific case
- Verified manually: the endpoint now returns 401 instead of 500

This is my first open source contribution. If anything is wrong or could
be improved, please let me know — I'm happy to learn and make any necessary
changes!

Fixes #2676

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it.
