### PR TITLE
Fix mozilla/remote-settings#1277: history entry on attachments creation

### DIFF
--- a/kinto/plugins/history/listener.py
+++ b/kinto/plugins/history/listener.py
@@ -19,7 +19,6 @@ def on_resource_changed(event):
     """
     payload = event.payload
     resource_name = payload["resource_name"]
-    event_uri = payload["uri"]
     user_id = payload["user_id"]
 
     storage = event.request.registry.storage
@@ -70,15 +69,18 @@ def on_resource_changed(event):
                 )
                 continue
 
-        # On POST .../records, the URI does not contain the newly created
-        # record id.
-        parts = event_uri.split("/")
-        if resource_name in parts[-1]:
-            parts.append(obj_id)
-        else:
-            # Make sure the id is correct on grouped events.
-            parts[-1] = obj_id
-        uri = "/".join(parts)
+        # Build the resource URI from the IDs we already have, rather than
+        # parsing ``event_uri`` (which is ``request.path``). Some plugins
+        # route resource writes through sub-paths (e.g. kinto-attachment's
+        # ``patch_record()`` hits ``.../records/<id>/attachment``);
+        # parsing the request path would produce a malformed
+        # ``.../records/<id>/<id>`` URI for those entries.
+        route_params = {"id": obj_id}
+        if resource_name != "bucket":
+            route_params["bucket_id"] = bucket_id
+        if "collection_id" in payload:
+            route_params["collection_id"] = payload["collection_id"]
+        uri = instance_uri(event.request, resource_name, **route_params)
 
         if uri in excluded_resources:
             logger.info(f"History entries for record {uri!r} are disabled in config")

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -3,6 +3,7 @@ import re
 import unittest
 from unittest import mock
 
+from kinto.core.events import ACTIONS, ResourceChanged
 from kinto.core.testing import get_user_headers, skip_if_no_statsd
 
 from .. import support
@@ -299,6 +300,72 @@ class HistoryViewTest(HistoryWebTest):
         resp = self.app.get(self.history_uri, headers=self.headers)
         deletion_entries = [e for e in resp.json["data"] if e["action"] == "delete"]
         assert len(deletion_entries) == 1
+
+
+def includeme(config):
+    """Test fake plugin.
+
+    Mutates ``ResourceChanged`` event payloads for records to append an extra
+    path segment to ``payload["uri"]``, simulating a request that hit a
+    sub-path of a record (e.g. ``.../records/<id>/attachment`` as done by
+    kinto-attachment's ``patch_record()``).
+    https://github.com/Kinto/kinto-attachment/blob/f539c6ccbd82971661/src/kinto_attachment/utils.py#L142
+    """
+
+    def append_subpath(event):
+        if event.payload["action"] in (ACTIONS.CREATE.value, ACTIONS.UPDATE.value):
+            if not event.payload["uri"].endswith("/attachment"):
+                event.payload["uri"] = event.payload["uri"] + "/attachment"
+
+    config.add_subscriber(append_subpath, ResourceChanged, for_resources=("record",))
+
+
+class SubpathEventURITest(HistoryWebTest):
+    """Test that history does not rely on object id as the last segment."""
+
+    @classmethod
+    def get_app_settings(cls, extras=None):
+        settings = super().get_app_settings(extras)
+        # Order matters: this helper must run before the history listener.
+        settings["includes"] = "tests.plugins.test_history " + settings["includes"]
+        return settings
+
+    def setUp(self):
+        self.app.put("/buckets/b", headers=self.headers)
+        self.app.put("/buckets/b/collections/c", headers=self.headers)
+
+    def test_record_create_history_uri_is_canonical(self):
+        self.app.put_json(
+            "/buckets/b/collections/c/records/r",
+            {"data": {"foo": 1}},
+            headers=self.headers,
+        )
+
+        resp = self.app.get("/buckets/b/history?resource_name=record", headers=self.headers)
+
+        entry = resp.json["data"][0]
+        assert entry["action"] == "create"
+        assert entry["uri"] == "/buckets/b/collections/c/records/r"
+
+    def test_record_update_history_uri_is_canonical(self):
+        self.app.put_json(
+            "/buckets/b/collections/c/records/r",
+            {"data": {"foo": 1}},
+            headers=self.headers,
+        )
+        self.app.patch_json(
+            "/buckets/b/collections/c/records/r",
+            {"data": {"foo": 2}},
+            headers=self.headers,
+        )
+
+        resp = self.app.get(
+            "/buckets/b/history?resource_name=record&action=update",
+            headers=self.headers,
+        )
+
+        entry = resp.json["data"][0]
+        assert entry["uri"] == "/buckets/b/collections/c/records/r"
 
 
 class HistoryDeletionTest(HistoryWebTest):

--- a/tests/plugins/test_history.py
+++ b/tests/plugins/test_history.py
@@ -1,13 +1,21 @@
 import json
 import re
+import shutil
+import tempfile
 import unittest
 from unittest import mock
 
-from kinto.core.events import ACTIONS, ResourceChanged
 from kinto.core.testing import get_user_headers, skip_if_no_statsd
 
 from .. import support
 
+
+try:
+    import kinto_attachment  # noqa: F401
+
+    HAS_KINTO_ATTACHMENT = True
+except ImportError:
+    HAS_KINTO_ATTACHMENT = False
 
 DATETIME_REGEX = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+\d{2}:\d{2}$"
 
@@ -302,70 +310,71 @@ class HistoryViewTest(HistoryWebTest):
         assert len(deletion_entries) == 1
 
 
-def includeme(config):
-    """Test fake plugin.
-
-    Mutates ``ResourceChanged`` event payloads for records to append an extra
-    path segment to ``payload["uri"]``, simulating a request that hit a
-    sub-path of a record (e.g. ``.../records/<id>/attachment`` as done by
-    kinto-attachment's ``patch_record()``).
-    https://github.com/Kinto/kinto-attachment/blob/f539c6ccbd82971661/src/kinto_attachment/utils.py#L142
+@unittest.skipUnless(HAS_KINTO_ATTACHMENT, "kinto-attachment is not installed")
+class AttachmentHistoryURITest(HistoryWebTest):
+    """When a record is created/updated via kinto-attachment's
+    sub-path endpoint (``.../records/<id>/attachment``), the resulting history
+    entries must use the canonical record URI and not the request path, which
+    would otherwise produce a malformed ``.../records/<id>/<id>`` URI.
     """
-
-    def append_subpath(event):
-        if event.payload["action"] in (ACTIONS.CREATE.value, ACTIONS.UPDATE.value):
-            if not event.payload["uri"].endswith("/attachment"):
-                event.payload["uri"] = event.payload["uri"] + "/attachment"
-
-    config.add_subscriber(append_subpath, ResourceChanged, for_resources=("record",))
-
-
-class SubpathEventURITest(HistoryWebTest):
-    """Test that history does not rely on object id as the last segment."""
 
     @classmethod
     def get_app_settings(cls, extras=None):
         settings = super().get_app_settings(extras)
-        # Order matters: this helper must run before the history listener.
-        settings["includes"] = "tests.plugins.test_history " + settings["includes"]
+        settings["includes"] = settings["includes"] + " kinto_attachment"
+        cls._attachments_folder = tempfile.mkdtemp(prefix="kinto-history-attach-")
+        settings["attachment.base_path"] = cls._attachments_folder
+        settings["attachment.base_url"] = "https://cdn.example/"
         return settings
 
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(cls._attachments_folder, ignore_errors=True)
+
     def setUp(self):
-        self.app.put("/buckets/b", headers=self.headers)
-        self.app.put("/buckets/b/collections/c", headers=self.headers)
+        self.app.put("/buckets/bid", headers=self.headers)
+        self.app.put("/buckets/bid/collections/cid", headers=self.headers)
 
-    def test_record_create_history_uri_is_canonical(self):
+    def _upload_attachment(self, record_id):
+        url = f"/buckets/bid/collections/cid/records/{record_id}/attachment"
+        files = [("attachment", "file.txt", b"hello")]
+        content_type, body = self.app.encode_multipart([], files)
+        headers = {**self.headers, "Content-Type": content_type}
+        return self.app.post(url, body, headers=headers)
+
+    def test_history_uri_for_new_record_via_attachment(self):
+        self._upload_attachment("rid")
+
+        resp = self.app.get("/buckets/bid/history?resource_name=record", headers=self.headers)
+
+        record_entries = resp.json["data"]
+        assert len(record_entries) == 1
+        assert record_entries[0]["action"] == "create"
+        assert "attachment" in record_entries[0]["target"]["data"]
+        record_uri = "/buckets/bid/collections/cid/records/rid"
+        assert record_entries[0]["uri"] == record_uri
+
+    def test_history_uri_for_existing_record_via_attachment(self):
         self.app.put_json(
-            "/buckets/b/collections/c/records/r",
+            "/buckets/bid/collections/cid/records/rid",
             {"data": {"foo": 1}},
             headers=self.headers,
         )
+        # Uploading an attachment routes through kinto-attachment's
+        # patch_record() shim, which is what produced the malformed URI.
+        self._upload_attachment("rid")
 
-        resp = self.app.get("/buckets/b/history?resource_name=record", headers=self.headers)
+        resp = self.app.get("/buckets/bid/history?resource_name=record", headers=self.headers)
 
-        entry = resp.json["data"][0]
-        assert entry["action"] == "create"
-        assert entry["uri"] == "/buckets/b/collections/c/records/r"
-
-    def test_record_update_history_uri_is_canonical(self):
-        self.app.put_json(
-            "/buckets/b/collections/c/records/r",
-            {"data": {"foo": 1}},
-            headers=self.headers,
-        )
-        self.app.patch_json(
-            "/buckets/b/collections/c/records/r",
-            {"data": {"foo": 2}},
-            headers=self.headers,
-        )
-
-        resp = self.app.get(
-            "/buckets/b/history?resource_name=record&action=update",
-            headers=self.headers,
-        )
-
-        entry = resp.json["data"][0]
-        assert entry["uri"] == "/buckets/b/collections/c/records/r"
+        record_entries = resp.json["data"]
+        assert len(record_entries) == 2
+        assert record_entries[-1]["action"] == "create"
+        assert "attachment" not in record_entries[-1]["target"]["data"]
+        assert record_entries[0]["action"] == "update"
+        assert "attachment" in record_entries[0]["target"]["data"]
+        record_uri = "/buckets/bid/collections/cid/records/rid"
+        assert record_entries[0]["uri"] == record_uri
 
 
 class HistoryDeletionTest(HistoryWebTest):


### PR DESCRIPTION
Fixes mozilla/remote-settings#1277