### PR TITLE
Reject null characters in list filters (fixes #3738)

### DIFF
--- a/kinto/core/resource/__init__.py
+++ b/kinto/core/resource/__init__.py
@@ -1091,6 +1091,15 @@ class Resource:
             tomorrow = msec_time() + 24 * 3600 * 1000
             return 0 <= ivalue < tomorrow
 
+        def has_null_character(value: Any) -> bool:
+            if isinstance(value, str):
+                return "\x00" in value
+            if isinstance(value, list | tuple):
+                return any(has_null_character(item) for item in value)
+            if isinstance(value, dict):
+                return any(has_null_character(item) for pair in value.items() for item in pair)
+            return False
+
         queryparams = self.request.validated["querystring"]
 
         filters = []
@@ -1156,7 +1165,7 @@ class Resource:
                 if has_invalid_value:
                     raise_invalid(self.request, **error_details)
 
-            if "\x00" in field or "\x00" in str(value):
+            if "\x00" in field or has_null_character(value):
                 error_details["description"] = "Invalid character 0x00"
                 raise_invalid(self.request, **error_details)
 

--- a/tests/core/resource/test_filter.py
+++ b/tests/core/resource/test_filter.py
@@ -275,6 +275,12 @@ class FilteringTest(BaseTest):
         self.validated["querystring"] = {"in_last_modified": ["a", "b"]}
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.plural_get)
 
+    def test_include_returns_400_if_string_list_value_has_null_character(self):
+        self.validated["querystring"] = {"in_id": ["abc\x00def"]}
+        with self.assertRaises(httpexceptions.HTTPBadRequest) as cm:
+            self.resource.plural_get()
+        self.assertIn("Invalid character 0x00", cm.exception.json["message"])
+
     def test_exclude_returns_400_if_value_has_wrong_type(self):
         self.validated["querystring"] = {"exclude_id": [0, 1]}
         with self.assertRaises(httpexceptions.HTTPBadRequest) as cm:
@@ -283,6 +289,12 @@ class FilteringTest(BaseTest):
 
         self.validated["querystring"] = {"exclude_last_modified": ["a", "b"]}
         self.assertRaises(httpexceptions.HTTPBadRequest, self.resource.plural_get)
+
+    def test_exclude_returns_400_if_string_list_value_has_null_character(self):
+        self.validated["querystring"] = {"exclude_id": ["abc\x00def"]}
+        with self.assertRaises(httpexceptions.HTTPBadRequest) as cm:
+            self.resource.plural_get()
+        self.assertIn("Invalid character 0x00", cm.exception.json["message"])
 
     def test_contains_can_filter_with_one_string(self):
         self.validated["querystring"] = {"contains_colors": ["red"]}


### PR DESCRIPTION
Fixes #3738

- [ ] Add documentation. Not applicable; this preserves the existing invalid-character behavior for malformed filters.
- [x] Add tests.
- [ ] Add your name in the contributors file. Already added in #3740 to avoid two parallel PRs adding the same line.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst). Not applicable; malformed filter values already return HTTP 400.
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it. Not applicable.

## Summary

The existing NUL-character guard used `str(value)`, which catches direct string values but misses strings inside list filters because `str(["a\x00b"])` escapes the NUL in the representation. As a result, malformed `in_`/`exclude_` filters could reach the PostgreSQL adapter and fail in psycopg2.

This changes the guard to inspect strings inside list/tuple/dict values directly, so malformed list filters are rejected as HTTP 400 before storage execution.

## Verification

```text
uv run --extra test pytest tests/core/resource/test_filter.py -q
uv run --extra dev ruff check kinto/core/resource/__init__.py tests/core/resource/test_filter.py
uv run --extra dev ruff format --check kinto/core/resource/__init__.py tests/core/resource/test_filter.py
git diff --check
```