### PR TITLE
Validate pagination token last_object

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -106,6 +106,7 @@ Contributors
 * Vamsi Sangam <vamsisangam@live.com>
 * Varna Suresh <varna96@gmail.com>
 * Vincent Fretin <@vincentfretin>
+* Vincent Gao <@gaoflow>
 * Vitor Falcao <vitor.falcaor@gmail.com>
 * Wil Clouser <wclouser@mozilla.com>
 * Yann Klis <yann.klis@gmail.com>

--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -1266,6 +1266,8 @@ class Resource:
                 if not isinstance(tokeninfo, dict):
                     raise ValueError()
                 last_object = tokeninfo["last_object"]
+                if not isinstance(last_object, dict):
+                    raise ValueError()
                 offset = tokeninfo["offset"]
                 nonce = tokeninfo["nonce"]
             except (ValueError, KeyError, TypeError):

--- a/tests/core/resource/test_pagination.py
+++ b/tests/core/resource/test_pagination.py
@@ -195,6 +195,20 @@ class PaginationTest(BasePaginationTest):
         }
         self.assertRaises(HTTPBadRequest, self.resource.plural_get)
 
+    def test_raises_bad_request_if_token_last_object_is_not_object(self):
+        invalid_token = json.dumps(
+            {
+                "last_object": ["not", "an", "object"],
+                "offset": 0,
+                "nonce": "nonce",
+            }
+        )
+        self.validated["querystring"] = {
+            "_limit": 20,
+            "_token": b64encode(invalid_token.encode("ascii")).decode("ascii"),
+        }
+        self.assertRaises(HTTPBadRequest, self.resource.plural_get)
+
     def test_next_page_url_works_with_optional_fields(self):
         self.validated["querystring"] = {"_limit": 10, "_sort": ["-optional"]}
         results1 = self.resource.plural_get()


### PR DESCRIPTION
Fixes #3736

- [ ] Add documentation. Not applicable; this rejects a malformed pagination token instead of changing documented API behavior.
- [x] Add tests.
- [x] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst). Not applicable; malformed `_token` already returns HTTP 400 for other invalid token shapes.
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it. Not applicable.

## Summary

Validate that the decoded pagination token's `last_object` value is a JSON object before building pagination rules from it. Previously a token with a list value reached `_build_pagination_rules()` and crashed with `AttributeError` when calling `.get()`.

## Verification

```text
uv run --extra test pytest tests/core/resource/test_pagination.py -q
uv run --extra dev ruff check kinto/core/resource/__init__.py tests/core/resource/test_pagination.py
uv run --extra dev ruff format --check kinto/core/resource/__init__.py tests/core/resource/test_pagination.py
git diff --check
```