### PR TITLE
OpenID: invalid auth payload not turned into proper 401

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -55,6 +55,7 @@ Contributors
 * Julien Bouquillon <contact@revolunet.com>
 * Julien Lebunetel <julien@lebunetel.com>
 * Kaloneh <kaloneh@gmail.com>
+* Kanishkraj Singh Chauhan <kanishkrajsinghchauhan@gmail.com>
 * Kulshekhar Kabra <@kulshekhar>
 * Lavish Aggarwal <lucky.lavish@gmail.com>
 * Maksym Shalenyi <supamaxy@gmail.com>

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -132,14 +132,10 @@ def validate_token_querystring(node: colander.SchemaNode, value: dict) -> None:
     has_code = "code" in value
     has_error = "error" in value
 
-    success_response = has_code
-    error_response = has_error
-
-    if success_response == error_response:
+    if has_code == has_error:
         raise colander.Invalid(
             node,
-            "Provide either 'state' and 'code', "
-            "or 'error' and 'error_description', but not both.",
+            "Provide either 'state' and 'code', or 'error' and 'error_description', but not both.",
         )
 
 
@@ -153,7 +149,7 @@ class TokenQuerystringSchema(colander.MappingSchema):
     error = colander.SchemaNode(colander.String(), missing=colander.drop)
     error_description = colander.SchemaNode(colander.String(), missing=colander.drop)
 
-    validator = validate_token_querystring
+    validator = staticmethod(validate_token_querystring)
 
 
 class TokenSchema(colander.MappingSchema):
@@ -203,14 +199,7 @@ def get_token(request: Request) -> None:
     oid_config = fetch_openid_config(issuer)
     token_endpoint = oid_config["token_endpoint"]
 
-    code = request.GET.get("code")
-    if not code:
-        # No error param and no code — malformed request.
-        error_details = {
-            "name": "code",
-            "description": "code in querystring: Required",
-        }
-        raise_invalid(request, **error_details)
+    code = request.GET["code"]
 
     # State can be used only once.
     callback = request.registry.cache.delete("openid:state:" + state)

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -127,7 +127,7 @@ def get_login(request: Request) -> None:
     raise httpexceptions.HTTPTemporaryRedirect(redirect)
 
 
-def validate_token_querystring(node: colander.SchemaNode, value: dict) -> None:
+def validate_token_querystring(node, value):
     """Enforce that exactly one of (code, error) is present, never both."""
     has_code = "code" in value
     has_error = "error" in value

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -127,6 +127,22 @@ def get_login(request: Request) -> None:
     raise httpexceptions.HTTPTemporaryRedirect(redirect)
 
 
+def validate_token_querystring(node: colander.SchemaNode, value: dict) -> None:
+    """Enforce that exactly one of (code, error) is present, never both."""
+    has_code = "code" in value
+    has_error = "error" in value
+
+    success_response = has_code
+    error_response = has_error
+
+    if success_response == error_response:
+        raise colander.Invalid(
+            node,
+            "Provide either 'state' and 'code', "
+            "or 'error' and 'error_description', but not both.",
+        )
+
+
 class TokenQuerystringSchema(colander.MappingSchema):
     """
     Querystring schema for the token endpoint.
@@ -134,6 +150,10 @@ class TokenQuerystringSchema(colander.MappingSchema):
 
     code = colander.SchemaNode(colander.String(), missing=colander.drop)
     state = colander.SchemaNode(colander.String())
+    error = colander.SchemaNode(colander.String(), missing=colander.drop)
+    error_description = colander.SchemaNode(colander.String(), missing=colander.drop)
+
+    validator = validate_token_querystring
 
 
 class TokenSchema(colander.MappingSchema):

--- a/kinto/plugins/openid/views.py
+++ b/kinto/plugins/openid/views.py
@@ -132,7 +132,7 @@ class TokenQuerystringSchema(colander.MappingSchema):
     Querystring schema for the token endpoint.
     """
 
-    code = colander.SchemaNode(colander.String())
+    code = colander.SchemaNode(colander.String(), missing=colander.drop)
     state = colander.SchemaNode(colander.String())
 
 
@@ -157,12 +157,40 @@ def get_token(request: Request) -> None:
     client_id = settings[settings_prefix + "client_id"]
     client_secret = settings[settings_prefix + "client_secret"]
 
