### PR TITLE
Ref #2391: remove redundant migration name parameter

### DIFF
--- a/docs/tutorials/write-plugin.rst
+++ b/docs/tutorials/write-plugin.rst
@@ -359,7 +359,7 @@ Register it in ``includeme()``:
 .. code-block:: python
 
     def includeme(config):
-        config.add_migration("myplugin", MyPluginMigration())
+        config.add_migration(MyPluginMigration())
 
 Running ``kinto migrate`` will now also apply your plugin's schema:
 
@@ -432,7 +432,7 @@ own storage and permission backends.
 .. code-block:: python
 
     def includeme(config):
-        config.add_migration("myplugin", MyPluginMigration())
+        config.add_migration(MyPluginMigration())
 
 .. note::
 

--- a/kinto/core/__init__.py
+++ b/kinto/core/__init__.py
@@ -198,8 +198,8 @@ def includeme(config):
     # Directive for plugins to declare schema migrations.
     from kinto.core.migrations import IMigratable
 
-    def add_migration(config, name, migration):
-        config.registry.registerUtility(migration, IMigratable, name=name)
+    def add_migration(config, migration):
+        config.registry.registerUtility(migration, IMigratable, name=migration.name)
 
     config.add_directive("add_migration", add_migration)
 

--- a/tests/core/test_initialization.py
+++ b/tests/core/test_initialization.py
@@ -143,7 +143,8 @@ class InitializationTest(unittest.TestCase):
         kinto.core.initialize(config, "0.0.1", "prefix")
 
         migration = mock.MagicMock()
-        config.add_migration("my_plugin", migration)
+        migration.name = "my_plugin"
+        config.add_migration(migration)
         config.commit()
 
         registered = dict(config.registry.getUtilitiesFor(IMigratable))  # ty: ignore[unresolved-attribute]


### PR DESCRIPTION
Ref #2391

Example of usage: https://github.com/Kinto/kinto-attachment/pull/786/changes/cfbde4061c451fe5511761378efa7dff83a487d4