+    state = request.GET["state"]
+
+    # If the auth server returned an error (e.g. access_denied when audience
+    # is not found), forward it back to the callback URI instead of trying
+    # to trade a code that was never issued.
+    error = request.GET.get("error")
+    if error:
+        callback = request.registry.cache.delete("openid:state:" + state)
+        if callback is None:
+            error_details = {
+                "name": "state",
+                "description": "Invalid state",
+                "errno": ERRORS.INVALID_AUTH_TOKEN.value,
+            }
+            raise_invalid(request, **error_details)
+        error_params = {"error": error}
+        error_description = request.GET.get("error_description")
+        if error_description:
+            error_params["error_description"] = error_description
+        redirect = callback + urllib.parse.urlencode(error_params)
+        raise httpexceptions.HTTPTemporaryRedirect(redirect)
+
     # Read OpenID configuration (cached by issuer)
     oid_config = fetch_openid_config(issuer)
     token_endpoint = oid_config["token_endpoint"]
 
-    code = request.GET["code"]
-    state = request.GET["state"]
+    code = request.GET.get("code")
+    if not code:
+        # No error param and no code — malformed request.
+        error_details = {
+            "name": "code",
+            "description": "code in querystring: Required",
+        }
+        raise_invalid(request, **error_details)
 
     # State can be used only once.
     callback = request.registry.cache.delete("openid:state:" + state)

--- a/tests/plugins/test_openid.py
+++ b/tests/plugins/test_openid.py
@@ -408,3 +408,73 @@ class TokenViewTest(OpenIDWebTest):
             )
         location = resp.headers["Location"]
         assert location == "http://ui/#token=eyJhY2Nlc3NfdG9rZW4iOiAidG9rZW4ifQ%3D%3D"
+
+
+class TokenViewErrorTest(OpenIDWebTest):
+    """The auth server may redirect back to the token endpoint with an error
+    instead of a code (e.g. when audience is not found).  Kinto must forward
+    the error to the original callback rather than returning a 400."""
+
+    def test_auth_server_error_redirects_to_callback(self):
+        """When the auth server returns error=access_denied (no code),
+        the token endpoint must redirect to the stored callback with the error
+        forwarded in the querystring."""
+        self.app.app.registry.cache.set("openid:state:mystate", "http://ui/?", ttl=100)
+        resp = self.app.get(
+            "/openid/auth0/token",
+            params={"error": "access_denied", "state": "mystate"},
+            status=307,
+        )
+        location = resp.headers["Location"]
+        assert "error=access_denied" in location
+        assert location.startswith("http://ui/?")
+
+    def test_auth_server_error_includes_error_description(self):
+        """error_description from the auth server must also be forwarded."""
+        self.app.app.registry.cache.set("openid:state:mystate", "http://ui/?", ttl=100)
+        resp = self.app.get(
+            "/openid/auth0/token",
+            params={
+                "error": "access_denied",
+                "error_description": "Service not found: kinto-nonprod",
+                "state": "mystate",
+            },
+            status=307,
+        )
+        location = resp.headers["Location"]
+        assert "error=access_denied" in location
+        assert "error_description=" in location
+        assert "Service+not+found" in location or "Service%20not%20found" in location
+
+    def test_auth_server_error_with_invalid_state_returns_400(self):
+        """If the state is unknown even when an error is returned, kinto
+        cannot recover the callback and must return 400."""
+        self.app.get(
+            "/openid/auth0/token",
+            params={"error": "access_denied", "state": "unknown-state"},
+            status=400,
+        )
+
+    def test_auth_server_error_state_cannot_be_reused(self):
+        """The state must be consumed even when an error is forwarded."""
+        self.app.app.registry.cache.set("openid:state:mystate", "http://ui/?", ttl=100)
+        self.app.get(
+            "/openid/auth0/token",
+            params={"error": "access_denied", "state": "mystate"},
+            status=307,
+        )
+        # Second request with same state must fail.
+        self.app.get(
+            "/openid/auth0/token",
+            params={"error": "access_denied", "state": "mystate"},
+            status=400,
+        )
+
+    def test_missing_code_and_no_error_returns_400(self):
+        """A request with state but neither code nor error is still a bad request."""
+        self.app.app.registry.cache.set("openid:state:mystate", "http://ui/?", ttl=100)
+        self.app.get(
+            "/openid/auth0/token",
+            params={"state": "mystate"},
+            status=400,
+        )


### PR DESCRIPTION
Fixes #3719 

- The `Example of login redirections` section in `docs/api/1.x/openid.rst` only documents the happy path. This fix is self-explanatory from the code, when the IdP returns `error=access_denied`, Kinto now forwards it to the callback instead of returning 400.

-  Added `TokenViewErrorTest` in `tests/plugins/test_openid.py` covering:
  Auth server error redirects to the stored callback
  `error_description` is forwarded alongside `error`
  Invalid state with an error still returns 400
  State is consumed (cannot be reused) even on error
  Missing `code` with no `error` still returns 400
  



